### PR TITLE
Fix bundle name by using project name

### DIFF
--- a/target-platform/com.codeminders.hidapi/pom.xml
+++ b/target-platform/com.codeminders.hidapi/pom.xml
@@ -94,7 +94,6 @@
 				<manifestLocation>META-INF</manifestLocation>
 				<instructions>
 					<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-					<Bundle-Name>%bundle.name</Bundle-Name>
 					<Bundle-Version>${project.version}</Bundle-Version>
 					<Include-Resource>
 						lib=${project.basedir}/src/main/lib,


### PR DESCRIPTION
This change does use the maven project name as bundle name, replacing
the unresolved variable which had missing translation resources.

Signed-off-by: Jens Reimann <jreimann@redhat.com>