### PR TITLE
Clean up javadoc

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/package-info.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/package-info.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 /**
  * Contains the necessary classes for the following framework related operations
+ * <p>
  * <ul>
  * <li>Management of Exceptions</li>
  * <li>Preconditions for Defensive Programming - @since 1.0.10</li>


### PR DESCRIPTION
This change cleans up a formatting issue with the package level
javadoc, stuffing all content (including the list) into the package
short description

Signed-off-by: Jens Reimann <jreimann@redhat.com>