### PR TITLE
Fix a possible Context Class Loader leak

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/OsgiRemoteServiceServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/OsgiRemoteServiceServlet.java
@@ -40,9 +40,13 @@ public class OsgiRemoteServiceServlet extends KuraRemoteServiceServlet
 	    // We are going to swap the class loader 
 	    ClassLoader oldContextClassLoader = 
 	    currentThread.getContextClassLoader(); 
-	    currentThread.setContextClassLoader(this.getClass().getClassLoader()); 
-	    super.service(req, resp); 
-	    currentThread.setContextClassLoader(oldContextClassLoader); 
+	    currentThread.setContextClassLoader(this.getClass().getClassLoader());
+	    try{
+	    	super.service(req, resp);
+	    }
+	    finally {
+	    	currentThread.setContextClassLoader(oldContextClassLoader);	
+	    }
 	}
 	
 	


### PR DESCRIPTION
In the case of an exception in the Web UI the context class loader
will not be cleaned up correctly. This may lead to all kinds of issues
later on.

Signed-off-by: Jens Reimann <jreimann@redhat.com>