### PR TITLE
Remove dependency on slf4j-log4j12

### DIFF
--- a/kura/org.eclipse.kura.web2/pom.xml
+++ b/kura/org.eclipse.kura.web2/pom.xml
@@ -10,6 +10,7 @@
 
     Contributors:
       Eurotech
+      Jens Reimann <jreimann@redhat.com> - remove dependency on slf4j:logj12
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -98,11 +99,6 @@
 	        <dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.6.4</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
 			<version>1.6.4</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
The project should only depend on slf4j-api and not on slf4j-log4j12.

slf4j-log4j12 is only required during the runtime of the module and
so the selection of the slf4j implemenation should be left to the
OSGi container/distribution.

Signed-off-by: Jens Reimann <jreimann@redhat.com>