### PR TITLE
Minor fixes to core.net.test

### DIFF
--- a/kura/test/org.eclipse.kura.core.net.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.core.net.test/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
-Import-Package: org.eclipse.kura.core.net.util;version="1.0.0",
- org.junit;version="4.12.0",
+Import-Package: org.junit;version="4.12.0",
  org.junit.runners;version="4.12.0",
  org.slf4j;version="1.6.4"
+Fragment-Host: org.eclipse.kura.core.net;bundle-version="1.0.10"
+

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/util/NetworkUtilTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/util/NetworkUtilTest.java
@@ -10,7 +10,6 @@ package org.eclipse.kura.core.net.util;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import org.junit.FixMethodOrder;
 import org.junit.Test;


### PR DESCRIPTION
* Make core.net.test a core.net fragment
  Tests will have to access internal packages of core.net.
  These packages may not be exported.
    
* Remove unused import from core.testutil
    
Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>
