### PR TITLE
Fix build warnings

### DIFF
--- a/kura/emulator/org.eclipse.kura.emulator.watchdog/build.properties
+++ b/kura/emulator/org.eclipse.kura.emulator.watchdog/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2016 Eurotech and others
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -8,11 +8,11 @@
 #
 # Contributors:
 #   Eurotech
+#   Red Hat Inc - fix build warnings
 #
 
 output.. = target/classes/
-source.. = src/main/java/,\
-           src/main/resources/
+source.. = src/main/java/
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\

--- a/kura/examples/org.eclipse.kura.example.gpio/META-INF/MANIFEST.MF
+++ b/kura/examples/org.eclipse.kura.example.gpio/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Import-Package: org.eclipse.kura;version="[1.0,2.0)",
  org.osgi.service.component;version="1.2.0",
  org.slf4j;version="1.6.4"
 Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy

--- a/kura/examples/org.eclipse.kura.example.project/META-INF/MANIFEST.MF
+++ b/kura/examples/org.eclipse.kura.example.project/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Import-Package: javax.comm;version="1.2.0",
  org.osgi.util.position;version="1.0.1",
  org.slf4j;version="1.6.4"
 Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy

--- a/kura/examples/org.eclipse.kura.raspberrypi.sensehat.example/META-INF/MANIFEST.MF
+++ b/kura/examples/org.eclipse.kura.raspberrypi.sensehat.example/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package: org.eclipse.kura.configuration;version="1.1.0",
  org.eclipse.kura.raspsberrypi.sensehat.joystick;version="[1.0.0,2.0.0)",
  org.osgi.service.component;version="1.2.0",
  org.slf4j;version="1.6.4"
+Bundle-ActivationPolicy: lazy

--- a/kura/examples/org.eclipse.kura.raspberrypi.sensehat/META-INF/MANIFEST.MF
+++ b/kura/examples/org.eclipse.kura.raspberrypi.sensehat/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Export-Package: org.eclipse.kura.raspberrypi.sensehat;version="1.0.1",
  org.eclipse.kura.raspberrypi.sensehat.ledmatrix;version="1.0.1",
  org.eclipse.kura.raspberrypi.sensehat.sensors;version="1.0.1",
  org.eclipse.kura.raspsberrypi.sensehat.joystick;version="1.0.1"
+Bundle-ActivationPolicy: lazy

--- a/kura/org.eclipse.kura.linux.net.test/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.linux.net.test/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Unit-Test: true
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.kura.test;bundle-version="1.0.0",
  org.junit;bundle-version="4.10.0"
+Bundle-ActivationPolicy: lazy

--- a/kura/org.eclipse.kura.test/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.test/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package: junit.framework,
  org.osgi.util.tracker;version="1.5.1",
  org.slf4j;version="1.6.4"
 Export-Package: org.eclipse.kura.test.annotation; version="1.0.0"
+Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Beside the missing directory this change will set the
Bundle-ActivationPolicy: lazy header as recommended by Eclipse.

Although setting the header should not make any difference, since Kura
does generate a config.ini file which already starts all bundles
explicitly. However it doesn't hurt either. On the other hand warnings
clutter up the IDE, users might get confused of warnings and at some
point the need may arise to enable the flag anyway.

Signed-off-by: Jens Reimann <jreimann@redhat.com>