### PR TITLE
clean up the error output to actually print out stack traces

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/FailureHandler.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/FailureHandler.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.util;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.messages.Messages;
@@ -51,7 +52,7 @@ public class FailureHandler
 			switch (code) {
 			
 			default:
-				logger.info(name + ": " + caught.getLocalizedMessage());
+				logger.log(Level.INFO, name + ": " + caught.getLocalizedMessage(), caught);
 				popup.show();
 				break;
 			}
@@ -63,9 +64,8 @@ public class FailureHandler
 	        // we can ignore this error and do nothing.
 		}
 		else {
-			logger.info(name + ": " + caught.getLocalizedMessage());
+			logger.log(Level.INFO, name + ": " + caught.getLocalizedMessage(), caught);
 			popup.show();
-			caught.printStackTrace();			
 		}
 	}
 	


### PR DESCRIPTION
This is a minor fix to the exception handling method.

It actually logs the exception stack trace. So when the code generation is not set to obfuscated, stack traces will help.

Signed-off-by: Jens Reimann <jreimann@redhat.com>