### PR TITLE
Corrected jacoco version due to build failure in JDK8

### DIFF
--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -198,7 +198,7 @@
 			<plugin>
 		        <groupId>org.jacoco</groupId>
 		        <artifactId>jacoco-maven-plugin</artifactId>
-		        <version>0.6.4.201312101107</version>
+		        <version>0.7.7.201606060606</version>
 		        <executions>
 		          <execution>
 				  	<phase>process-test-classes</phase>


### PR DESCRIPTION
Due to a potential issue in jacoco older versions (0.6.x), the build
in JDK8 failed. The issue has been fixed in newer versions (0.7.x).
For more information, check the following links.
https://netbeans.org/bugzilla/show_bug.cgi?id=240630
https://github.com/jacoco/jacoco/issues/74#ref-issue-11332605

Signed-off-by: Amit Kumar Mondal <admin@amitinside.com>