### PR TITLE
Increment API bundle version to 1.2.0

### DIFF
--- a/kura/distrib/config/kura.build.properties
+++ b/kura/distrib/config/kura.build.properties
@@ -1,5 +1,5 @@
 kura.version=2.1.0-SNAPSHOT
-org.eclipse.kura.api.version=1.1.0-SNAPSHOT
+org.eclipse.kura.api.version=1.2.0-SNAPSHOT
 org.eclipse.kura.asset.provider.version=1.0.0-SNAPSHOT
 org.eclipse.kura.test.version=1.0.2-SNAPSHOT
 org.eclipse.kura.core.version=1.0.10-SNAPSHOT

--- a/kura/org.eclipse.kura.api/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.api
 Bundle-SymbolicName: org.eclipse.kura.api;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.eclipse.kura;version="1.2.1",

--- a/kura/org.eclipse.kura.api/pom.xml
+++ b/kura/org.eclipse.kura.api/pom.xml
@@ -19,7 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.api</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>


### PR DESCRIPTION
After the change of the bundle version to 1.1.0 on the release branch,
the version has to be incremented again on the develop branch.

Signed-off-by: Jens Reimann <jreimann@redhat.com>