### PR TITLE
Let example services export ConfigurableComponent

### DIFF
--- a/kura/examples/org.eclipse.kura.example.gpio/OSGI-INF/gpio.xml
+++ b/kura/examples/org.eclipse.kura.example.gpio/OSGI-INF/gpio.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2016 Eurotech and others
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -10,6 +10,7 @@
 
     Contributors:
       Eurotech
+      Red Hat Inc - Export ConfigurableComponent
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
@@ -25,7 +26,7 @@
    <!-- If the component is configurable through the Kura ConfigurationService, it must expose a Service. -->
    <property name="service.pid" type="String" value="org.eclipse.kura.example.gpio.GpioComponent"/>
    <service>
-       <provide interface="org.eclipse.kura.example.gpio.GpioComponent"/>
+       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <reference name="GPIOService" 
               cardinality="1..1" 

--- a/kura/examples/org.eclipse.kura.example.publisher/OSGI-INF/example.xml
+++ b/kura/examples/org.eclipse.kura.example.publisher/OSGI-INF/example.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2016 Eurotech and others
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -10,6 +10,7 @@
 
     Contributors:
       Eurotech
+      Red Hat Inc - Export ConfigurableComponent
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
@@ -25,7 +26,7 @@
    <!-- If the component is configurable through the Kura ConfigurationService, it must expose a Service. -->
    <property name="service.pid" type="String" value="org.eclipse.kura.example.publisher.ExamplePublisher"/>
    <service>
-       <provide interface="org.eclipse.kura.example.publisher.ExamplePublisher"/>
+       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    
    <reference name="CloudService"

--- a/kura/examples/org.eclipse.kura.example.serial.publisher/OSGI-INF/example.xml
+++ b/kura/examples/org.eclipse.kura.example.serial.publisher/OSGI-INF/example.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2016 Eurotech and others
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -10,6 +10,7 @@
 
     Contributors:
       Eurotech
+      Red Hat Inc - Export ConfigurableComponent
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
@@ -25,7 +26,7 @@
    <!-- If the component is configurable through the Kura ConfigurationService, it must expose a Service. -->
    <property name="service.pid" type="String" value="org.eclipse.kura.example.serial.publisher.ExampleSerialPublisher"/>
    <service>
-       <provide interface="org.eclipse.kura.example.serial.publisher.ExampleSerialPublisher"/>
+       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    
    <reference name="CloudService"


### PR DESCRIPTION
This change does export the interface ConfigurableComponent when
components do implement this.

This is necessary since the ConfigurationService can now be configured
to only track matching services.

Signed-off-by: Jens Reimann <jreimann@redhat.com>