### PR TITLE
add a Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+
+sudo: false
+
+jdk:
+  - oraclejdk7
+
+script: ./build-all.sh
+
+


### PR DESCRIPTION
This change adds a Travis CI build file.

By default the build will not be active since it still has to be registered with Travis CI.

Signed-off-by: Jens Reimann <jreimann@redhat.com>