### PR TITLE
Fix two typos in legal requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ A proper header must be in place for any file contributed to Eclipse Kura. For a
 
 ```
 /*******************************************************************************
- * Copyright (c) 2016 <legal entity> and/or its affiliates and others
+ * Copyright (c) 2016 <legal entity> and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -51,7 +51,7 @@ A proper header must be in place for any file contributed to Eclipse Kura. For a
  
  ```
  /*******************************************************************************
- * Copyright (c) 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016 <legal entity> and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
1) Most other contributors don't use "and/or its affiliates" so making
making this a hard requirement for all seems odd to me

2) The second example had "Eurotech" still hardcoded

Signed-off-by: Jens Reimann <jreimann@redhat.com>