### PR TITLE
Add support for drag and drop from Eclipse Marketplace.

### DIFF
--- a/kura/org.eclipse.kura.web2/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.web2/META-INF/MANIFEST.MF
@@ -27,6 +27,7 @@ Import-Package: com.google.gwt.http.client,
  javax.servlet;version="2.6.0",
  javax.servlet.http;version="2.6.0",
  javax.xml.bind;resolution:=optional,
+ javax.xml.parsers,
  org.apache.commons.fileupload;version="1.2.2",
  org.apache.commons.fileupload.disk;version="1.2.2",
  org.apache.commons.fileupload.servlet;version="1.2.2",
@@ -64,5 +65,7 @@ Import-Package: com.google.gwt.http.client,
  org.osgi.service.metatype;version="1.2.0",
  org.osgi.util.measurement;version="1.0.1",
  org.osgi.util.position;version="1.0.1",
- org.slf4j;version="1.6.4"
+ org.slf4j;version="1.6.4",
+ org.w3c.dom,
+ org.xml.sax
 Bundle-ClassPath: .

--- a/kura/org.eclipse.kura.web2/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.web2/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: EUROTECH
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Service-Component: OSGI-INF/*.xml
-Import-Package: com.google.gwt.safehtml.shared,
+Import-Package: com.google.gwt.http.client,
+ com.google.gwt.safehtml.shared,
  com.google.gwt.user.client,
  com.google.gwt.user.client.rpc,
  com.google.gwt.user.client.rpc.core.java.lang,

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -31,6 +31,8 @@ import org.eclipse.kura.web.shared.model.GwtSession;
 import org.eclipse.kura.web.shared.model.GwtXSRFToken;
 import org.eclipse.kura.web.shared.service.GwtComponentService;
 import org.eclipse.kura.web.shared.service.GwtComponentServiceAsync;
+import org.eclipse.kura.web.shared.service.GwtPackageService;
+import org.eclipse.kura.web.shared.service.GwtPackageServiceAsync;
 import org.eclipse.kura.web.shared.service.GwtSecurityTokenService;
 import org.eclipse.kura.web.shared.service.GwtSecurityTokenServiceAsync;
 import org.gwtbootstrap3.client.shared.event.ModalHideEvent;
@@ -54,6 +56,12 @@ import org.gwtbootstrap3.client.ui.html.Span;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.http.client.Request;
+import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.http.client.RequestCallback;
+import com.google.gwt.http.client.RequestException;
+import com.google.gwt.http.client.Response;
+import com.google.gwt.http.client.URL;
 import com.google.gwt.logging.client.HasWidgetsLogHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
@@ -84,6 +92,7 @@ public class EntryClassUi extends Composite {
 	private final NetworkPanelUi networkBinder   = GWT.create(NetworkPanelUi.class);
 	private final WiresPanelUi   wiresBinder     = GWT.create(WiresPanelUi.class);
 
+	private final GwtPackageServiceAsync gwtPackageService = GWT.create(GwtPackageService.class);
 	private final GwtComponentServiceAsync gwtComponentService = GWT.create(GwtComponentService.class);
 	private final GwtSecurityTokenServiceAsync gwtXSRFService = GWT.create(GwtSecurityTokenService.class);
 
@@ -150,6 +159,10 @@ public class EntryClassUi extends Composite {
 				errorLogArea.clear();
 			}
 		});
+		
+		//
+		dragDropInit(this);
+		
 		FailureHandler.setPopup(errorPopup);
 	}
 
@@ -558,4 +571,107 @@ public class EntryClassUi extends Composite {
 			settingsBinder.setDirty(false);
 		}
 	}
+	
+	private void eclipseMarketplaceInstall(String url) {
+		
+		// Construct the REST URL for Eclipse Marketplace
+		String appId = url.split("=")[1];
+		final String empApi = "http://marketplace.eclipse.org/node/" + appId + "/api/p";
+		
+		// Generate security token
+		EntryClassUi.showWaitModal();
+		gwtXSRFService.generateSecurityToken(new AsyncCallback<GwtXSRFToken> () {
+
+			@Override
+			public void onFailure(Throwable ex) {
+				EntryClassUi.hideWaitModal();
+				FailureHandler.handle(ex, EntryClassUi.class.getName());
+			}
+
+			@Override
+			public void onSuccess(GwtXSRFToken token) {
+				// Retrieve the URL of the DP via the Eclipse Marketplace API
+				gwtPackageService.getMarketplaceUri(token, empApi, new AsyncCallback<String>() {
+
+					@Override
+					public void onFailure(Throwable ex) {
+						EntryClassUi.hideWaitModal();
+						logger.log(Level.SEVERE, ex.getMessage(), ex);
+						FailureHandler.handle(ex, EntryClassUi.class.getName());
+					}
+
+					@Override
+					public void onSuccess(String result) {
+						installMarketplaceDp(result);
+						EntryClassUi.hideWaitModal();
+					}
+					
+				});
+				
+			}
+		});
+	}
+	
+	private void installMarketplaceDp(final String uri) {
+		String url = "/" + GWT.getModuleName()	+ "/file/deploy/url";
+		final RequestBuilder builder = new RequestBuilder(RequestBuilder.POST, URL.encode(url));
+		
+		gwtXSRFService.generateSecurityToken(new AsyncCallback<GwtXSRFToken> () {
+
+			@Override
+			public void onFailure(Throwable ex) {
+				EntryClassUi.hideWaitModal();
+				FailureHandler.handle(ex, EntryClassUi.class.getName());
+			}
+
+			@Override
+			public void onSuccess(GwtXSRFToken token) {
+				StringBuilder sb = new StringBuilder();
+				sb.append("xsrfToken=" + token.getToken());
+				sb.append("&packageUrl=" + uri);
+				
+				builder.setHeader("Content-type", "application/x-www-form-urlencoded");
+				try {
+					builder.sendRequest(sb.toString(), new RequestCallback() {
+
+						@Override
+						public void onResponseReceived(Request request, Response response) {
+							logger.info(response.getText());
+						}
+
+						@Override
+						public void onError(Request request, Throwable ex) {
+							logger.log(Level.SEVERE, ex.getMessage(), ex);
+							FailureHandler.handle(ex, EntryClassUi.class.getName());
+						}
+						
+					});
+				} catch (RequestException e) {
+					logger.log(Level.SEVERE, e.getMessage(), e);
+					FailureHandler.handle(e, EntryClassUi.class.getName());
+				}
+			}
+		});
+	}
+	
+	public static native void dragDropInit(EntryClassUi ecu) /*-{
+		$wnd.$("html").on("dragover", function(event) {
+		    event.preventDefault();  
+		    event.stopPropagation();
+		});
+		
+		$wnd.$("html").on("dragleave", function(event) {
+		    event.preventDefault();  
+		    event.stopPropagation();
+		});
+		
+		$wnd.$("html").on("drop", function(event) {
+		    event.preventDefault();  
+		    event.stopPropagation();
+		    console.log(event.originalEvent.dataTransfer.getData("text"));
+		    if (confirm("Install file?") == true) {
+		    	ecu.@org.eclipse.kura.web.client.ui.EntryClassUi::eclipseMarketplaceInstall(Ljava/lang/String;)(event.originalEvent.dataTransfer.getData("text"));
+		    }
+		});
+	}-*/;
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtPackageServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtPackageServiceImpl.java
@@ -11,8 +11,16 @@
  *******************************************************************************/
 package org.eclipse.kura.web.server;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.kura.deployment.agent.DeploymentAgentService;
 import org.eclipse.kura.web.client.util.GwtSafeHtmlUtils;
@@ -26,6 +34,8 @@ import org.eclipse.kura.web.shared.service.GwtPackageService;
 import org.osgi.service.deploymentadmin.BundleInfo;
 import org.osgi.service.deploymentadmin.DeploymentAdmin;
 import org.osgi.service.deploymentadmin.DeploymentPackage;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
 public class GwtPackageServiceImpl extends OsgiRemoteServiceServlet implements GwtPackageService
 {
@@ -79,9 +89,45 @@ public class GwtPackageServiceImpl extends OsgiRemoteServiceServlet implements G
 			deploymentAgentService.uninstallDeploymentPackageAsync(GwtSafeHtmlUtils.htmlEscape(packageName));
 		} 
 		catch (Exception e) {
-			// TODO Auto-generated catch block
 			throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
 		}
+	}
+	
+	public String getMarketplaceUri(GwtXSRFToken xsrfToken, String url) throws GwtKuraException {
+		String uri = null;
+		URL mpUrl = null;
+		HttpURLConnection connection = null;
+	    
+	    try {
+	    	mpUrl = new URL(url);
+	    	connection = (HttpURLConnection) mpUrl.openConnection();
+	    	
+	    	connection.setRequestMethod("GET");
+	    	connection.connect();
+	        
+	        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+	        DocumentBuilder db = dbf.newDocumentBuilder();
+	        Document doc = db.parse(connection.getInputStream());
+
+	        uri = doc.getElementsByTagName("updateurl").item(0).getTextContent();
+	    	
+	    } catch (MalformedURLException e) {
+	    	throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
+		} catch (IOException e) {
+			throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
+		} catch (SAXException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (ParserConfigurationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} finally {
+	    	if (connection != null) {
+	    		connection.disconnect();
+	    	}
+	      }
+		
+		return uri;
 	}
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtPackageService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtPackageService.java
@@ -26,5 +26,7 @@ public interface GwtPackageService extends RemoteService
 	public List<GwtDeploymentPackage> findDeviceDeploymentPackages(GwtXSRFToken xsrfToken) throws GwtKuraException;
 	
 	public void uninstallDeploymentPackage(GwtXSRFToken xsrfToken, String packageName) throws GwtKuraException;
+	
+	public String getMarketplaceUri(GwtXSRFToken xsrfToken, String url) throws GwtKuraException;
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/denali.gwt.xml
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/denali.gwt.xml
@@ -36,6 +36,7 @@
   <!-- Other module inherits                                      -->
   <inherits name='org.gwtbootstrap3.GwtBootstrap3'/>
   <inherits name="com.google.gwt.i18n.I18N"/>
+  <inherits name="com.google.gwt.http.HTTP" />
 
   <!-- Locales: English language, independent of country -->
   <extend-property name="locale" values="en"/>


### PR DESCRIPTION
This pull requests addresses Issue #138 . 

To test, use the example app https://marketplace.eclipse.org/content/eclipse-kura-heater-demo . Drag the "Install" button to any page within the Kura UI and the heater demo should install automatically.

--Dave
