### PR TITLE
Javadoc: current maven-javadoc-plugin configuration causes a lot of "Forking" messages in the submodules.

### DIFF
--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -306,6 +306,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<inherited>false</inherited>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
See:
http://stackoverflow.com/questions/27935661/how-to-avoid-duplicate-forking-when-generating-aggregated-javadoc-in-a-multimodu
Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>