### PR TITLE
Fix Camel imports

### DIFF
--- a/kura/examples/org.eclipse.kura.example.camel.aggregation/META-INF/MANIFEST.MF
+++ b/kura/examples/org.eclipse.kura.example.camel.aggregation/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/*.xml
 Import-Package: org.apache.camel;version="[2.17.0,3.0.0)",
  org.apache.camel.builder;version="[2.17.0,3.0.0)",
- org.apache.camel.component.kura;version="[2.17.0,3.0.0)",
  org.apache.camel.model;version="[2.17.0,3.0.0)",
  org.apache.camel.processor.aggregate;version="[2.17.0,3.0.0)",
  org.apache.camel.support;version="[2.17.0,3.0.0)",


### PR DESCRIPTION
Don't import org.apache.camel.component.kura anymore

Signed-off-by: Jens Reimann <jreimann@redhat.com>