### PR TITLE
#779: Unit tests for EthernetInterfaceConfigImpl class

### DIFF
--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -282,8 +282,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/AbstractNetInterface.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/AbstractNetInterface.java
@@ -12,6 +12,7 @@
 package org.eclipse.kura.core.net;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -228,4 +229,110 @@ public abstract class AbstractNetInterface<T extends NetInterfaceAddress> implem
 
         return sb.toString();
     }
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (autoConnect ? 1231 : 1237);
+		result = prime * result + ((driver == null) ? 0 : driver.hashCode());
+		result = prime * result + ((driverVersion == null) ? 0 : driverVersion.hashCode());
+		result = prime * result + ((firmwareVersion == null) ? 0 : firmwareVersion.hashCode());
+		result = prime * result + Arrays.hashCode(hardwareAddress);
+		result = prime * result + ((interfaceAddresses == null) ? 0 : interfaceAddresses.hashCode());
+		result = prime * result + (loopback ? 1231 : 1237);
+		result = prime * result + mtu;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + (pointToPoint ? 1231 : 1237);
+		result = prime * result + ((state == null) ? 0 : state.hashCode());
+		result = prime * result + (supportsMulticast ? 1231 : 1237);
+		result = prime * result + (up ? 1231 : 1237);
+		result = prime * result + ((usbDevice == null) ? 0 : usbDevice.hashCode());
+		result = prime * result + (virtual ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof AbstractNetInterface)) {
+			return false;
+		}
+		AbstractNetInterface other = (AbstractNetInterface) obj;
+		if (autoConnect != other.autoConnect) {
+			return false;
+		}
+		if (driver == null) {
+			if (other.driver != null) {
+				return false;
+			}
+		} else if (!driver.equals(other.driver)) {
+			return false;
+		}
+		if (driverVersion == null) {
+			if (other.driverVersion != null) {
+				return false;
+			}
+		} else if (!driverVersion.equals(other.driverVersion)) {
+			return false;
+		}
+		if (firmwareVersion == null) {
+			if (other.firmwareVersion != null) {
+				return false;
+			}
+		} else if (!firmwareVersion.equals(other.firmwareVersion)) {
+			return false;
+		}
+		if (!Arrays.equals(hardwareAddress, other.hardwareAddress)) {
+			return false;
+		}
+		if (interfaceAddresses == null) {
+			if (other.interfaceAddresses != null) {
+				return false;
+			}
+		} else if (!interfaceAddresses.equals(other.interfaceAddresses)) {
+			return false;
+		}
+		if (loopback != other.loopback) {
+			return false;
+		}
+		if (mtu != other.mtu) {
+			return false;
+		}
+		if (name == null) {
+			if (other.name != null) {
+				return false;
+			}
+		} else if (!name.equals(other.name)) {
+			return false;
+		}
+		if (pointToPoint != other.pointToPoint) {
+			return false;
+		}
+		if (state != other.state) {
+			return false;
+		}
+		if (supportsMulticast != other.supportsMulticast) {
+			return false;
+		}
+		if (up != other.up) {
+			return false;
+		}
+		if (usbDevice == null) {
+			if (other.usbDevice != null) {
+				return false;
+			}
+		} else if (!usbDevice.equals(other.usbDevice)) {
+			return false;
+		}
+		if (virtual != other.virtual) {
+			return false;
+		}
+		return true;
+	}
 }

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/EthernetInterfaceImpl.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/EthernetInterfaceImpl.java
@@ -65,4 +65,30 @@ public class EthernetInterfaceImpl<T extends NetInterfaceAddress> extends Abstra
         sb.append(super.toString()).append(" :: linkUp=").append(this.linkUp);
         return sb.toString();
     }
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + (linkUp ? 1231 : 1237);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!super.equals(obj)) {
+			return false;
+		}
+		if (!(obj instanceof EthernetInterfaceImpl)) {
+			return false;
+		}
+		EthernetInterfaceImpl other = (EthernetInterfaceImpl) obj;
+		if (linkUp != other.linkUp) {
+			return false;
+		}
+		return true;
+	}    
 }

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetInterfaceAddressConfigImpl.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetInterfaceAddressConfigImpl.java
@@ -45,11 +45,10 @@ public class NetInterfaceAddressConfigImpl extends NetInterfaceAddressImpl imple
             return true;
         }
 
-        /*
-         * if(!super.equals(obj)) {
-         * return false;
-         * }
-         */
+		if (!super.equals(obj)) {
+			return false;
+		}
+        
         if (!(obj instanceof NetInterfaceAddressConfigImpl)) {
             return false;
         }
@@ -58,6 +57,15 @@ public class NetInterfaceAddressConfigImpl extends NetInterfaceAddressImpl imple
 
         List<NetConfig> thisNetConfigs = getConfigs();
         List<NetConfig> otherNetConfigs = other.getConfigs();
+        
+        if ((thisNetConfigs == null) && (otherNetConfigs == null)) {
+        	// Both configurations are null
+        	return true;
+        }
+        else if ((thisNetConfigs == null) || (otherNetConfigs == null)) {
+        	// One configuration is null but the other one is not, so a null pointer exception would be thrown below!
+            return false;
+        }
 
         if (thisNetConfigs.size() != otherNetConfigs.size()) {
             return false;

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/EthernetInterfaceConfigImplTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/EthernetInterfaceConfigImplTest.java
@@ -1,0 +1,342 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.net;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.core.net.util.NetworkUtil;
+import org.eclipse.kura.net.IPAddress;
+import org.eclipse.kura.net.NetInterfaceState;
+import org.eclipse.kura.net.NetInterfaceType;
+import org.eclipse.kura.usb.UsbDevice;
+import org.eclipse.kura.usb.UsbNetDevice;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class EthernetInterfaceConfigImplTest {
+
+	@Test
+	public void testEqualsObject() throws UnknownHostException {
+		EthernetInterfaceConfigImpl a = createConfig(2);
+		assertEquals(a, a);
+
+		EthernetInterfaceConfigImpl b = createConfig(2);
+		assertEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentLinkUp() throws UnknownHostException {
+		EthernetInterfaceConfigImpl a = createConfig(2);
+		EthernetInterfaceConfigImpl b = createConfig(2);
+
+		a.setLinkUp(true);
+		b.setLinkUp(false);
+
+		assertNotEquals(a, b);
+	}
+
+    @Test
+    public void testEthernetInterfaceConfigImplString() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name1");
+        assertEquals("name1", config.getName());
+        assertTrue(config.getNetInterfaceAddresses().isEmpty());
+
+        config = new EthernetInterfaceConfigImpl("name2");
+        assertEquals("name2", config.getName());
+        assertTrue(config.getNetInterfaceAddresses().isEmpty());
+    }
+
+    @Test
+    public void testEthernetInterfaceConfigImplEthernetInterfaceOfQextendsNetInterfaceAddressEmptyAddress()
+            throws UnknownHostException {
+        EthernetInterfaceConfigImpl config = createConfig(0);
+
+        assertEquals("ethInterface", config.getName());
+        assertEquals(1, config.getNetInterfaceAddresses().size());
+    }
+
+    @Test
+    public void testEthernetInterfaceConfigImplEthernetInterfaceOfQextendsNetInterfaceAddressNonEmptyAddress()
+            throws UnknownHostException {
+        EthernetInterfaceConfigImpl config = createConfig(2);
+
+        assertEquals("ethInterface", config.getName());
+        assertEquals(2, config.getNetInterfaceAddresses().size());
+
+        assertEquals(createAddress("10.0.0.1"), config.getNetInterfaceAddresses().get(0));
+        assertEquals(createAddress("10.0.0.2"), config.getNetInterfaceAddresses().get(1));
+    }
+
+    @Test
+    public void testToString1() throws UnknownHostException {
+        EthernetInterfaceConfigImpl config = createConfig(0);
+
+        String expected = "name=ethInterface :: loopback=false :: pointToPoint=false :: virtual=false"
+                + " :: supportsMulticast=false :: up=false :: mtu=0 :: driver=null :: driverVersion=null"
+                + " :: firmwareVersion=null :: state=null :: autoConnect=false"
+                + " :: InterfaceAddress=NetConfig: no configurations  :: linkUp=false";
+
+        assertEquals(expected, config.toString());
+    }
+
+    @Test
+    public void testToString2() throws UnknownHostException {
+        EthernetInterfaceConfigImpl config = createConfig(2);
+
+        config.setHardwareAddress(NetworkUtil.macToBytes("12:34:56:78:90:AB"));
+        config.setLoopback(true);
+        config.setPointToPoint(true);
+        config.setVirtual(true);
+        config.setSupportsMulticast(true);
+        config.setUp(true);
+        config.setMTU(42);
+        config.setUsbDevice(new UsbNetDevice("vendorId", "productId", "manufacturerName", "productName", "usbBusNumber",
+                "usbDevicePath", "interfaceName"));
+        config.setDriver("driverName");
+        config.setDriverVersion("driverVersion");
+        config.setFirmwareVersion("firmwareVersion");
+        config.setState(NetInterfaceState.ACTIVATED);
+        config.setAutoConnect(true);
+        config.setLinkUp(true);
+
+        String expected = "name=ethInterface :: hardwareAddress=12:34:56:78:90:AB :: loopback=true"
+                + " :: pointToPoint=true :: virtual=true :: supportsMulticast=true :: up=true :: mtu=42"
+                + " :: usbDevice=UsbNetDevice [getInterfaceName()=interfaceName, getVendorId()=vendorId,"
+                + " getProductId()=productId, getManufacturerName()=manufacturerName, getProductName()=productName,"
+                + " getUsbBusNumber()=usbBusNumber, getUsbDevicePath()=usbDevicePath,"
+                + " getUsbPort()=usbBusNumber-usbDevicePath] :: driver=driverName :: driverVersion=driverVersion"
+                + " :: firmwareVersion=firmwareVersion :: state=ACTIVATED :: autoConnect=true"
+                + " :: InterfaceAddress=NetConfig: no configurations NetConfig: no configurations  :: linkUp=true";
+
+        assertEquals(expected, config.toString());
+    }
+
+    @Test
+    public void testGetType() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+        assertEquals(NetInterfaceType.ETHERNET, config.getType());
+    }
+
+    @Test
+    public void testLinkUp() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setLinkUp(true);
+        assertEquals(true, config.isLinkUp());
+
+        config.setLinkUp(false);
+        assertEquals(false, config.isLinkUp());
+    }
+
+    @Test
+    public void testName() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name1");
+        assertEquals("name1", config.getName());
+
+        config.setName("name2");
+        assertEquals("name2", config.getName());
+    }
+
+    @Test
+    public void testGetHardwareAddress() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setHardwareAddress(NetworkUtil.macToBytes("12:34:56:78:90:AB"));
+        assertArrayEquals(NetworkUtil.macToBytes("12:34:56:78:90:AB"), config.getHardwareAddress());
+
+        config.setHardwareAddress(NetworkUtil.macToBytes("11:22:33:44:55:66"));
+        assertArrayEquals(NetworkUtil.macToBytes("11:22:33:44:55:66"), config.getHardwareAddress());
+    }
+
+    @Test
+    public void testIsLoopback() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setLoopback(true);
+        assertEquals(true, config.isLoopback());
+
+        config.setLoopback(false);
+        assertEquals(false, config.isLoopback());
+    }
+
+    @Test
+    public void testIsPointToPoint() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setPointToPoint(true);
+        assertEquals(true, config.isPointToPoint());
+
+        config.setPointToPoint(false);
+        assertEquals(false, config.isPointToPoint());
+    }
+
+    @Test
+    public void testIsVirtual() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setVirtual(true);
+        assertEquals(true, config.isVirtual());
+
+        config.setVirtual(false);
+        assertEquals(false, config.isVirtual());
+    }
+
+    @Test
+    public void testSupportsMulticast() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setSupportsMulticast(true);
+        assertEquals(true, config.supportsMulticast());
+
+        config.setSupportsMulticast(false);
+        assertEquals(false, config.supportsMulticast());
+    }
+
+    @Test
+    public void testIsUp() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setUp(true);
+        assertEquals(true, config.isUp());
+
+        config.setUp(false);
+        assertEquals(false, config.isUp());
+    }
+
+    @Test
+    public void testMTU() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setMTU(42);
+        assertEquals(42, config.getMTU());
+
+        config.setMTU(1000);
+        assertEquals(1000, config.getMTU());
+    }
+
+    @Test
+    public void testDriver() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setDriver("driverName1");
+        assertEquals("driverName1", config.getDriver());
+
+        config.setDriver("driverName2");
+        assertEquals("driverName2", config.getDriver());
+    }
+
+    @Test
+    public void testDriverVersion() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setDriverVersion("driverVersion1");
+        assertEquals("driverVersion1", config.getDriverVersion());
+
+        config.setDriverVersion("driverVersion2");
+        assertEquals("driverVersion2", config.getDriverVersion());
+    }
+
+    @Test
+    public void testFirmwareVersion() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setFirmwareVersion("firmwareVersion1");
+        assertEquals("firmwareVersion1", config.getFirmwareVersion());
+
+        config.setFirmwareVersion("firmwareVersion2");
+        assertEquals("firmwareVersion2", config.getFirmwareVersion());
+    }
+
+    @Test
+    public void testState() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setState(NetInterfaceState.DISCONNECTED);
+        assertEquals(NetInterfaceState.DISCONNECTED, config.getState());
+
+        config.setState(NetInterfaceState.PREPARE);
+        assertEquals(NetInterfaceState.PREPARE, config.getState());
+    }
+
+    @Test
+    public void testUsbDevice() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        UsbDevice usbDevice1 = new UsbNetDevice("vendorId1", "productId1", "manufacturerName1", "productName1",
+                "usbBusNumber1", "usbDevicePath1", "interfaceName1");
+        config.setUsbDevice(usbDevice1);
+        assertEquals(usbDevice1, config.getUsbDevice());
+
+        UsbDevice usbDevice2 = new UsbNetDevice("vendorId2", "productId2", "manufacturerName2", "productName2",
+                "usbBusNumber2", "usbDevicePath2", "interfaceName2");
+        config.setUsbDevice(usbDevice2);
+        assertEquals(usbDevice2, config.getUsbDevice());
+    }
+
+    @Test
+    public void testAutoConnect() {
+        EthernetInterfaceConfigImpl config = new EthernetInterfaceConfigImpl("name");
+
+        config.setAutoConnect(true);
+        assertEquals(true, config.isAutoConnect());
+
+        config.setAutoConnect(false);
+        assertEquals(false, config.isAutoConnect());
+    }
+
+    @Test
+    public void testNetInterfaceAddresses() throws UnknownHostException {
+        EthernetInterfaceConfigImpl config = createConfig(2);
+
+        assertEquals(2, config.getNetInterfaceAddresses().size());
+
+        assertEquals(createAddress("10.0.0.1"), config.getNetInterfaceAddresses().get(0));
+        assertEquals(createAddress("10.0.0.2"), config.getNetInterfaceAddresses().get(1));
+    }
+
+    EthernetInterfaceConfigImpl createConfig(int noOfAddresses) throws UnknownHostException {
+        EthernetInterfaceImpl<NetInterfaceAddressConfigImpl> interfaceImpl = new EthernetInterfaceImpl<>(
+                "ethInterface");
+
+        if (noOfAddresses > 0) {
+            List<NetInterfaceAddressConfigImpl> interfaceAddresses = new ArrayList<>();
+
+            for (int i = 0; i < noOfAddresses; i++) {
+                String ipAddress = "10.0.0." + Integer.toString(i + 1);
+                NetInterfaceAddressConfigImpl interfaceAddress = createAddress(ipAddress);
+                interfaceAddresses.add(interfaceAddress);
+            }
+
+            interfaceImpl.setNetInterfaceAddresses(interfaceAddresses);
+        } else {
+            interfaceImpl.setNetInterfaceAddresses(null);
+        }
+
+        return new EthernetInterfaceConfigImpl(interfaceImpl);
+    }
+
+    NetInterfaceAddressConfigImpl createAddress(String ipAddress) throws UnknownHostException {
+        NetInterfaceAddressConfigImpl interfaceAddress = new NetInterfaceAddressConfigImpl();
+
+        interfaceAddress.setAddress(IPAddress.parseHostAddress(ipAddress));
+
+        return interfaceAddress;
+    }
+}

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetInterfaceAddressConfigImplTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetInterfaceAddressConfigImplTest.java
@@ -1,0 +1,293 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.net;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+
+import org.eclipse.kura.net.IPAddress;
+import org.eclipse.kura.net.NetConfig;
+import org.eclipse.kura.net.NetConfigIP4;
+import org.eclipse.kura.net.NetInterfaceStatus;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class NetInterfaceAddressConfigImplTest {
+
+	@Test
+	public void testEqualsObject() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl a = createConfig();
+		assertEquals(a, a);
+
+		NetInterfaceAddressConfigImpl b = createConfig();
+		assertEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentIPAddress() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl a = createConfig();
+		NetInterfaceAddressConfigImpl b = createConfig();
+
+		a.setAddress(IPAddress.parseHostAddress("10.0.0.101"));
+		b.setAddress(IPAddress.parseHostAddress("10.0.0.102"));
+
+		assertNotEquals(a, b);
+
+		a.setAddress(null);
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentBroadcast() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl a = createConfig();
+		NetInterfaceAddressConfigImpl b = createConfig();
+
+		a.setBroadcast(IPAddress.parseHostAddress("10.0.1.255"));
+		b.setBroadcast(IPAddress.parseHostAddress("10.0.2.255"));
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentDnsServers() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl a = createConfig();
+		NetInterfaceAddressConfigImpl b = createConfig();
+
+		ArrayList<IPAddress> dnsServersA = new ArrayList<>();
+		dnsServersA.add(IPAddress.parseHostAddress("10.0.2.1"));
+		dnsServersA.add(IPAddress.parseHostAddress("10.0.2.2"));
+		a.setDnsServers(dnsServersA);
+
+		ArrayList<IPAddress> dnsServersB = new ArrayList<>();
+		dnsServersB.add(IPAddress.parseHostAddress("10.0.3.1"));
+		dnsServersB.add(IPAddress.parseHostAddress("10.0.3.2"));
+		b.setDnsServers(dnsServersB);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentGateway() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl a = createConfig();
+		NetInterfaceAddressConfigImpl b = createConfig();
+
+		a.setGateway(IPAddress.parseHostAddress("10.0.1.1"));
+		b.setGateway(IPAddress.parseHostAddress("10.0.2.1"));
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentNetConfigs() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl a = createConfig();
+		NetInterfaceAddressConfigImpl b = createConfig();
+
+		ArrayList<NetConfig> configsA = new ArrayList<>();
+		configsA.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledLAN, true));
+		configsA.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		a.setNetConfigs(configsA);
+
+		ArrayList<NetConfig> configsB = new ArrayList<>();
+		configsB.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		configsB.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		b.setNetConfigs(configsB);
+
+		assertNotEquals(a, b);
+
+		a.setNetConfigs(null);
+		assertNotEquals(a, b);
+
+		a.setNetConfigs(configsA);
+		b.setNetConfigs(null);
+		assertNotEquals(a, b);
+
+		ArrayList<NetConfig> configsA2 = new ArrayList<>();
+		configsA2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		configsA2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		a.setNetConfigs(configsA2);
+
+		ArrayList<NetConfig> configsB2 = new ArrayList<>();
+		configsB2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		b.setNetConfigs(configsB2);
+
+		assertNotEquals(a, b);
+
+		configsB2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		b.setNetConfigs(configsB2);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentNetmask() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl a = createConfig();
+		NetInterfaceAddressConfigImpl b = createConfig();
+
+		a.setNetmask(IPAddress.parseHostAddress("255.255.0.0"));
+		b.setNetmask(IPAddress.parseHostAddress("255.0.0.0"));
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentNetworkPrefixLength() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl a = createConfig();
+		NetInterfaceAddressConfigImpl b = createConfig();
+
+		a.setNetworkPrefixLength((short) 20);
+		b.setNetworkPrefixLength((short) 30);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectNetInterfaceAddress() {
+		NetInterfaceAddressImpl a = new NetInterfaceAddressImpl();
+		String b = "";
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectNetInterfaceAddressConfig() {
+		NetInterfaceAddressConfigImpl a = new NetInterfaceAddressConfigImpl();
+		NetInterfaceAddressImpl b = new NetInterfaceAddressImpl();
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testNetInterfaceAddressConfigImpl() {
+		NetInterfaceAddressConfigImpl value = new NetInterfaceAddressConfigImpl();
+
+		assertNull(value.getAddress());
+		assertEquals(0, value.getNetworkPrefixLength());
+		assertNull(value.getNetmask());
+		assertNull(value.getGateway());
+		assertNull(value.getBroadcast());
+		assertNull(value.getDnsServers());
+	}
+
+	@Test
+	public void testNetInterfaceAddressConfigImplNetInterfaceAddress() throws UnknownHostException {
+		ArrayList<IPAddress> dnsServers = new ArrayList<>();
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.1"));
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.2"));
+
+		NetInterfaceAddressImpl address = new NetInterfaceAddressImpl();
+		address.setAddress(IPAddress.parseHostAddress("10.0.0.100"));
+		address.setBroadcast(IPAddress.parseHostAddress("10.0.0.255"));
+		address.setDnsServers(dnsServers);
+		address.setGateway(IPAddress.parseHostAddress("10.0.0.1"));
+		address.setNetmask(IPAddress.parseHostAddress("255.255.255.0"));
+		address.setNetworkPrefixLength((short) 24);
+
+		NetInterfaceAddressConfigImpl value = new NetInterfaceAddressConfigImpl(address);
+
+		assertEquals(IPAddress.parseHostAddress("10.0.0.100"), value.getAddress());
+		assertEquals(24, value.getNetworkPrefixLength());
+		assertEquals(IPAddress.parseHostAddress("255.255.255.0"), value.getNetmask());
+		assertEquals(IPAddress.parseHostAddress("10.0.0.1"), value.getGateway());
+		assertEquals(IPAddress.parseHostAddress("10.0.0.255"), value.getBroadcast());
+		assertEquals(dnsServers, value.getDnsServers());
+	}
+
+	@Test
+	public void testNetConfigs() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl value = createConfig();
+
+		ArrayList<NetConfig> configs = new ArrayList<>();
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledLAN, true));
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		value.setNetConfigs(configs);
+		assertEquals(value.getConfigs(), configs);
+
+		configs = new ArrayList<>();
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		value.setNetConfigs(configs);
+		assertEquals(value.getConfigs(), configs);
+	}
+
+	@Test
+	public void testToStringNoConfigs() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl value = createConfig();
+		value.setNetConfigs(null);
+
+		String expected = "NetConfig: no configurations";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testToStringEmptyConfigs() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl value = createConfig();
+		value.setNetConfigs(new ArrayList<NetConfig>());
+
+		String expected = "";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testToStringNullConfig() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl value = createConfig();
+
+		ArrayList<NetConfig> configs = new ArrayList<>();
+		configs.add(null);
+		value.setNetConfigs(configs);
+
+		String expected = "NetConfig: null - ";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testToStringWithConfigs() throws UnknownHostException {
+		NetInterfaceAddressConfigImpl value = createConfig();
+
+		String expected = "NetConfig: NetConfigIP4 [winsServers=[], super.toString()=NetConfigIP"
+				+ " [m_status=netIPv4StatusEnabledLAN, m_autoConnect=true, m_dhcp=false, m_address=null,"
+				+ " m_networkPrefixLength=-1, m_subnetMask=null, m_gateway=null, m_dnsServers=[],"
+				+ " m_domains=[], m_properties={}]] - "
+				+ "NetConfig: NetConfigIP4 [winsServers=[], super.toString()=NetConfigIP"
+				+ " [m_status=netIPv4StatusEnabledWAN, m_autoConnect=false, m_dhcp=false, m_address=null,"
+				+ " m_networkPrefixLength=-1, m_subnetMask=null, m_gateway=null, m_dnsServers=[],"
+				+ " m_domains=[], m_properties={}]] - ";
+
+		assertEquals(expected, value.toString());
+	}
+
+	private NetInterfaceAddressConfigImpl createConfig() throws UnknownHostException {
+		ArrayList<IPAddress> dnsServers = new ArrayList<>();
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.1"));
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.2"));
+
+		ArrayList<NetConfig> configs = new ArrayList<>();
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledLAN, true));
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+
+		NetInterfaceAddressConfigImpl value = new NetInterfaceAddressConfigImpl();
+		value.setAddress(IPAddress.parseHostAddress("10.0.0.100"));
+		value.setBroadcast(IPAddress.parseHostAddress("10.0.0.255"));
+		value.setDnsServers(dnsServers);
+		value.setGateway(IPAddress.parseHostAddress("10.0.0.1"));
+		value.setNetConfigs(configs);
+		value.setNetmask(IPAddress.parseHostAddress("255.255.255.0"));
+		value.setNetworkPrefixLength((short) 24);
+
+		return value;
+	}
+}


### PR DESCRIPTION
- Prepared unit tests for EthernetInterfaceConfigImpl class from package
  org.eclipse.kura.core.net
- Fixed or implemented comparison of classes: AbstractNetInterface,
  EthernetInterfaceConfigImpl, and NetInterfaceAddressConfigImpl

Signed-off-by: Djuro Drljaca <djuro.drljaca@comtrade.com>