### PR TITLE
Fix a possible NPE followed by a NCDFE when system property is missing

### DIFF
--- a/kura/org.eclipse.kura.core.crypto/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core.crypto/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Import-Package: javax.crypto,
  javax.crypto.spec,
  javax.xml.bind;resolution:=optional,
  org.eclipse.kura;version="[1.0,2.0)",
- org.eclipse.kura.crypto;version="[1.2,1.3)"
+ org.eclipse.kura.crypto;version="[1.2,1.3)",
+ org.slf4j;version="1.6.0"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
+++ b/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Jens Reimann <jreimann@redhat.com> Fix possible NPE
  *******************************************************************************/
 package org.eclipse.kura.core.crypto;
 
@@ -35,8 +36,12 @@ import javax.crypto.spec.SecretKeySpec;
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.crypto.CryptoService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CryptoServiceImpl implements CryptoService {
+	private static final Logger logger = LoggerFactory.getLogger(CryptoServiceImpl.class);
+	
 	private static final String ALGORITHM   = "AES";
 	private static final byte[] SECRET_KEY  = "rv;ipse329183!@#".getBytes();
 
@@ -321,7 +326,12 @@ public class CryptoServiceImpl implements CryptoService {
 	}
 
 	private static void initKeystorePasswordPath() {
-		String uriSpec = System.getProperty("kura.configuration");
+		final String uriSpec = System.getProperty("kura.configuration");
+		if (uriSpec == null || uriSpec.isEmpty()) {
+			logger.error("Unable to initialize keystore password. 'kura.configuration' is not set.");
+			return;
+		}
+		
 		Properties props = new Properties();
 		FileInputStream fis = null;
 		try {


### PR DESCRIPTION
A missing system property will cause a NullPointerException and, since
it occurs in a static initializer block, cause a
NoClassDefFoundError if the 'kura.configuration' property is not set.

Signed-off-by: Jens Reimann <jreimann@redhat.com>