### PR TITLE
Camel examples: fix component name not matching metatype pid.

### DIFF
--- a/kura/examples/org.eclipse.kura.example.camel.aggregation/src/main/resources/OSGI-INF/GatewayRouter.xml
+++ b/kura/examples/org.eclipse.kura.example.camel.aggregation/src/main/resources/OSGI-INF/GatewayRouter.xml
@@ -13,7 +13,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
-    name="io.rhiot.quickstarts.kura.camel.GatewayRouter"
+    name="org.eclipse.kura.example.camel.aggregation.GatewayRouter"
 	configuration-policy="require" enabled="true" immediate="true"
     activate="activate" deactivate="deactivate" modified="modified">
 	<implementation class="org.eclipse.kura.example.camel.aggregation.GatewayRouter"/>

--- a/kura/examples/org.eclipse.kura.example.camel.quickstart/src/main/resources/OSGI-INF/GatewayRouter.xml
+++ b/kura/examples/org.eclipse.kura.example.camel.quickstart/src/main/resources/OSGI-INF/GatewayRouter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
-    name="io.rhiot.quickstarts.kura.camel.GatewayRouter"
+    name="org.eclipse.kura.example.camel.quickstart.GatewayRouter"
 	configuration-policy="require" enabled="true" immediate="true"
     activate="activate" deactivate="deactivate" modified="modified">
 	<implementation class="org.eclipse.kura.example.camel.quickstart.GatewayRouter"/>


### PR DESCRIPTION
The offending commit is f0b5c5db8221244ec58563a28b78e5bc91274b38.
Closes issue #260.

Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>