### PR TITLE
Fix a few resource leaks

### DIFF
--- a/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.core
 Bundle-SymbolicName: org.eclipse.kura.core;singleton:=true
 Bundle-Version: 1.0.10.qualifier
-Bundle-Vendor: EUROTECH
+Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.eclipse.kura.core.linux.util; version="1.0.0", org.eclipse.kura.core.util; version="1.1.0"
 Service-Component: OSGI-INF/*.xml


### PR DESCRIPTION
This change does properly close input streams after loading of 
properties.

As the Java documentation for `load` states:

 > The specified stream remains open after this method returns.

It also wraps some close calls into a finally section in order to ensure
that the close is called in case of an error.