### PR TITLE
Changes to include platform-dependent jdk.dio native libs in installers 

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -441,10 +441,11 @@ fi]]>
 			<zipfileset dir="${kura.osgi.repo}/plugins/"
                         prefix="${build.output.name}/plugins"/>
 
-			<zipfileset dir="../target-definition/common/source/plugins" excludes="com.google.protobuf_2.6.0.jar,org.eclipse.paho.*,com.gwt.user_*,org.eclipse.kura.windows.*"
+			<zipfileset dir="../target-definition/common/source/plugins" excludes="com.google.protobuf_2.6.0.jar,org.eclipse.paho.*,com.gwt.user_*,org.eclipse.kura.windows.*,jdk.dio*"
                         prefix="${build.output.name}/plugins"/>
-
-
+			<zipfileset dir="../target-definition/common/source/plugins" includes="jdk.dio_${jdk.dio.version}.jar,jdk.dio.${native.tag}_${jdk.dio.version}.jar"
+                        prefix="${build.output.name}/plugins"/>
+                        
 			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.deployment.agent_${org.eclipse.kura.deployment.agent.version}.jar"
                         prefix="${build.output.name}/kura/plugins" />
 			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.api_${org.eclipse.kura.api.version}.jar"
@@ -763,10 +764,20 @@ Resource-Processor: org.eclipse.kura.deployment.customizer.upgrade.rp.UpgradeScr
 		<copy todir="${build.install.dir.kura}/plugins">
 			<fileset dir="${kura.osgi.repo}/plugins" />
 		</copy>
+		
+		<copy todir="${build.install.dir.kura}/plugins">
+			<fileset dir="../target-definition/common/repository/plugins">
+				<exclude name="jdk.dio*"/>
+				<exclude name="com.google.protobuf_2.6.0.jar"/>
+				<exclude name="org.eclipse.paho.*"/>
+				<exclude name="com.gwt.user_*"/>
+			</fileset>
+		</copy>
                         
 		<copy todir="${build.install.dir.kura}/plugins">
 			<fileset dir="../target-definition/common/repository/plugins">
-				<exclude name="com.google.protobuf_2.6.0.jar,org.eclipse.paho.*,com.gwt.user_*"/>
+				<include name="jdk.dio_${jdk.dio.version}.jar"/>
+				<include name="jdk.dio.${native.tag}_${jdk.dio.version}.jar"/>
 			</fileset>
 		</copy>                        
 


### PR DESCRIPTION
The change affects distrib.
Only the specific native library will be included for each platform and architecture.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>