### PR TITLE
Fix build warnings

### DIFF
--- a/kura/examples/org.eclipse.kura.example.beacon.scanner/build.properties
+++ b/kura/examples/org.eclipse.kura.example.beacon.scanner/build.properties
@@ -1,4 +1,4 @@
-output.. = target/
+output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/

--- a/kura/examples/org.eclipse.kura.example.beacon/build.properties
+++ b/kura/examples/org.eclipse.kura.example.beacon/build.properties
@@ -8,9 +8,10 @@
 #
 # Contributors:
 #   Eurotech
+#   Jens Reimann <jreimann@redhat.com> - Fix build warning
 #
 
-output.. = target/
+output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag/build.properties
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag/build.properties
@@ -10,7 +10,7 @@
 #   Eurotech
 #
 
-output.. = target/
+output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/

--- a/kura/examples/org.eclipse.kura.raspberrypi.sensehat.example/build.properties
+++ b/kura/examples/org.eclipse.kura.raspberrypi.sensehat.example/build.properties
@@ -8,9 +8,10 @@
 #
 # Contributors:
 #   Eurotech
+#   Jens Reimann <jreimann@redhat.com> - Fix build warning
 #
 
-output.. = target/
+output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/

--- a/kura/examples/org.eclipse.kura.raspberrypi.sensehat/build.properties
+++ b/kura/examples/org.eclipse.kura.raspberrypi.sensehat/build.properties
@@ -8,8 +8,9 @@
 #
 # Contributors:
 #   Eurotech
+#   Jens Reimann <jreimann@redhat.com> - Fix build warning
 #
-output.. = target/
+output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                src/main/resources/,\

--- a/kura/org.eclipse.kura.deployment.agent/build.properties
+++ b/kura/org.eclipse.kura.deployment.agent/build.properties
@@ -8,11 +8,12 @@
 #
 # Contributors:
 #   Eurotech
+#   Jens Reimann <jreimann@redhat.com> - Fix build warning
 #
 
 source.. = src/main/java/,\
            src/test/java/
-output.  = target/classes/
+output..  = target/classes/
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\

--- a/kura/org.eclipse.kura.linux.bluetooth/build.properties
+++ b/kura/org.eclipse.kura.linux.bluetooth/build.properties
@@ -10,7 +10,7 @@
 #   Eurotech
 #
 
-output.. = target/
+output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/


### PR DESCRIPTION
This change fixes a few build warnings based on wrong paths.

Signed-off-by: Jens Reimann <jreimann@redhat.com>