### PR TITLE
Minor cleanups to the Linux ClockServiceImpl

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/clock/ClockEvent.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/clock/ClockEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2016 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,9 +8,11 @@
  *
  * Contributors:
  *     Eurotech
+ *     Red Hat Inc - provide a default instance
  *******************************************************************************/
 package org.eclipse.kura.clock;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.osgi.service.event.Event;
@@ -22,6 +24,8 @@ public class ClockEvent extends Event {
 
     /** Topic of the ClockEvent */
     public static final String CLOCK_EVENT_TOPIC = "org/eclipse/kura/clock";
+
+    public static final ClockEvent EMPTY = new ClockEvent(Collections.<String, Object> emptyMap());
 
     public ClockEvent(Map<String, ?> properties) {
         super(CLOCK_EVENT_TOPIC, properties);

--- a/kura/org.eclipse.kura.linux.clock/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.linux.clock/META-INF/MANIFEST.MF
@@ -10,12 +10,11 @@ Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.commons.net;version="3.1.0",
  org.apache.commons.net.ntp;version="3.1.0",
- org.eclipse.kura; version="[1.0,2.0)",
- org.eclipse.kura.clock; version="[1.0,1.1)",
- org.eclipse.kura.configuration; version="[1.1,1.2)",
- org.eclipse.kura.core.util; version="[1.0,2.0)",
- org.eclipse.kura.position; version="[1.0,2.0)",
+ org.eclipse.kura;version="[1.0,2.0)",
+ org.eclipse.kura.clock;version="[1.0,1.1)",
+ org.eclipse.kura.configuration;version="[1.1,1.2)",
+ org.eclipse.kura.core.util;version="[1.0,2.0)",
+ org.eclipse.kura.position;version="[1.0,2.0)",
  org.osgi.framework;version="1.5.0",
- org.osgi.service.component;version="1.2.0",
  org.osgi.service.event;version="1.3.0",
  org.slf4j;version="1.6.4"


### PR DESCRIPTION
This change:

 * Uses a static instance of the ClockEvent in order to not generate
   empty instances
 * Shows the return code when the hwlock command fails
 * Cleans up a few minor things

Signed-off-by: Jens Reimann <jreimann@redhat.com>