### PR TITLE
Don't generate Javadoc for "internal" packages

### DIFF
--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -411,7 +411,7 @@
 						<!-- Remove packages from the list to have them included in the aggregate
 							javadocs -->
 						<excludePackageNames>
-							*.ermes:*.demo*:*.example:*.core:*.cloud.app:*.net.admin:*.deployment:*.emulator:*.linux:*.qa:*.web:*.service.io:*.test
+							*.ermes:*.demo*:*.example:*.core:*.cloud.app:*.net.admin:*.deployment:*.emulator:*.linux:*.qa:*.web:*.service.io:*.test:*.internal.*
 						</excludePackageNames>
 						<!-- Add URLs for open source javadocs below -->
 					</configuration>


### PR DESCRIPTION
Signed-off-by: Jens Reimann <jreimann@redhat.com>