### PR TITLE
Start cleaning up kura.configuration handling by using the constant

### DIFF
--- a/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
+++ b/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2016 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,8 @@
  *
  * Contributors:
  *     Eurotech
- *     Jens Reimann <jreimann@redhat.com> Fix possible NPE, fix loading error
+ *     Red Hat Inc - Fix possible NPE, fix loading error
+ *       - Clean up kura.properties handling
  *******************************************************************************/
 package org.eclipse.kura.core.crypto;
 
@@ -36,6 +37,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.crypto.CryptoService;
+import org.eclipse.kura.system.SystemService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -326,7 +328,7 @@ public class CryptoServiceImpl implements CryptoService {
 	}
 
 	private static void initKeystorePasswordPath() {
-		final String uriSpec = System.getProperty("kura.configuration");
+		final String uriSpec = System.getProperty(SystemService.KURA_CONFIG);
 		if (uriSpec == null || uriSpec.isEmpty()) {
 			logger.error("Unable to initialize keystore password. 'kura.configuration' is not set.");
 			return;

--- a/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/CloudDeploymentHandlerV2.java
+++ b/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/CloudDeploymentHandlerV2.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Jens Reimann <jreimann@redhat.com> - Clean up kura properties handling
  *******************************************************************************/
 
 package org.eclipse.kura.core.deployment;
@@ -48,6 +49,7 @@ import org.eclipse.kura.message.KuraPayload;
 import org.eclipse.kura.message.KuraRequestPayload;
 import org.eclipse.kura.message.KuraResponsePayload;
 import org.eclipse.kura.ssl.SslManagerService;
+import org.eclipse.kura.system.SystemService;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
@@ -65,7 +67,7 @@ public class CloudDeploymentHandlerV2 extends Cloudlet {
 	public static final String APP_ID = "DEPLOY-V2";
 
 	private static final String DPA_CONF_PATH_PROPNAME = "dpa.configuration";
-	private static final String KURA_CONF_URL_PROPNAME = "kura.configuration";
+	private static final String KURA_CONF_URL_PROPNAME = SystemService.KURA_CONFIG;
 	private static final String PACKAGES_PATH_PROPNAME = "kura.packages";
 	private static final String KURA_DATA_DIR = "kura.data";
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/util/LinuxProcessUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/util/LinuxProcessUtil.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Jens Reimann <jreimann@redhat.com> - Clean up kura properties handling
  *******************************************************************************/
 package org.eclipse.kura.core.linux.util;
 
@@ -24,6 +25,7 @@ import java.util.StringTokenizer;
 
 import org.eclipse.kura.core.util.ProcessUtil;
 import org.eclipse.kura.core.util.SafeProcess;
+import org.eclipse.kura.system.SystemService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +36,7 @@ public class LinuxProcessUtil {
 	private static String s_platform = null;
 
 	static {
-		String uriSpec = System.getProperty("kura.configuration");
+		String uriSpec = System.getProperty(SystemService.KURA_CONFIG);
 		Properties props = new Properties();
 		FileInputStream fis = null;
 		try {

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Jens Reimann <jreimann@redhat.com> - Clean up kura properties handling
  *******************************************************************************/
 package org.eclipse.kura.deployment.agent.impl;
 
@@ -35,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.kura.deployment.agent.DeploymentAgentService;
+import org.eclipse.kura.system.SystemService;
 import org.osgi.framework.Version;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.ComponentException;
@@ -72,7 +74,7 @@ public class DeploymentAgent implements DeploymentAgentService {
 	private static Logger s_logger = LoggerFactory.getLogger(DeploymentAgent.class);
 
 	private static final String DPA_CONF_PATH_PROPNAME = "dpa.configuration";
-	private static final String KURA_CONF_URL_PROPNAME  = "kura.configuration";
+	private static final String KURA_CONF_URL_PROPNAME  = SystemService.KURA_CONFIG;
 	private static final String PACKAGES_PATH_PROPNAME = "kura.packages";
 
 	private static final String CONN_TIMEOUT_PROPNAME = "dpa.connection.timeout";

--- a/kura/org.eclipse.kura.deployment.customizer/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.deployment.customizer/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Vendor: EUROTECH
 Bundle-Activator: org.eclipse.kura.deployment.rp.sh.impl.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: org.apache.commons.io;version="2.4.0",
+ org.eclipse.kura.system;version="1.1.0",
  org.osgi.framework;version="1.5.0",
  org.osgi.service.component;version="1.2.0",
  org.osgi.service.deploymentadmin,

--- a/kura/org.eclipse.kura.deployment.customizer/src/main/java/org/eclipse/kura/deployment/rp/sh/impl/ShellScriptResourceProcessorImpl.java
+++ b/kura/org.eclipse.kura.deployment.customizer/src/main/java/org/eclipse/kura/deployment/rp/sh/impl/ShellScriptResourceProcessorImpl.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Jens Reimann <jreimann@redhat.com> - Clean up kura properties handling
  *******************************************************************************/
 package org.eclipse.kura.deployment.rp.sh.impl;
 
@@ -28,6 +29,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
+import org.eclipse.kura.system.SystemService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentException;
@@ -41,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public class ShellScriptResourceProcessorImpl implements ResourceProcessor {
 	private static Logger s_logger = LoggerFactory.getLogger(ShellScriptResourceProcessorImpl.class);
 	
-	private static final String KURA_CONF_URL_PROPNAME = "kura.configuration";
+	private static final String KURA_CONF_URL_PROPNAME = SystemService.KURA_CONFIG;
 	private static final String PACKAGES_PATH_PROPNAME = "kura.packages";
 	
 	private static final String INSTALL_ACTION = "install";

--- a/kura/org.eclipse.kura.linux.gpio/src/main/java/org/eclipse/kura/linux/gpio/GPIOServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.gpio/src/main/java/org/eclipse/kura/linux/gpio/GPIOServiceImpl.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Jens Reimann <jreimann@redhat.com> - Clean up kura properties handling
  *******************************************************************************/
 package org.eclipse.kura.linux.gpio;
 
@@ -58,7 +59,7 @@ public class GPIOServiceImpl implements GPIOService {
 			String configFile = System.getProperty("jdk.dio.registry");
 			if(configFile == null){
 				//Emulator?
-				configFile = m_SystemService.getProperties().getProperty("kura.configuration").replace("kura.properties", "jdk.dio.properties");
+				configFile = m_SystemService.getProperties().getProperty(SystemService.KURA_CONFIG).replace("kura.properties", "jdk.dio.properties");
 			}else{
 				configFile = "file:"+configFile;
 			}


### PR DESCRIPTION
This change starts cleaning up the kura.configuration handling throughout the system by using the SystemService.KURA_CONFIG constant in all places instead of a string literal.

Signed-off-by: Jens Reimann <jreimann@redhat.com>