### PR TITLE
Fix issue #596 by providing `null` as location

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -312,7 +312,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
             mergedProperties.put(ConfigurationService.KURA_SERVICE_PID, pid);
 
             Dictionary<String, Object> dict = CollectionsUtil.mapToDictionary(mergedProperties);
-            Configuration config = this.m_configurationAdmin.getConfiguration(servicePid, null);
+            Configuration config = this.m_configurationAdmin.getConfiguration(servicePid, "?");
             config.update(dict);
 
             registerComponentConfiguration(pid, servicePid, factoryPid);
@@ -337,7 +337,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
         try {
             s_logger.info("Deleting configuration for pid {}", pid);
-            Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), null);
+            Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
 
             if (config != null) {
                 config.delete();
@@ -673,7 +673,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         if (servicePid == null) {
             servicePid = pid;
         }
-        Configuration config = this.m_configurationAdmin.getConfiguration(servicePid, null);
+        Configuration config = this.m_configurationAdmin.getConfiguration(servicePid,  "?");
         if (config != null) {
             // get the properties from ConfigurationAdmin if any are present
             Map<String, Object> props = new HashMap<String, Object>();
@@ -904,7 +904,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
             Tocd ocd = getOCDForPid(pid);
 
-            Configuration cfg = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), null);
+            Configuration cfg = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
             Map<String, Object> props = CollectionsUtil.dictionaryToMap(cfg.getProperties(), ocd);
 
             cc = new ComponentConfigurationImpl(pid, ocd, props);
@@ -1098,7 +1098,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
                             s_logger.debug("Pushing config to config admin: {}", config.getPid());
 
                             // push it to the ConfigAdmin
-                            Configuration cfg = this.m_configurationAdmin.getConfiguration(config.getPid(), null);
+                            Configuration cfg = this.m_configurationAdmin.getConfiguration(config.getPid(),  "?");
 
                             // set kura.service.pid if missing
                             Map<String, Object> newProperties = new HashMap<String, Object>(props);
@@ -1229,7 +1229,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         if (!this.m_activatedSelfConfigComponents.contains(pid)) {
             try {
                 // get the current running configuration for the selected component
-                Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), null);
+                Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
                 Map<String, Object> runningProps = CollectionsUtil.dictionaryToMap(config.getProperties(),
                         registerdOCD);
 
@@ -1302,7 +1302,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
         // Update the new properties
         // use ConfigurationAdmin to do the update
-        Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), null);
+        Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
         config.update(CollectionsUtil.mapToDictionary(mergedProperties));
 
         if (snapshotOnConfirmation) {

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech
- *     Red Hat Inc - Fix issue #462, Fix build warnings
+ *     Red Hat Inc - Fix issue #462, Fix build warnings, Fix issue #596
  *******************************************************************************/
 package org.eclipse.kura.core.configuration;
 
@@ -337,7 +337,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
         try {
             s_logger.info("Deleting configuration for pid {}", pid);
-            Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid));
+            Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), null);
 
             if (config != null) {
                 config.delete();
@@ -673,7 +673,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         if (servicePid == null) {
             servicePid = pid;
         }
-        Configuration config = this.m_configurationAdmin.getConfiguration(servicePid);
+        Configuration config = this.m_configurationAdmin.getConfiguration(servicePid, null);
         if (config != null) {
             // get the properties from ConfigurationAdmin if any are present
             Map<String, Object> props = new HashMap<String, Object>();
@@ -1229,7 +1229,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         if (!this.m_activatedSelfConfigComponents.contains(pid)) {
             try {
                 // get the current running configuration for the selected component
-                Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid));
+                Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), null);
                 Map<String, Object> runningProps = CollectionsUtil.dictionaryToMap(config.getProperties(),
                         registerdOCD);
 

--- a/kura/org.eclipse.kura.test/src/org/eclipse/kura/test/RemoteTargetTest.java
+++ b/kura/org.eclipse.kura.test/src/org/eclipse/kura/test/RemoteTargetTest.java
@@ -198,7 +198,7 @@ public class RemoteTargetTest {
         // hijack the settings
         try {
             Configuration mqttConfig = this.m_configAdmin
-                    .getConfiguration("org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport", null);
+                    .getConfiguration("org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport",  "?");
             Dictionary<String, Object> mqttProps = mqttConfig.getProperties();
             mqttProps.put("broker-url", "mqtt://broker-sandbox.everyware-cloud.com:1883/");
             mqttProps.put("topic.context.account-name", "EDC-KURA-CI");
@@ -206,7 +206,7 @@ public class RemoteTargetTest {
             mqttProps.put("password", "PYtv3?s@");
             mqttConfig.update(mqttProps);
 
-            Configuration dataConfig = this.m_configAdmin.getConfiguration("org.eclipse.kura.data.DataService", null);
+            Configuration dataConfig = this.m_configAdmin.getConfiguration("org.eclipse.kura.data.DataService", "?");
             Dictionary<String, Object> dataProps = dataConfig.getProperties();
             dataProps.put("connect.auto-on-startup", true);
             dataConfig.update(dataProps);

--- a/kura/org.eclipse.kura.test/src/org/eclipse/kura/test/RemoteTargetTest.java
+++ b/kura/org.eclipse.kura.test/src/org/eclipse/kura/test/RemoteTargetTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2016 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,7 +8,7 @@
  *
  * Contributors:
  *     Eurotech
- *     Red Hat Inc - Fix build warnings
+ *     Red Hat Inc - Fix build warnings, Fix issue #596
  *******************************************************************************/
 package org.eclipse.kura.test;
 
@@ -198,7 +198,7 @@ public class RemoteTargetTest {
         // hijack the settings
         try {
             Configuration mqttConfig = this.m_configAdmin
-                    .getConfiguration("org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport");
+                    .getConfiguration("org.eclipse.kura.core.data.transport.mqtt.MqttDataTransport", null);
             Dictionary<String, Object> mqttProps = mqttConfig.getProperties();
             mqttProps.put("broker-url", "mqtt://broker-sandbox.everyware-cloud.com:1883/");
             mqttProps.put("topic.context.account-name", "EDC-KURA-CI");
@@ -206,7 +206,7 @@ public class RemoteTargetTest {
             mqttProps.put("password", "PYtv3?s@");
             mqttConfig.update(mqttProps);
 
-            Configuration dataConfig = this.m_configAdmin.getConfiguration("org.eclipse.kura.data.DataService");
+            Configuration dataConfig = this.m_configAdmin.getConfiguration("org.eclipse.kura.data.DataService", null);
             Dictionary<String, Object> dataProps = dataConfig.getProperties();
             dataProps.put("connect.auto-on-startup", true);
             dataConfig.update(dataProps);


### PR DESCRIPTION
This change does fix the issue of wrongly bound configurations by
calling getConfiguration(String,String) with `null` as location
argument.

Signed-off-by: Jens Reimann <jreimann@redhat.com>