### PR TITLE
Set the 'kura.ui.service.hide' property

### DIFF
--- a/kura/org.eclipse.kura.camel.cloud.factory/OSGI-INF/factory.xml
+++ b/kura/org.eclipse.kura.camel.cloud.factory/OSGI-INF/factory.xml
@@ -4,4 +4,5 @@
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
+   <property name="kura.ui.service.hide" type="Boolean" value="true"/>
 </scr:component>


### PR DESCRIPTION
Cloud services have their own UI. And thus the Camel cloud services
should be hidden from the main UI.

Signed-off-by: Jens Reimann <jreimann@redhat.com>