### PR TITLE
Enable BREE validation on Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@ language: java
 sudo: false
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
-script: ./build-all.sh
+before_script:
+  - ls /usr/lib/jvm
+  - cp kura/setups/toolchains/toolchains-travis.xml ~/.m2/toolchains.xml
+
+script: ./build-all.sh -Pbree
 
 

--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -159,6 +159,21 @@
 			</build>
 		</profile>
 		
+        <profile>
+            <id>bree</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-compiler-plugin</artifactId>
+                        <version>${tycho-version}</version>
+                        <configuration>
+                            <useJDK>BREE</useJDK>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 		
 	</profiles>
 
@@ -275,8 +290,6 @@
 				<artifactId>tycho-compiler-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
 					<compilerArgument>-warn:[+|-]warning_tokens_separated_by_comma</compilerArgument>
 				</configuration>
 			</plugin>

--- a/kura/setups/toolchains/toolchains-rhel7.xml
+++ b/kura/setups/toolchains/toolchains-rhel7.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF8"?>
+<!--
+  - RHEL based toolchain file:
+  -   sudo yum install java-1.6.0-openjdk-devel java-1.7.0-openjdk-devel java-1.8.0-openjdk-devel
+  -->
+<toolchains>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<version>1.6</version>
+			<id>JavaSE-1.6</id>
+		</provides>
+		<configuration>
+			<jdkHome>/usr/lib/jvm/java-1.6.0/jre</jdkHome>
+		</configuration>
+	</toolchain>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<version>1.7</version>
+			<id>JavaSE-1.7</id>
+		</provides>
+		<configuration>
+			<jdkHome>/usr/lib/jvm/java-1.7.0</jdkHome>
+		</configuration>
+	</toolchain>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<version>1.8</version>
+			<id>JavaSE-1.8</id>
+		</provides>
+		<configuration>
+			<jdkHome>/usr/lib/jvm/java-1.8.0</jdkHome>
+		</configuration>
+	</toolchain>
+</toolchains>

--- a/kura/setups/toolchains/toolchains-travis.xml
+++ b/kura/setups/toolchains/toolchains-travis.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF8"?>
+<!--
+  - Travis CI based toolchain file
+  -->
+<toolchains>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<version>1.6</version>
+			<id>JavaSE-1.6</id>
+		</provides>
+		<configuration>
+			<jdkHome>/usr/lib/jvm/java-6-openjdk-amd64/jre</jdkHome>
+		</configuration>
+	</toolchain>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<version>1.7</version>
+			<id>JavaSE-1.7</id>
+		</provides>
+		<configuration>
+			<jdkHome>/usr/lib/jvm/java-7-openjdk-amd64/jre</jdkHome>
+		</configuration>
+	</toolchain>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<version>1.8</version>
+			<id>JavaSE-1.8</id>
+		</provides>
+		<configuration>
+			<jdkHome>/usr/lib/jvm/java-8-oracle/jre</jdkHome>
+		</configuration>
+	</toolchain>
+</toolchains>


### PR DESCRIPTION
This change adds a BREE validation profile to the existing tycho build.
A profile can be used to enable this validation and by default this
profile is not active.

This profile is turned on during the Travis CI build, so that code can
be validated against the actual configured BREE.

Signed-off-by: Jens Reimann <jreimann@redhat.com>