### PR TITLE
Try a fix for the startup exception, missing "kura-cloud"

### DIFF
--- a/kura/org.eclipse.kura.camel.xml/OSGI-INF/metatype/org.eclipse.kura.camel.xml.XmlRouterComponent.xml
+++ b/kura/org.eclipse.kura.camel.xml/OSGI-INF/metatype/org.eclipse.kura.camel.xml.XmlRouterComponent.xml
@@ -24,6 +24,7 @@
             cardinality="1"
             required="false"
             max="2147483647"
+            default="kura-cloud"
             />
         
         <AD id="cloudService.prereqs" name="Cloud Service Mappings"


### PR DESCRIPTION
This could be a possible fix for the start issue where the logs shows
an exception about the missing "kura-cloud" component.

Signed-off-by: Jens Reimann <jreimann@redhat.com>