### PR TITLE
Add DependencyManagement to Camel Examples

### DIFF
--- a/kura/examples/org.eclipse.kura.example.camel.aggregation/pom.xml
+++ b/kura/examples/org.eclipse.kura.example.camel.aggregation/pom.xml
@@ -24,7 +24,20 @@
 		</repository>
 	</repositories>
 
-	<build>
+    <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>Kura Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/kura-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>Kura Repository - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
+        </snapshotRepository>
+	</distributionManagement>
+
+    <build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>

--- a/kura/examples/org.eclipse.kura.example.camel.quickstart/pom.xml
+++ b/kura/examples/org.eclipse.kura.example.camel.quickstart/pom.xml
@@ -24,7 +24,20 @@
 		</repository>
 	</repositories>
 
-	<build>
+	<distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>Kura Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/kura-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>Kura Repository - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
+        </snapshotRepository>
+	</distributionManagement>
+
+    <build>
 		<plugins>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
This fix adds the DependencyManagement section to the pom so artifacts can
be distributed to the Nexus repo.

@ctron I assume we want to distribute these. If not we will need to skip the deploy step during a release build.