### PR TITLE
Fix missing "org.eclipse.soda.dk.comm" dependency

### DIFF
--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -4,7 +4,7 @@ javax.usb.api.version=1.0.2
 javax.usb.common.version=1.0.2
 javax.usb.linux.version=1.0.3
 org.eclipse.paho.client.mqttv3.version=1.0.1
-org.eclipse.soda.dk.comm.version=1.2.2-SNAPSHOT
+org.eclipse.soda.dk.comm.version=1.2.2.SNAPSHOT
 org.usb4java.version=1.0.0
 usb4java-javax.version=1.0.0
 


### PR DESCRIPTION
Commit 3675b9bde0c5994e14a963cd9963ac2c1bef0fe2 did change the version to 1.2.2-SNAPSHOT where it in fact it has to be "1.2.2.SNAPSHOT", so ".SNAPSHOT" instead of "-SNAPSHOT".

This was necessery due to the commit 7a18e616c97859664dd44c2d4cf781f27e5b69b2 which did change the version from 1.2.1 to 1.2.2-SNAPSHOT.

Signed-off-by: Jens Reimann <jreimann@redhat.com>