### PR TITLE
Fix issue #302. The "osgi.command.function" property better be an arr…

### DIFF
--- a/kura/org.eclipse.kura.core.cloud/OSGI-INF/cloudServiceFactory.xml
+++ b/kura/org.eclipse.kura.core.cloud/OSGI-INF/cloudServiceFactory.xml
@@ -6,5 +6,7 @@
       <provide interface="org.eclipse.kura.cloud.factory.CloudServiceFactory"/>
    </service>
    <property name="osgi.command.scope" type="String" value="kura.cloud"/>
-   <property name="osgi.command.function" type="String" value="createConfiguration"/>
+   <property name="osgi.command.function" type="String">
+      createConfiguration
+   </property>
 </scr:component>


### PR DESCRIPTION
…ay so as the command can properly be handled with old-ish versions of Apache Gogo shell/command.

Signed-off-by: Benjamin Cabé <benjamin@eclipse.org>