### PR TITLE
Removing mtoolkit from the installer

### DIFF
--- a/kura/setups/kura.setup
+++ b/kura/setups/kura.setup
@@ -68,8 +68,6 @@
   <setupTask
       xsi:type="setup.p2:P2Task">
     <requirement
-        name="org.tigris.mtoolkit.feature.group"/>
-    <requirement
         name="org.eclipse.m2e.feature.feature.group"/>
     <requirement
         name="org.sonatype.tycho.m2e.feature.feature.group"/>
@@ -77,8 +75,6 @@
         name="org.eclipse.m2e.wtp.feature.feature.group"/>
     <requirement
         name="org.eclipse.oomph.setup.projects.feature.group"/>
-    <repository
-        url="http://mtoolkit.tigris.org/updates/stable"/>
     <repository
         url="http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.8.0/N/0.8.0.201409231215/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>


### PR DESCRIPTION
Since the repo is reportedly unreachable the mtoolkit elements are
removed from the installer. It is still possible to install them
afterwards.

Signed-off-by: Jens Reimann <jreimann@redhat.com>