### PR TITLE
Dots in mqtt client id are now implicitly substituted by dashes.

### DIFF
--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport.xml
@@ -58,7 +58,7 @@
             cardinality="0"
             required="false"
             default="" 
-            description="Client identifier to be used when connecting to the MQTT broker. The identifier has to be unique within your account. Characters '/', '+', and '#' are invalid and they will be replaced by '-'. If left empty, this is automatically determined by the client software as the MAC address of the main network interface (in general uppercase and without ':')."/>
+            description="Client identifier to be used when connecting to the MQTT broker. The identifier has to be unique within your account. Characters '/', '+', '#' and '.' are invalid and they will be replaced by '-'. If left empty, this is automatically determined by the client software as the MAC address of the main network interface (in general uppercase and without ':')."/>
         
         <AD id="keep-alive"  
             name="keep-alive"

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
@@ -673,6 +673,7 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
 			clientId = clientId.replace('/', '-');
 			clientId = clientId.replace('+', '-');
 			clientId = clientId.replace('#', '-');
+			clientId = clientId.replace('.', '-');
 
 
 			// Configure the broker URL


### PR DESCRIPTION
Signed-off-by: MMaiero <matteo.maiero@eurotech.com>

Closes #272 