### PR TITLE
Fix username displayed null in Device Status.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtStatusServiceImpl.java
@@ -145,7 +145,10 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
                     for (DataTransportService dataTransportService : dataTransportServices) {
                         pairs.add(new GwtGroupedNVPair("cloudStatus", "Broker URL", dataTransportService.getBrokerUrl()));
                         pairs.add(new GwtGroupedNVPair("cloudStatus", "Account", dataTransportService.getAccountName()));
-                        pairs.add(new GwtGroupedNVPair("cloudStatus", "Username", dataTransportService.getUsername()));
+                        if(dataTransportService.getUsername()==null)
+                            pairs.add(new GwtGroupedNVPair("cloudStatus", "Username", ""));
+                        else 
+                            pairs.add(new GwtGroupedNVPair("cloudStatus", "Username", dataTransportService.getUsername()));
                         pairs.add(new GwtGroupedNVPair("cloudStatus", "Client ID", dataTransportService.getClientId()));
                     }
                     ServiceLocator.getInstance().ungetService(dataServiceReference);


### PR DESCRIPTION
When the username is empty in MqttDataTransport configuration, Device Status in the web ui displays username null. 
This PR solves issue #296 