### PR TITLE
#408 Let service tracker only track relevant services

### DIFF
--- a/kura/emulator/org.eclipse.kura.emulator.clock/OSGI-INF/clock.xml
+++ b/kura/emulator/org.eclipse.kura.emulator.clock/OSGI-INF/clock.xml
@@ -17,6 +17,7 @@
    <implementation class="org.eclipse.kura.emulator.clock.ClockServiceImpl"/>
    <service>
       <provide interface="org.eclipse.kura.clock.ClockService"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.clock.ClockService"/>
    <reference name="EventAdmin" 

--- a/kura/emulator/org.eclipse.kura.emulator.watchdog/OSGI-INF/watchdog.xml
+++ b/kura/emulator/org.eclipse.kura.emulator.watchdog/OSGI-INF/watchdog.xml
@@ -16,6 +16,7 @@
    <implementation class="org.eclipse.kura.emulator.watchdog.WatchdogServiceImpl"/>
    <service>
       <provide interface="org.eclipse.kura.watchdog.WatchdogService"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.watchdog.WatchdogService"/>
 </scr:component>

--- a/kura/examples/org.eclipse.kura.demo.heater/OSGI-INF/heater.xml
+++ b/kura/examples/org.eclipse.kura.demo.heater/OSGI-INF/heater.xml
@@ -26,6 +26,7 @@
    <property name="service.pid" type="String" value="org.eclipse.kura.demo.heater.Heater"/>
    <service>
        <provide interface="org.eclipse.kura.demo.heater.Heater"/>
+       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    
    <reference name="CloudService"

--- a/kura/examples/org.eclipse.kura.demo.modbus/OSGI-INF/modbusexample.xml
+++ b/kura/examples/org.eclipse.kura.demo.modbus/OSGI-INF/modbusexample.xml
@@ -16,6 +16,7 @@
    <implementation class="org.eclipse.kura.demo.modbus.ModbusExample"/>
    <service>
       <provide interface="org.eclipse.kura.demo.modbus.ModbusExample"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.demo.modbus.ModbusExample"/>
 

--- a/kura/examples/org.eclipse.kura.example.beacon.scanner/OSGI-INF/beaconExample.xml
+++ b/kura/examples/org.eclipse.kura.example.beacon.scanner/OSGI-INF/beaconExample.xml
@@ -3,6 +3,7 @@
    <implementation class="org.eclipse.kura.example.beacon.scanner.BeaconScannerExample"/>
    <service>
       <provide interface="org.eclipse.kura.example.beacon.scanner.BeaconScannerExample"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
     <reference bind="setBluetoothService" 
               cardinality="1..1" 

--- a/kura/examples/org.eclipse.kura.example.beacon/OSGI-INF/beaconExample.xml
+++ b/kura/examples/org.eclipse.kura.example.beacon/OSGI-INF/beaconExample.xml
@@ -16,6 +16,7 @@
    <implementation class="org.eclipse.kura.example.beacon.BeaconExample"/>
    <service>
       <provide interface="org.eclipse.kura.example.beacon.BeaconExample"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.example.beacon.BeaconExample"/>
     <reference bind="setBluetoothService" 

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag/OSGI-INF/bleExample.xml
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag/OSGI-INF/bleExample.xml
@@ -17,6 +17,7 @@
    <implementation class="org.eclipse.kura.example.ble.tisensortag.BluetoothLe"/>
    <service>
       <provide interface="org.eclipse.kura.example.ble.tisensortag.BluetoothLe"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.example.ble.tisensortag.BluetoothLe"/>
    <reference bind="setCloudService" 

--- a/kura/examples/org.eclipse.kura.raspberrypi.sensehat.example/OSGI-INF/org.eclipse.kura.raspberrypi.sensehat.example.xml
+++ b/kura/examples/org.eclipse.kura.raspberrypi.sensehat.example/OSGI-INF/org.eclipse.kura.raspberrypi.sensehat.example.xml
@@ -18,5 +18,6 @@
    <property name="service.pid" type="String" value="org.eclipse.kura.raspberrypi.sensehat.example.SenseHatExample"/>
    <service>
       <provide interface="org.eclipse.kura.raspberrypi.sensehat.example.SenseHatExample"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
 </scr:component>

--- a/kura/org.eclipse.kura.core.cloud/OSGI-INF/commandCloudApp.xml
+++ b/kura/org.eclipse.kura.core.cloud/OSGI-INF/commandCloudApp.xml
@@ -30,6 +30,7 @@
    	<service>
    		<provide interface="org.eclipse.kura.cloud.app.command.CommandCloudApp"/>
    		<provide interface="org.eclipse.kura.command.PasswordCommandService"/>
+     <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    	</service>
    	<property name="service.pid" type="String" value="org.eclipse.kura.cloud.app.command.CommandCloudApp"/>
 </scr:component>

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -83,37 +83,41 @@ public class ConfigurationServiceImpl implements ConfigurationService {
     private static final Logger s_logger = LoggerFactory.getLogger(ConfigurationServiceImpl.class);
 
     private interface ServiceHandler {
-    	void add ( String servicePid, String kuraPid, String factoryPid );
-    	void remove ( String servicePid, String kuraPid );
-    }
-    
-    private final ServiceHandler trackerHandler1 = new ServiceHandler() {
-		@Override
-		public void add(String servicePid, String kuraPid, String factoryPid) {
-			registerComponentConfiguration(kuraPid, servicePid, factoryPid);
-		}
-		
-		@Override
-		public void remove(String servicePid, String kuraPid) {
-			unregisterComponentConfiguration(kuraPid);
-		}
-	};
-	
-	private final ServiceHandler trackerHandler2 = new ServiceHandler () {
-		@Override
-		public void add(String servicePid, String kuraPid, String factoryPid) {
-			registerSelfConfiguringComponent(servicePid);
-		}
 
-		@Override
-		public void remove(String servicePid, String kuraPid) {
-			unregisterComponentConfiguration(servicePid);
-		}
-	};
-    
+        void add(String servicePid, String kuraPid, String factoryPid);
+
+        void remove(String servicePid, String kuraPid);
+    }
+
+    private final ServiceHandler trackerHandler1 = new ServiceHandler() {
+
+        @Override
+        public void add(String servicePid, String kuraPid, String factoryPid) {
+            registerComponentConfiguration(kuraPid, servicePid, factoryPid);
+        }
+
+        @Override
+        public void remove(String servicePid, String kuraPid) {
+            unregisterComponentConfiguration(kuraPid);
+        }
+    };
+
+    private final ServiceHandler trackerHandler2 = new ServiceHandler() {
+
+        @Override
+        public void add(String servicePid, String kuraPid, String factoryPid) {
+            registerSelfConfiguringComponent(servicePid);
+        }
+
+        @Override
+        public void remove(String servicePid, String kuraPid) {
+            unregisterComponentConfiguration(servicePid);
+        }
+    };
+
     private ComponentContext m_ctx;
     private ServiceTracker<ConfigurableComponent, ConfigurableComponent> serviceTracker1;
-	private ServiceTracker<SelfConfiguringComponent, SelfConfiguringComponent> serviceTracker2;
+    private ServiceTracker<SelfConfiguringComponent, SelfConfiguringComponent> serviceTracker2;
     private BundleTracker<Bundle> m_bundleTracker;
 
     @SuppressWarnings("unused")
@@ -213,61 +217,63 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         //
         // start the trackers
         s_logger.info("Trackers being opened...");
-        
-		this.serviceTracker1 = createTracker(ConfigurableComponent.class, this.trackerHandler1);
-		this.serviceTracker2 = createTracker(SelfConfiguringComponent.class, this.trackerHandler2);
-        
+
+        this.serviceTracker1 = createTracker(ConfigurableComponent.class, this.trackerHandler1);
+        this.serviceTracker2 = createTracker(SelfConfiguringComponent.class, this.trackerHandler2);
+
         this.serviceTracker1.open();
         this.serviceTracker2.open();
 
-        this.m_bundleTracker = new ComponentMetaTypeBundleTracker(m_ctx.getBundleContext(), this);
+        this.m_bundleTracker = new ComponentMetaTypeBundleTracker(this.m_ctx.getBundleContext(), this);
         this.m_bundleTracker.open();
     }
 
-	private <T> ServiceTracker<T, T> createTracker(final Class<T> clazz, final ServiceHandler handler) {
-		return new ServiceTracker<T, T>(this.m_ctx.getBundleContext(), clazz, null) {
-        	@Override
-        	public T addingService(ServiceReference<T> reference) {
-        		s_logger.debug("addingService - ref: {}", reference);
-        		
-        		final String servicePid = makeString(reference.getProperty(Constants.SERVICE_PID));
-        		final String kuraPid = makeString(reference.getProperty(ConfigurationService.KURA_SERVICE_PID));
-        		final String factoryPid = makeString(reference.getProperty(ConfigurationAdmin.SERVICE_FACTORYPID));
-        		
-        		if ( servicePid == null ) {
-        			s_logger.debug("No servicePid found");
-        			return null;
-        		}
-        		
-        		T service = super.addingService(reference);
-        		
-        		s_logger.debug("Adding service: {}", service);
-        		
-        		handler.add(servicePid, kuraPid, factoryPid);
-        		
-        		return service;
-        	}
-        	
-        	@Override
-        	public void removedService(ServiceReference<T> reference, T service) {
-        		s_logger.debug("removedService - ref: {}", reference);
-        		
-        		final String servicePid = makeString(reference.getProperty(Constants.SERVICE_PID));
-        		final String kuraPid = makeString(reference.getProperty(ConfigurationService.KURA_SERVICE_PID));
-        		
-        		if ( servicePid == null ) {
-        			s_logger.debug("No servicePid found");
-        			return;
-        		}
-        		
-        		s_logger.debug ("remove - servicePid: {}, kuraPid: {}, service: {}", new Object[]{servicePid, kuraPid, service} );
-        		
-        		handler.remove(servicePid, kuraPid );
-        		
-        		super.removedService(reference, service);
-        	}
+    private <T> ServiceTracker<T, T> createTracker(final Class<T> clazz, final ServiceHandler handler) {
+        return new ServiceTracker<T, T>(this.m_ctx.getBundleContext(), clazz, null) {
+
+            @Override
+            public T addingService(ServiceReference<T> reference) {
+                s_logger.debug("addingService - ref: {}", reference);
+
+                final String servicePid = makeString(reference.getProperty(Constants.SERVICE_PID));
+                final String kuraPid = makeString(reference.getProperty(ConfigurationService.KURA_SERVICE_PID));
+                final String factoryPid = makeString(reference.getProperty(ConfigurationAdmin.SERVICE_FACTORYPID));
+
+                if (servicePid == null) {
+                    s_logger.debug("No servicePid found");
+                    return null;
+                }
+
+                T service = super.addingService(reference);
+
+                s_logger.debug("Adding service: {}", service);
+
+                handler.add(servicePid, kuraPid, factoryPid);
+
+                return service;
+            }
+
+            @Override
+            public void removedService(ServiceReference<T> reference, T service) {
+                s_logger.debug("removedService - ref: {}", reference);
+
+                final String servicePid = makeString(reference.getProperty(Constants.SERVICE_PID));
+                final String kuraPid = makeString(reference.getProperty(ConfigurationService.KURA_SERVICE_PID));
+
+                if (servicePid == null) {
+                    s_logger.debug("No servicePid found");
+                    return;
+                }
+
+                s_logger.debug("remove - servicePid: {}, kuraPid: {}, service: {}",
+                        new Object[] { servicePid, kuraPid, service });
+
+                handler.remove(servicePid, kuraPid);
+
+                super.removedService(reference, service);
+            }
         };
-	}
+    }
 
     protected void deactivate(ComponentContext componentContext) {
         s_logger.info("deactivate...");
@@ -275,16 +281,16 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         //
         // stop the trackers
         if (this.serviceTracker2 != null) {
-        	this.serviceTracker2.close();
-        	this.serviceTracker2 = null;
+            this.serviceTracker2.close();
+            this.serviceTracker2 = null;
         }
         if (this.serviceTracker1 != null) {
-        	this.serviceTracker1.close();
-        	this.serviceTracker1 = null;
+            this.serviceTracker1.close();
+            this.serviceTracker1 = null;
         }
         if (this.m_bundleTracker != null) {
-        	this.m_bundleTracker.close();
-        	this.m_bundleTracker = null;
+            this.m_bundleTracker.close();
+            this.m_bundleTracker = null;
         }
     }
 
@@ -423,7 +429,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
         try {
             s_logger.info("Deleting configuration for pid {}", pid);
-            Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
+            Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), "?");
 
             if (config != null) {
                 config.delete();
@@ -759,7 +765,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         if (servicePid == null) {
             servicePid = pid;
         }
-        Configuration config = this.m_configurationAdmin.getConfiguration(servicePid,  "?");
+        Configuration config = this.m_configurationAdmin.getConfiguration(servicePid, "?");
         if (config != null) {
             // get the properties from ConfigurationAdmin if any are present
             Map<String, Object> props = new HashMap<String, Object>();
@@ -990,7 +996,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
             Tocd ocd = getOCDForPid(pid);
 
-            Configuration cfg = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
+            Configuration cfg = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), "?");
             Map<String, Object> props = CollectionsUtil.dictionaryToMap(cfg.getProperties(), ocd);
 
             cc = new ComponentConfigurationImpl(pid, ocd, props);
@@ -1184,7 +1190,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
                             s_logger.debug("Pushing config to config admin: {}", config.getPid());
 
                             // push it to the ConfigAdmin
-                            Configuration cfg = this.m_configurationAdmin.getConfiguration(config.getPid(),  "?");
+                            Configuration cfg = this.m_configurationAdmin.getConfiguration(config.getPid(), "?");
 
                             // set kura.service.pid if missing
                             Map<String, Object> newProperties = new HashMap<String, Object>(props);
@@ -1315,7 +1321,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         if (!this.m_activatedSelfConfigComponents.contains(pid)) {
             try {
                 // get the current running configuration for the selected component
-                Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
+                Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), "?");
                 Map<String, Object> runningProps = CollectionsUtil.dictionaryToMap(config.getProperties(),
                         registerdOCD);
 
@@ -1388,7 +1394,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
         // Update the new properties
         // use ConfigurationAdmin to do the update
-        Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
+        Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), "?");
         config.update(CollectionsUtil.mapToDictionary(mergedProperties));
 
         if (snapshotOnConfirmation) {
@@ -1545,16 +1551,18 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
     /**
      * Convert property value to string
-     * @param value the input value
+     *
+     * @param value
+     *            the input value
      * @return the string property value, or {@code null}
      */
     private static String makeString(Object value) {
-		if ( value == null ) {
-			return null;
-		}
-		if ( value instanceof String ) {
-			return (String)value;
-		}
-		return value.toString();
-	}
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String) {
+            return (String) value;
+        }
+        return value.toString();
+    }
 }

--- a/kura/org.eclipse.kura.core.test/OSGI-INF/configuration-test.xml
+++ b/kura/org.eclipse.kura.core.test/OSGI-INF/configuration-test.xml
@@ -16,6 +16,7 @@
    <implementation class="org.eclipse.kura.core.test.ConfigurationServiceTest"/>
    <service>
       <provide interface="org.eclipse.kura.core.test.IConfigurationServiceTest"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.core.test.IConfigurationServiceTest"/>
    <reference bind="setConfigurationService" cardinality="1..1" interface="org.eclipse.kura.configuration.ConfigurationService" name="ConfigurationService" policy="static" unbind="unsetConfigurationService"/>

--- a/kura/org.eclipse.kura.core/OSGI-INF/ssl.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/ssl.xml
@@ -16,6 +16,7 @@
    <implementation class="org.eclipse.kura.core.ssl.SslManagerServiceImpl"/>
    <service>
       <provide interface="org.eclipse.kura.ssl.SslManagerService"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.ssl.SslManagerService"/>
    <reference name="ConfigurationService" 

--- a/kura/org.eclipse.kura.linux.clock/OSGI-INF/clock.xml
+++ b/kura/org.eclipse.kura.linux.clock/OSGI-INF/clock.xml
@@ -16,6 +16,7 @@
    <implementation class="org.eclipse.kura.linux.clock.ClockServiceImpl"/>
    <service>
       <provide interface="org.eclipse.kura.clock.ClockService"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.clock.ClockService"/>
    <reference name="EventAdmin" 

--- a/kura/org.eclipse.kura.linux.position/OSGI-INF/position.xml
+++ b/kura/org.eclipse.kura.linux.position/OSGI-INF/position.xml
@@ -17,6 +17,7 @@
    <service>
       <provide interface="org.eclipse.kura.position.PositionService"/>
       <provide interface="org.osgi.service.event.EventHandler"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.position.PositionService"/>
    <reference bind="setConnectionFactory" cardinality="1..1" interface="org.osgi.service.io.ConnectionFactory" name="ConnectionFactory" policy="static" unbind="unsetConnectionFactory"/>

--- a/kura/org.eclipse.kura.linux.watchdog/OSGI-INF/watchdog.xml
+++ b/kura/org.eclipse.kura.linux.watchdog/OSGI-INF/watchdog.xml
@@ -16,6 +16,7 @@
    <implementation class="org.eclipse.kura.linux.watchdog.WatchdogServiceImpl"/>
    <service>
       <provide interface="org.eclipse.kura.watchdog.WatchdogService"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.watchdog.WatchdogService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.net.admin/OSGI-INF/firewallConfigurationService.xml
+++ b/kura/org.eclipse.kura.net.admin/OSGI-INF/firewallConfigurationService.xml
@@ -23,6 +23,7 @@
    <property name="service.pid" value="org.eclipse.kura.net.admin.FirewallConfigurationService"/>
    <service>
       <provide interface="org.eclipse.kura.net.admin.FirewallConfigurationService"/>
+      <provide interface="org.eclipse.kura.configuration.SelfConfiguringComponent"/>
    </service>
    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
 </scr:component>

--- a/kura/org.eclipse.kura.net.admin/OSGI-INF/networkConfigurationService.xml
+++ b/kura/org.eclipse.kura.net.admin/OSGI-INF/networkConfigurationService.xml
@@ -18,6 +18,7 @@
    <reference bind="setNetworkService" cardinality="1..1" interface="org.eclipse.kura.net.NetworkService" name="NetworkService" policy="static" unbind="unsetNetworkService"/>
    <service>
       <provide interface="org.eclipse.kura.net.admin.NetworkConfigurationService"/>
+      <provide interface="org.eclipse.kura.configuration.SelfConfiguringComponent"/>
    </service>
    <reference bind="setUsbService" cardinality="1..1" interface="org.eclipse.kura.usb.UsbService" name="UsbService" policy="static" unbind="unsetUsbService"/>
    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>

--- a/kura/org.eclipse.kura.protocol.can.test/OSGI-INF/can.xml
+++ b/kura/org.eclipse.kura.protocol.can.test/OSGI-INF/can.xml
@@ -20,6 +20,7 @@
    <implementation class="org.eclipse.kura.protocol.can.test.CanSocketTest"/>
    <service>
       <provide interface="org.eclipse.kura.protocol.can.test.CanSocketTest"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.protocol.can.test.CanSocketTest"/>
 

--- a/kura/org.eclipse.kura.protocol.modbus.test/OSGI-INF/modbusmanager.xml
+++ b/kura/org.eclipse.kura.protocol.modbus.test/OSGI-INF/modbusmanager.xml
@@ -16,6 +16,7 @@
    <implementation class="org.eclipse.kura.protocol.modbus.test.ModbusManager"/>
    <service>
       <provide interface="org.eclipse.kura.protocol.modbus.test.ModbusManager"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.protocol.modbus.test.ModbusManager"/>
 

--- a/kura/org.eclipse.kura.stress/OSGI-INF/stress.xml
+++ b/kura/org.eclipse.kura.stress/OSGI-INF/stress.xml
@@ -26,6 +26,7 @@
    <property name="service.pid" type="String" value="org.eclipse.kura.stress.Stress"/>
    <service>
        <provide interface="org.eclipse.kura.stress.Stress"/>
+       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    
 </scr:component>

--- a/kura/org.eclipse.kura.web2/OSGI-INF/web.xml
+++ b/kura/org.eclipse.kura.web2/OSGI-INF/web.xml
@@ -35,5 +35,6 @@
    <property name="service.pid" type="String" value="org.eclipse.kura.web.Console"/>
    <service>
       <provide interface="org.eclipse.kura.web.Console"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>   
 </scr:component>


### PR DESCRIPTION
This change re-implements the service tracking of the default 
configuration service implementation to use standard service trackers
and only track relevant services from the beginning.

In addition all service registrations have been fixed to actually export
the ConfigurableService and SelfConfiguringService.

Beside improving the performance this also prevents services to be
activated which would not have been activated otherwise e.g. in Karaf.

Signed-off-by: Jens Reimann <jreimann@redhat.com>