### PR TITLE
BLE Beacon scanning

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/BluetoothAdapter.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/BluetoothAdapter.java
@@ -59,6 +59,17 @@ public interface BluetoothAdapter {
 	 */
 	public void startLeScan(BluetoothLeScanListener listener);
 	
+
+    /**
+     * Starts an asynchronous scan for Bluetooth LE beacons. Beacon data is
+     * relayed through the {@link BluetoothBeaconScanListener} when the scan
+     * is complete.
+     * 
+     * @param listener Interface for collecting beacon data.
+     */
+    void startBeaconScan(BluetoothBeaconScanListener listener);
+	
+	
 	/**
 	 * Get a remote Bluetooth device based on hardware adress
 	 * 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/BluetoothAdapter.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/BluetoothAdapter.java
@@ -62,8 +62,7 @@ public interface BluetoothAdapter {
 
     /**
      * Starts an asynchronous scan for Bluetooth LE beacons. Beacon data is
-     * relayed through the {@link BluetoothBeaconScanListener} when the scan
-     * is complete.
+     * relayed through the {@link BluetoothBeaconScanListener} as it arrives.
      * 
      * @param listener Interface for collecting beacon data.
      */

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/BluetoothBeaconData.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/BluetoothBeaconData.java
@@ -1,0 +1,14 @@
+package org.eclipse.kura.bluetooth;
+
+public class BluetoothBeaconData {
+	public String uuid;
+	public String address;
+	public int major, minor;
+	public int rssi;
+	
+	@Override
+	public String toString() {
+		return "BluetoothBeaconData [uuid=" + uuid + ", address=" + address + ", major=" + major + ", minor=" + minor
+				+ ", rssi=" + rssi + "]";
+	}
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/BluetoothBeaconScanListener.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/BluetoothBeaconScanListener.java
@@ -1,0 +1,18 @@
+package org.eclipse.kura.bluetooth;
+
+/**
+ * BluetoothLeScanListener must be implemented by any class
+ * wishing to receive notifications on Bluetooth LE
+ * scan events.
+ *
+ */
+public interface BluetoothBeaconScanListener {
+	
+	/**
+	 * Fired when bluetooth beacon data is received
+	 * 
+	 * @param beaconData
+	 */
+	public void onBeaconDataReceived(BluetoothBeaconData beaconData);
+	
+}

--- a/kura/org.eclipse.kura.linux.bluetooth/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.linux.bluetooth/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-Name: org.eclipse.kura.linux.bluetooth
 Bundle-SymbolicName: org.eclipse.kura.linux.bluetooth;singleton:=true
 Bundle-Version: 1.0.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Import-Package: org.eclipse.kura;version="[1.0,2.0)",
+Import-Package: org.apache.commons.io;version="2.4.0",
+ org.eclipse.kura;version="[1.0,2.0)",
  org.eclipse.kura.bluetooth;version="[1.0,1.1)",
  org.osgi.framework;version="1.7.0",
  org.osgi.service.component;version="1.2.0",

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/BluetoothAdapterImpl.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/BluetoothAdapterImpl.java
@@ -9,11 +9,12 @@ import java.util.Map;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.bluetooth.BluetoothAdapter;
 import org.eclipse.kura.bluetooth.BluetoothBeaconCommandListener;
+import org.eclipse.kura.bluetooth.BluetoothBeaconScanListener;
 import org.eclipse.kura.bluetooth.BluetoothDevice;
 import org.eclipse.kura.bluetooth.BluetoothLeScanListener;
 import org.eclipse.kura.linux.bluetooth.le.BluetoothLeScanner;
 import org.eclipse.kura.linux.bluetooth.le.beacon.BluetoothAdvertisingData;
-import org.eclipse.kura.linux.bluetooth.le.beacon.BluetoothBeaconListener;
+import org.eclipse.kura.linux.bluetooth.le.beacon.BluetoothConfigurationProcessListener;
 import org.eclipse.kura.linux.bluetooth.util.BluetoothUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,8 +111,16 @@ public class BluetoothAdapterImpl implements BluetoothAdapter {
 
 	@Override
 	public void startLeScan(BluetoothLeScanListener listener) {
+		killLeScan();
 		m_bls = new BluetoothLeScanner();
 		m_bls.startScan(m_name, listener);
+	}
+	
+	@Override
+	public void startBeaconScan(BluetoothBeaconScanListener listener) {
+		killLeScan();
+		m_bls = new BluetoothLeScanner();
+		m_bls.startBeaconScan(m_name, listener);
 	}
 
 	public void killLeScan() {
@@ -150,7 +159,7 @@ public class BluetoothAdapterImpl implements BluetoothAdapter {
 	@Override
 	public void startBeaconAdvertising() {
 		
-		BluetoothBeaconListener bbl = new BluetoothBeaconListener(m_bbcl);
+		BluetoothConfigurationProcessListener bbl = new BluetoothConfigurationProcessListener(m_bbcl);
 		
 		s_logger.debug("Start Advertising : hcitool -i " + m_name + " cmd " + OGF_CONTROLLER_CMD + " " + OCF_ADVERTISING_ENABLE_CMD + " 01");
 		s_logger.info("Start Advertising on interface " + m_name);
@@ -162,7 +171,7 @@ public class BluetoothAdapterImpl implements BluetoothAdapter {
 	@Override
 	public void stopBeaconAdvertising() {
 		
-		BluetoothBeaconListener bbl = new BluetoothBeaconListener(m_bbcl);
+		BluetoothConfigurationProcessListener bbl = new BluetoothConfigurationProcessListener(m_bbcl);
 		
 		s_logger.debug("Stop Advertising : hcitool -i " + m_name + " cmd " + OGF_CONTROLLER_CMD + " " + OCF_ADVERTISING_ENABLE_CMD + " 00");
 		s_logger.info("Stop Advertising on interface " + m_name);
@@ -173,7 +182,7 @@ public class BluetoothAdapterImpl implements BluetoothAdapter {
 	@Override
 	public void setBeaconAdvertisingInterval(Integer min, Integer max) {
 		
-		BluetoothBeaconListener bbl = new BluetoothBeaconListener(m_bbcl);
+		BluetoothConfigurationProcessListener bbl = new BluetoothConfigurationProcessListener(m_bbcl);
 		
 		// See http://stackoverflow.com/questions/21124993/is-there-a-way-to-increase-ble-advertisement-frequency-in-bluez
 		String[] minHex = toStringArray(BluetoothAdvertisingData.to2BytesHex(min));
@@ -190,7 +199,7 @@ public class BluetoothAdapterImpl implements BluetoothAdapter {
 	public void setBeaconAdvertisingData(String uuid, Integer major, Integer minor, String companyCode, Integer txPower, boolean LELimited, boolean LEGeneral,
 			boolean BR_EDRSupported, boolean LE_BRController, boolean LE_BRHost) {
 		
-		BluetoothBeaconListener bbl = new BluetoothBeaconListener(m_bbcl);
+		BluetoothConfigurationProcessListener bbl = new BluetoothConfigurationProcessListener(m_bbcl);
 		
 		String[] dataHex = toStringArray(BluetoothAdvertisingData.getData(uuid, major, minor, companyCode, txPower, LELimited, LEGeneral, BR_EDRSupported, LE_BRController, LE_BRHost));
 		String[] cmd = new String[3 + dataHex.length];
@@ -209,7 +218,7 @@ public class BluetoothAdapterImpl implements BluetoothAdapter {
 	@Override
 	public void ExecuteCmd(String ogf, String ocf, String parameter) {
 		
-		BluetoothBeaconListener bbl = new BluetoothBeaconListener(m_bbcl);
+		BluetoothConfigurationProcessListener bbl = new BluetoothConfigurationProcessListener(m_bbcl);
 		
 		String[] paramArray = toStringArray(parameter);
 		s_logger.info("Execute custom command : hcitool -i " + m_name + "cmd " + ogf + " " + ocf + " " + Arrays.toString(paramArray));

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BTSnoopParser.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BTSnoopParser.java
@@ -1,0 +1,55 @@
+package org.eclipse.kura.linux.bluetooth.le.beacon;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Parses a btsnoop stream into btsnoop records
+ */
+public class BTSnoopParser {
+	
+	private InputStream is;
+	private boolean gotHeader = false;
+	
+	public BTSnoopParser(InputStream is) {
+		this.is = is;
+	}
+	
+	@SuppressWarnings("unused")
+	public byte[] readRecord() throws InterruptedException, IOException {
+		if(!gotHeader) {
+			// Read past the 16-byte header
+			IOUtils.readFully(is, new byte[16]);
+			gotHeader = true;
+		}
+		
+		// btsnoop record header
+		int originalLength = readInt();
+		int includedLength = readInt();
+		int packetFlags = readInt();
+		int cumulativeDrops = readInt();
+		int timestampHigh = readInt();
+		int timestampLow = readInt();
+		byte[] packetData = new byte[includedLength];
+		
+		// bluetooth record
+		IOUtils.readFully(is, packetData);
+		
+		return packetData;
+	}
+	
+	
+	private int readInt() throws IOException {
+
+		byte[] intBytes = new byte[4];
+		
+		IOUtils.readFully(is, intBytes);
+		
+		return intBytes[0] << 24 |
+				intBytes[1] << 16 |
+				intBytes[2] << 8 |
+				intBytes[3];
+	}
+}

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BluetoothConfigurationProcessListener.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BluetoothConfigurationProcessListener.java
@@ -5,13 +5,13 @@ import org.eclipse.kura.linux.bluetooth.util.BluetoothProcessListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BluetoothBeaconListener implements BluetoothProcessListener {
+public class BluetoothConfigurationProcessListener implements BluetoothProcessListener {
 
-	private static final Logger s_logger = LoggerFactory.getLogger(BluetoothBeaconListener.class);
+	private static final Logger s_logger = LoggerFactory.getLogger(BluetoothConfigurationProcessListener.class);
 	
 	private BluetoothBeaconCommandListener m_listener = null;
 	
-	public BluetoothBeaconListener(BluetoothBeaconCommandListener listener) {
+	public BluetoothConfigurationProcessListener(BluetoothBeaconCommandListener listener) {
 		m_listener = listener;
 	}
 	
@@ -24,7 +24,7 @@ public class BluetoothBeaconListener implements BluetoothProcessListener {
 	public void processInputStream(String string) {
 
 		// Check if the command succedeed and return the last line
-		s_logger.debug("Command response : " + string);
+		s_logger.debug("Command response : {}", string);
 		String[] lines = string.split("\n");
 		if (lines[0].toLowerCase().contains("usage")) {
 			s_logger.info("Command failed. Error in command syntax.");

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BTSnoopListener.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BTSnoopListener.java
@@ -1,0 +1,14 @@
+package org.eclipse.kura.linux.bluetooth.util;
+
+/**
+ * For listening to btsnoop streams
+ */
+public interface BTSnoopListener {
+
+	/**
+	 * Process a BTSnoop Record
+	 * @param record
+	 */
+	public void processBTSnoopRecord(byte[] record);
+
+}

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
@@ -1,20 +1,23 @@
 package org.eclipse.kura.linux.bluetooth.util;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.apache.commons.io.FileUtils;
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.linux.bluetooth.util.BluetoothSafeProcess;
-import org.eclipse.kura.linux.bluetooth.util.BluetoothProcessUtil;
+import org.eclipse.kura.bluetooth.BluetoothBeaconData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,11 +26,31 @@ public class BluetoothUtil {
 	private static final Logger s_logger = LoggerFactory.getLogger(BluetoothUtil.class);
 	private static final ExecutorService s_processExecutor = Executors.newSingleThreadExecutor();
 
+	public static final String HCITOOL        = "hcitool";
+	public static final String BTDUMP         = "/tmp/BluetoothUtil.btsnoopdump.sh";
 	private static final String BD_ADDRESS    = "BD Address:";
 	private static final String HCI_VERSION   = "HCI Version:";
 	private static final String HCICONFIG     = "hciconfig";
-	private static final String HCITOOL       = "hcitool";
 	private static final String GATTTOOL      = "gatttool";
+	
+	
+	// Write bluetooth dumping script into /tmp
+	static {
+		try {
+			File f = new File(BTDUMP);
+			FileUtils.writeStringToFile(f,
+					"#!/bin/bash\n"													+ 
+					"set -e\n"														+
+					"ADAPTER=$1\n"													+
+					"{ hcidump -i $ADAPTER -R -w /dev/fd/3 >/dev/null; } 3>&1", false);
+			
+			f.setExecutable(true);
+		} catch (IOException e) {
+			
+			s_logger.info("Unable to update", e);
+		}
+		
+	}
 	
 	/*
 	 * Use hciconfig utility to return information about the bluetooth adapter
@@ -200,6 +223,26 @@ public class BluetoothUtil {
 		}
 	}
 	
+	/**
+	 * Start an hci dump process for the examination of BLE advertisement packets
+	 * @param name Name of HCI device (hci0, for example)
+	 * @param listener Listener for receiving btsnoop records
+	 * @return BluetoothProcess created
+	 */
+	public static BluetoothProcess btdumpCmd (String name, BTSnoopListener listener) {
+		String[] command = { BTDUMP, name };
+
+		BluetoothProcess proc = null;
+		try {
+			s_logger.debug("Command executed : {}", Arrays.toString(command));
+			proc = execSnoop(command, listener);
+		} catch (Exception e) {
+			s_logger.error("Error executing command: {}", command, e);
+		}
+		
+		return proc;
+	}
+	
 	/*
 	 * Method to utilize BluetoothProcess and the hcitool utility. These processes run indefinitely, so the
 	 * BluetoothProcessListener is used to receive output from the process. 
@@ -230,7 +273,7 @@ public class BluetoothUtil {
 			command[i+3] = cmd[i];
 		BluetoothProcess proc = null;
 		try {
-			s_logger.debug("Command executed: {}", Arrays.toString(command));
+			s_logger.debug("Command executed : {}", Arrays.toString(command));
 			proc = exec(command, listener);
 		} catch (Exception e) {
 			s_logger.error("Error executing command: {}", command, e);
@@ -249,7 +292,7 @@ public class BluetoothUtil {
 		try {
 			proc = exec(command, listener);
 		} catch (Exception e) {
-			s_logger.error("Error executing command: ", command, e);
+			s_logger.error("Error executing command: {}", command, e);
 		}
 		return proc;
 	}
@@ -277,5 +320,151 @@ public class BluetoothUtil {
             s_logger.error("Error waiting from SafeProcess output", e);
             throw new IOException(e);
         }
+	}
+	
+	/*
+	 * Method to create a separate thread for the BluetoothProcesses.
+	 */
+	private static BluetoothProcess execSnoop(final String[] cmdArray, final BTSnoopListener listener) throws IOException {
+
+		// Serialize process executions. One at a time so we can consume all streams.
+        Future<BluetoothProcess> futureSafeProcess = s_processExecutor.submit( new Callable<BluetoothProcess>() {
+            @Override
+            public BluetoothProcess call() throws Exception {
+                Thread.currentThread().setName("BTSnoopProcessExecutor");
+                BluetoothProcess bluetoothProcess = new BluetoothProcess();
+                bluetoothProcess.execSnoop(cmdArray, listener);
+                return bluetoothProcess;
+            }           
+        });
+        
+        try {
+            return futureSafeProcess.get();
+        } 
+        catch (Exception e) {
+            s_logger.error("Error waiting from SafeProcess output", e);
+            throw new IOException(e);
+        }
+	}
+	
+	/**
+	 * Parse EIR data from a BLE advertising report,
+	 * extracting UUID, major and minor number.
+	 * 
+	 * See Bluetooth Core 4.0; 8 EXTENDED INQUIRY RESPONSE DATA FORMAT
+	 * 
+	 * @param b Array containing EIR data
+	 * @param i Index of first byte of EIR data
+	 * @return BeaconInfo or null if no beacon data present
+	 */
+	private static BluetoothBeaconData parseEIRData(byte[] b, int payloadPtr, int len) {
+		
+		for(int ptr = payloadPtr; ptr < payloadPtr + len;) {
+			
+			int structSize = b[ptr];
+			if(structSize == 0)
+				break;
+			
+			byte dataType = b[ptr+1];
+
+			if(dataType == (byte)0xFF) { // Data-Type: Manufacturer-Specific
+
+				int prefixPtr = ptr + 2;
+				byte[] prefix = new byte[] {
+						0x4c,
+						0x00,
+						0x02,
+						0x15
+				};
+				
+				if(Arrays.equals(prefix, Arrays.copyOfRange(b, prefixPtr, prefixPtr + prefix.length))) {
+					BluetoothBeaconData bi = new BluetoothBeaconData();
+					
+					int uuidPtr = ptr + 2 + prefix.length;
+					int majorPtr = uuidPtr + 16;
+					int minorPtr = uuidPtr + 18;
+					
+					bi.uuid = "";
+					for(byte ub : Arrays.copyOfRange(b, uuidPtr, majorPtr)) {
+						bi.uuid += String.format("%02X", (byte)ub);
+					}
+					
+					int majorl = b[majorPtr+1] & 0xFF;
+					int majorh = b[majorPtr] & 0xFF;
+					int minorl = b[minorPtr+1] & 0xFF;
+					int minorh = b[minorPtr] & 0xFF;
+					bi.major = majorh << 8 | majorl;
+					bi.minor = minorh << 8 | minorl;
+					// Can't fill this in from here
+					bi.address = "";
+					return bi;
+				}
+			}
+			
+			ptr += structSize + 1;	
+		}
+		
+		return null;
+	}
+	
+	
+	/**
+	 * Parse BLE beacons out of an HCL LE Advertising Report Event
+	 * 
+	 * See Bluetooth Core 4.0; 7.7.65.2 LE Advertising Report Event
+	 * @param b
+	 * @return
+	 */
+	@SuppressWarnings("unused")
+	public static List<BluetoothBeaconData> parseLEAdvertisingReport(byte[] b) {
+		
+		List<BluetoothBeaconData> results = new LinkedList<BluetoothBeaconData>();
+		
+		// Packet Type: Event
+		if(b[0] != 4)
+			return results;
+		
+		// Event Type: LE Advertisement Report
+		if(b[1] != 0x3E)
+			return results;
+
+		int paramLen = b[2];
+		
+		// LE Advertisement Subevent Code: 0x02
+		if(b[3] != 0x02)
+			return results;
+		
+		int numReports = b[4];
+		
+		int ptr = 5;
+		for(int i = 0; i < numReports; i++) {
+			int eventType = b[ptr++];
+			int addressType = b[ptr++];
+			
+			// Extract remote address
+			String address = String.format("%02X:%02X:%02X:%02X:%02X:%02X",
+											b[ptr+5],
+											b[ptr+4],
+											b[ptr+3],
+											b[ptr+2],
+											b[ptr+1],
+											b[ptr+0]);
+			ptr += 6;
+			
+			
+			int len = b[ptr++];
+			
+			BluetoothBeaconData bi = parseEIRData(b, ptr, len);
+			if(bi != null) {
+
+				bi.address = address;
+				bi.rssi = b[ptr + len];
+				results.add(bi);
+			}
+			
+			ptr += len;
+		}
+		
+		return results;
 	}
 }


### PR DESCRIPTION
Added BluetoothAdapter.startBeaconScan method, which begins an ongoing scan for iBeacon devices.
Each received packet fitting the iBeacon advertising format is returned via the BluetoothBeaconScanListener interface.

'hcidump' is required in order for this functionality to work correctly, as we need to get at the iBeacon data which hcitool doesn't return. It could also be made to work with tcpdump.