### PR TITLE
Fix bug 480434 - Multiple bluetooth le devices connection problem;

### DIFF
--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 public class BluetoothProcess {
 
 	private static final Logger s_logger = LoggerFactory.getLogger(BluetoothProcess.class);
-	private static final ExecutorService s_streamGobblers = Executors.newFixedThreadPool(2);
+	private static final ExecutorService s_streamGobblers = Executors.newCachedThreadPool();
 
 	private Process m_process;
 	private Future<?> m_futureInputGobbler;


### PR DESCRIPTION
The existing code limits only one bluetooth device to connect by using a fixed thread pool  (each device consumes two threads), considering the number of actual connected bluetooth device could not be very big in practical use case, so use a cached thread pool should be OK. 
