### PR TITLE
Fix for invalid XSRF token issue when adding factory components

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/denali.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/denali.java
@@ -177,7 +177,7 @@ public class denali implements EntryPoint {
                                                 denali.this.binder.setFooter(gwtSession);
                                                 denali.this.binder.initSystemPanel(gwtSession, denali.this.m_connected);
                                                 denali.this.binder.setSession(gwtSession);
-                                                denali.this.binder.initServicesTree();
+                                                denali.this.binder.fetchAvailableServices();
                                                 // binder.setDirty(false);
                                             }
 
@@ -190,7 +190,7 @@ public class denali implements EntryPoint {
                                                 denali.this.binder.setFooter(gwtSession);
                                                 denali.this.binder.initSystemPanel(gwtSession, denali.this.m_connected);
                                                 denali.this.binder.setSession(gwtSession);
-                                                denali.this.binder.initServicesTree();
+                                                denali.this.binder.fetchAvailableServices();
                                                 // binder.setDirty(false);
                                             }
                                         });

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -245,6 +245,8 @@ public class EntryClassUi extends Composite {
         FailureHandler.setPopup(this.errorPopup);
 
         showSidenav();
+
+        initServicesTree();
     }
 
     public void setSession(GwtSession GwtSession) {
@@ -497,7 +499,7 @@ public class EntryClassUi extends Composite {
 
     }
 
-    public void initServicesTree() {
+    public void fetchAvailableServices() {
         // (Re)Fetch Available Services
         this.gwtXSRFService.generateSecurityToken(new AsyncCallback<GwtXSRFToken>() {
 
@@ -530,7 +532,9 @@ public class EntryClassUi extends Composite {
                         });
             }
         });
+    }
 
+    private void initServicesTree() {
         // Keypress handler
         textSearch.addValueChangeHandler(changeHandler);
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Packages/PackagesPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Packages/PackagesPanelUi.java
@@ -432,7 +432,7 @@ public class PackagesPanelUi extends Composite {
                             PackagesPanelUi.this.notification.setVisible(false);
                         }
                         if (PackagesPanelUi.this.entryClassUi != null) {
-                            PackagesPanelUi.this.entryClassUi.initServicesTree();
+                            PackagesPanelUi.this.entryClassUi.fetchAvailableServices();
                         }
 
                         PackagesPanelUi.this.refreshRequests--;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.java
@@ -186,7 +186,7 @@ public class ServicesUi extends AbstractServicesUi {
                     ServicesUi.this.apply.setEnabled(false);
                     ServicesUi.this.reset.setEnabled(false);
                     setDirty(false);
-                    ServicesUi.this.entryClass.initServicesTree();
+                    ServicesUi.this.entryClass.fetchAvailableServices();
                 }
             });
             group.add(yes);
@@ -234,7 +234,7 @@ public class ServicesUi extends AbstractServicesUi {
                             apply.setEnabled(false);
                             reset.setEnabled(false);
                             setDirty(false);
-                            entryClass.initServicesTree();
+                            entryClass.fetchAvailableServices();
                             EntryClassUi.hideWaitModal();
                         }
                     });
@@ -348,7 +348,7 @@ public class ServicesUi extends AbstractServicesUi {
                                         ServicesUi.this.apply.setEnabled(false);
                                         ServicesUi.this.reset.setEnabled(false);
                                         setDirty(false);
-                                        ServicesUi.this.entryClass.initServicesTree();
+                                        ServicesUi.this.entryClass.fetchAvailableServices();
                                         EntryClassUi.hideWaitModal();
                                     }
                                 });


### PR DESCRIPTION
EntryClassUi.initServicesTree() is now private and only adds event handlers for the ui elements without refreshing the service list.
Added public method EntryClassUi.fetchAvailableServices() used to fetch/update the services.

Closes #838 

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>