### PR TITLE
Initial support for generating P2 repository

### DIFF
--- a/kura/features/org.eclipse.kura.api.feature/build.properties
+++ b/kura/features/org.eclipse.kura.api.feature/build.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2016 Red Hat Inc
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#    Red Hat Inc
+###############################################################################
+
+bin.includes = feature.xml,\
+               feature.properties

--- a/kura/features/org.eclipse.kura.api.feature/feature.properties
+++ b/kura/features/org.eclipse.kura.api.feature/feature.properties
@@ -1,0 +1,25 @@
+###############################################################################
+# Copyright (c) 2016 Red Hat Inc
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#    Red Hat Inc
+###############################################################################
+
+featureName=Eclipse Kura - API
+providerName=Eclipse Kura
+description=Main API feature
+
+copyright=\
+Copyright (c) 2016 Red Hat Inc\n\
+All rights reserved. This program and the accompanying materials\n\
+are made available under the terms of the Eclipse Public License v1.0\n\
+which accompanies this distribution, and is available at\n\
+http://www.eclipse.org/legal/epl-v10.html\n\
+\n\
+Contributors:\n\
+    Red Hat Inc\n

--- a/kura/features/org.eclipse.kura.api.feature/feature.xml
+++ b/kura/features/org.eclipse.kura.api.feature/feature.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.kura.api"
+      label="%featureName"
+      version="2.1.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.license"
+      license-feature-version="0.0.0">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <plugin
+         id="org.eclipse.kura.api"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/kura/features/org.eclipse.kura.api.feature/pom.xml
+++ b/kura/features/org.eclipse.kura.api.feature/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.kura.feature</groupId>
+		<artifactId>features</artifactId>
+		<version>2.1.0-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.kura.api</artifactId>
+	<packaging>eclipse-feature</packaging>
+</project>

--- a/kura/features/org.eclipse.kura.api.feature/sourceTemplateFeature/feature.properties
+++ b/kura/features/org.eclipse.kura.api.feature/sourceTemplateFeature/feature.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2016 Red Hat Inc
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#    Red Hat Inc
+###############################################################################
+

--- a/kura/features/pom.xml
+++ b/kura/features/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.kura</groupId>
+		<artifactId>kura</artifactId>
+		<version>2.1.0-SNAPSHOT</version>
+		<relativePath>../manifest_pom.xml</relativePath>
+	</parent>
+
+	<groupId>org.eclipse.kura.feature</groupId>
+	<artifactId>features</artifactId>
+	<packaging>pom</packaging>
+
+	<!-- provide valid links for all feature projects -->
+
+	<repositories>
+		<repository>
+			<id>p2-repo-equinox_3.11.1</id>
+			<layout>p2</layout>
+			<url>file:////${basedir}/../../../target-platform/p2-repo-equinox_3.11.1/target/repository/</url>
+		</repository>
+		<repository>
+			<id>p2-repo-common</id>
+			<layout>p2</layout>
+			<url>file:////${basedir}/../../../target-platform/p2-repo-common/target/repository/</url>
+		</repository>
+	</repositories>
+
+	<modules>
+		<module>org.eclipse.kura.api.feature</module>
+	</modules>
+
+	<profiles>
+		<profile>
+			<id>source-feature-generation</id>
+			<activation>
+				<file>
+					<exists>sourceTemplateFeature/feature.properties</exists>
+				</file>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho.extras</groupId>
+						<artifactId>tycho-source-feature-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<executions>
+							<execution>
+								<id>source-feature</id>
+								<goals>
+									<goal>source-feature</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-plugin</artifactId>
+						<version>${tycho-version}</version>
+						<executions>
+							<execution>
+								<id>attach-p2-metadata</id>
+								<phase>package</phase>
+								<goals>
+									<goal>p2-metadata</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/kura/manifest_pom.xml
+++ b/kura/manifest_pom.xml
@@ -100,9 +100,14 @@
         <module>org.eclipse.kura.wire.provider.test</module>
         -->
 
+        <module>features</module>
+        
         <module>emulator</module>
         <module>examples</module>
         <module>test</module>
+        
+        <!-- final p2 repository -->
+        <module>org.eclipse.kura-p2</module>
         
         <!-- A module containing log4j configuration for running unit tests -->
         <module>log4j.test.configuration</module>
@@ -218,6 +223,11 @@
     </profiles>
 
     <repositories>
+        <repository>
+            <id>license-feature</id>
+            <url>http://download.eclipse.org/cbi/updates/license/</url>
+            <layout>p2</layout>
+        </repository>
         <repository>
             <id>p2-repo-common</id>
             <layout>p2</layout>
@@ -362,6 +372,19 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-compiler-plugin</artifactId>
                 <version>${tycho-version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-source-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <executions>
+                    <execution>
+                        <id>plugin-source</id>
+                        <goals>
+                            <goal>plugin-source</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>

--- a/kura/org.eclipse.kura-p2/category.xml
+++ b/kura/org.eclipse.kura-p2/category.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <feature url="features/org.eclipse.kura.api_0.0.0.qualifier.jar" id="org.eclipse.kura.api" version="0.0.0">
+      <category name="org.eclipse.kura.api"/>
+   </feature>
+   <feature url="features/org.eclipse.kura.api.source_0.0.0.jar" id="org.eclipse.kura.api.source" version="0.0.0">
+      <category name="org.eclipse.kura.api.sdk"/>
+   </feature>
+   <category-def name="org.eclipse.kura.api" label="Eclipse Kura™ API">
+      <description>
+         The main API bundles of Eclipse Kura™
+      </description>
+   </category-def>
+   <category-def name="org.eclipse.kura.api.sdk" label="Eclipse Kura™ API SDK">
+      <description>
+         Eclipse Kura™ bundles and sources for the main API
+      </description>
+   </category-def>
+</site>

--- a/kura/org.eclipse.kura-p2/pom.xml
+++ b/kura/org.eclipse.kura-p2/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	>
+	
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.kura</groupId>
+		<artifactId>kura</artifactId>
+		<version>2.1.0-SNAPSHOT</version>
+		<relativePath>../manifest_pom.xml</relativePath>
+	</parent>
+
+    <groupId>org.eclipse.kura.p2</groupId>
+	<artifactId>org.eclipse.kura</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+	<properties>
+		<kura.basedir>${project.basedir}/..</kura.basedir>
+	</properties>
+</project>


### PR DESCRIPTION
This change provides initial support for generating a P2 repository
during the main build.

Currently only the the API bundle gets packaged.

Signed-off-by: Jens Reimann <jreimann@redhat.com>