### PR TITLE
Fix issue with ClassCastException in OSGi console

### DIFF
--- a/kura/org.eclipse.kura.core.cloud/OSGI-INF/cloudServiceFactory.xml
+++ b/kura/org.eclipse.kura.core.cloud/OSGI-INF/cloudServiceFactory.xml
@@ -6,5 +6,6 @@
       <provide interface="org.eclipse.kura.cloud.factory.CloudServiceFactory"/>
    </service>
    <property name="osgi.command.scope" type="String" value="kura.cloud"/>
-   <property name="osgi.command.function" type="String" value="createConfiguration"/>
+   <property name="osgi.command.function" type="String">createConfiguration
+   </property>
 </scr:component>


### PR DESCRIPTION
This change fixes an issue which breaks the OSGi console. All
registered commands must register functions as String array. However
using the "value" attribute in OSGi DS does register a String instead
of String[]. In order to register a String[] the element data has to
be used.

Signed-off-by: Jens Reimann <jreimann@redhat.com>

----

I do think this issue is rather serious since is breaks the whole `help` functionality of the OSGi console.