### PR TITLE
#573: Fix client side NPE on field entries

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.java
@@ -346,8 +346,8 @@ public class ServicesUi extends Composite {
             logger.fine("Widget: " + fg.getClass());
 
             if (fg.getWidget(i) instanceof FormLabel) {
-                String id = ((FormLabel) fg.getWidget(i)).getText();
-                param = m_configurableComponent.getParameter(id.trim().replaceAll("\\*$", ""));
+                final String id = ((FormLabel) fg.getWidget(i)).getTitle();
+                param = m_configurableComponent.getParameter(id);
 
             } else if (fg.getWidget(i) instanceof ListBox || fg.getWidget(i) instanceof Input || fg.getWidget(i) instanceof TextBoxBase) {
 
@@ -453,11 +453,11 @@ public class ServicesUi extends Composite {
 
         if (isFirstInstance) {
             FormLabel formLabel = new FormLabel();
+            formLabel.setTitle(param.getId()); // title is used to hold ID
             formLabel.setText(param.getName());
             if (param.isRequired()) {
                 formLabel.setShowRequiredIndicator(true);
             }
-            formLabel.setTitle(param.getId());
             formGroup.add(formLabel);
 
             InlineHelpBlock ihb = new InlineHelpBlock();
@@ -615,6 +615,7 @@ public class ServicesUi extends Composite {
 
         if (isFirstInstance) {
             FormLabel formLabel = new FormLabel();
+            formLabel.setTitle(param.getId()); // title is used to hold ID
             formLabel.setText(param.getName());
             if (param.isRequired()) {
                 formLabel.setShowRequiredIndicator(true);
@@ -682,6 +683,7 @@ public class ServicesUi extends Composite {
 
         if (isFirstInstance) {
             FormLabel formLabel = new FormLabel();
+            formLabel.setTitle(param.getId()); // title is used to hold ID
             formLabel.setText(param.getName());
             if (param.isRequired()) {
                 formLabel.setShowRequiredIndicator(true);
@@ -747,6 +749,7 @@ public class ServicesUi extends Composite {
 
         if (isFirstInstance) {
             FormLabel formLabel = new FormLabel();
+            formLabel.setTitle(param.getId()); // title is used to hold ID
             formLabel.setText(param.getName());
             if (param.isRequired()) {
                 formLabel.setShowRequiredIndicator(true);


### PR DESCRIPTION
This change does revert the regression introduced by commits 41c3180c9054ac1871687cff00bf36df8c22f5a1 and 06ce1f387ee17cf6c0c1c5b890b1c860d389c656 which does shift the information of the "id" to the "title" attribute rather then the field's label.

The original commit 06ce1f387ee17cf6c0c1c5b890b1c860d389c656 did not fill the title though for fields other than the text field and commit 41c3180c9054ac1871687cff00bf36df8c22f5a1 only reverted this partly, removing the null check, letting the client run into a NPE.

Signed-off-by: Jens Reimann <jreimann@redhat.com>