### PR TITLE
Wifi passphrase is now Password and not string. Added fallback code i…

### DIFF
--- a/kura/distrib/src/main/resources/beaglebone/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/beaglebone/snapshot_0.xml
@@ -246,7 +246,7 @@
             <esf:property name="net.interface.wlan0.config.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>testKEYS</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.autoconnect" array="false" encrypted="false" type="Boolean">
@@ -324,7 +324,7 @@
             <esf:property name="net.interface.wlan0.config.dhcpServer4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>wepKeyInfraWlan0</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.domains" array="false" encrypted="false" type="String">

--- a/kura/distrib/src/main/resources/intel-edison/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/intel-edison/snapshot_0.xml
@@ -193,7 +193,7 @@
             <esf:property name="net.interface.usb0.config.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>testKEYS</esf:value>
             </esf:property>
             <esf:property name="net.interface.usb0.driver" array="false" encrypted="false" type="String">
@@ -364,7 +364,7 @@
             <esf:property name="net.interface.usb0.loopback" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>wepKeyInfraWlan0</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.domains" array="false" encrypted="false" type="String">

--- a/kura/distrib/src/main/resources/raspberry-pi-2/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/snapshot_0.xml
@@ -40,7 +40,7 @@
             <esf:property name="net.interface.eth0.config.dhcpServer4.passDns" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>testKEYS</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.driver" array="false" encrypted="false" type="String">
@@ -318,7 +318,7 @@
             <esf:property name="net.interface.wlan0.config.ip4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>wepKeyInfraWlan0</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.dnsServers" array="false" encrypted="false" type="String">

--- a/kura/distrib/src/main/resources/raspberry-pi-bplus/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-bplus/snapshot_0.xml
@@ -40,7 +40,7 @@
             <esf:property name="net.interface.eth0.config.dhcpServer4.passDns" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>testKEYS</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.driver" array="false" encrypted="false" type="String">
@@ -318,7 +318,7 @@
             <esf:property name="net.interface.wlan0.config.ip4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>wepKeyInfraWlan0</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.dnsServers" array="false" encrypted="false" type="String">

--- a/kura/distrib/src/main/resources/raspberry-pi/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi/snapshot_0.xml
@@ -40,7 +40,7 @@
             <esf:property name="net.interface.eth0.config.dhcpServer4.passDns" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>testKEYS</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.driver" array="false" encrypted="false" type="String">
@@ -318,7 +318,7 @@
             <esf:property name="net.interface.wlan0.config.ip4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="String">
+            <esf:property name="net.interface.wlan0.config.wifi.infra.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>wepKeyInfraWlan0</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.dnsServers" array="false" encrypted="false" type="String">

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/util/WifiVisitorUtil.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/util/WifiVisitorUtil.java
@@ -62,8 +62,10 @@ public class WifiVisitorUtil {
 			}
 			if (netConfigServiceComponentConfig != null) {
 				Map<String, Object> props = netConfigServiceComponentConfig.getConfigurationProperties();
-				if (props.containsKey(key)) {
+				if (props.containsKey(key) && props.get(key) instanceof Password) {
 					passphrase = ((Password)props.get(key)).toString();
+				} else if (props.containsKey(key) && props.get(key) instanceof String) {
+				    passphrase = (new Password((String)props.get(key))).toString();
 				}
 			}
 		}


### PR DESCRIPTION
…n WifiVisitorUtil.java

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>

@ibinshtok this should solve the issue with old snapshots that have a passphrase type= String. Could you take a look at it?