### PR TITLE
Fix the version import for Kura API in the Web UI

### DIFF
--- a/kura/org.eclipse.kura.web2/pom.xml
+++ b/kura/org.eclipse.kura.web2/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>org.eclipse.kura</groupId>
 			<artifactId>org.eclipse.kura.api</artifactId>
-			<version>[1.0,2.0)</version>
+			<version>[1.1,2.0)</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
The Web UI requires kura.api 1.1

Signed-off-by: Jens Reimann <jreimann@redhat.com>