### PR TITLE
Expose the "control prefix" as a setting to allow users to change the…

### DIFF
--- a/kura/org.eclipse.kura.core.cloud/OSGI-INF/metatype/org.eclipse.kura.cloud.CloudService.xml
+++ b/kura/org.eclipse.kura.core.cloud/OSGI-INF/metatype/org.eclipse.kura.cloud.CloudService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2014 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2015 Eurotech and/or its affiliates, and others
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -10,6 +10,7 @@
 
     Contributors:
       Eurotech
+      Benjamin Cabé <benjamin@eclipse.org>
 
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
@@ -40,6 +41,15 @@
         	required="false"
         	default=""
         	description='Custom name for the device. This value is applied ONLY if device.display-name is set to "Custom"'>
+        </AD>
+                    
+        <AD id="topic.control-prefix"
+            name="topic.control-prefix"
+            type="String"
+            cardinality="0"
+            required="true"
+            default="$EDC"
+            description='Topic prefix for system messages.'>
         </AD>
                     
         <AD id="encode.gzip"


### PR DESCRIPTION
… MQTT namespace used by CloudService

Signed-off-by: Benjamin Cabé <benjamin@eclipse.org>