### PR TITLE
Start the Web UI component immediately

### DIFF
--- a/kura/org.eclipse.kura.web2/OSGI-INF/web.xml
+++ b/kura/org.eclipse.kura.web2/OSGI-INF/web.xml
@@ -12,8 +12,7 @@
       Eurotech
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
-               activate="activate" configuration-policy="require" deactivate="deactivate" modified="updated" name="org.eclipse.kura.web.Console">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" immediate="true" modified="updated" name="org.eclipse.kura.web.Console">
    <implementation class="org.eclipse.kura.web.Console"/>
    <property name="servlet.alias.root" value="/denali"/>
    <reference name="HttpService" 


### PR DESCRIPTION
The Web UI component should be started immediately on startup. If the
immediate attribute is not set, the component will become a "delayed"
component and only be activated once there is a reference to it (also
see 112.5.4 of the OSGi compendium specification). However no one will
actively reference this component.

Signed-off-by: Jens Reimann <jreimann@redhat.com>