### PR TITLE
Add ethtool dependency to kura nn version;

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -742,7 +742,7 @@
 		<profile>
 			<id>beaglebone-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, ethtool</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -980,7 +980,7 @@
 		<profile>
 			<id>raspberry-pi-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, ethtool</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1215,7 +1215,7 @@
 		<profile>
 			<id>raspberry-pi-bplus-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, ethtool</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1441,7 +1441,7 @@
 		<profile>
 			<id>raspberry-pi-2-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, ethtool</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->


### PR DESCRIPTION
A patch for bug 480606. Tested on Raspberry Pi 2. 

Signed-off-by: Ying Shaodong <helloysd@gmail.com>