### PR TITLE
Trace log messages use common string formatting instead of concatenation

### DIFF
--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -85,7 +85,7 @@ public class NetworkConfiguration {
 
 	/**
 	 * Constructor for create a completely new NetComponentConfiguration based on a set of properties
-	 * 
+	 *
 	 * @param properties				The properties that represent the new configuration
 	 * @throws UnknownHostException		If some hostnames can not be resolved
 	 * @throws KuraException				It there is an internal error
@@ -123,7 +123,7 @@ public class NetworkConfiguration {
 				if(properties.get(keyBuffer.toString()) != null) {
 					type = NetInterfaceType.valueOf((String) properties.get(keyBuffer.toString()));
 				}
-				s_logger.trace("Adding interface: " + availableInterfaces[i] + " of type " + type);
+				s_logger.trace("Adding interface: {} of type {}", availableInterfaces[i], type);
 				addInterfaceConfiguration(availableInterfaces[i], type, properties);
 			}
 		}
@@ -184,7 +184,7 @@ public class NetworkConfiguration {
 
 		List<? extends NetInterfaceAddressConfig> netInterfaceAddressConfigs = netInterfaceConfig.getNetInterfaceAddresses();
 
-		s_logger.trace("Adding a netConfig: " + netConfig);
+		s_logger.trace("Adding a netConfig: {}", netConfig);
 		for(NetInterfaceAddressConfig netInterfaceAddressConfig : netInterfaceAddressConfigs) {
 			NetInterfaceAddressConfigImpl netInterfaceAddressConfigImpl = (NetInterfaceAddressConfigImpl)netInterfaceAddressConfig;
 			List<NetConfig> netConfigs = netInterfaceAddressConfig.getConfigs();
@@ -448,8 +448,8 @@ public class NetworkConfiguration {
 	//
 	// ---------------------------------------------------------------
 
-	private void recomputeNetworkProperties() 
-	{		
+	private void recomputeNetworkProperties()
+	{
 		Map<String,Object> properties = new HashMap<String,Object>();
 
 		String netIfPrefix = null;
@@ -482,7 +482,7 @@ public class NetworkConfiguration {
 			sbInterfaces.append(netInterfaceConfig.getName());
 
 			// build the prefixes for all the properties associated with this interface
-			sbPrefix = new StringBuilder("net.interface.").append(netInterfaceConfig.getName()).append(".");	        
+			sbPrefix = new StringBuilder("net.interface.").append(netInterfaceConfig.getName()).append(".");
 			netIfReadOnlyPrefix = sbPrefix.toString();
 			netIfPrefix = sbPrefix.append("config.").toString();
 			netIfConfigPrefix = sbPrefix.toString();
@@ -598,7 +598,7 @@ public class NetworkConfiguration {
 
 			for (NetInterfaceAddress nia : netInterfaceConfig.getNetInterfaceAddresses()) {
 				String typePrefix = "ip4.";
-				if (nia != null) {				    
+				if (nia != null) {
 					if(nia.getAddress() != null) {
 						properties.put(netIfReadOnlyPrefix+typePrefix+"address", nia.getAddress().getHostAddress());
 					}
@@ -663,23 +663,23 @@ public class NetworkConfiguration {
 			// add the properties of the network configurations associated to the interface
 
 			List<? extends NetInterfaceAddressConfig> netInterfaceAddressConfigs = netInterfaceConfig.getNetInterfaceAddresses();
-			s_logger.trace("netInterfaceAddressConfigs.size() for " + netInterfaceConfig.getName() + ": " + netInterfaceAddressConfigs.size());
+			s_logger.trace("netInterfaceAddressConfigs.size() for {}: {}", netInterfaceConfig.getName(), netInterfaceAddressConfigs.size());
 
 			for(NetInterfaceAddressConfig netInterfaceAddressConfig : netInterfaceAddressConfigs) {
 				List<NetConfig> netConfigs = netInterfaceAddressConfig.getConfigs();
 
 				if(netConfigs != null) {
-					s_logger.trace("netConfigs.size(): " + netConfigs.size());
+					s_logger.trace("netConfigs.size(): {}", netConfigs.size());
 
 					for(NetConfig netConfig : netConfigs) {
 						if (netConfig instanceof WifiConfig) {
-							s_logger.trace("adding netconfig WifiConfigIP4 for " + netInterfaceConfig.getName());
+							s_logger.trace("adding netconfig WifiConfigIP4 for {}", netInterfaceConfig.getName());
 							addWifiConfigIP4Properties((WifiConfig) netConfig, netIfConfigPrefix, properties);
 						} else if (netConfig instanceof ModemConfig) {
-							s_logger.trace("adding netconfig ModemConfig for " + netInterfaceConfig.getName());
+							s_logger.trace("adding netconfig ModemConfig for {}", netInterfaceConfig.getName());
 							addModemConfigProperties((ModemConfig) netConfig, netIfConfigPrefix, properties);
 						} else if (netConfig instanceof NetConfigIP4) {
-							s_logger.trace("adding netconfig NetConfigIP4 for " + netInterfaceConfig.getName());
+							s_logger.trace("adding netconfig NetConfigIP4 for {}", netInterfaceConfig.getName());
 							addNetConfigIP4Properties((NetConfigIP4) netConfig, netIfConfigPrefix, properties);
 
 							/*
@@ -689,7 +689,7 @@ public class NetworkConfiguration {
 								System.out.println("\t\t\t"+key+"="+properties.get(key));
 							}*/
 						} else if (netConfig instanceof NetConfigIP6) {
-							s_logger.trace("adding netconfig NetConfigIP6 for " + netInterfaceConfig.getName());
+							s_logger.trace("adding netconfig NetConfigIP6 for {}", netInterfaceConfig.getName());
 							addNetConfigIP6Properties((NetConfigIP6) netConfig, netIfConfigPrefix, properties);
 
 							/*
@@ -699,10 +699,10 @@ public class NetworkConfiguration {
 								System.out.println("\t\t\t"+key+"="+properties.get(key));
 							}*/
 						} else if (netConfig instanceof DhcpServerConfig4) {
-							s_logger.trace("adding netconfig DhcpServerConfig4 for " + netInterfaceConfig.getName());
+							s_logger.trace("adding netconfig DhcpServerConfig4 for {}", netInterfaceConfig.getName());
 							addDhcpServerConfig4((DhcpServerConfig4) netConfig, netIfConfigPrefix, properties);
 						} else if (netConfig instanceof FirewallAutoNatConfig) {
-							s_logger.trace("adding netconfig FirewallNatConfig for " + netInterfaceConfig.getName());
+							s_logger.trace("adding netconfig FirewallNatConfig for {}", netInterfaceConfig.getName());
 							addFirewallNatConfig((FirewallAutoNatConfig) netConfig, netIfConfigPrefix, properties);
 						}
 					}
@@ -715,12 +715,12 @@ public class NetworkConfiguration {
 	}
 
 	private void addWifiConfigIP4Properties(WifiConfig wifiConfig,
-			String netIfConfigPrefix, 
+			String netIfConfigPrefix,
 			Map<String,Object> properties) {
 
 		WifiMode mode = wifiConfig.getMode();
 		if(mode == null) {
-			s_logger.trace("WifiMode is null - could not add wifiConfig: " + wifiConfig);
+			s_logger.trace("WifiMode is null - could not add wifiConfig: {}", wifiConfig);
 			return;
 		}
 
@@ -800,7 +800,7 @@ public class NetworkConfiguration {
 		StringBuilder prefix = new StringBuilder(netIfConfigPrefix).append("wifi.").append(mode.toString().toLowerCase());
 
 		// mode
-		s_logger.trace("mode is " + mode.toString());
+		s_logger.trace("mode is {}", mode);
 		wifiConfig.setMode(mode);
 
 		// ssid
@@ -809,8 +809,8 @@ public class NetworkConfiguration {
 		if(ssid == null) {
 			ssid = "";
 		}
-		s_logger.trace("SSID is " + ssid);
-		wifiConfig.setSSID(ssid);       
+		s_logger.trace("SSID is {}", ssid);
+		wifiConfig.setSSID(ssid);
 
 		// driver
 		key = prefix + ".driver";
@@ -818,14 +818,14 @@ public class NetworkConfiguration {
 		if(driver == null) {
 			driver = "";
 		}
-		s_logger.trace("driver is " + driver);
-		wifiConfig.setDriver(driver);	    
+		s_logger.trace("driver is {}", driver);
+		wifiConfig.setDriver(driver);
 
 		// security
 		key = prefix + ".securityType";
 		WifiSecurity wifiSecurity = WifiSecurity.NONE;
 		String securityString = (String)properties.get(key);
-		s_logger.trace("securityString is " + securityString);
+		s_logger.trace("securityString is {}", securityString);
 		if(securityString != null && !securityString.isEmpty()) {
 			try {
 				wifiSecurity = WifiSecurity.valueOf(securityString);
@@ -838,7 +838,7 @@ public class NetworkConfiguration {
 		// channels
 		key = prefix + ".channel";
 		String channelsString = (String)properties.get(key);
-		s_logger.trace("channelsString is " + channelsString);
+		s_logger.trace("channelsString is {}", channelsString);
 		if(channelsString != null) {
 			channelsString = channelsString.trim();
 			if (channelsString.length() > 0) {
@@ -865,8 +865,8 @@ public class NetworkConfiguration {
 		if(passphrase == null) {
 			passphrase = "";
 		}
-		s_logger.trace("passphrase is " + passphrase);
-		wifiConfig.setPasskey(passphrase);       
+		s_logger.trace("passphrase is {}", passphrase);
+		wifiConfig.setPasskey(passphrase);
 
 		// hardware mode
 		key = prefix + ".hardwareMode";
@@ -874,7 +874,7 @@ public class NetworkConfiguration {
 		if(hwMode == null) {
 			hwMode = "";
 		}
-		s_logger.trace("hwMode is " + hwMode);
+		s_logger.trace("hwMode is {}", hwMode);
 		wifiConfig.setHardwareMode(hwMode);
 
 		// ignore SSID
@@ -888,7 +888,7 @@ public class NetworkConfiguration {
 		}
 
 		wifiConfig.setIgnoreSSID(ignoreSSID);
-		
+
 		key = prefix + ".pairwiseCiphers";
 		String pairwiseCiphers = (String)properties.get(key);
 		if (pairwiseCiphers != null) {
@@ -901,7 +901,7 @@ public class NetworkConfiguration {
 			if(bgscan == null) {
 				bgscan = "";
 			}
-			s_logger.trace("bgscan is " + bgscan);
+			s_logger.trace("bgscan is {}", bgscan);
 			wifiConfig.setBgscan(new WifiBgscan(bgscan));
 
 			/*
@@ -911,7 +911,7 @@ public class NetworkConfiguration {
 				wifiConfig.setPairwiseCiphers(WifiCiphers.valueOf(pairwiseCiphers));
 			}
 			*/
-			
+
 			key = prefix + ".groupCiphers";
 			String groupCiphers = (String)properties.get(key);
 			if (groupCiphers != null) {
@@ -937,13 +937,13 @@ public class NetworkConfiguration {
 		if(broadcast != null) {
 			wifiConfig.setBroadcast(broadcast);
 		}
-		s_logger.trace("hwMode is " + hwMode);
+		s_logger.trace("hwMode is {}", hwMode);
 
 		// radio mode
 		key = prefix + ".radioMode";
 		WifiRadioMode radioMode;
 		String radioModeString = (String)properties.get(key);
-		s_logger.trace("radioModeString is " + radioModeString);
+		s_logger.trace("radioModeString is {}", radioModeString);
 		if(radioModeString != null && !radioModeString.isEmpty()) {
 			try {
 				radioMode = WifiRadioMode.valueOf(radioModeString);
@@ -956,13 +956,13 @@ public class NetworkConfiguration {
 		if(!wifiConfig.isValid()) {
 			return null;
 		} else {
-			s_logger.trace("Returning wifiConfig: " + wifiConfig);
+			s_logger.trace("Returning wifiConfig: {}", wifiConfig);
 			return wifiConfig;
 		}
 	}
 
 	private void addModemConfigProperties(ModemConfig modemConfig,
-			String prefix, 
+			String prefix,
 			Map<String, Object> properties) {
 
 		properties.put(prefix+"apn", modemConfig.getApn());
@@ -997,14 +997,14 @@ public class NetworkConfiguration {
 		// apn
 		key = prefix + "apn";
 		String apn = (String)properties.get(key);
-		s_logger.trace("APN is " + apn);
-		modemConfig.setApn(apn);       
+		s_logger.trace("APN is {}", apn);
+		modemConfig.setApn(apn);
 
 		// auth type
 		key = prefix + "authType";
 		String authTypeString = (String)properties.get(key);
 		AuthType authType = AuthType.NONE;
-		s_logger.trace("Auth type is " + authTypeString);
+		s_logger.trace("Auth type is {}", authTypeString);
 		if(authTypeString != null && !authTypeString.isEmpty()) {
 			try {
 				authType = AuthType.valueOf(authTypeString);
@@ -1020,8 +1020,8 @@ public class NetworkConfiguration {
 		key = prefix + "dataCompression";
 		if(properties.get(key) != null) {
 			int dataCompression = (Integer)properties.get(key);
-			s_logger.trace("Data compression is " + dataCompression);
-			modemConfig.setDataCompression(dataCompression);     
+			s_logger.trace("Data compression is {}", dataCompression);
+			modemConfig.setDataCompression(dataCompression);
 		} else {
 			s_logger.trace("Data compression is null");
 		}
@@ -1029,15 +1029,15 @@ public class NetworkConfiguration {
 		// dial string
 		key = prefix + "dialString";
 		String dialString = (String)properties.get(key);
-		s_logger.trace("Dial string is " + dialString);
-		modemConfig.setDialString(dialString);       
+		s_logger.trace("Dial string is {}", dialString);
+		modemConfig.setDialString(dialString);
 
 		// header compression
 		key = prefix + "headerCompression";
 		if(properties.get(key) != null) {
 			int headerCompression = (Integer)properties.get(key);
-			s_logger.trace("Header compression is " + headerCompression);
-			modemConfig.setHeaderCompression(headerCompression);       
+			s_logger.trace("Header compression is {}", headerCompression);
+			modemConfig.setHeaderCompression(headerCompression);
 		} else {
 			s_logger.trace("Header compression is null");
 		}
@@ -1045,7 +1045,7 @@ public class NetworkConfiguration {
 		// ip address
 		String ipAddressString = (String)properties.get(prefix + "ipAddress");
 		IPAddress ipAddress = null;
-		s_logger.trace("IP address is " + ipAddressString);
+		s_logger.trace("IP address is {}", ipAddressString);
 		if(ipAddressString != null && !ipAddressString.isEmpty()) {
 			try {
 				IP4Address.parseHostAddress(ipAddressString);
@@ -1055,12 +1055,12 @@ public class NetworkConfiguration {
 		} else {
 			s_logger.trace("IP address is null");
 		}
-		modemConfig.setIpAddress(ipAddress);       
+		modemConfig.setIpAddress(ipAddress);
 
 		// password
 		String password = (String)properties.get(prefix + "password");
-		s_logger.trace("Password is " + password);
-		modemConfig.setPassword(password);       
+		s_logger.trace("Password is {}", password);
+		modemConfig.setPassword(password);
 
 		// pdp type
 		String pdpTypeString = (String)properties.get(prefix + "pdpType");
@@ -1072,15 +1072,15 @@ public class NetworkConfiguration {
 				throw new KuraException(KuraErrorCode.INTERNAL_ERROR, "Could not parse pdp type " + pdpTypeString);
 			}
 		}
-		s_logger.trace("Pdp type is " + pdpTypeString);
-		modemConfig.setPdpType(pdpType);       
+		s_logger.trace("Pdp type is {}", pdpTypeString);
+		modemConfig.setPdpType(pdpType);
 
 		// profile id
 		key = prefix + "profileId";
 		if(properties.get(key) != null) {
 			int profileId = (Integer)properties.get(key);
-			s_logger.trace("Profile id is " + profileId);
-			modemConfig.setProfileID(profileId);       
+			s_logger.trace("Profile id is {}", profileId);
+			modemConfig.setProfileID(profileId);
 		} else {
 			s_logger.trace("Profile id is null");
 		}
@@ -1089,7 +1089,7 @@ public class NetworkConfiguration {
 		key = prefix + "pppNum";
 		if(properties.get(key) != null) {
 			int pppNum = (Integer)properties.get(key);
-			s_logger.trace("PPP number is " + pppNum);
+			s_logger.trace("PPP number is {}", pppNum);
 			modemConfig.setPppNumber(pppNum);
 		} else {
 			s_logger.trace("PPP number is null");
@@ -1099,7 +1099,7 @@ public class NetworkConfiguration {
 		key = prefix + "persist";
 		if(properties.get(key) != null) {
 			boolean persist = (Boolean)properties.get(key);
-			s_logger.trace("persist is " + persist);
+			s_logger.trace("persist is {}", persist);
 			modemConfig.setPersist(persist);
 		} else {
 			s_logger.trace("persist is null");
@@ -1109,7 +1109,7 @@ public class NetworkConfiguration {
 		key = prefix + "maxFail";
 		if(properties.get(key) != null) {
 			int maxFail = (Integer)properties.get(key);
-			s_logger.trace("maxfail is " + maxFail);
+			s_logger.trace("maxfail is {}", maxFail);
 			modemConfig.setMaxFail(maxFail);
 		} else {
 			s_logger.trace("maxfail is null");
@@ -1119,7 +1119,7 @@ public class NetworkConfiguration {
 		key = prefix + "resetTimeout";
 		if(properties.get(key) != null) {
 			int resetTimeout = (Integer)properties.get(key);
-			s_logger.trace("resetTimeout is " + resetTimeout);
+			s_logger.trace("resetTimeout is {}", resetTimeout);
 			modemConfig.setResetTimeout(resetTimeout);
 		} else {
 			s_logger.trace("resetTimeout is null");
@@ -1129,7 +1129,7 @@ public class NetworkConfiguration {
 		key = prefix + "idle";
 		if(properties.get(key) != null) {
 			int idle = (Integer)properties.get(key);
-			s_logger.trace("idle is " + idle);
+			s_logger.trace("idle is {}", idle);
 			modemConfig.setIdle(idle);
 		} else {
 			s_logger.trace("idle is null");
@@ -1139,7 +1139,7 @@ public class NetworkConfiguration {
 		key = prefix + "activeFilter";
 		if (properties.get(key) != null) {
 			String activeFilter = (String)properties.get(key);
-			s_logger.trace("activeFilter is " + activeFilter);
+			s_logger.trace("activeFilter is {}", activeFilter);
 			modemConfig.setActiveFilter(activeFilter);
 		} else {
 			s_logger.trace("activeFilter is null");
@@ -1149,7 +1149,7 @@ public class NetworkConfiguration {
 		key = prefix + "lcpEchoInterval";
 		if(properties.get(key) != null) {
 			int lcpEchoInterval = (Integer)properties.get(key);
-			s_logger.trace("LCP Echo Interval is " + lcpEchoInterval);
+			s_logger.trace("LCP Echo Interval is {}", lcpEchoInterval);
 			modemConfig.setLcpEchoInterval(lcpEchoInterval);
 		} else {
 			s_logger.trace("LCP Echo Interval is null");
@@ -1159,7 +1159,7 @@ public class NetworkConfiguration {
 		key = prefix + "lcpEchoFailure";
 		if(properties.get(key) != null) {
 			int lcpEchoFailure = (Integer)properties.get(key);
-			s_logger.trace("LCP Echo Failure is " + lcpEchoFailure);
+			s_logger.trace("LCP Echo Failure is {}", lcpEchoFailure);
 			modemConfig.setLcpEchoFailure(lcpEchoFailure);
 		} else {
 			s_logger.trace("LCP Echo Failure is null");
@@ -1167,19 +1167,19 @@ public class NetworkConfiguration {
 
 		// username
 		String username = (String)properties.get(prefix + "username");
-		s_logger.trace("Username is " + username);
-		modemConfig.setUsername(username);       
+		s_logger.trace("Username is {}", username);
+		modemConfig.setUsername(username);
 
 		// enabled
 		key = prefix + "enabled";
 		boolean enabled = false;
 		if(properties.get(key) != null) {
 			enabled = (Boolean)properties.get(key);
-			s_logger.trace("Enabled is " + enabled);
+			s_logger.trace("Enabled is {}", enabled);
 		} else {
 			s_logger.trace("Enabled is null");
 		}
-		modemConfig.setEnabled(enabled);      
+		modemConfig.setEnabled(enabled);
 
 		// GPS enabled
 		key = prefix + "gpsEnabled";
@@ -1196,7 +1196,7 @@ public class NetworkConfiguration {
 	}
 
 	private void addNetConfigIP4Properties(NetConfigIP4 nc,
-			String netIfConfigPrefix, 
+			String netIfConfigPrefix,
 			Map<String,Object> properties) {
 
 		properties.put(netIfConfigPrefix+"autoconnect", nc.isAutoConnect());
@@ -1257,7 +1257,7 @@ public class NetworkConfiguration {
 	}
 
 	private void addNetConfigIP6Properties(NetConfigIP6 nc,
-			String netIfConfigPrefix, 
+			String netIfConfigPrefix,
 			Map<String,Object> properties) {
 
 		properties.put(netIfConfigPrefix+"ip6.status", nc.getStatus().toString());
@@ -1291,7 +1291,7 @@ public class NetworkConfiguration {
 	}
 
 	private void addDhcpServerConfig4(DhcpServerConfig4 nc,
-			String netIfConfigPrefix, 
+			String netIfConfigPrefix,
 			Map<String,Object> properties) {
 
 		/*
@@ -1314,7 +1314,7 @@ public class NetworkConfiguration {
 	}
 
 	private void addFirewallNatConfig(FirewallAutoNatConfig nc,
-			String netIfConfigPrefix, 
+			String netIfConfigPrefix,
 			Map<String,Object> properties) {
 
 		/*
@@ -1335,8 +1335,8 @@ public class NetworkConfiguration {
 
 		switch(type) {
 		case LOOPBACK:
-			LoopbackInterfaceConfigImpl loopbackInterfaceConfig = new LoopbackInterfaceConfigImpl(interfaceName);            
-			List<NetInterfaceAddressConfig> loopbackInterfaceAddressConfigs = new ArrayList<NetInterfaceAddressConfig>();                            
+			LoopbackInterfaceConfigImpl loopbackInterfaceConfig = new LoopbackInterfaceConfigImpl(interfaceName);
+			List<NetInterfaceAddressConfig> loopbackInterfaceAddressConfigs = new ArrayList<NetInterfaceAddressConfig>();
 			loopbackInterfaceAddressConfigs.add(new NetInterfaceAddressConfigImpl());
 			loopbackInterfaceConfig.setNetInterfaceAddresses(loopbackInterfaceAddressConfigs);
 
@@ -1352,7 +1352,7 @@ public class NetworkConfiguration {
 
 			this.populateNetInterfaceConfiguration(ethernetInterfaceConfig, props);
 
-			m_netInterfaceConfigs.put(interfaceName, ethernetInterfaceConfig);            
+			m_netInterfaceConfigs.put(interfaceName, ethernetInterfaceConfig);
 			break;
 		case WIFI:
 			WifiInterfaceConfigImpl wifiInterfaceConfig = new WifiInterfaceConfigImpl(interfaceName);
@@ -1363,7 +1363,7 @@ public class NetworkConfiguration {
 
 			this.populateNetInterfaceConfiguration(wifiInterfaceConfig, props);
 
-			m_netInterfaceConfigs.put(interfaceName, wifiInterfaceConfig);            
+			m_netInterfaceConfigs.put(interfaceName, wifiInterfaceConfig);
 			break;
 		case MODEM:
 			ModemInterfaceConfigImpl modemInterfaceConfig = new ModemInterfaceConfigImpl(interfaceName);
@@ -1374,10 +1374,10 @@ public class NetworkConfiguration {
 
 			this.populateNetInterfaceConfiguration(modemInterfaceConfig, props);
 
-			m_netInterfaceConfigs.put(interfaceName, modemInterfaceConfig);            
+			m_netInterfaceConfigs.put(interfaceName, modemInterfaceConfig);
 			break;
 		case UNKNOWN:
-			s_logger.trace("Found interface of unknown type in current configuration: " + interfaceName);
+			s_logger.trace("Found interface of unknown type in current configuration: {}", interfaceName);
 			break;
 			/*
         default:
@@ -1387,7 +1387,7 @@ public class NetworkConfiguration {
 			addEthernetConfiguration(interfaceName, props);
 			break;
 		case WIFI:
-			addWifiConfiguration(interfaceName, props); 
+			addWifiConfiguration(interfaceName, props);
 			break;
 			 */
 		default:
@@ -1406,7 +1406,7 @@ public class NetworkConfiguration {
 		StringBuffer keyBuffer = new StringBuffer();
 		keyBuffer.append("net.interface.").append(interfaceName).append(".type");
 		NetInterfaceType interfaceType = NetInterfaceType.valueOf((String) props.get(keyBuffer.toString()));
-		s_logger.trace("Populating interface: " + interfaceName + " of type " + interfaceType);
+		s_logger.trace("Populating interface: {} of type {}", interfaceName, interfaceType);
 
 
 		// build the prefixes for all the properties associated with this interface
@@ -1422,7 +1422,7 @@ public class NetworkConfiguration {
 		if (props.containsKey(stateConfig)) {
 			try {
 				NetInterfaceState state = (NetInterfaceState) props.get(stateConfig);
-				s_logger.trace("got state: " + state);
+				s_logger.trace("got state: {}", state);
 				netInterfaceConfig.setState(state);
 			}
 			catch (Exception e) {
@@ -1435,7 +1435,7 @@ public class NetworkConfiguration {
 		String autoConnectKey = netIfPrefix + "autoconnect";
 		if (props.containsKey(autoConnectKey)) {
 			autoConnect = (Boolean) props.get(autoConnectKey);
-			s_logger.trace("got autoConnect: " + autoConnect);
+			s_logger.trace("got autoConnect: {}", autoConnect);
 			netInterfaceConfig.setAutoConnect(autoConnect);
 		}
 
@@ -1443,7 +1443,7 @@ public class NetworkConfiguration {
 		String mtuConfig = netIfPrefix + "mtu";
 		if (props.containsKey(mtuConfig)) {
 			int mtu = (Integer) props.get(mtuConfig);
-			s_logger.trace("got MTU: " + mtu);
+			s_logger.trace("got MTU: {}", mtu);
 			netInterfaceConfig.setMTU(mtu);
 		}
 
@@ -1451,7 +1451,7 @@ public class NetworkConfiguration {
 		String driverKey = netIfReadOnlyPrefix + "driver";
 		if (props.containsKey(driverKey)) {
 			String driver = (String) props.get(driverKey);
-			s_logger.trace("got Driver: " + driver);
+			s_logger.trace("got Driver: {}", driver);
 			netInterfaceConfig.setDriver(driver);
 		}
 
@@ -1459,7 +1459,7 @@ public class NetworkConfiguration {
 		String driverVersionKey = netIfReadOnlyPrefix + "driver.version";
 		if (props.containsKey(driverVersionKey)) {
 			String driverVersion = (String) props.get(driverVersionKey);
-			s_logger.trace("got Driver Version: " + driverVersion);
+			s_logger.trace("got Driver Version: {}", driverVersion);
 			netInterfaceConfig.setDriverVersion(driverVersion);
 		}
 
@@ -1467,7 +1467,7 @@ public class NetworkConfiguration {
 		String firmwardVersionKey = netIfReadOnlyPrefix + "firmware.version";
 		if (props.containsKey(firmwardVersionKey)) {
 			String firmwareVersion = (String) props.get(firmwardVersionKey);
-			s_logger.trace("got Firmware Version: " + firmwareVersion);
+			s_logger.trace("got Firmware Version: {}", firmwareVersion);
 			netInterfaceConfig.setFirmwareVersion(firmwareVersion);
 		}
 
@@ -1475,7 +1475,7 @@ public class NetworkConfiguration {
 		String macAddressKey = netIfReadOnlyPrefix + "mac";
 		if (props.containsKey(macAddressKey)) {
 			String macAddress = (String) props.get(macAddressKey);
-			s_logger.trace("got Mac Address: " + macAddress);
+			s_logger.trace("got Mac Address: {}", macAddress);
 			netInterfaceConfig.setHardwareAddress(NetUtil.hardwareAddressToBytes(macAddress));
 		}
 
@@ -1483,7 +1483,7 @@ public class NetworkConfiguration {
 		String loopbackKey = netIfReadOnlyPrefix + "loopback";
 		if (props.containsKey(loopbackKey)) {
 			Boolean isLoopback = (Boolean) props.get(loopbackKey);
-			s_logger.trace("got Is Loopback: " + isLoopback);
+			s_logger.trace("got Is Loopback: {}", isLoopback);
 			netInterfaceConfig.setLoopback(isLoopback);
 		}
 
@@ -1491,7 +1491,7 @@ public class NetworkConfiguration {
 		String ptpKey = netIfReadOnlyPrefix + "ptp";
 		if (props.containsKey(ptpKey)) {
 			Boolean isPtp = (Boolean) props.get(ptpKey);
-			s_logger.trace("got Is PtP: " + isPtp);
+			s_logger.trace("got Is PtP: {}", isPtp);
 			netInterfaceConfig.setPointToPoint(isPtp);
 		}
 
@@ -1499,7 +1499,7 @@ public class NetworkConfiguration {
 		String upKey = netIfReadOnlyPrefix + "up";
 		if (props.containsKey(upKey)) {
 			Boolean isUp = (Boolean) props.get(upKey);
-			s_logger.trace("got Is Up: " + isUp);
+			s_logger.trace("got Is Up: {}", isUp);
 			netInterfaceConfig.setUp(isUp);
 
 			if(isUp) {
@@ -1508,7 +1508,7 @@ public class NetworkConfiguration {
 				netInterfaceConfig.setState(NetInterfaceState.DISCONNECTED);
 			}
 		} else {
-			s_logger.trace("Setting state to");
+			s_logger.trace("Setting state to NetInterfaceState.DISCONNECTED");
 			netInterfaceConfig.setState(NetInterfaceState.DISCONNECTED);
 		}
 
@@ -1516,7 +1516,7 @@ public class NetworkConfiguration {
 		String virtualKey = netIfReadOnlyPrefix + "virtual";
 		if (props.containsKey(virtualKey)) {
 			Boolean isVirtual = (Boolean) props.get(virtualKey);
-			s_logger.trace("got Is Virtual: " + isVirtual);
+			s_logger.trace("got Is Virtual: {}", isVirtual);
 			netInterfaceConfig.setVirtual(isVirtual);
 		}
 
@@ -1530,7 +1530,7 @@ public class NetworkConfiguration {
 
 		if ((vendorId != null) && (productId != null)) {
 			UsbDevice usbDevice = new UsbNetDevice(vendorId, productId, vendorName, productName, usbBusNumber, usbDevicePath, interfaceName);
-			s_logger.trace("adding usbDevice: " + usbDevice + ", port: " + usbDevice.getUsbPort());	  
+			s_logger.trace("adding usbDevice: {}, port: {}", usbDevice, usbDevice.getUsbPort());
 			netInterfaceConfig.setUsbDevice(usbDevice);
 		}
 
@@ -1539,7 +1539,7 @@ public class NetworkConfiguration {
 			String linkUpKey = netIfReadOnlyPrefix + "eth.link.up";
 			if (props.containsKey(linkUpKey)) {
 				Boolean linkUp = (Boolean) props.get(linkUpKey);
-				s_logger.trace("got Is Link Up: " + linkUp);
+				s_logger.trace("got Is Link Up: {}", linkUp);
 				((EthernetInterfaceConfigImpl)netInterfaceConfig).setLinkUp(linkUp);
 			}
 		} else if(netInterfaceConfig instanceof WifiInterfaceConfigImpl) {
@@ -1653,7 +1653,7 @@ public class NetworkConfiguration {
 		if(configStatus4 == null) {
 			configStatus4 = NetInterfaceStatus.netIPv4StatusDisabled.name();
 		}
-		s_logger.trace("Status Ipv4? " + configStatus4);
+		s_logger.trace("Status Ipv4? {}", configStatus4);
 
 		String configStatus6 = null;
 		String configStatus6Key = "net.interface." + interfaceName+".config.ip6.status";
@@ -1668,7 +1668,7 @@ public class NetworkConfiguration {
 		// POPULATE NetInterfaceAddresses
 		for(NetInterfaceAddressConfig netInterfaceAddress : netInterfaceConfig.getNetInterfaceAddresses()) {
 
-			List<NetConfig> netConfigs = new ArrayList<NetConfig>();            
+			List<NetConfig> netConfigs = new ArrayList<NetConfig>();
 			if(netInterfaceAddress instanceof NetInterfaceAddressConfigImpl) {
 				((NetInterfaceAddressConfigImpl) netInterfaceAddress).setNetConfigs(netConfigs);
 			} else if (netInterfaceAddress instanceof WifiInterfaceAddressConfigImpl) {
@@ -1689,14 +1689,14 @@ public class NetworkConfiguration {
 				String key = "net.interface." + interfaceName + addressType + ".address";
 				if(props.containsKey(key)) {
 					IPAddress address = IP4Address.parseHostAddress((String)props.get(key));
-					s_logger.trace("got " + key + ": " + address);
+					s_logger.trace("got {}:{}", key, address);
 					netInterfaceAddressImpl.setAddress(address);
 				}
 
 				key = "net.interface." + interfaceName + addressType + ".broadcast";
 				if(props.containsKey(key)) {
 					IPAddress broadcast = IP4Address.parseHostAddress((String)props.get(key));
-					s_logger.trace("got " + key + ": " + broadcast);
+					s_logger.trace("got {}:{}", key, broadcast);
 					netInterfaceAddressImpl.setBroadcast(broadcast);
 				}
 
@@ -1704,7 +1704,7 @@ public class NetworkConfiguration {
 				if(props.containsKey(key)) {
 					List<IPAddress> dnsServers = new ArrayList<IPAddress>();
 					String dnsServersString = (String) props.get(key);
-					s_logger.trace("got " + key + ": " + dnsServersString);
+					s_logger.trace("got {}:{}", key, dnsServersString);
 					for(String dnsServer : dnsServersString.split(",")) {
 						dnsServers.add(IP4Address.parseHostAddress(dnsServer));
 					}
@@ -1715,10 +1715,10 @@ public class NetworkConfiguration {
 				if(props.containsKey(key)) {
 					if(props.get(key) != null && !((String)props.get(key)).trim().equals("")) {
 						IPAddress gateway = IP4Address.parseHostAddress((String)props.get(key));
-						s_logger.trace("got " + key + ": " + gateway);
+						s_logger.trace("got {}:{}", key, gateway);
 						netInterfaceAddressImpl.setGateway(gateway);
 					} else {
-						s_logger.trace("got " + key + ": null");
+						s_logger.trace("got {}:null", key);
 						netInterfaceAddressImpl.setGateway(null);
 					}
 				}
@@ -1726,16 +1726,16 @@ public class NetworkConfiguration {
 				key = "net.interface." + interfaceName + addressType + ".netmask";
 				if(props.containsKey(key)) {
 					IPAddress netmask = IP4Address.parseHostAddress((String)props.get(key));
-					s_logger.trace("got " + key + ": " + netmask);
+					s_logger.trace("got {}:{}", key, netmask);
 					netInterfaceAddressImpl.setBroadcast(netmask);
 				}
 
 				key = "net.interface." + interfaceName + addressType + ".prefix";
 				if(props.containsKey(key)) {
 					Short prefix = (Short) props.get(key);
-					s_logger.trace("got " + key + ": " + prefix);
+					s_logger.trace("got {}:{}", key, prefix);
 					netInterfaceAddressImpl.setNetworkPrefixLength(prefix);
-				}                
+				}
 			}
 
 			// WifiInterfaceAddress
@@ -1752,7 +1752,7 @@ public class NetworkConfiguration {
 						mode = WifiMode.valueOf((String) props.get(configWifiMode));
 					}
 
-					s_logger.trace("Adding wifiMode: " + mode);
+					s_logger.trace("Adding wifiMode: {}", mode);
 					wifiInterfaceAddressImpl.setMode(mode);
 				}
 			}
@@ -1766,12 +1766,12 @@ public class NetworkConfiguration {
 				String configConnType = netIfPrefix + "connection.type";
 				if (props.containsKey(configConnType)) {
 					ModemConnectionType connType = ModemConnectionType.PPP;
-					String connTypeStr = (String)props.get(configConnType); 
+					String connTypeStr = (String)props.get(configConnType);
 					if(connTypeStr != null && !connTypeStr.isEmpty()) {
 						connType = ModemConnectionType.valueOf(connTypeStr);
 					}
 
-					s_logger.trace("Adding modem connection type: " + connType);
+					s_logger.trace("Adding modem connection type: {}", connType);
 					modemInterfaceAddressImpl.setConnectionType(connType);
 				}
 
@@ -1784,9 +1784,9 @@ public class NetworkConfiguration {
 						connStatus = ModemConnectionStatus.valueOf(connStatusStr);
 					}
 
-					s_logger.trace("Adding modem connection status: " + connStatus);
+					s_logger.trace("Adding modem connection status: {}", connStatus);
 					modemInterfaceAddressImpl.setConnectionStatus(connStatus);
-				}                
+				}
 			}
 
 
@@ -1799,7 +1799,7 @@ public class NetworkConfiguration {
 			boolean dhcpEnabled = false;
 			if (props.containsKey(configDhcp4)) {
 				dhcpEnabled = (Boolean) props.get(configDhcp4);
-				s_logger.trace("DHCP 4 enabled? " + dhcpEnabled);
+				s_logger.trace("DHCP 4 enabled? {}", dhcpEnabled);
 			}
 
 			netConfigIP4 = new NetConfigIP4(NetInterfaceStatus.valueOf(configStatus4), autoConnect, dhcpEnabled);
@@ -1809,11 +1809,11 @@ public class NetworkConfiguration {
 				// NetConfigIP4
 				String configIp4 = "net.interface." + interfaceName+".config.ip4.address";
 				if (props.containsKey(configIp4)) {
-					s_logger.trace("got " + configIp4 + ": " + props.get(configIp4));
+					s_logger.trace("got {}:{}", configIp4, props.get(configIp4));
 
 					// address
 					String addressIp4 = (String) props.get(configIp4);
-					s_logger.trace("IPv4 address: " + addressIp4);
+					s_logger.trace("IPv4 address: {}", addressIp4);
 					if(addressIp4 != null && !addressIp4.isEmpty()) {
 						IP4Address ip4Address = (IP4Address) IPAddress.parseHostAddress(addressIp4);
 						netConfigIP4.setAddress(ip4Address);
@@ -1850,7 +1850,7 @@ public class NetworkConfiguration {
 					if (props.containsKey(configIp4Gateway)) {
 
 						String gatewayIp4 = (String) props.get(configIp4Gateway);
-						s_logger.trace("IPv4 gateway: " + gatewayIp4);
+						s_logger.trace("IPv4 gateway: {}", gatewayIp4);
 						if(gatewayIp4 != null && !gatewayIp4.isEmpty()) {
 							IP4Address ip4Gateway = (IP4Address) IPAddress.parseHostAddress(gatewayIp4);
 							netConfigIP4.setGateway(ip4Gateway);
@@ -1868,7 +1868,7 @@ public class NetworkConfiguration {
 				String[] dnss = dnsAll.split(",");
 				for (String dns : dnss) {
 					if (dns != null && dns.length() > 0) {
-						s_logger.trace("IPv4 DNS: " + dns);
+						s_logger.trace("IPv4 DNS: {}", dns);
 						IP4Address dnsIp4 = (IP4Address) IPAddress.parseHostAddress(dns);
 						dnsIPs.add(dnsIp4);
 					}
@@ -1884,7 +1884,7 @@ public class NetworkConfiguration {
 				String winsAll = (String) props.get(configWINSs);
 				String[] winss = winsAll.split(",");
 				for (String wins : winss) {
-					s_logger.trace("WINS: " + wins);
+					s_logger.trace("WINS: {}", wins);
 					IP4Address winsIp4 = (IP4Address) IPAddress.parseHostAddress(wins);
 					winsIPs.add(winsIp4);
 				}
@@ -1899,7 +1899,7 @@ public class NetworkConfiguration {
 				String domainsAll = (String) props.get(configDomains);
 				String[] domains = domainsAll.split(",");
 				for (String domain : domains) {
-					s_logger.trace("IPv4 Domain: " + domain);
+					s_logger.trace("IPv4 Domain: {}", domain);
 					domainNames.add(domain);
 				}
 				netConfigIP4.setDomains(domainNames);
@@ -1909,7 +1909,7 @@ public class NetworkConfiguration {
 			String configNatEnabled = "net.interface." + interfaceName + ".config.nat.enabled";
 			if (props.containsKey(configNatEnabled)) {
 				boolean natEnabled = (Boolean) props.get(configNatEnabled);
-				s_logger.trace("NAT enabled? " + natEnabled);
+				s_logger.trace("NAT enabled? {}", natEnabled);
 
 				if(natEnabled) {
 					FirewallAutoNatConfig natConfig = new FirewallAutoNatConfig(interfaceName, "unknown", true);
@@ -1921,7 +1921,7 @@ public class NetworkConfiguration {
 			String configDhcpServerEnabled = "net.interface." + interfaceName + ".config.dhcpServer4.enabled";
 			if (props.containsKey(configDhcpServerEnabled)) {
 				boolean dhcpServerEnabled = (Boolean) props.get(configDhcpServerEnabled);
-				s_logger.trace("DHCP Server 4 enabled? " + dhcpServerEnabled);
+				s_logger.trace("DHCP Server 4 enabled? {}", dhcpServerEnabled);
 
 				IP4Address subnet = null;
 				IP4Address routerAddress = (dhcpEnabled) ? (IP4Address)netInterfaceAddress.getAddress() : netConfigIP4.getAddress();
@@ -1932,7 +1932,7 @@ public class NetworkConfiguration {
 				IP4Address rangeStart = null;
 				IP4Address rangeEnd = null;
 				boolean passDns = false;
-				List<IP4Address> dnServers = new ArrayList<IP4Address>();   
+				List<IP4Address> dnServers = new ArrayList<IP4Address>();
 
 				// prefix
 				String configDhcpServerPrefix = "net.interface." + interfaceName+".config.dhcpServer4.prefix";
@@ -1942,14 +1942,14 @@ public class NetworkConfiguration {
 					} else if(props.get(configDhcpServerPrefix) instanceof String) {
 						prefix = Short.parseShort((String) props.get(configDhcpServerPrefix));
 					}
-					s_logger.trace("DHCP Server prefix: " + prefix);
+					s_logger.trace("DHCP Server prefix: {}", prefix);
 				}
 
 				// rangeStart
 				String configDhcpServerRangeStart = "net.interface." + interfaceName+".config.dhcpServer4.rangeStart";
 				if (props.containsKey(configDhcpServerRangeStart)) {
 					String dhcpServerRangeStart = (String) props.get(configDhcpServerRangeStart);
-					s_logger.trace("DHCP Server Range Start: " + dhcpServerRangeStart);
+					s_logger.trace("DHCP Server Range Start: {}", dhcpServerRangeStart);
 					if(dhcpServerRangeStart != null && !dhcpServerRangeStart.isEmpty()) {
 						rangeStart = (IP4Address) IPAddress.parseHostAddress(dhcpServerRangeStart);
 					}
@@ -1959,7 +1959,7 @@ public class NetworkConfiguration {
 				String configDhcpServerRangeEnd = "net.interface." + interfaceName+".config.dhcpServer4.rangeEnd";
 				if (props.containsKey(configDhcpServerRangeEnd)) {
 					String dhcpServerRangeEnd = (String) props.get(configDhcpServerRangeEnd);
-					s_logger.trace("DHCP Server Range End: " + dhcpServerRangeEnd);
+					s_logger.trace("DHCP Server Range End: {}", dhcpServerRangeEnd);
 					if(dhcpServerRangeEnd != null && !dhcpServerRangeEnd.isEmpty()) {
 						rangeEnd = (IP4Address) IPAddress.parseHostAddress(dhcpServerRangeEnd);
 					}
@@ -1973,7 +1973,7 @@ public class NetworkConfiguration {
 					} else if(props.get(configDhcpServerDefaultLeaseTime) instanceof String) {
 						defaultLeaseTime = Integer.parseInt((String) props.get(configDhcpServerDefaultLeaseTime));
 					}
-					s_logger.trace("DHCP Server Default Lease Time: " + defaultLeaseTime);
+					s_logger.trace("DHCP Server Default Lease Time: {}", defaultLeaseTime);
 				}
 
 				// max lease time
@@ -1984,7 +1984,7 @@ public class NetworkConfiguration {
 					} else if(props.get(configDhcpServerMaxLeaseTime) instanceof String) {
 						maximumLeaseTime = Integer.parseInt((String) props.get(configDhcpServerMaxLeaseTime));
 					}
-					s_logger.trace("DHCP Server Maximum Lease Time: " + maximumLeaseTime);
+					s_logger.trace("DHCP Server Maximum Lease Time: {}", maximumLeaseTime);
 				}
 
 				// passDns
@@ -1995,13 +1995,13 @@ public class NetworkConfiguration {
 					} else if(props.get(configDhcpServerPassDns) instanceof String) {
 						passDns = Boolean.parseBoolean((String) props.get(configDhcpServerPassDns));
 					}
-					s_logger.trace("DHCP Server Pass DNS?: " + passDns);
+					s_logger.trace("DHCP Server Pass DNS?: {}", passDns);
 				}
 
 				if(routerAddress != null && rangeStart != null && rangeEnd != null) {
 					//get the netmask and subnet
 					int prefixInt = (int)prefix;
-					int mask = ~((1 << (32 - prefixInt)) - 1);                  
+					int mask = ~((1 << (32 - prefixInt)) - 1);
 					String subnetMaskString = NetworkUtil.dottedQuad(mask);
 					String subnetString =  NetworkUtil.calculateNetwork(routerAddress.getHostAddress(), subnetMaskString);
 					subnet = (IP4Address) IPAddress.parseHostAddress(subnetString);
@@ -2023,19 +2023,19 @@ public class NetworkConfiguration {
 			boolean dhcp6Enabled = false;
 			if (props.containsKey(configDhcp6)) {
 				dhcp6Enabled = (Boolean) props.get(configDhcp6);
-				s_logger.trace("DHCP 6 enabled? " + dhcp6Enabled);
+				s_logger.trace("DHCP 6 enabled? {}", dhcp6Enabled);
 			}
 
 			if(!dhcp6Enabled) {
 				// ip6
 				String configIp6 = "net.interface." + interfaceName + ".config.ip6.address";
-				if (props.containsKey(configIp6)) {                    
+				if (props.containsKey(configIp6)) {
 
 					// address
 					String addressIp6 = (String) props.get(configIp6);
-					s_logger.trace("IPv6 address: " + addressIp6);
+					s_logger.trace("IPv6 address: {}", addressIp6);
 					if(addressIp6 != null && !addressIp6.isEmpty()) {
-						IP6Address ip6Address = (IP6Address) IPAddress.parseHostAddress(addressIp6); 
+						IP6Address ip6Address = (IP6Address) IPAddress.parseHostAddress(addressIp6);
 						netConfigIP6.setAddress(ip6Address);
 					}
 
@@ -2047,7 +2047,7 @@ public class NetworkConfiguration {
 						String dnsAll = (String) props.get(configDNSs6);
 						String[] dnss = dnsAll.split(",");
 						for (String dns : dnss) {
-							s_logger.trace("IPv6 DNS: " + dns);
+							s_logger.trace("IPv6 DNS: {}", dns);
 							IP6Address dnsIp6 = (IP6Address) IPAddress.parseHostAddress(dns);
 							dnsIPs.add(dnsIp6);
 						}
@@ -2062,7 +2062,7 @@ public class NetworkConfiguration {
 						String domainsAll = (String) props.get(configDomains6);
 						String[] domains = domainsAll.split(",");
 						for (String domain : domains) {
-							s_logger.trace("IPv6 Domain: " + domain);
+							s_logger.trace("IPv6 Domain: {}", domain);
 							domainNames.add(domain);
 						}
 						netConfigIP6.setDomains(domainNames);

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/util/LinuxProcessUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/util/LinuxProcessUtil.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.kura.core.linux.util;
 
-/* 
+/*
  * Copyright (c) 2013 Eurotech Inc. All rights reserved.
  */
 
@@ -179,7 +179,7 @@ public class LinuxProcessUtil {
 		try {
 
 			if (command != null && !command.isEmpty()) {
-				s_logger.trace("searching process list for " + command);
+				s_logger.trace("searching process list for {}", command);
 
 				if ("intel-edison".equals(s_platform)) {
 					proc = ProcessUtil.exec("ps");
@@ -203,8 +203,7 @@ public class LinuxProcessUtil {
 
 					// see if the line has our command
 					if (line.indexOf(command) >= 0) {
-						s_logger.trace("found pid " + pid + " for command: "
-								+ command);
+						s_logger.trace("found pid {} for command: {}", pid, command);
 						return Integer.parseInt(pid);
 					}
 				}
@@ -227,7 +226,7 @@ public class LinuxProcessUtil {
 		SafeProcess proc = null;
 		try {
 			if(command != null && !command.isEmpty()) {
-				s_logger.trace("searching process list for " + command);
+				s_logger.trace("searching process list for {}", command);
 				if ("intel-edison".equals(s_platform)) {
 					proc = ProcessUtil.exec("ps");
 				} else {
@@ -257,7 +256,7 @@ public class LinuxProcessUtil {
 							}
 						}
 						if (allTokensPresent) {
-							s_logger.trace("found pid " + pid + " for command: " + command);
+							s_logger.trace("found pid {} for command: {}", pid, command);
 							return Integer.parseInt(pid);
 						}
 					}
@@ -271,7 +270,7 @@ public class LinuxProcessUtil {
 		finally {
 			ProcessUtil.destroy(proc);
 		}
-	}	
+	}
 
 	public static int getKuraPid() throws Exception {
 
@@ -349,9 +348,9 @@ public class LinuxProcessUtil {
 			while ((len = br.read(cbuf)) > 0) {
 				sb.append(cbuf, 0, len);
 			}
-		} 
+		}
 		finally {
-			if(br != null) br.close();		
+			if(br != null) br.close();
 		}
 		return sb.toString();
 	}

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BluetoothUtil {
-	
+
 	private static final Logger s_logger = LoggerFactory.getLogger(BluetoothUtil.class);
 	private static final ExecutorService s_processExecutor = Executors.newSingleThreadExecutor();
 
@@ -28,7 +28,7 @@ public class BluetoothUtil {
 	private static final String HCICONFIG     = "hciconfig";
 	private static final String HCITOOL       = "hcitool";
 	private static final String GATTTOOL      = "gatttool";
-	
+
 	/*
 	 * Use hciconfig utility to return information about the bluetooth adapter
 	 */
@@ -52,8 +52,8 @@ public class BluetoothUtil {
 				}
 				sb.append(line + "\n");
 			}
-			
-			//TODO: Pull more parameters from hciconfig? 
+
+			//TODO: Pull more parameters from hciconfig?
 			String[] results = sb.toString().split("\n");
 			props.put("leReady", "false");
 			for (String result : results) {
@@ -72,7 +72,7 @@ public class BluetoothUtil {
 //					String[] tmpAddress = address.split("\\s", 2);
 //					address = tmpAddress[0].trim();
 					props.put("address", address);
-					s_logger.trace("Bluetooth adapter address set to: " + address);
+					s_logger.trace("Bluetooth adapter address set to: {}", address);
 				}
 				if((result.indexOf(HCI_VERSION)) >= 0) {
 					// HCI version : 4.0 (0x6) or HCI version : 4.1 (0x7)
@@ -82,7 +82,7 @@ public class BluetoothUtil {
 					}
 				}
 			}
-			
+
 		} catch (Exception e) {
 			s_logger.error("Failed to execute command: " + command, e);
 			throw new KuraException(KuraErrorCode.INTERNAL_ERROR);
@@ -93,21 +93,21 @@ public class BluetoothUtil {
 			} catch (IOException e) {
 				s_logger.error("Error closing read buffer", e);
 			}
-			
+
 		}
-		
+
 		return props;
 	}
-	
+
 	/*
 	 * Use hciconfig utility to determine status of bluetooth adapter
 	 */
 	public static boolean isEnabled(String name) {
-		
+
 		String[] command = { HCICONFIG, name };
 		BluetoothSafeProcess proc = null;
 		BufferedReader br = null;
-		
+
 		try {
 			proc = BluetoothProcessUtil.exec(command);
 			br = new BufferedReader(new InputStreamReader(proc.getInputStream()));
@@ -130,10 +130,10 @@ public class BluetoothUtil {
 				s_logger.error("Error closing read buffer", e);
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/*
 	 * Utility method that allows sending any hciconfig command. The buffered
 	 * response is returned in case results are needed.
@@ -157,7 +157,7 @@ public class BluetoothUtil {
 		}
 		return br;
 	}
-	
+
 	/*
 	 * Utility method to send specific kill commands to processes.
 	 */
@@ -171,13 +171,13 @@ public class BluetoothUtil {
 			proc.waitFor();
 			br = new BufferedReader(new InputStreamReader(proc.getInputStream()));
 			String pid = br.readLine();
-			
+
 			// Check if the pid is not empty
 			if (pid != null) {
 				String[] commandKill = { "kill", "-" + signal, pid };
 				proc = BluetoothProcessUtil.exec(commandKill);
 			}
-			
+
 		} catch (IOException e) {
 			s_logger.error("Error executing command: " + commandPidOf, e);
 		} catch (InterruptedException e) {
@@ -191,10 +191,10 @@ public class BluetoothUtil {
 			}
 		}
 	}
-	
+
 	/*
 	 * Method to utilize BluetoothProcess and the hcitool utility. These processes run indefinitely, so the
-	 * BluetoothProcessListener is used to receive output from the process. 
+	 * BluetoothProcessListener is used to receive output from the process.
 	 */
 	public static BluetoothProcess hcitoolCmd (String name, String cmd, BluetoothProcessListener listener) {
 		String[] command = { HCITOOL, "-i", name, cmd };
@@ -205,13 +205,13 @@ public class BluetoothUtil {
 		} catch (Exception e) {
 			s_logger.error("Error executing command: " + command, e);
 		}
-		
+
 		return proc;
 	}
-	
+
 	/*
 	 * Method to utilize BluetoothProcess and the hcitool utility. These processes run indefinitely, so the
-	 * BluetoothProcessListener is used to receive output from the process. 
+	 * BluetoothProcessListener is used to receive output from the process.
 	 */
 	public static BluetoothProcess hcitoolCmd (String name, String[] cmd, BluetoothProcessListener listener) {
 		String[] command = new String[3 + cmd.length];
@@ -227,13 +227,13 @@ public class BluetoothUtil {
 		} catch (Exception e) {
 			s_logger.error("Error executing command: " + command, e);
 		}
-		
+
 		return proc;
 	}
-	
+
 	/*
 	 * Method to start an interactive session with a remote Bluetooth LE device using the gatttool utility. The
-	 * listener is used to receive output from the process. 
+	 * listener is used to receive output from the process.
 	 */
 	public static BluetoothProcess startSession(String address, BluetoothProcessListener listener) {
 		String[] command = { GATTTOOL, "-b", address, "-I" };
@@ -245,7 +245,7 @@ public class BluetoothUtil {
 		}
 		return proc;
 	}
-	
+
 	/*
 	 * Method to create a separate thread for the BluetoothProcesses.
 	 */
@@ -259,12 +259,12 @@ public class BluetoothUtil {
                 BluetoothProcess bluetoothProcess = new BluetoothProcess();
                 bluetoothProcess.exec(cmdArray, listener);
                 return bluetoothProcess;
-            }           
+            }
         });
-        
+
         try {
             return futureSafeProcess.get();
-        } 
+        }
         catch (Exception e) {
             s_logger.error("Error waiting from SafeProcess output", e);
             throw new IOException(e);

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/EthTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/EthTool.java
@@ -27,33 +27,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Defines ethtool utility 
- * 
+ * Defines ethtool utility
+ *
  * @author ilya.binshtok
  *
  */
 public class EthTool implements LinkTool {
-	
+
 	private static final Logger s_logger = LoggerFactory.getLogger(LinuxNetworkUtil.class);
-	
+
 	private static final String LINK_DETECTED = "Link detected:";
 	private static final String DUPLEX = "Duplex:";
 	private static final String SPEED = "Speed:";
-	
-	private String ifaceName = null; 
+
+	private String ifaceName = null;
 	private boolean linkDetected = false;
 	private int speed = 0; // in b/s
 	private String duplex = null;
 
 	/**
 	 * ethtool constructor
-	 * 
+	 *
 	 * @param ifaceName - interface name as {@link String}
 	 */
 	public EthTool (String ifaceName) {
 		this.ifaceName = ifaceName;
 	}
-	
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.eclipse.kura.util.net.service.ILinkTool#get()
@@ -63,14 +63,14 @@ public class EthTool implements LinkTool {
 		BufferedReader br = null;
 		boolean result = false;
 		try {
-			proc = ProcessUtil.exec("ethtool " + this.ifaceName);	
+			proc = ProcessUtil.exec("ethtool " + this.ifaceName);
 			result = (proc.waitFor() == 0)? true : false;
 			br = new BufferedReader(new InputStreamReader(proc.getInputStream()));
 			String line = null;
 			int ind = -1;
 		    while((line = br.readLine()) != null) {
 		    	if ((ind = line.indexOf(LINK_DETECTED)) >= 0) {
-		    		s_logger.trace("Link detected from: " + line);
+		    		s_logger.trace("Link detected from: {}", line);
 		    		line = line.substring(ind + LINK_DETECTED.length()).trim();
 		    		this.linkDetected = (line.compareTo("yes") == 0)? true : false;
 		    	} else if ((ind = line.indexOf(DUPLEX)) >= 0) {
@@ -98,11 +98,11 @@ public class EthTool implements LinkTool {
 				}catch(IOException ex){
 					s_logger.error("I/O Exception while closing BufferedReader!");
 				}
-			}			
-		
+			}
+
 			if (proc != null) ProcessUtil.destroy(proc);
 		}
-		
+
 		return result;
 	}
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
@@ -361,7 +361,7 @@ public class DnsMonitorServiceImpl implements DnsMonitorService, EventHandler {
 			        	if(isEnabledForWan(netInterfaceConfig)) {
 			        		try {
 			        			Set<IPAddress> servers = getConfiguredDnsServers(netInterfaceConfig);
-			        			s_logger.trace(netInterfaceConfig.getName() + " is WAN, adding its dns servers: " + servers);
+			        			s_logger.trace("{} is WAN, adding its dns servers: {}", netInterfaceConfig.getName(), servers);
 								serverList.addAll(servers);
 							} catch (KuraException e) {
 								s_logger.error("Error adding dns servers for " + netInterfaceConfig.getName(), e);
@@ -377,7 +377,7 @@ public class DnsMonitorServiceImpl implements DnsMonitorService, EventHandler {
 	// Get a list of dns servers for the specified NetInterfaceConfig
     private Set<IPAddress> getConfiguredDnsServers(NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig) throws KuraException {
     	String interfaceName = netInterfaceConfig.getName();
-    	s_logger.trace("Getting dns servers for " + interfaceName);
+    	s_logger.trace("Getting dns servers for {}", interfaceName);
     	LinuxDns linuxDns = LinuxDns.getInstance();
     	LinkedHashSet<IPAddress> serverList = new LinkedHashSet<IPAddress>();
     	

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/IfcfgConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/IfcfgConfigWriter.java
@@ -258,13 +258,13 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
 				try {
 					if(!FileUtils.contentEquals(tmpFile, outputFile)) {
 						if(tmpFile.renameTo(outputFile)){
-							s_logger.trace("Successfully wrote network interface file for " + interfaceName);
+							s_logger.trace("Successfully wrote network interface file for {}", interfaceName);
 						}else{
 							s_logger.error("Failed to write network interface file");
 							throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR, "error while building up new configuration file for network interface " + interfaceName);
 						}
 					} else {
-						s_logger.info("Not rewriting network interfaces file for " + interfaceName + " because it is the same");
+						s_logger.info("Not rewriting network interfaces file for {} because it is the same", interfaceName);
 					}
 				} catch(IOException e) {
 					throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);


### PR DESCRIPTION
Cleaned up a little the TRACE log messages. Instead of string concatenation, the regular string formatting is used (passing variables to be logged in the trace method call).
This should also be a small performance gain when a higher log level is used (which is the default setting).
I did a quick build and no compile time errors showed up.
I am thinking about improving also DEBUG and INFO levels formatting, if you think it's worth.