### PR TITLE
Added "build all" script

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2016 Red Hat and/or its affiliates
+#
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+#
+
+#!/usr/bin/env bash
+
+mvn -f target-platform/pom.xml clean install &&
+mvn -f kura/manifest_pom.xml clean install -Dmaven.test.skip=true &&
+mvn -f kura/pom_pom.xml clean install -Dmaven.test.skip=true -Pweb

--- a/kura/examples/org.eclipse.kura.example.camel.aggregation/src/main/resources/OSGI-INF/GatewayRouter.xml
+++ b/kura/examples/org.eclipse.kura.example.camel.aggregation/src/main/resources/OSGI-INF/GatewayRouter.xml
@@ -13,7 +13,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
-    name="io.rhiot.quickstarts.kura.camel.GatewayRouter"
+    name="org.eclipse.kura.example.camel.aggregation.GatewayRouter"
 	configuration-policy="require" enabled="true" immediate="true"
     activate="activate" deactivate="deactivate" modified="modified">
 	<implementation class="org.eclipse.kura.example.camel.aggregation.GatewayRouter"/>

--- a/kura/examples/org.eclipse.kura.example.camel.quickstart/src/main/resources/OSGI-INF/GatewayRouter.xml
+++ b/kura/examples/org.eclipse.kura.example.camel.quickstart/src/main/resources/OSGI-INF/GatewayRouter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
-    name="io.rhiot.quickstarts.kura.camel.GatewayRouter"
+    name="org.eclipse.kura.example.camel.quickstart.GatewayRouter"
 	configuration-policy="require" enabled="true" immediate="true"
     activate="activate" deactivate="deactivate" modified="modified">
 	<implementation class="org.eclipse.kura.example.camel.quickstart.GatewayRouter"/>


### PR DESCRIPTION
Hi,

Many folks wanting to build Kura complains that there is no single script to perform full build of typical Kura installation. I propose to add the following script then.

What do you think?

PS I also propose to push Cristiano's fix to quickstarts as well - see the other commit. 