### PR TITLE
Fixed Out Of Bounds bug #635 on BluetoothAdapterImpl

### DIFF
--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/BluetoothAdapterImpl.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/BluetoothAdapterImpl.java
@@ -259,7 +259,7 @@ public class BluetoothAdapterImpl implements BluetoothAdapter {
         cmd[0] = "cmd";
         cmd[1] = ogf;
         cmd[2] = ocf;
-        for (int i = 0; i < cmd.length; i++) {
+        for (int i = 0; i < paramArray.length; i++) {
             cmd[i + 3] = paramArray[i];
         }
 


### PR DESCRIPTION
The method ExecuteCmd in org.eclipse.kura.linux.bluetooth.BluetoothAdapterImpl gives an index out of bounds error. The issue is due to a wrong condition in the for loop.
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>