### PR TITLE
Prepend kura- to modem log files.

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/PppConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/PppConfigWriter.java
@@ -290,6 +290,7 @@ public class PppConfigWriter implements NetworkConfigurationVisitor {
     public static String formPppLogFilename(UsbDevice usbDevice) {
         StringBuffer buf = new StringBuffer();
         buf.append(OS_PPP_LOG_DIRECTORY);
+        buf.append("kura-");
         buf.append(formBaseFilename(usbDevice));
         return buf.toString();
     }


### PR DESCRIPTION
The change prepends "kura-" to the usual modem log file name in order to
align kura-related logging file names to the same format.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>