### PR TITLE
#706: Enable unit tests when running on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ before_script:
   - ls /usr/lib/jvm
   - cp kura/setups/toolchains/toolchains-travis.xml ~/.m2/toolchains.xml
 
-script: ./build-all.sh -Pbree
+script: RUN_TESTS=true ./build-all.sh -Pbree
 
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -12,6 +12,8 @@
 #     Red Hat - Initial API and implementation
 #
 
-mvn "$@" -f target-platform/pom.xml clean install &&
-mvn "$@" -f kura/manifest_pom.xml clean install -Dmaven.test.skip=true &&
-mvn "$@" -f kura/pom_pom.xml clean install -Dmaven.test.skip=true -Pweb
+[ -z "$RUN_TESTS" ] && MAVEN_PROPS="-Dmaven.test.skip=true"
+
+mvn "$@" -f target-platform/pom.xml clean install $MAVEN_PROPS &&
+mvn "$@" -f kura/manifest_pom.xml clean install  $MAVEN_PROPS &&
+mvn "$@" -f kura/pom_pom.xml clean install $MAVEN_PROPS -Pweb

--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -105,6 +105,9 @@
         <module>emulator</module>
         <module>examples</module>
         <module>test</module>
+        
+        <!-- A module containing log4j configuration for running unit tests -->
+        <module>log4j.test.configuration</module>
     </modules>
 
     <properties>

--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -100,8 +100,6 @@
         <module>org.eclipse.kura.wire.provider.test</module>
         -->
 
-        <module>log4j.test.configuration</module>
-
         <module>emulator</module>
         <module>examples</module>
         <module>test</module>

--- a/kura/org.eclipse.kura.core.test/pom.xml
+++ b/kura/org.eclipse.kura.core.test/pom.xml
@@ -38,10 +38,6 @@
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <version>${tycho-version}</version>
                 <configuration>
-                
-                    <!-- skip execution of this package until it is working again -->
-                    <skip>true</skip>
-                
                     <providerHint>junit4</providerHint>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <testSuite>org.eclipse.kura.core.test</testSuite>

--- a/kura/org.eclipse.kura.core.test/pom.xml
+++ b/kura/org.eclipse.kura.core.test/pom.xml
@@ -38,6 +38,10 @@
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <version>${tycho-version}</version>
                 <configuration>
+                
+                    <!-- skip execution of this package until it is working again -->
+                    <skip>true</skip>
+                
                     <providerHint>junit4</providerHint>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <testSuite>org.eclipse.kura.core.test</testSuite>


### PR DESCRIPTION
This PR allows to run the unit tests with the `build-all.sh` script on request. The default is still not to run those tests.

On Travis CI the flag is set and unit tests get executed. The intention is to fail the build if unit tests fail.