### PR TITLE
Allow camel component to be initialized

### DIFF
--- a/kura/org.eclipse.kura.camel.cloud.factory/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.camel.cloud.factory/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Import-Package: org.apache.camel;version="[2.17.0,3.0.0)",
  org.eclipse.kura.camel.camelcloud;version="[1.1,2.0)",
  org.eclipse.kura.camel.cloud;version="[1.1,2.0)",
  org.eclipse.kura.camel.component;version="[1.1,2.0)",
+ org.eclipse.kura.camel.runner;version="[1.1,2.0)",
  org.eclipse.kura.cloud;version="[1.0,2.0)",
  org.eclipse.kura.cloud.factory;version="[1.1,1.2)",
  org.eclipse.kura.configuration;version="[1.1,1.2)",
@@ -26,3 +27,4 @@ Import-Package: org.apache.camel;version="[2.17.0,3.0.0)",
  org.slf4j;version="1.7.0"
 Service-Component: OSGI-INF/factory.xml,
  OSGI-INF/manager.xml
+DynamicImport-Package: *

--- a/kura/org.eclipse.kura.camel.cloud.factory/OSGI-INF/metatype/org.eclipse.kura.camel.cloud.factory.CamelFactory.xml
+++ b/kura/org.eclipse.kura.camel.cloud.factory/OSGI-INF/metatype/org.eclipse.kura.camel.cloud.factory.CamelFactory.xml
@@ -24,6 +24,13 @@
             required="true"
             description="The camel XML router configuration|TextArea"/>
             
+        <AD id="initCode"
+            name="JavaScript init code"
+            type="String"
+            cardinality="1"
+            required="true"
+            description="JavaScript code which is called when the router is initialized first|TextArea"/>
+            
          <AD id="serviceRanking"
             name="Service Ranking"
             type="Integer"

--- a/kura/org.eclipse.kura.camel.cloud.factory/src/org/eclipse/kura/camel/cloud/factory/internal/CamelFactory.java
+++ b/kura/org.eclipse.kura.camel.cloud.factory/src/org/eclipse/kura/camel/cloud/factory/internal/CamelFactory.java
@@ -60,6 +60,7 @@ public class CamelFactory implements ConfigurableComponent {
         final ServiceConfiguration configuration = new ServiceConfiguration();
         configuration.setXml(asString(properties, "xml"));
         configuration.setServiceRanking(asInteger(properties, "serviceRanking"));
+        configuration.setInitCode(asString(properties, "initCode"));
 
         createService(pid, configuration);
     }

--- a/kura/org.eclipse.kura.camel.cloud.factory/src/org/eclipse/kura/camel/cloud/factory/internal/ServiceConfiguration.java
+++ b/kura/org.eclipse.kura.camel.cloud.factory/src/org/eclipse/kura/camel/cloud/factory/internal/ServiceConfiguration.java
@@ -14,6 +14,7 @@ public class ServiceConfiguration {
 
     private String xml;
     private Integer serviceRanking;
+    private String initCode;
 
     /**
      * Set the router XML
@@ -37,10 +38,19 @@ public class ServiceConfiguration {
         return this.serviceRanking;
     }
 
+    public void setInitCode(String initCode) {
+        this.initCode = initCode;
+    }
+
+    public String getInitCode() {
+        return this.initCode;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
+        result = prime * result + (this.initCode == null ? 0 : this.initCode.hashCode());
         result = prime * result + (this.serviceRanking == null ? 0 : this.serviceRanking.hashCode());
         result = prime * result + (this.xml == null ? 0 : this.xml.hashCode());
         return result;
@@ -58,6 +68,13 @@ public class ServiceConfiguration {
             return false;
         }
         ServiceConfiguration other = (ServiceConfiguration) obj;
+        if (this.initCode == null) {
+            if (other.initCode != null) {
+                return false;
+            }
+        } else if (!this.initCode.equals(other.initCode)) {
+            return false;
+        }
         if (this.serviceRanking == null) {
             if (other.serviceRanking != null) {
                 return false;

--- a/kura/org.eclipse.kura.camel.test/pom.xml
+++ b/kura/org.eclipse.kura.camel.test/pom.xml
@@ -75,6 +75,14 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
+
+			<plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-checkstyle-plugin</artifactId>
+			    <configuration>
+                    <skip>true</skip>
+                </configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/kura/org.eclipse.kura.camel.test/src/org/eclipse/kura/camel/runner/ScriptRunnerTest.java
+++ b/kura/org.eclipse.kura.camel.test/src/org/eclipse/kura/camel/runner/ScriptRunnerTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kura.camel.runner;
+
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScriptRunnerTest {
+
+    /**
+     * Test a simple call
+     */
+    @Test
+    public void testScript1() throws ScriptException {
+        final ScriptRunner runner = ScriptRunner.create(null, "JavaScript", "42;");
+
+        final Object result = runner.run();
+
+        Assert.assertTrue(result instanceof Number);
+        Assert.assertEquals(42.0, ((Number) result).doubleValue(),0.001);
+    }
+
+    /**
+     * Test a call with arguments
+     */
+    @Test
+    public void testScript2() throws ScriptException {
+        final ScriptRunner runner = ScriptRunner.create(null, "JavaScript", "foo + 'bar';");
+
+        SimpleBindings bindings = new SimpleBindings();
+        bindings.put("foo", "bar");
+        final Object result = runner.run(bindings);
+
+        Assert.assertEquals("barbar", result);
+    }
+}

--- a/kura/org.eclipse.kura.camel/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.camel/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
-Import-Package: org.apache.camel;version="[2.17.0,3.0.0)",
+Import-Package: javax.script,
+ org.apache.camel;version="[2.17.0,3.0.0)",
  org.apache.camel.builder;version="[2.17.0,3.0.0)",
  org.apache.camel.core.osgi;version="[2.17.0,3.0.0)",
  org.apache.camel.impl;version="[2.17.0,3.0.0)",

--- a/kura/org.eclipse.kura.camel/src/main/java/org/eclipse/kura/camel/runner/ScriptRunner.java
+++ b/kura/org.eclipse.kura.camel/src/main/java/org/eclipse/kura/camel/runner/ScriptRunner.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat Inc and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kura.camel.runner;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+/**
+ * A runner for scripts which takes care of class loader issues in OSGi
+ * <br>
+ * This class helps running java.script script inside an OSGi container.
+ * There are some oddities of Rhino and Nashorn this runner takes care of
+ * so that at least the standard "JavaScript" language works inside of OSGi.
+ * <br>
+ * In order to execute a script use:
+ * <code><pre>
+ * ScriptRunner runner = ScriptRunner.create(ServiceClass.class.getClassLoader(), "JavaScript", "callFooBar();" );
+ * runner.run();
+ * </pre></code>
+ */
+public abstract class ScriptRunner {
+
+    private static class EvalScriptRunner extends ScriptRunner {
+
+        private final ClassLoader classLoader;
+        private final ScriptEngine engine;
+        private final String script;
+
+        public EvalScriptRunner(final ClassLoader classLoader, final ScriptEngine engine, final String script) {
+            this.classLoader = classLoader;
+            this.engine = engine;
+            this.script = script;
+        }
+
+        @Override
+        public Object run() throws ScriptException {
+            return runWithClassLoader(this.classLoader, new Callable<Object>() {
+
+                @Override
+                public Object call() throws Exception {
+                    return EvalScriptRunner.this.engine.eval(EvalScriptRunner.this.script);
+                }
+            });
+        }
+
+        @Override
+        public Object run(final Bindings bindings) throws ScriptException {
+            return runWithClassLoader(this.classLoader, new Callable<Object>() {
+
+                @Override
+                public Object call() throws Exception {
+                    return EvalScriptRunner.this.engine.eval(EvalScriptRunner.this.script, bindings);
+                }
+            });
+        }
+
+        @Override
+        public Object run(final ScriptContext context) throws ScriptException {
+            return runWithClassLoader(this.classLoader, new Callable<Object>() {
+
+                @Override
+                public Object call() throws Exception {
+                    return EvalScriptRunner.this.engine.eval(EvalScriptRunner.this.script, context);
+                }
+            });
+        }
+    }
+
+    private ScriptRunner() {
+    }
+
+    public abstract Object run() throws ScriptException;
+
+    public abstract Object run(Bindings bindings) throws ScriptException;
+
+    public abstract Object run(ScriptContext context) throws ScriptException;
+
+    public static ScriptRunner create(final ClassLoader classLoader, final String scriptEngineName, final String script)
+            throws ScriptException {
+
+        final ScriptEngine engine = createEngine(classLoader, scriptEngineName);
+        return new EvalScriptRunner(classLoader, engine, script);
+
+    }
+
+    private static ScriptEngineManager createManager(final ClassLoader classLoader) throws ScriptException {
+        return runWithClassLoader(classLoader, new Callable<ScriptEngineManager>() {
+
+            @Override
+            public ScriptEngineManager call() throws Exception {
+                // passing null here since this will trigger
+                // the script engine lookup to use java basic
+                // support for JavaScript
+                return new ScriptEngineManager(null);
+            }
+        });
+    }
+
+    private static ScriptEngine createEngine(final ClassLoader classLoader, final ScriptEngineManager manager,
+            final String engineName) throws ScriptException {
+        Objects.requireNonNull(manager);
+        Objects.requireNonNull(engineName);
+
+        return runWithClassLoader(classLoader, new Callable<ScriptEngine>() {
+
+            @Override
+            public ScriptEngine call() throws Exception {
+                return manager.getEngineByName(engineName);
+            }
+        });
+    }
+
+    private static ScriptEngine createEngine(final ClassLoader classLoader, final String engineName)
+            throws ScriptException {
+        return createEngine(classLoader, createManager(classLoader), engineName);
+    }
+
+    /**
+     * Run a Callable while swapping the context class loader
+     *
+     * @param classLoader
+     *            the class loader to set while calling the code
+     * @param code
+     *            the code to call
+     * @return the return value of the code
+     * @throws ScriptException
+     *             if anything goes wrong
+     */
+    public static <T> T runWithClassLoader(final ClassLoader classLoader, final Callable<T> code)
+            throws ScriptException {
+        if (classLoader == null) {
+            try {
+                return code.call();
+            } catch (ScriptException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ScriptException(e);
+            }
+        }
+
+        final ClassLoader ccl = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            return code.call();
+        } catch (ScriptException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ScriptException(e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(ccl);
+        }
+    }
+}


### PR DESCRIPTION
Without OSGi blueprint support for Camel some components cannot be
properly initialized. Therefore the CloudServiceFactory allows to set
a init code snippet for setting up Camel components before starting
the router.

The same change is needed for the Kura apps based Camel router. But this
change has to wait until PR #756 is merged.

Signed-off-by: Jens Reimann <jreimann@redhat.com>