### PR TITLE
Web: Prevent NPE in GwtNetworkServiceImpl.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Firewall/NatTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Firewall/NatTabUi.java
@@ -127,7 +127,7 @@ public class NatTabUi extends Composite implements Tab {
 
 			@Override
 			public void onSuccess(GwtXSRFToken token) {
-				gwtNetworkService.findDeviceFirewallNATs(token, new AsyncCallback<ArrayList<GwtFirewallNatEntry>>() {
+				gwtNetworkService.findDeviceFirewallNATs(token, new AsyncCallback<List<GwtFirewallNatEntry>>() {
 					@Override
 					public void onFailure(Throwable caught) {
 						EntryClassUi.hideWaitModal();
@@ -135,7 +135,7 @@ public class NatTabUi extends Composite implements Tab {
 					}
 
 					@Override
-					public void onSuccess(ArrayList<GwtFirewallNatEntry> result) {
+					public void onSuccess(List<GwtFirewallNatEntry> result) {
 						for (GwtFirewallNatEntry pair : result) {
 							natDataProvider.getList().add(pair);
 						}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Firewall/OpenPortsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Firewall/OpenPortsTabUi.java
@@ -133,7 +133,7 @@ public class OpenPortsTabUi extends Composite implements Tab {
 
 			@Override
 			public void onSuccess(GwtXSRFToken token) {
-				gwtNetworkService.findDeviceFirewallOpenPorts(token, new AsyncCallback<ArrayList<GwtFirewallOpenPortEntry>>() {
+				gwtNetworkService.findDeviceFirewallOpenPorts(token, new AsyncCallback<List<GwtFirewallOpenPortEntry>>() {
 					@Override
 					public void onFailure(Throwable caught) {
 						EntryClassUi.hideWaitModal();
@@ -141,7 +141,7 @@ public class OpenPortsTabUi extends Composite implements Tab {
 					}
 
 					@Override
-					public void onSuccess(ArrayList<GwtFirewallOpenPortEntry> result) {
+					public void onSuccess(List<GwtFirewallOpenPortEntry> result) {
 						for (GwtFirewallOpenPortEntry pair : result) {
 							openPortsDataProvider.getList().add(pair);
 						}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Firewall/PortForwardingTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Firewall/PortForwardingTabUi.java
@@ -147,7 +147,7 @@ public class PortForwardingTabUi extends Composite implements Tab {
 
 			@Override
 			public void onSuccess(GwtXSRFToken token) {
-				gwtNetworkService.findDeviceFirewallPortForwards(token, new AsyncCallback<ArrayList<GwtFirewallPortForwardEntry>>() {
+				gwtNetworkService.findDeviceFirewallPortForwards(token, new AsyncCallback<List<GwtFirewallPortForwardEntry>>() {
 
 					@Override
 					public void onFailure(Throwable caught) {
@@ -156,7 +156,7 @@ public class PortForwardingTabUi extends Composite implements Tab {
 					}
 
 					@Override
-					public void onSuccess(ArrayList<GwtFirewallPortForwardEntry> result) {
+					public void onSuccess(List<GwtFirewallPortForwardEntry> result) {
 						for (GwtFirewallPortForwardEntry pair : result) {
 							portForwardDataProvider.getList().add(pair);
 						}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/NetworkInterfacesTableUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/NetworkInterfacesTableUi.java
@@ -11,8 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui.Network;
 
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
@@ -188,7 +188,7 @@ public class NetworkInterfacesTableUi extends Composite {
 	private void loadData() {
 		EntryClassUi.showWaitModal();
 		interfacesProvider.getList().clear();
-		gwtNetworkService.findNetInterfaceConfigurations(new AsyncCallback<ArrayList<GwtNetInterfaceConfig>>() {
+		gwtNetworkService.findNetInterfaceConfigurations(new AsyncCallback<List<GwtNetInterfaceConfig>>() {
 
 			@Override
 			public void onFailure(Throwable caught) {
@@ -197,7 +197,7 @@ public class NetworkInterfacesTableUi extends Composite {
 			}
 
 			@Override
-			public void onSuccess(ArrayList<GwtNetInterfaceConfig> result) {
+			public void onSuccess(List<GwtNetInterfaceConfig> result) {
 				ListHandler<GwtNetInterfaceConfig> columnSortHandler = new ListHandler<GwtNetInterfaceConfig>(interfacesProvider.getList());
 			    columnSortHandler.setComparator(col1, new Comparator<GwtNetInterfaceConfig>() {
 			          public int compare(GwtNetInterfaceConfig o1, GwtNetInterfaceConfig o2) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabTcpIpUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabTcpIpUi.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui.Network;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -361,7 +361,7 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
 				// changed to WAN
 				if (isWanEnabled()) {
 					EntryClassUi.showWaitModal();
-					gwtNetworkService.findNetInterfaceConfigurations(new AsyncCallback<ArrayList<GwtNetInterfaceConfig>>() {
+					gwtNetworkService.findNetInterfaceConfigurations(new AsyncCallback<List<GwtNetInterfaceConfig>>() {
 						@Override
 						public void onFailure(Throwable caught) {
 							EntryClassUi.hideWaitModal();
@@ -369,7 +369,7 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
 						}
 
 						@Override
-						public void onSuccess(ArrayList<GwtNetInterfaceConfig> result) {
+						public void onSuccess(List<GwtNetInterfaceConfig> result) {
 							EntryClassUi.hideWaitModal();
 							for (GwtNetInterfaceConfig config : result) {
 								if (config.getStatusEnum().equals(GwtNetIfStatus.netIPv4StatusEnabledWAN) && !config.getName().equals(selectedNetIfConfig.getName())) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabWirelessUi.java
@@ -12,6 +12,7 @@
 package org.eclipse.kura.web.client.ui.Network;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -31,8 +32,8 @@ import org.eclipse.kura.web.shared.model.GwtWifiConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiHotspotEntry;
 import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiRadioMode;
-import org.eclipse.kura.web.shared.model.GwtWifiWirelessMode;
 import org.eclipse.kura.web.shared.model.GwtWifiSecurity;
+import org.eclipse.kura.web.shared.model.GwtWifiWirelessMode;
 import org.eclipse.kura.web.shared.model.GwtXSRFToken;
 import org.eclipse.kura.web.shared.service.GwtDeviceService;
 import org.eclipse.kura.web.shared.service.GwtDeviceServiceAsync;
@@ -1353,7 +1354,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
 				@Override
 				public void onSuccess(GwtXSRFToken token) {
-					gwtNetworkService.findWifiHotspots(token, selectedNetIfConfig.getName(), new AsyncCallback<ArrayList<GwtWifiHotspotEntry>>() {
+					gwtNetworkService.findWifiHotspots(token, selectedNetIfConfig.getName(), new AsyncCallback<List<GwtWifiHotspotEntry>>() {
 						@Override
 						public void onFailure(Throwable caught) {
 							//EntryClassUi.hideWaitModal();
@@ -1365,7 +1366,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 						}
 
 						@Override
-						public void onSuccess(ArrayList<GwtWifiHotspotEntry> result) {
+						public void onSuccess(List<GwtWifiHotspotEntry> result) {
 							for (GwtWifiHotspotEntry pair : result) {
 								ssidDataProvider.getList().add(pair);
 							}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -103,10 +103,9 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
     private static final Logger s_logger = LoggerFactory.getLogger(GwtNetworkServiceImpl.class);
 
     @Override
-    public ArrayList<GwtNetInterfaceConfig> findNetInterfaceConfigurations() throws GwtKuraException {
-        ArrayList<GwtNetInterfaceConfig> result= privateFindNetInterfaceConfigurations();
+    public List<GwtNetInterfaceConfig> findNetInterfaceConfigurations() throws GwtKuraException {
+        List<GwtNetInterfaceConfig> result= privateFindNetInterfaceConfigurations();
 
-        //List<GwtNetInterfaceConfig> listResult= result.
         for(GwtNetInterfaceConfig netConfig: result){
             if(netConfig instanceof GwtWifiNetInterfaceConfig){
                 GwtWifiNetInterfaceConfig wifiConfig= (GwtWifiNetInterfaceConfig) netConfig;
@@ -128,15 +127,16 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private ArrayList<GwtNetInterfaceConfig> privateFindNetInterfaceConfigurations() throws GwtKuraException {
+    private List<GwtNetInterfaceConfig> privateFindNetInterfaceConfigurations() throws GwtKuraException {
         s_logger.debug("Starting");
 
+        List<GwtNetInterfaceConfig> gwtNetConfigs = new ArrayList<GwtNetInterfaceConfig>();
         NetworkAdminService nas = null;
         try {
             nas = ServiceLocator.getInstance().getService(NetworkAdminService.class);
         } catch (Throwable t) {
             s_logger.warn("Exception", t);
-            return null;
+            return gwtNetConfigs;
         }
 
         ModemManagerService modemManagerService = null;
@@ -153,7 +153,6 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             s_logger.warn("{WifiClientMonitorService} Exception", t);
         }
 
-        List<GwtNetInterfaceConfig> gwtNetConfigs = new ArrayList<GwtNetInterfaceConfig>();
         try {
 
             GwtNetInterfaceConfig gwtNetConfig = null;		
@@ -679,7 +678,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
         }
 
         s_logger.debug("Returning");
-        return new ArrayList<GwtNetInterfaceConfig>(gwtNetConfigs);
+        return gwtNetConfigs;
     }
 
     @Override
@@ -802,7 +801,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
                         String passKey= new String(wifiConfig.getPasskey().getPassword());
                         if (passKey != null && passKey.equals(PLACEHOLDER)){
 
-                            ArrayList<GwtNetInterfaceConfig> result= privateFindNetInterfaceConfigurations();
+                            List<GwtNetInterfaceConfig> result= privateFindNetInterfaceConfigurations();
                             for (GwtNetInterfaceConfig netConfig: result){
                                 if (netConfig instanceof GwtWifiNetInterfaceConfig && 
                                         config.getName().equals(((GwtWifiNetInterfaceConfig) netConfig).getName())){
@@ -851,7 +850,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
 
                     String passKey= new String(gwtModemConfig.getPassword());
                     if (passKey != null && passKey.equals(PLACEHOLDER)){
-                        ArrayList<GwtNetInterfaceConfig> result= privateFindNetInterfaceConfigurations();
+                        List<GwtNetInterfaceConfig> result= privateFindNetInterfaceConfigurations();
                         for (GwtNetInterfaceConfig netConfig: result){
                             if (netConfig instanceof GwtModemInterfaceConfig){
                                 GwtModemInterfaceConfig oldModemConfig= (GwtModemInterfaceConfig) netConfig;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtNetworkService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtNetworkService.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kura.web.shared.service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.kura.web.shared.GwtKuraException;
@@ -29,17 +28,17 @@ import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 @RemoteServiceRelativePath("network")
 public interface GwtNetworkService extends RemoteService
 {
-	public ArrayList<GwtNetInterfaceConfig> findNetInterfaceConfigurations() throws GwtKuraException;
+	public List<GwtNetInterfaceConfig> findNetInterfaceConfigurations() throws GwtKuraException;
 
 	public void updateNetInterfaceConfigurations(GwtXSRFToken xsrfToken, GwtNetInterfaceConfig config) throws GwtKuraException;
 		
-	public ArrayList<GwtFirewallOpenPortEntry> findDeviceFirewallOpenPorts(GwtXSRFToken xsrfToken) throws GwtKuraException;
+	public List<GwtFirewallOpenPortEntry> findDeviceFirewallOpenPorts(GwtXSRFToken xsrfToken) throws GwtKuraException;
 
 	public void updateDeviceFirewallOpenPorts(GwtXSRFToken xsrfToken, List<GwtFirewallOpenPortEntry> entries) throws GwtKuraException;
 		
-	public ArrayList<GwtFirewallPortForwardEntry> findDeviceFirewallPortForwards(GwtXSRFToken xsrfToken) throws GwtKuraException;
+	public List<GwtFirewallPortForwardEntry> findDeviceFirewallPortForwards(GwtXSRFToken xsrfToken) throws GwtKuraException;
 	
-	public ArrayList<GwtFirewallNatEntry> findDeviceFirewallNATs(GwtXSRFToken xsrfToken) throws GwtKuraException;
+	public List<GwtFirewallNatEntry> findDeviceFirewallNATs(GwtXSRFToken xsrfToken) throws GwtKuraException;
 	
 	public void updateDeviceFirewallPortForwards(GwtXSRFToken xsrfToken, List<GwtFirewallPortForwardEntry> entries) throws GwtKuraException;
 	
@@ -47,7 +46,7 @@ public interface GwtNetworkService extends RemoteService
 	
 	public void renewDhcpLease(GwtXSRFToken xsrfToken, String interfaceName) throws GwtKuraException;
 	
-	public ArrayList<GwtWifiHotspotEntry> findWifiHotspots(GwtXSRFToken xsrfToken, String interfaceName) throws GwtKuraException;
+	public List<GwtWifiHotspotEntry> findWifiHotspots(GwtXSRFToken xsrfToken, String interfaceName) throws GwtKuraException;
 	
 	public boolean verifyWifiCredentials(GwtXSRFToken xsrfToken, String interfaceName, GwtWifiConfig gwtWifiConfig) throws GwtKuraException;
 


### PR DESCRIPTION
Fixes #468 by returning an empty list instead of null.

Modified GwtNetworkService to return ListS instead of ArrayListS.

Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>