### PR TITLE
Replace current process when starting Kura

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2011, 2016 Eurotech and others
+    Copyright (c) 2011, 2017 Eurotech and others
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -10,7 +10,6 @@
     Contributors:
       Eurotech
       Red Hat Inc
-      
 -->
 <project name="build_equinox_distrib" default="dist-linux" basedir="../../../">
 
@@ -171,7 +170,7 @@ cp ${DIR}/kura/config.ini /tmp/.kura/configuration/
 KURA_RUNNING=`ps ax | grep java | grep "org.eclipse.osgi"`
 
 if [ -z "$KURA_RUNNING" ] ; then
-        java -Xms${kura.mem.size} -Xmx${kura.mem.size} \
+        exec java -Xms${kura.mem.size} -Xmx${kura.mem.size} \
         -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/kura-heapdump.hprof \
         -XX:ErrorFile=/var/log/kura-error.log \
         -Dkura.os.version=${kura.os.version} \
@@ -210,7 +209,7 @@ cp ${DIR}/kura/config.ini /tmp/.kura/configuration/
 KURA_RUNNING=`ps ax | grep java | grep "org.eclipse.osgi"`
 
 if [ -z "$KURA_RUNNING" ] ; then
-        java -Xms${kura.mem.size} -Xmx${kura.mem.size} \
+        exec java -Xms${kura.mem.size} -Xmx${kura.mem.size} \
         -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -Xloggc:/var/log/kura-gc.log \
         -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M \
         -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/kura-heapdump.hprof \


### PR DESCRIPTION
This change does replace the current process instead of forking another
instance and keeping the resources.

Signed-off-by: Jens Reimann <jreimann@redhat.com>