### PR TITLE
Solved possible IllegalArgumentException due to null pid

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -337,7 +337,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
         try {
             s_logger.info("Deleting configuration for pid {}", pid);
-            Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
+            Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), "?");
 
             if (config != null) {
                 config.delete();
@@ -673,7 +673,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         if (servicePid == null) {
             servicePid = pid;
         }
-        Configuration config = this.m_configurationAdmin.getConfiguration(servicePid,  "?");
+        Configuration config = this.m_configurationAdmin.getConfiguration(servicePid, "?");
         if (config != null) {
             // get the properties from ConfigurationAdmin if any are present
             Map<String, Object> props = new HashMap<String, Object>();
@@ -791,7 +791,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
                 StringBuilder entireFile = new StringBuilder();
                 while ((line = br.readLine()) != null) {
                     entireFile.append(line);
-                }     // end while
+                }        // end while
                 xmlConfigs = XmlUtil.unmarshal(entireFile.toString(), XmlComponentConfigurations.class);
             } finally {
                 if (br != null) {
@@ -904,10 +904,14 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
             Tocd ocd = getOCDForPid(pid);
 
-            Configuration cfg = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
-            Map<String, Object> props = CollectionsUtil.dictionaryToMap(cfg.getProperties(), ocd);
+            String servicePid = this.m_servicePidByPid.get(pid);
 
-            cc = new ComponentConfigurationImpl(pid, ocd, props);
+            if (servicePid != null) {
+                Configuration cfg = this.m_configurationAdmin.getConfiguration(servicePid, "?");
+                Map<String, Object> props = CollectionsUtil.dictionaryToMap(cfg.getProperties(), ocd);
+
+                cc = new ComponentConfigurationImpl(pid, ocd, props);
+            }
         } catch (Exception e) {
             s_logger.error("Error getting Configuration for component: " + pid + ". Ignoring it.", e);
         }
@@ -1098,7 +1102,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
                             s_logger.debug("Pushing config to config admin: {}", config.getPid());
 
                             // push it to the ConfigAdmin
-                            Configuration cfg = this.m_configurationAdmin.getConfiguration(config.getPid(),  "?");
+                            Configuration cfg = this.m_configurationAdmin.getConfiguration(config.getPid(), "?");
 
                             // set kura.service.pid if missing
                             Map<String, Object> newProperties = new HashMap<String, Object>(props);
@@ -1229,7 +1233,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
         if (!this.m_activatedSelfConfigComponents.contains(pid)) {
             try {
                 // get the current running configuration for the selected component
-                Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
+                Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), "?");
                 Map<String, Object> runningProps = CollectionsUtil.dictionaryToMap(config.getProperties(),
                         registerdOCD);
 
@@ -1302,7 +1306,7 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
         // Update the new properties
         // use ConfigurationAdmin to do the update
-        Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid),  "?");
+        Configuration config = this.m_configurationAdmin.getConfiguration(this.m_servicePidByPid.get(pid), "?");
         config.update(CollectionsUtil.mapToDictionary(mergedProperties));
 
         if (snapshotOnConfirmation) {


### PR DESCRIPTION
In slow devices it could happen that the pid is tracked but the map that maps the
pid with a servicePid has not the correct entry. This could lead to an
IllegalArgumentException in org.eclipse.equinox.internal.cm.ConfigurationAdminImpl.checkPID

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>