### PR TITLE
#559: Upgrade to Tycho 0.26.0

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -2071,9 +2071,9 @@
 						</executions>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.tycho</groupId>
+						<groupId>org.eclipse.tycho.extras</groupId>
 						<artifactId>tycho-p2-extras-plugin</artifactId>
-						<version>0.11.0</version>
+						<version>${tycho-version}</version>
 						<executions>
 							<execution>
 								<phase>package</phase>

--- a/kura/examples/org.eclipse.kura.example.camel.aggregation/pom.xml
+++ b/kura/examples/org.eclipse.kura.example.camel.aggregation/pom.xml
@@ -12,8 +12,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<tycho-version>0.20.0</tycho-version>
-		<tycho-extras-version>0.20.0</tycho-extras-version>
+		<tycho-version>0.26.0</tycho-version>
+		<tycho-extras-version>0.26.0</tycho-extras-version>
 	</properties>
 
 	<repositories>

--- a/kura/examples/org.eclipse.kura.example.camel.quickstart/pom.xml
+++ b/kura/examples/org.eclipse.kura.example.camel.quickstart/pom.xml
@@ -12,8 +12,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<tycho-version>0.20.0</tycho-version>
-		<tycho-extras-version>0.20.0</tycho-extras-version>
+		<tycho-version>0.26.0</tycho-version>
+		<tycho-extras-version>0.26.0</tycho-extras-version>
 	</properties>
 
 	<repositories>

--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -96,7 +96,7 @@
     </modules>
 
     <properties>
-        <tycho-version>0.20.0</tycho-version>
+        <tycho-version>0.26.0</tycho-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
@@ -349,9 +349,6 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-compiler-plugin</artifactId>
                 <version>${tycho-version}</version>
-                <configuration>
-                    <compilerArgument>-warn:[+|-]warning_tokens_separated_by_comma</compilerArgument>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>

--- a/kura/pom_pom.xml
+++ b/kura/pom_pom.xml
@@ -23,13 +23,10 @@
     <packaging>pom</packaging>
 
     <properties>
-        <tycho-version>0.18.1</tycho-version>
-        <project.build.sourceEncoding>UTF-8
-        </project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8
-        </project.reporting.outputEncoding>
-        <maven.build.timestamp.format>yyyyMMddHHmm
-        </maven.build.timestamp.format>
+        <tycho-version>0.26.0</tycho-version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
         <kura.basedir>${project.basedir}</kura.basedir>
         <org.eclipse.kura.web.skip>true</org.eclipse.kura.web.skip>
         <org.eclipse.kura.web2.skip>true</org.eclipse.kura.web2.skip>

--- a/kura/setups/launchers/build-full.launch
+++ b/kura/setups/launchers/build-full.launch
@@ -13,6 +13,6 @@
 <stringAttribute key="M2_USER_SETTINGS" value=""/>
 <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
 <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${working_set:&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;resources&gt;&#10;&lt;item path=&quot;/target-definition&quot; type=&quot;4&quot;/&gt;&#10;&lt;item path=&quot;/target-platform&quot; type=&quot;4&quot;/&gt;&#10;&lt;/resources&gt;}"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:target-platform}/../kura"/>
 </launchConfiguration>

--- a/kura/setups/launchers/build-target-platform.launch
+++ b/kura/setups/launchers/build-target-platform.launch
@@ -13,6 +13,6 @@
 <stringAttribute key="M2_USER_SETTINGS" value=""/>
 <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
 <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${project}"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:target-platform}"/>
 </launchConfiguration>

--- a/kura/setups/launchers/build-web-ui-2.launch
+++ b/kura/setups/launchers/build-web-ui-2.launch
@@ -13,6 +13,6 @@
 <stringAttribute key="M2_USER_SETTINGS" value=""/>
 <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
 <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${project}"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:org.eclipse.kura.web2}"/>
 </launchConfiguration>

--- a/kura/tools/archetype/example/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
+++ b/kura/tools/archetype/example/src/main/resources/archetype-resources/__rootArtifactId__/pom.xml
@@ -24,13 +24,13 @@
     		<plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-maven-plugin</artifactId>
-                <version>0.20.0</version>
+                <version>0.26.0</version>
                 <extensions>true</extensions>
             </plugin>
         	<plugin>
             	<groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-packaging-plugin</artifactId>
-                <version>0.20.0</version>
+                <version>0.26.0</version>
                 <configuration>
                 	<archive>
                     	<compress>false</compress>

--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -244,9 +244,9 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.sonatype.tycho</groupId>
+				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-p2-extras-plugin</artifactId>
-				<version>0.11.0</version>
+				<version>0.26.0</version>
 				<executions>
 					<execution>
 						<phase>prepare-package</phase>

--- a/target-platform/p2-repo-equinox_3.11.1/pom.xml
+++ b/target-platform/p2-repo-equinox_3.11.1/pom.xml
@@ -72,9 +72,9 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.sonatype.tycho</groupId>
+				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-p2-extras-plugin</artifactId>
-				<version>0.11.0</version>
+				<version>0.26.0</version>
 				<executions>
 					<execution>
 						<phase>prepare-package</phase>


### PR DESCRIPTION
This change switches from Tycho 0.11.0, 0.18.0 and 0.20.0 to
Tycho 0.26.0 for all plugins.

Signed-off-by: Jens Reimann <jreimann@redhat.com>