### PR TITLE
Fix warning of missing files

### DIFF
--- a/kura/org.eclipse.kura.deployment.update/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.deployment.update/META-INF/MANIFEST.MF
@@ -5,5 +5,4 @@ Bundle-SymbolicName: org.eclipse.kura.deployment.update;singleton:=true
 Bundle-Version: 1.0.3.qualifier
 Bundle-Vendor: EUROTECH
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
The bundle does not provide any OSGi DS files, so remove the manifest
header for loading files. This fill fix the warning printed on the
console.

Signed-off-by: Jens Reimann <jreimann@redhat.com>