### PR TITLE
#523 only calculate checksums once

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2016 Eurotech and others
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -10,6 +10,7 @@
 
     Contributors:
       Eurotech
+      Red Hat Inc - Fix issue #532, minor cleanups
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -23,9 +24,9 @@
 	</parent>
 
 	<artifactId>distrib</artifactId>
-
 	<name>distrib</name>
-	<url>http://maven.apache.org</url>
+	<packaging>pom</packaging>
+	
 	<properties>
 		<kura.basedir>${project.parent.basedir}</kura.basedir>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -355,10 +356,23 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<!--  rename bundles with version appended -->
 				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
+				    <execution>
+				        <!-- create a dummy file to not let the checksum mojo fail -->
+				        <id>touch-dummy-file</id>
+				        <phase>initialize</phase>
+				        <goals>
+				            <goal>run</goal>
+				        </goals>
+				        <configuration>
+				            <tasks>
+				                <touch file="target/dummy" />
+				            </tasks>
+				        </configuration>
+				    </execution>
 					<execution>
+					    <!--  rename bundles with version appended -->
 						<id>setup</id>
 						<phase>generate-resources</phase>
 						<goals>
@@ -412,7 +426,7 @@
 					</execution>
 					<execution>
 						<id>verify-if-snapshot</id>
-						<phase>install</phase>
+						<phase>initialize</phase>
 						<goals>
 							<goal>run</goal>
 						</goals>
@@ -516,6 +530,37 @@
 					</execution>
 				</executions>
 			</plugin>
+			
+			<plugin>
+				<groupId>net.ju-n.maven.plugins</groupId>
+				<artifactId>checksum-maven-plugin</artifactId>
+				<version>1.3</version>
+				<executions>
+					<execution>
+						<id>deb-checksums</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>files</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<algorithms>
+						<algorithm>MD5</algorithm>
+						<algorithm>SHA-1</algorithm>
+					</algorithms>
+					<fileSets>
+						<fileSet>
+							<directory>${basedir}/target</directory>
+							<includes>
+							    <include>dummy</include> <!-- prevent errors when there are no *.deb files -->
+								<include>*.deb</include>
+							</includes>
+						</fileSet>
+					</fileSets>
+				</configuration>
+			</plugin>
+			
 		</plugins>
 		<pluginManagement>
 			<plugins>
@@ -698,7 +743,7 @@
                         <executions>
                             <execution>
                                 <id>intel-edison-jars</id>
-                                <phase>install</phase>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
@@ -763,7 +808,7 @@
                         <executions>
                             <execution>
                                 <id>intel-edison-nn-jars</id>
-                                <phase>install</phase>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
@@ -831,7 +876,7 @@
 						<executions>
 							<execution>
 								<id>beaglebone-jars</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>run</goal>
 								</goals>
@@ -881,7 +926,7 @@
 						<executions>
 							<execution>
 								<id>beaglebone-deb</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
@@ -903,34 +948,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-        				<groupId>net.ju-n.maven.plugins</groupId>
-        				<artifactId>checksum-maven-plugin</artifactId>
-        				<version>1.3</version>
-        				<executions>
-          					<execution>
-          						<id>beaglebone-deb-checksums</id>
-								<phase>install</phase>
-            					<goals>
-              						<goal>files</goal>
-            					</goals>
-          					</execution>
-        				</executions>
-        				<configuration>
-          					<algorithms>
-             					<algorithm>MD5</algorithm>
-             					<algorithm>SHA-1</algorithm>
-             				</algorithms>
-             				<fileSets>
-  								<fileSet>
-    								<directory>${basedir}/target</directory>
-    								<includes>
-      									<include>*.deb</include>
-    								</includes>
-  								</fileSet>
-							</fileSets>
-        				</configuration>
-      				</plugin>
 				</plugins>
 			</build>
 		</profile>
@@ -974,7 +991,7 @@
 						<executions>
 							<execution>
 								<id>beaglebone-nn-jars</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>run</goal>
 								</goals>
@@ -1004,7 +1021,7 @@
 						<executions>
 							<execution>
 								<id>beaglebone-nn-deb</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
@@ -1026,34 +1043,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-        				<groupId>net.ju-n.maven.plugins</groupId>
-        				<artifactId>checksum-maven-plugin</artifactId>
-        				<version>1.3</version>
-        				<executions>
-          					<execution>
-          						<id>beaglebone-nn-deb-checksums</id>
-								<phase>install</phase>
-            					<goals>
-              						<goal>files</goal>
-            					</goals>
-          					</execution>
-        				</executions>
-        				<configuration>
-          					<algorithms>
-             					<algorithm>MD5</algorithm>
-             					<algorithm>SHA-1</algorithm>
-             				</algorithms>
-             				<fileSets>
-  								<fileSet>
-    								<directory>${basedir}/target</directory>
-    								<includes>
-      									<include>*.deb</include>
-    								</includes>
-  								</fileSet>
-							</fileSets>
-        				</configuration>
-      				</plugin>
 				</plugins>
 			</build>
 		</profile>
@@ -1097,7 +1086,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-jars</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>run</goal>
 								</goals>
@@ -1137,7 +1126,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-deb</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
@@ -1159,34 +1148,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-        				<groupId>net.ju-n.maven.plugins</groupId>
-        				<artifactId>checksum-maven-plugin</artifactId>
-        				<version>1.3</version>
-        				<executions>
-          					<execution>
-          						<id>raspberry-pi-deb-checksums</id>
-								<phase>install</phase>
-            					<goals>
-              						<goal>files</goal>
-            					</goals>
-          					</execution>
-        				</executions>
-        				<configuration>
-          					<algorithms>
-             					<algorithm>MD5</algorithm>
-             					<algorithm>SHA-1</algorithm>
-             				</algorithms>
-             				<fileSets>
-  								<fileSet>
-    								<directory>${basedir}/target</directory>
-    								<includes>
-      									<include>*.deb</include>
-    								</includes>
-  								</fileSet>
-							</fileSets>
-        				</configuration>
-      				</plugin>
 				</plugins>
 			</build>
 		</profile>
@@ -1229,7 +1190,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-nn-jars</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>run</goal>
 								</goals>
@@ -1258,7 +1219,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-nn-deb</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
@@ -1280,34 +1241,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-        				<groupId>net.ju-n.maven.plugins</groupId>
-        				<artifactId>checksum-maven-plugin</artifactId>
-        				<version>1.3</version>
-        				<executions>
-          					<execution>
-          						<id>raspberry-pi-nn-deb-checksums</id>
-								<phase>install</phase>
-            					<goals>
-              						<goal>files</goal>
-            					</goals>
-          					</execution>
-        				</executions>
-        				<configuration>
-          					<algorithms>
-             					<algorithm>MD5</algorithm>
-             					<algorithm>SHA-1</algorithm>
-             				</algorithms>
-             				<fileSets>
-  								<fileSet>
-    								<directory>${basedir}/target</directory>
-    								<includes>
-      									<include>*.deb</include>
-    								</includes>
-  								</fileSet>
-							</fileSets>
-        				</configuration>
-      				</plugin>
 				</plugins>
 			</build>
 		</profile>
@@ -1351,7 +1284,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-bplus-jars</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>run</goal>
 								</goals>
@@ -1391,7 +1324,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-bplus-deb</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
@@ -1413,34 +1346,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-        				<groupId>net.ju-n.maven.plugins</groupId>
-        				<artifactId>checksum-maven-plugin</artifactId>
-        				<version>1.3</version>
-        				<executions>
-          					<execution>
-          						<id>raspberry-pi-bplus-deb-checksums</id>
-								<phase>install</phase>
-            					<goals>
-              						<goal>files</goal>
-            					</goals>
-          					</execution>
-        				</executions>
-        				<configuration>
-          					<algorithms>
-             					<algorithm>MD5</algorithm>
-             					<algorithm>SHA-1</algorithm>
-             				</algorithms>
-             				<fileSets>
-  								<fileSet>
-    								<directory>${basedir}/target</directory>
-    								<includes>
-      									<include>*.deb</include>
-    								</includes>
-  								</fileSet>
-							</fileSets>
-        				</configuration>
-      				</plugin>
 				</plugins>
 			</build>
 		</profile>
@@ -1483,7 +1388,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-bplus-nn-jars</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>run</goal>
 								</goals>
@@ -1512,7 +1417,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-bplus-nn-deb</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
@@ -1534,34 +1439,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-        				<groupId>net.ju-n.maven.plugins</groupId>
-        				<artifactId>checksum-maven-plugin</artifactId>
-        				<version>1.3</version>
-        				<executions>
-          					<execution>
-          						<id>raspberry-pi-bplus-nn-deb-checksums</id>
-								<phase>install</phase>
-            					<goals>
-              						<goal>files</goal>
-            					</goals>
-          					</execution>
-        				</executions>
-        				<configuration>
-          					<algorithms>
-             					<algorithm>MD5</algorithm>
-             					<algorithm>SHA-1</algorithm>
-             				</algorithms>
-             				<fileSets>
-  								<fileSet>
-    								<directory>${basedir}/target</directory>
-    								<includes>
-      									<include>*.deb</include>
-    								</includes>
-  								</fileSet>
-							</fileSets>
-        				</configuration>
-      				</plugin>
 				</plugins>
 			</build>
 		</profile>
@@ -1605,7 +1482,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-2-jars</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>run</goal>
 								</goals>
@@ -1635,7 +1512,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-2-deb</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
@@ -1657,34 +1534,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-        				<groupId>net.ju-n.maven.plugins</groupId>
-        				<artifactId>checksum-maven-plugin</artifactId>
-        				<version>1.3</version>
-        				<executions>
-          					<execution>
-          						<id>raspberry-pi-2-deb-checksums</id>
-								<phase>install</phase>
-            					<goals>
-              						<goal>files</goal>
-            					</goals>
-          					</execution>
-        				</executions>
-        				<configuration>
-          					<algorithms>
-             					<algorithm>MD5</algorithm>
-             					<algorithm>SHA-1</algorithm>
-             				</algorithms>
-             				<fileSets>
-  								<fileSet>
-    								<directory>${basedir}/target</directory>
-    								<includes>
-      									<include>*.deb</include>
-    								</includes>
-  								</fileSet>
-							</fileSets>
-        				</configuration>
-      				</plugin>
 				</plugins>
 			</build>
 		</profile>
@@ -1728,7 +1577,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-2-nn-jars</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>run</goal>
 								</goals>
@@ -1758,7 +1607,7 @@
 						<executions>
 							<execution>
 								<id>raspberry-pi-2-nn-deb</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
@@ -1780,34 +1629,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<plugin>
-        				<groupId>net.ju-n.maven.plugins</groupId>
-        				<artifactId>checksum-maven-plugin</artifactId>
-        				<version>1.3</version>
-        				<executions>
-          					<execution>
-          						<id>raspberry-pi-2-nn-deb-checksums</id>
-								<phase>install</phase>
-            					<goals>
-              						<goal>files</goal>
-            					</goals>
-          					</execution>
-        				</executions>
-        				<configuration>
-          					<algorithms>
-             					<algorithm>MD5</algorithm>
-             					<algorithm>SHA-1</algorithm>
-             				</algorithms>
-             				<fileSets>
-  								<fileSet>
-    								<directory>${basedir}/target</directory>
-    								<includes>
-      									<include>*.deb</include>
-    								</includes>
-  								</fileSet>
-							</fileSets>
-        				</configuration>
-      				</plugin>
 				</plugins>
 			</build>
 		</profile>
@@ -1845,7 +1666,7 @@
 						<executions>
 							<execution>
 								<id>Win64-nn-jars</id>
-								<phase>install</phase>
+								<phase>package</phase>
 								<goals>
 									<goal>run</goal>
 								</goals>


### PR DESCRIPTION
This changed does restructure the build so that they get only calculated
once. Before that each device profile did generate the checksums for
all other device profiles in addition.

The main change is that the calls to "build_equinix_distrib.xml" get
shifted to the "package" phase and that there is only one call to the
checksum plugin in the "install" phase.

In order to not let the checksum plugin fail when do "deb" profile is
active, a dummy file is being generated early in the build.

Signed-off-by: Jens Reimann <jreimann@redhat.com>