### PR TITLE
Renamed .deb name to include support for raspberry pi 3

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -1440,7 +1440,7 @@
 		</profile>
 
 		<profile>
-			<id>raspberry-pi-2</id>
+			<id>raspberry-pi-2-3</id>
 			<properties>
 				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw, dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies>
 <!--
@@ -1477,7 +1477,7 @@
 						<version>1.7</version>
 						<executions>
 							<execution>
-								<id>raspberry-pi-2-jars</id>
+								<id>raspberry-pi-2-3-jars</id>
 								<phase>prepare-package</phase>
 								<goals>
 									<goal>run</goal>
@@ -1507,14 +1507,14 @@
 						<version>1.0</version>
 						<executions>
 							<execution>
-								<id>raspberry-pi-2-deb</id>
+								<id>raspberry-pi-2-3-deb</id>
 								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
 								<configuration>
 									<verbose>true</verbose>
-									<deb>${basedir}/target/kura_${project.version}_raspberry-pi-2_installer.deb</deb>
+									<deb>${basedir}/target/kura_${project.version}_raspberry-pi-2-3_installer.deb</deb>
 									<controlDir>${basedir}/src/main/deb/control</controlDir>
 									<dataSet>
 										<data>
@@ -1535,7 +1535,7 @@
 		</profile>
 
 		<profile>
-			<id>raspberry-pi-2-nn</id>
+			<id>raspberry-pi-2-3-nn</id>
 			<properties>
 				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies.nn>
 <!--
@@ -1572,7 +1572,7 @@
 						<version>1.7</version>
 						<executions>
 							<execution>
-								<id>raspberry-pi-2-nn-jars</id>
+								<id>raspberry-pi-2-3-nn-jars</id>
 								<phase>prepare-package</phase>
 								<goals>
 									<goal>run</goal>
@@ -1602,14 +1602,14 @@
 						<version>1.0</version>
 						<executions>
 							<execution>
-								<id>raspberry-pi-2-nn-deb</id>
+								<id>raspberry-pi-2-3-nn-deb</id>
 								<phase>package</phase>
 								<goals>
 									<goal>jdeb</goal>
 								</goals>
 								<configuration>
 									<verbose>true</verbose>
-									<deb>${basedir}/target/kura_${project.version}_raspberry-pi-2-nn_installer.deb</deb>
+									<deb>${basedir}/target/kura_${project.version}_raspberry-pi-2-3-nn_installer.deb</deb>
 									<controlDir>${basedir}/src/main/deb/control_nn</controlDir>
 									<dataSet>
 										<data>

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -1,4 +1,4 @@
-kura.version=2.1.0-SNAPSHOT
+kura.version=2.1.0
 com.codeminders.hidapi.version=1.1.1
 javax.usb.api.version=1.0.2
 javax.usb.common.version=1.0.2


### PR DESCRIPTION
Solved small issue in version.

Closes #642 

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>