### PR TITLE
Reset the original state of the accessible flag

### DIFF
--- a/kura/org.eclipse.kura.camel/src/main/java/org/eclipse/kura/camel/router/CamelRouter.java
+++ b/kura/org.eclipse.kura.camel/src/main/java/org/eclipse/kura/camel/router/CamelRouter.java
@@ -176,9 +176,15 @@ public abstract class CamelRouter extends KuraRouter implements ConfigurableComp
 	protected void registerLanguage(String languageName, Language language) {
 		try {
 			Field field = DefaultCamelContext.class.getDeclaredField("languages");
+			boolean accessible = field.isAccessible();
 			field.setAccessible(true);
-			Map<String, Language> languages = (Map<String, Language>) field.get(camelContext);
-			languages.put(languageName, language);
+			try {
+				Map<String, Language> languages = (Map<String, Language>) field.get(camelContext);
+				languages.put(languageName, language);
+			}
+			finally {
+				field.setAccessible(accessible);
+			}
 		} catch (NoSuchFieldException e) {
 			throw new RuntimeException(e);
 		} catch (IllegalAccessException e) {


### PR DESCRIPTION
This change does reset the original state of the accessible attribute
of the field "languages".

Signed-off-by: Jens Reimann <jreimann@redhat.com>