### PR TITLE
Fix a possible NPE and do minor cleanups

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/Console.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/Console.java
@@ -8,14 +8,13 @@
  *
  * Contributors:
  *     Eurotech
+ *     Jens Reimann <jreimann@redhat.com> - Fix possible NPE, cleanup
  *******************************************************************************/
 package org.eclipse.kura.web;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import javax.servlet.ServletException;
 
@@ -63,8 +62,6 @@ public class Console implements ConfigurableComponent {
 
 	private HttpService m_httpService;
 
-	private ExecutorService m_worker;
-
 	private SystemService m_systemService;
 	private CryptoService m_cryptoService;
 
@@ -78,11 +75,6 @@ public class Console implements ConfigurableComponent {
 	// Dependencies
 	//
 	// ----------------------------------------------------------------
-
-	public Console() {
-		super();
-		m_worker = Executors.newSingleThreadExecutor();
-	}
 
 	public void setHttpService(HttpService httpService) {
 		this.m_httpService = httpService;
@@ -125,7 +117,7 @@ public class Console implements ConfigurableComponent {
 	protected void activate(ComponentContext context, Map<String, Object> properties) {
 		try {
 			// Check if web interface is enabled.
-			Boolean webEnabled = Boolean.valueOf(m_systemService.getKuraWebEnabled());
+			boolean webEnabled = Boolean.parseBoolean((m_systemService.getKuraWebEnabled()));
 
 			if (webEnabled) {
 				s_logger.info("activate...");
@@ -135,7 +127,7 @@ public class Console implements ConfigurableComponent {
 				s_appRoot = (String) properties.get(APP_ROOT);
 				String servletRoot = s_aliasRoot;
 
-				m_properties= new HashMap<String, Object>();
+				m_properties = new HashMap<String, Object>();
 				Iterator<String> keys = properties.keySet().iterator();
 				while (keys.hasNext()) {
 					String key = keys.next();
@@ -145,7 +137,7 @@ public class Console implements ConfigurableComponent {
 
 				Object pwdProp = properties.get(CONSOLE_PASSWORD);
 				char[] propertyPassword = null;
-				if(pwdProp instanceof char[]){
+				if (pwdProp instanceof char[]) {
 					propertyPassword = (char[]) properties.get(CONSOLE_PASSWORD);
 				} else {
 					propertyPassword = properties.get(CONSOLE_PASSWORD).toString().toCharArray();
@@ -165,7 +157,7 @@ public class Console implements ConfigurableComponent {
 				}
 				propertyPassword = m_cryptoService.sha1Hash(new String(decryptedPassword)).toCharArray();
 
-				String registeredUsername= (String) properties.get(CONSOLE_USERNAME);
+				String registeredUsername = (String) properties.get(CONSOLE_USERNAME);
 				authMgr = new AuthenticationManager(registeredUsername, propertyPassword);
 				initHTTPService(authMgr, servletRoot);
 
@@ -185,9 +177,14 @@ public class Console implements ConfigurableComponent {
 
 	protected void updated(Map<String, Object> properties) {
 
+		boolean webEnabled = Boolean.parseBoolean((m_systemService.getKuraWebEnabled()));
+		if (!webEnabled) {
+			return;
+		}
+
 		char[] propertyPassword = null;
 
-		String registeredUsername= (String) properties.get(CONSOLE_USERNAME);
+		String registeredUsername = (String) properties.get(CONSOLE_USERNAME);
 		authMgr.updateUsername(registeredUsername);
 
 		try {
@@ -198,9 +195,9 @@ public class Console implements ConfigurableComponent {
 			} catch (Exception e) {
 				decryptedPassword = value.toString().toCharArray();
 			}
-			
+
 			propertyPassword = m_cryptoService.sha1Hash(new String(decryptedPassword)).toCharArray();
-			
+
 			authMgr.updatePassword(propertyPassword);
 		} catch (Exception e) {
 			s_logger.warn("Error Updating Web properties", e);
@@ -212,7 +209,6 @@ public class Console implements ConfigurableComponent {
 		s_logger.info("deactivate...");
 
 		s_context = null;
-		m_worker.shutdown();
 
 		unregisterServlet();
 	}
@@ -253,7 +249,8 @@ public class Console implements ConfigurableComponent {
 		return s_aliasRoot;
 	}
 
-	private void initHTTPService(AuthenticationManager authMgr, String servletRoot) throws NamespaceException, ServletException {
+	private void initHTTPService(AuthenticationManager authMgr, String servletRoot)
+			throws NamespaceException, ServletException {
 		// Initialize HttpService
 
 		HttpContext httpCtx = new SecureBasicHttpContext(m_httpService.createDefaultHttpContext(), authMgr);


### PR DESCRIPTION
This change fixes a possible NPE which can be triggered if the web ui
is disabled. In that case the update method will try to access a field
which never got initialized. This is sovled by adding another check
if the web ui is enabled.

I addition the unused executor service was removed.

Signed-off-by: Jens Reimann <jreimann@redhat.com>