### PR TITLE
Lower camel imports to 2.17.0

### DIFF
--- a/kura/org.eclipse.kura.camel.cloud.factory/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.camel.cloud.factory/META-INF/MANIFEST.MF
@@ -6,11 +6,11 @@ Bundle-Version: 1.0.0
 Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
-Import-Package: org.apache.camel;version="[2.17.2,3.0.0)",
- org.apache.camel.core.osgi;version="[2.17.2,3.0.0)",
- org.apache.camel.impl;version="[2.17.2,3.0.0)",
- org.apache.camel.model;version="[2.17.2,3.0.0)",
- org.apache.camel.support;version="[2.17.2,3.0.0)",
+Import-Package: org.apache.camel;version="[2.17.0,3.0.0)",
+ org.apache.camel.core.osgi;version="[2.17.0,3.0.0)",
+ org.apache.camel.impl;version="[2.17.0,3.0.0)",
+ org.apache.camel.model;version="[2.17.0,3.0.0)",
+ org.apache.camel.support;version="[2.17.0,3.0.0)",
  org.eclipse.kura;version="[1.2,2.0)",
  org.eclipse.kura.camel.camelcloud;version="[1.1,2.0)",
  org.eclipse.kura.camel.cloud;version="[1.1,2.0)",

--- a/kura/org.eclipse.kura.camel/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.camel/META-INF/MANIFEST.MF
@@ -7,12 +7,12 @@ Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
-Import-Package: org.apache.camel;version="[2.17.2,3.0.0)",
- org.apache.camel.builder;version="[2.17.2,3.0.0)",
- org.apache.camel.core.osgi;version="[2.17.2,3.0.0)",
- org.apache.camel.impl;version="[2.17.2,3.0.0)",
- org.apache.camel.model;version="[2.17.2,3.0.0)",
- org.apache.camel.spi;version="[2.17.2,3.0.0)",
+Import-Package: org.apache.camel;version="[2.17.0,3.0.0)",
+ org.apache.camel.builder;version="[2.17.0,3.0.0)",
+ org.apache.camel.core.osgi;version="[2.17.0,3.0.0)",
+ org.apache.camel.impl;version="[2.17.0,3.0.0)",
+ org.apache.camel.model;version="[2.17.0,3.0.0)",
+ org.apache.camel.spi;version="[2.17.0,3.0.0)",
  org.eclipse.kura;version="[1.0,2.0)",
  org.eclipse.kura.cloud;version="[1.0,2.0)",
  org.eclipse.kura.configuration;version="[1.0,2.0)",


### PR DESCRIPTION
This change lowers the camel package import to allow for camel 2.17.0
versions as well.

Please also backport to `develop`.

Signed-off-by: Jens Reimann <jreimann@redhat.com>