### PR TITLE
Remove default values for username and password as they are optional

### DIFF
--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport.xml
@@ -41,7 +41,7 @@
             type="String"
             cardinality="0"
             required="false"
-            default="username" 
+            default=""
             description="Username to be used when connecting to the MQTT broker."/>
 
         <AD id="password"  
@@ -49,7 +49,7 @@
             type="Password"
             cardinality="0" 
             required="false"
-            default="password" 
+            default=""
             description="Password to be used when connecting to the MQTT broker."/>
 
         <AD id="client-id"


### PR DESCRIPTION
The parameters 'username' and 'password' have been made optional in #63. Because they were still having default values you could set them to empty values (for instance needed by AWS IoT) but once you restart Kura they would always be coming back with their default values. Setting them to empty defaults as many other optional parameters already use.