### PR TITLE
Reverts change in commit 7704d180296551b0acb68044f7cd6b4c3e77f56a

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/clock/ClockEvent.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/clock/ClockEvent.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kura.clock;
 
-import java.util.Collections;
 import java.util.Map;
 
 import org.osgi.service.event.Event;
@@ -24,8 +23,6 @@ public class ClockEvent extends Event {
 
     /** Topic of the ClockEvent */
     public static final String CLOCK_EVENT_TOPIC = "org/eclipse/kura/clock";
-
-    public static final ClockEvent EMPTY = new ClockEvent(Collections.<String, Object> emptyMap());
 
     public ClockEvent(Map<String, ?> properties) {
         super(CLOCK_EVENT_TOPIC, properties);

--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ClockServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ClockServiceImpl.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kura.linux.clock;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 
@@ -27,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ClockServiceImpl implements ConfigurableComponent, ClockService, ClockSyncListener {
+
+    private static final ClockEvent EMPTY_EVENT = new ClockEvent(Collections.<String, Object> emptyMap());
 
     private static final String PROP_CLOCK_PROVIDER = "clock.provider";
     private static final String PROP_CLOCK_SET_HWCLOCK = "clock.set.hwclock";
@@ -226,7 +229,7 @@ public class ClockServiceImpl implements ConfigurableComponent, ClockService, Cl
 
         // Raise the event
         if (bClockUpToDate) {
-            this.eventAdmin.postEvent(ClockEvent.EMPTY);
+            this.eventAdmin.postEvent(EMPTY_EVENT);
         }
     }
 }


### PR DESCRIPTION
This allows to keep the api at the same version. The empty event is defined as a static
variable in the clock implementation code.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>