### PR TITLE
[doc] install mToolkit from update site

### DIFF
--- a/_posts/doc/2014-09-12-kura-setup.textile
+++ b/_posts/doc/2014-09-12-kura-setup.textile
@@ -45,20 +45,18 @@ Download the current distribution of Eclipse for your OS from ["http://www.eclip
 
 The zipped Eclipse file will be downloaded to the local file system and can be saved to a temporary location that can be deleted after Eclipse has been installed. After the file has been downloaded, it should be extracted to the Eclipse installs directory.  The following screen capture shows the installation in Linux using an eclipse\installs\ directory. The Eclipse executable will then be found in the eclipse\installs\eclipse\ directory.  This installation will be different depending on the operating system.
 
-!{{ site.baseurl }}/assets/images/kura_setup/image001.png!<br>Because there may potentially be future Eclipse installs extracted into this location, before doing anything else rename the directory, such as to “eclipse\installs\+juno1+\”.  Once you begin using this Eclipse install, +it should not be moved or renamed later+.
+!{{ site.baseurl }}/assets/images/kura_setup/image001.png!<br>
+
+Because there may potentially be future Eclipse installs extracted into this location, before doing anything else rename the directory, such as to “eclipse\installs\+juno1+\”. Once you begin using this Eclipse install, +it should not be moved or renamed later+.
 !{{ site.baseurl }}/assets/images/kura_setup/image002.png!
 
 h3. Installing mToolkit
 
 An additional plugin, mToolkit, is needed to allow remote connectivity to an OSGi framework on a Kura-enabled target device.  To install mToolkit into Eclipse, use the following steps:
 
-* Download the mToolkit plugin in archive format from ["mtoolkit.tigris.org":http://mtoolkit.tigris.org] (look for the ["latest stable release":http://mtoolkit.tigris.org/servlets/ProjectProcess?pageID=FhaayB] under Download and Install, in zipped format).
-* It is recommended to create an mToolkit directory under dropins in the Eclipse install location (_path_to_eclipse_/dropins/mToolkit).
-* Copy the zip file to the new directory (_path_to_eclipse_/dropins/mToolkit).
-* Extract the contents of the zip file in the mToolkit folder, which should result in a directory structure something like:
-
-bc. eclipse/dropins/mToolkit/eclipse/features
-eclipse/dropins/mToolkit/eclipse/plugins
+* Open the *Help | Install New Software...* menu.
+* Add @http://mtoolkit.tigris.org/updates/stable@ as an update site
+* Install the "mToolkit" feature (you need to uncheck the *Group items by category* checkbox in order to see the feature)
 
 * Restart Eclipse.  In the menu *Window | Show View | Other*, there should be an *mToolkit | Frameworks* option.  If so, the plugin has been installed correctly.
 
@@ -76,7 +74,11 @@ If a workspace has not already been defined, or if you are creating a different 
 
 !{{ site.baseurl }}/assets/images/kura_setup/image003.png!<br>
 
-Otherwise, select an existing workspace and click *OK*.  After Eclipse is running, you can select the Eclipse menu *File | Switch Workspace | Other* to create or open a different workspace.After the new workspace opens, click the Workbench icon to display the development environment.<br>!{{ site.baseurl }}/assets/images/kura_setup/image004.png!<br>
+Otherwise, select an existing workspace and click *OK*.  After Eclipse is running, you can select the Eclipse menu *File | Switch Workspace | Other* to create or open a different workspace.
+
+After the new workspace opens, click the Workbench icon to display the development environment.<br>
+
+!{{ site.baseurl }}/assets/images/kura_setup/image004.png!<br>
 
 h3. Importing Kura User Workspace
 
@@ -88,7 +90,15 @@ Now click the *Select archive file* option button and browse to the archive file
 
 !{{ site.baseurl }}/assets/images/kura_setup/image005.png!<br>
 
-Finally, click *Finish* to import the projects.  At this point, you should have four projects in your workspace.  The four projects are as follows:<ul>  <li>org.eclipse.kura.api – This is the core Kura API.</li>  <li>org.eclipse.kura.demo.heater – This is an example project that you can use as a starting point for creating your own bundle.</li>  <li>org.eclipse.kura.emulator – This is the emulator project for running Kura within Eclipse (Linux/Mac only).</li>  <li>target-definition – This is a set of required bundles that are dependencies of the APIs and Kura.</li></ul><br>!{{ site.baseurl }}/assets/images/kura_setup/image006.png!<br>
+Finally, click *Finish* to import the projects.  At this point, you should have four projects in your workspace.  The four projects are as follows:
+<ul>
+  <li>org.eclipse.kura.api – This is the core Kura API.</li>
+  <li>org.eclipse.kura.demo.heater – This is an example project that you can use as a starting point for creating your own bundle.</li>
+  <li>org.eclipse.kura.emulator – This is the emulator project for running Kura within Eclipse (Linux/Mac only).</li>
+  <li>target-definition – This is a set of required bundles that are dependencies of the APIs and Kura.</li>
+</ul><br>
+
+!{{ site.baseurl }}/assets/images/kura_setup/image006.png!<br>
 
 Eclipse will also report some errors at this point.  See the next section to resolve those errors.
 


### PR DESCRIPTION
Change mToolkit instructions and indicate to use regular update site instead of dropins-based install.