### PR TITLE
Allow speeding up the build by disabling "jdeps"

### DIFF
--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -137,6 +137,28 @@
 				<module>org.eclipse.kura.protocol.can.test</module>
 			</modules>
 		</profile>
+		
+		<profile>
+			<id>speedup</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>verify-compact2-compliance</id>
+								<configuration>
+									<skip>true</skip>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
+		
 	</profiles>
 
 	<repositories>
@@ -549,6 +571,7 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+	
 	<!-- Use the below format to specify specific reports to run <reporting>
 		<plugins> <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-project-info-reports-plugin</artifactId>
 		<version>2.7</version> <reportSets> <reportSet> <reports> <report>index</report>


### PR DESCRIPTION
This change adds a Maven profile ("speedup") to the build, which
allows disabling the "jdeps" build.

Signed-off-by: Jens Reimann <jreimann@redhat.com>