### PR TITLE
Add License Headers to Udev

### DIFF
--- a/kura/org.eclipse.kura.linux.usb/about.html
+++ b/kura/org.eclipse.kura.linux.usb/about.html
@@ -24,5 +24,17 @@ provided with the Content.  If no such license exists, contact the Redistributor
 indicated below, the terms and conditions of the EPL still apply to any source code in the Content
 and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
 
+h3>Third Party Content</h3>
+<p>
+The Content includes items that have been sourced from third parties as set out below. If you did not
+receive this Content directly from the Eclipse Foundation, the following is provided for informational
+purposes only, and you should look to the Redistributor's license for terms and conditions of use.
+</p>
+<p>
+<strong>LinuxUdev</strong><br/>
+This bundle includes native code that was developed referencing <a href="http://www.signal11.us/oss/udev/udev_example.c">this example</a>.
+The original terms of use and appropriate attribution can be found at the above URL.
+<br/><br/>
+</p>
 </body>
 </html>

--- a/kura/org.eclipse.kura.linux.usb/src/main/c/udev/LinuxUdev.c
+++ b/kura/org.eclipse.kura.linux.usb/src/main/c/udev/LinuxUdev.c
@@ -1,3 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+/*******************************************
+ This code is meant to be a teaching
+ resource. It can be used for anyone for
+ any reason, including embedding into
+ a commercial product.
+ 
+ The document describing this file, and
+ updated versions can be found at:
+    http://www.signal11.us/oss/udev/
+
+ Alan Ott
+ Signal 11 Software
+*******************************************/
+
 #include "LinuxUdev.h"
 
 JNIEXPORT jobject JNICALL Java_org_eclipse_kura_linux_usb_LinuxUdevNative_getUsbDevices(JNIEnv *env, jclass LinuxUdevNative, jstring deviceClass) {

--- a/kura/org.eclipse.kura.linux.usb/src/main/c/udev/LinuxUdev.h
+++ b/kura/org.eclipse.kura.linux.usb/src/main/c/udev/LinuxUdev.h
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 #include "org_eclipse_kura_linux_usb_LinuxUdevNative.h"
 
 #include <libudev.h>


### PR DESCRIPTION
This PR adds missing copyright/EPL headers to LinuxUdev source files. It also
gives proper credit to the originator of the code used to create this library.

This should close #649 . @MMaiero @ctron Can you review and merge? The CQ for this can be found here: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=12155