### PR TITLE
Fix output of executed commands

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Device/CommandTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Device/CommandTabUi.ui.xml
@@ -25,6 +25,8 @@
 	.output-panel {
 		height: 250px;
 		margin-top: 20px;
+		overflow: scroll;
+		font-family: monospace;
 	}
 	</ui:style>
 	<b:Container fluid="true">


### PR DESCRIPTION
The output of executed command overlaps the rest of the layout.

This change enabled scroll mode for the inner panel containing the
command output and sets the font to monospace.

Signed-off-by: Jens Reimann <jreimann@redhat.com>