### PR TITLE
459830 Fix jdk.dio.policy for SPI device access

### DIFF
--- a/kura/distrib/src/main/resources/common/jdk.dio.policy
+++ b/kura/distrib/src/main/resources/common/jdk.dio.policy
@@ -16,7 +16,7 @@ grant {
 	permission jdk.dio.gpio.GPIOPinPermission "*:*", "open,setdirection";
 	permission jdk.dio.gpio.GPIOPortPermission "*:*";
 	permission jdk.dio.i2cbus.I2CPermission "*:*";
-	permission jdk.dio.spi.SPIPermission "*:*";
+	permission jdk.dio.spibus.SPIPermission "*:*";
 	permission jdk.dio.uart.UARTPermission "*:*";
 	permission jdk.dio.watchdog.WatchdogTimerPermission "*:*";
 };


### PR DESCRIPTION
Fix for the [bug 459830 - Error in the jdk.dio.policy shiped with Kura, that denies SPI access](https://bugs.eclipse.org/bugs/show_bug.cgi?id=459830)

Replace jdk.dio.spi.SPIPermission with jdk.dio.spibus.SPIPermission which is the correct fully qualified name for the SPI permission.
