### PR TITLE
Added base Apache Camel dependencies to Kura platform

### DIFF
--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -14,6 +14,10 @@
 	<version>1.0.0</version>
 	<packaging>pom</packaging>
 
+	<properties>
+		<camel.version>2.16.0</camel.version>
+	</properties>
+
 	<build>
 		<plugins>
 			<!-- Copying common artifacts across all platforms into a known location 
@@ -123,6 +127,28 @@
 									<groupId>jdk</groupId>
 									<artifactId>jdk.dio</artifactId>
 									<version>1.0.2</version>
+								</artifactItem>
+
+								<!-- Apache Camel core bundles -->
+								<artifactItem>
+									<groupId>org.apache.camel</groupId>
+									<artifactId>camel-core</artifactId>
+									<version>${camel.version}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.camel</groupId>
+									<artifactId>camel-core-osgi</artifactId>
+									<version>${camel.version}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.camel</groupId>
+									<artifactId>camel-kura</artifactId>
+									<version>${camel.version}</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.camel</groupId>
+									<artifactId>camel-paho</artifactId>
+									<version>${camel.version}</version>
 								</artifactItem>
 							</artifactItems>
 							<outputDirectory>${project.basedir}/target/source/plugins</outputDirectory>


### PR DESCRIPTION
Hi,

I have created Camel Kura integration module [1] some time ago and I've been promoting [2][3] using Kura as a target gateway for Camel deployments. Kura and Camel are really nice fit and I'd love to see more of our Camel users using Kura in a field.   

Can you consider including Apache Camel jars into the Kura distribution? That would simplify setup required to get Camel running in Kura and help with Kura adoption among the Camel users.

Cheers! 

[1] http://camel.apache.org/kura.html
[2] https://dzone.com/articles/apache-camel-iot-world-eclipse
[3] https://dzone.com/articles/creating-camel-routes-for-eclipse-kura