### PR TITLE
Fix missing "org.eclipse.soda.dk.comm" dependency

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -684,7 +684,7 @@ Resource-Processor: org.eclipse.kura.deployment.customizer.upgrade.rp.UpgradeScr
 			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/kura/plugins/com.codeminders.hidapi_${com.codeminders.hidapi.version}.jar@3:start" />
 			<entry key="osgi.bundles" operation="+"
-				value=", reference:file:${kura.install.dir}/kura/plugins/org.eclipse.soda.dk.comm_1.2.2.SNAPSHOT.jar@3:start" /> <!-- ${org.eclipse.soda.dk.comm.version} -->
+				value=", reference:file:${kura.install.dir}/kura/plugins/org.eclipse.soda.dk.comm_${org.eclipse.soda.dk.comm.version}.jar@3:start" />
 			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/kura/plugins/org.apache.commons.lang3_${org.apache.commons.lang3.version}.jar@4:start" />
 			<entry key="osgi.bundles" operation="+"

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -4,7 +4,7 @@ javax.usb.api.version=1.0.2
 javax.usb.common.version=1.0.2
 javax.usb.linux.version=1.0.3
 org.eclipse.paho.client.mqttv3.version=1.0.1
-org.eclipse.soda.dk.comm.version=1.2.2-SNAPSHOT
+org.eclipse.soda.dk.comm.version=1.2.2
 org.usb4java.version=1.0.0
 usb4java-javax.version=1.0.0
 

--- a/target-platform/org.eclipse.soda.dk.comm/pom.xml
+++ b/target-platform/org.eclipse.soda.dk.comm/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.eclipse</groupId>
     <artifactId>org.eclipse.soda.dk.comm</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.2.2</version>
     <packaging>bundle</packaging>
 
     <name>Serial Device based on SODA DK comm</name>


### PR DESCRIPTION
Commit 3675b9bde0c5994e14a963cd9963ac2c1bef0fe2 did change the version to 1.2.2-SNAPSHOT where it in fact it has to be "1.2.2.SNAPSHOT", so ".SNAPSHOT" instead of "-SNAPSHOT".

This was necessery due to the commit 7a18e616c97859664dd44c2d4cf781f27e5b69b2 which did change the version from 1.2.1 to 1.2.2-SNAPSHOT.

Signed-off-by: Jens Reimann <jreimann@redhat.com>

---
It seems there are some issues with the combination of tools involved here which make it tricky to use -SNAPSHOT versions. I incremented the "soda comm" dependency to simply used 1.2.2 instead.