### PR TITLE
Modified wrong entry in snapshot 0s

### DIFF
--- a/kura/distrib/src/main/resources/Win64-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/Win64-nn/snapshot_0.xml
@@ -161,7 +161,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Beaglebone</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/beaglebone-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/beaglebone-nn/snapshot_0.xml
@@ -161,7 +161,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Beaglebone</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/beaglebone/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/beaglebone/snapshot_0.xml
@@ -498,7 +498,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Beaglebone</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/fedorapi/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/fedorapi/snapshot_0.xml
@@ -502,7 +502,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Raspberry Pi 2</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/intel-edison-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/intel-edison-nn/snapshot_0.xml
@@ -158,7 +158,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Intel Edison</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/intel-edison/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/intel-edison/snapshot_0.xml
@@ -538,7 +538,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Inte Edison</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/snapshot_0.xml
@@ -161,7 +161,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Raspberry Pi 2</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/raspberry-pi-2/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/snapshot_0.xml
@@ -501,7 +501,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Raspberry Pi 2</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/raspberry-pi-bplus-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-bplus-nn/snapshot_0.xml
@@ -161,7 +161,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Raspberry Pi</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/raspberry-pi-bplus/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-bplus/snapshot_0.xml
@@ -501,7 +501,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Raspberry Pi</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/raspberry-pi-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-nn/snapshot_0.xml
@@ -161,7 +161,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Raspberry Pi</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/raspberry-pi/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi/snapshot_0.xml
@@ -501,7 +501,7 @@
             <esf:property name="encode.gzip" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="device.display-name" array="false" encrypted="false" type="String">
+            <esf:property name="device.custom-name" array="false" encrypted="false" type="String">
                 <esf:value>Raspberry Pi</esf:value>
             </esf:property>
         </esf:properties>


### PR DESCRIPTION
The CloudService configuration in snapshot 0 now provides the custom name under
the device.custom-name property instead of wrongly specifying it under device.display-name.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>