### PR TITLE
Use Import-Package in preference of Require-Bundle

### DIFF
--- a/kura/examples/org.eclipse.kura.raspberrypi.sensehat.example/META-INF/MANIFEST.MF
+++ b/kura/examples/org.eclipse.kura.raspberrypi.sensehat.example/META-INF/MANIFEST.MF
@@ -6,10 +6,10 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .
-Import-Package: org.eclipse.kura.raspberrypi.sensehat;version="[1.0.0,2.0.0)",
+Import-Package: org.eclipse.kura.configuration;version="1.1.0",
+ org.eclipse.kura.raspberrypi.sensehat;version="[1.0.0,2.0.0)",
  org.eclipse.kura.raspberrypi.sensehat.ledmatrix;version="[1.0.0,2.0.0)",
  org.eclipse.kura.raspberrypi.sensehat.sensors;version="[1.0.0,2.0.0)",
- org.eclipse.kura.raspsberrypi.sensehat.joystick;version="[1.0.0,2.0.0)"
-Require-Bundle: slf4j.api,
- org.eclipse.osgi.services,
- org.eclipse.kura.api
+ org.eclipse.kura.raspsberrypi.sensehat.joystick;version="[1.0.0,2.0.0)",
+ org.osgi.service.component;version="1.2.0",
+ org.slf4j;version="1.6.4"

--- a/kura/examples/org.eclipse.kura.raspberrypi.sensehat/META-INF/MANIFEST.MF
+++ b/kura/examples/org.eclipse.kura.raspberrypi.sensehat/META-INF/MANIFEST.MF
@@ -5,12 +5,12 @@ Bundle-SymbolicName: org.eclipse.kura.raspberrypi.sensehat;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Service-Component: OSGI-INF/*.xml
-Require-Bundle: org.eclipse.kura.api,
- slf4j.api,
- org.eclipse.osgi.services
 Import-Package: jdk.dio;version="[1.0.2,2.0.0)",
  jdk.dio.i2cbus;version="[1.0.2,2.0.0)",
- org.osgi.framework;version="[1.7.0,2.0.0)"
+ org.eclipse.kura;version="1.2.0",
+ org.osgi.framework;version="[1.7.0,2.0.0)",
+ org.osgi.service.component;version="1.2.0",
+ org.slf4j;version="1.6.4"
 Bundle-ClassPath: .
 Export-Package: org.eclipse.kura.raspberrypi.sensehat;version="1.0.0",
  org.eclipse.kura.raspberrypi.sensehat.ledmatrix;version="1.0.0",


### PR DESCRIPTION
This change converts to Require-Bundle statements to Import-Package in
order to remove hard dependencies on bundles.

Signed-off-by: Jens Reimann <jreimann@redhat.com>