### PR TITLE
Add support for forwarding OSGI events to the Web Ui

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/CloudServices/CloudInstancesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/CloudServices/CloudInstancesUi.java
@@ -147,12 +147,14 @@ public class CloudInstancesUi extends Composite {
     }
 
     public void loadData() {
+        EntryClassUi.showWaitModal();
         this.cloudServicesDataProvider.getList().clear();
 
         this.gwtCloudService.findCloudServices(new AsyncCallback<List<GwtCloudConnectionEntry>>() {
 
             @Override
             public void onFailure(Throwable caught) {
+                EntryClassUi.hideWaitModal();
                 FailureHandler.handle(caught, CloudInstancesUi.this.gwtCloudService.getClass().getSimpleName());
             }
 
@@ -162,6 +164,7 @@ public class CloudInstancesUi extends Composite {
                     CloudInstancesUi.this.cloudServicesDataProvider.getList().add(pair);
                 }
                 CloudInstancesUi.this.cloudServicesUi.refreshInternal();
+                EntryClassUi.hideWaitModal();
             }
         });
     }
@@ -294,20 +297,21 @@ public class CloudInstancesUi extends Composite {
                 CloudInstancesUi.this.gwtCloudService.createCloudServiceFromFactory(token, factoryPid,
                         newCloudServicePid, new AsyncCallback<Void>() {
 
-                    @Override
-                    public void onFailure(Throwable caught) {
-                        EntryClassUi.hideWaitModal();
-                        FailureHandler.handle(caught, CloudInstancesUi.this.gwtCloudService.getClass().getSimpleName());
-                        CloudInstancesUi.this.newConnectionModal.hide();
-                    }
+                            @Override
+                            public void onFailure(Throwable caught) {
+                                EntryClassUi.hideWaitModal();
+                                FailureHandler.handle(caught,
+                                        CloudInstancesUi.this.gwtCloudService.getClass().getSimpleName());
+                                CloudInstancesUi.this.newConnectionModal.hide();
+                            }
 
-                    @Override
-                    public void onSuccess(Void result) {
-                        CloudInstancesUi.this.newConnectionModal.hide();
-                        EntryClassUi.hideWaitModal();
-                        CloudInstancesUi.this.cloudServicesUi.refresh(2000);
-                    }
-                });
+                            @Override
+                            public void onSuccess(Void result) {
+                                CloudInstancesUi.this.newConnectionModal.hide();
+                                EntryClassUi.hideWaitModal();
+                                CloudInstancesUi.this.cloudServicesUi.refresh(2000);
+                            }
+                        });
             }
 
         });
@@ -369,18 +373,17 @@ public class CloudInstancesUi extends Composite {
                 CloudInstancesUi.this.gwtStatusService.connectDataService(token, connectionId,
                         new AsyncCallback<Void>() {
 
-                    @Override
-                    public void onSuccess(Void result) {
-                        EntryClassUi.hideWaitModal();
-                        CloudInstancesUi.this.cloudServicesUi.refresh(1000);
-                    }
+                            @Override
+                            public void onSuccess(Void result) {
+                                EntryClassUi.hideWaitModal();
+                            }
 
-                    @Override
-                    public void onFailure(Throwable caught) {
-                        EntryClassUi.hideWaitModal();
-                        FailureHandler.handle(caught);
-                    }
-                });
+                            @Override
+                            public void onFailure(Throwable caught) {
+                                EntryClassUi.hideWaitModal();
+                                FailureHandler.handle(caught);
+                            }
+                        });
             }
         });
     }
@@ -400,18 +403,17 @@ public class CloudInstancesUi extends Composite {
                 CloudInstancesUi.this.gwtStatusService.disconnectDataService(token, connectionId,
                         new AsyncCallback<Void>() {
 
-                    @Override
-                    public void onSuccess(Void result) {
-                        EntryClassUi.hideWaitModal();
-                        CloudInstancesUi.this.cloudServicesUi.refresh(1000);
-                    }
+                            @Override
+                            public void onSuccess(Void result) {
+                                EntryClassUi.hideWaitModal();
+                            }
 
-                    @Override
-                    public void onFailure(Throwable caught) {
-                        EntryClassUi.hideWaitModal();
-                        FailureHandler.handle(caught);
-                    }
-                });
+                            @Override
+                            public void onFailure(Throwable caught) {
+                                EntryClassUi.hideWaitModal();
+                                FailureHandler.handle(caught);
+                            }
+                        });
             }
         });
     }
@@ -431,18 +433,18 @@ public class CloudInstancesUi extends Composite {
                 CloudInstancesUi.this.gwtCloudService.deleteCloudServiceFromFactory(token, factoryPid, cloudServicePid,
                         new AsyncCallback<Void>() {
 
-                    @Override
-                    public void onSuccess(Void result) {
-                        EntryClassUi.hideWaitModal();
-                        CloudInstancesUi.this.cloudServicesUi.refresh(2000);
-                    }
+                            @Override
+                            public void onSuccess(Void result) {
+                                EntryClassUi.hideWaitModal();
+                                CloudInstancesUi.this.cloudServicesUi.refresh(2000);
+                            }
 
-                    @Override
-                    public void onFailure(Throwable caught) {
-                        EntryClassUi.hideWaitModal();
-                        FailureHandler.handle(caught);
-                    }
-                });
+                            @Override
+                            public void onFailure(Throwable caught) {
+                                EntryClassUi.hideWaitModal();
+                                FailureHandler.handle(caught);
+                            }
+                        });
             }
         });
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/CloudServices/CloudServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/CloudServices/CloudServicesUi.java
@@ -15,7 +15,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.messages.Messages;
+import org.eclipse.kura.web.client.util.EventService;
+import org.eclipse.kura.web.shared.ForwardedEventTopic;
 import org.eclipse.kura.web.shared.model.GwtCloudConnectionEntry;
+import org.eclipse.kura.web.shared.model.GwtEventInfo;
 import org.gwtbootstrap3.client.ui.Alert;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ButtonGroup;
@@ -67,6 +70,20 @@ public class CloudServicesUi extends Composite {
 
         cloudServiceConfigurationsBinder = new CloudServiceConfigurationsUi(this);
         this.cloudConfigurationsPanel.add(cloudServiceConfigurationsBinder);
+
+        EventService.Handler onConnectionStatusChangedHandler = new EventService.Handler() {
+
+            @Override
+            public void handleEvent(GwtEventInfo eventInfo) {
+                if (CloudServicesUi.this.isVisible() && CloudServicesUi.this.isAttached()) {
+                    CloudServicesUi.this.refresh();
+                }
+            }
+        };
+
+        EventService.subscribe(ForwardedEventTopic.CLOUD_CONNECTION_STATUS_ESTABLISHED,
+                onConnectionStatusChangedHandler);
+        EventService.subscribe(ForwardedEventTopic.CLOUD_CONNECTION_STATUS_LOST, onConnectionStatusChangedHandler);
     }
 
     public void refresh() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -23,8 +23,11 @@ import org.eclipse.kura.web.client.ui.Packages.PackagesPanelUi;
 import org.eclipse.kura.web.client.ui.Settings.SettingsPanelUi;
 import org.eclipse.kura.web.client.ui.Status.StatusPanelUi;
 import org.eclipse.kura.web.client.ui.wires.WiresPanelUi;
+import org.eclipse.kura.web.client.util.EventService;
 import org.eclipse.kura.web.client.util.FailureHandler;
+import org.eclipse.kura.web.shared.ForwardedEventTopic;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
+import org.eclipse.kura.web.shared.model.GwtEventInfo;
 import org.eclipse.kura.web.shared.model.GwtSession;
 import org.eclipse.kura.web.shared.model.GwtXSRFToken;
 import org.eclipse.kura.web.shared.service.GwtComponentService;
@@ -206,6 +209,7 @@ public class EntryClassUi extends Composite {
         logger.log(Level.FINER, "Initiating UiBinder");
         this.ui = this;
         initWidget(uiBinder.createAndBindUi(this));
+        initWaitModal();
 
         // TODO : standardize the URL?
         // header.setUrl("eclipse/kura/icons/kura_logo_small.png");
@@ -241,6 +245,21 @@ public class EntryClassUi extends Composite {
 
         //
         dragDropInit(this);
+
+        EventService.subscribe(ForwardedEventTopic.CLOUD_CONNECTION_STATUS_ESTABLISHED, new EventService.Handler() {
+
+            @Override
+            public void handleEvent(GwtEventInfo eventInfo) {
+                updateConnectionStatusImage(true);
+            }
+        });
+        EventService.subscribe(ForwardedEventTopic.CLOUD_CONNECTION_STATUS_LOST, new EventService.Handler() {
+
+            @Override
+            public void handleEvent(GwtEventInfo eventInfo) {
+                updateConnectionStatusImage(false);
+            }
+        });
 
         FailureHandler.setPopup(this.errorPopup);
 
@@ -803,7 +822,7 @@ public class EntryClassUi extends Composite {
         }
     }
 
-    public static void showWaitModal() {
+    private void initWaitModal() {
         m_waitModal = new PopupPanel(false, true);
         Icon icon = new Icon();
         icon.setType(IconType.COG);
@@ -812,13 +831,15 @@ public class EntryClassUi extends Composite {
         m_waitModal.setWidget(icon);
         m_waitModal.setGlassEnabled(true);
         m_waitModal.center();
+        m_waitModal.hide();
+    }
+
+    public static void showWaitModal() {
         m_waitModal.show();
     }
 
     public static void hideWaitModal() {
-        if (m_waitModal != null) {
-            m_waitModal.hide();
-        }
+        m_waitModal.hide();
     }
 
     private void forceTabsCleaning() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/EventService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/EventService.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.client.util;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.kura.web.shared.ForwardedEventTopic;
+import org.eclipse.kura.web.shared.model.GwtEventInfo;
+import org.eclipse.kura.web.shared.service.GwtEventService;
+import org.eclipse.kura.web.shared.service.GwtEventServiceAsync;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.http.client.RequestBuilder;
+import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.rpc.RpcRequestBuilder;
+import com.google.gwt.user.client.rpc.ServiceDefTarget;
+
+public final class EventService {
+
+    private static final int ON_FAILURE_RESEND_DELAY = 5000;
+    private static final EventService instance = new EventService();
+
+    private final GwtEventServiceAsync gwtEventService = GWT.create(GwtEventService.class);
+    private HashMap<String, LinkedList<Handler>> subscribedHandlers = new HashMap<String, LinkedList<Handler>>();
+    private long lastEventTimestamp = 0;
+    private Timer resendTimer;
+
+    private class TimeoutRequestBuilder extends RpcRequestBuilder {
+
+        @Override
+        protected RequestBuilder doCreate(String serviceEntryPoint) {
+            RequestBuilder builder = super.doCreate(serviceEntryPoint);
+            builder.setTimeoutMillis(GwtEventService.POLL_TIMEOUT_SECONDS * 1000);
+            return builder;
+        }
+    }
+
+    private EventService() {
+        ((ServiceDefTarget) gwtEventService).setRpcRequestBuilder(new TimeoutRequestBuilder());
+        gwtEventService.getLastEventTimestamp(new AsyncCallback<String>() {
+
+            @Override
+            public void onSuccess(String result) {
+                lastEventTimestamp = Long.parseLong(result);
+                gwtEventService.getNextEvents(Long.toString(lastEventTimestamp), eventCallback);
+            }
+
+            @Override
+            public void onFailure(Throwable caught) {
+            }
+        });
+    }
+
+    private final AsyncCallback<List<GwtEventInfo>> eventCallback = new AsyncCallback<List<GwtEventInfo>>() {
+
+        @Override
+        public void onSuccess(List<GwtEventInfo> result) {
+
+            for (GwtEventInfo event : result)
+                processEvent(event);
+
+            stopResendTimer();
+
+            gwtEventService.getNextEvents(Long.toString(lastEventTimestamp), eventCallback);
+        }
+
+        @Override
+        public void onFailure(Throwable caught) {
+            startResendTimer(ON_FAILURE_RESEND_DELAY);
+        }
+    };
+
+    private void stopResendTimer() {
+        if (resendTimer != null) {
+            resendTimer.cancel();
+        }
+
+        resendTimer = null;
+    }
+
+    private void startResendTimer(int timeout) {
+        stopResendTimer();
+
+        resendTimer = new Timer() {
+
+            @Override
+            public void run() {
+                gwtEventService.getNextEvents(Long.toString(lastEventTimestamp), eventCallback);
+            }
+        };
+        resendTimer.schedule(timeout);
+    }
+
+    private void processEvent(GwtEventInfo event) {
+
+        if (event == null) {
+            return;
+        }
+
+        lastEventTimestamp = Long.parseLong(event.getTimestamp());
+
+        LinkedList<Handler> topicHandlers = subscribedHandlers.get(event.getTopic());
+
+        if (topicHandlers != null) {
+            for (Handler handler : topicHandlers) {
+                handler.handleEvent(event);
+            }
+        }
+    }
+
+    public static void subscribe(ForwardedEventTopic topic, Handler handler) {
+        LinkedList<Handler> topicHandlers = instance.subscribedHandlers.get(topic.toString());
+        if (topicHandlers == null) {
+            topicHandlers = new LinkedList<Handler>();
+            instance.subscribedHandlers.put(topic.toString(), topicHandlers);
+        }
+        topicHandlers.push(handler);
+    }
+
+    public static void unsubscribe(ForwardedEventTopic topic, Handler handler) {
+        LinkedList<Handler> topicHandlers = instance.subscribedHandlers.get(topic.toString());
+        if (topicHandlers != null) {
+            topicHandlers.remove(handler);
+        }
+    }
+
+    public interface Handler {
+
+        public void handleEvent(GwtEventInfo eventInfo);
+    }
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtEventServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtEventServiceImpl.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.server;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.kura.web.shared.ForwardedEventTopic;
+import org.eclipse.kura.web.shared.model.GwtEventInfo;
+import org.eclipse.kura.web.shared.service.GwtEventService;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventConstants;
+import org.osgi.service.event.EventHandler;
+
+public class GwtEventServiceImpl extends OsgiRemoteServiceServlet implements GwtEventService, EventHandler {
+
+    private static final int MAX_EVENT_COUNT = 50;
+
+    private LinkedList<String> topics = new LinkedList<String>();
+    private LinkedList<GwtEventInfo> events = new LinkedList<GwtEventInfo>();
+    private ServiceRegistration<EventHandler> registration;
+
+    public GwtEventServiceImpl() {
+        for (ForwardedEventTopic topic : ForwardedEventTopic.values()) {
+            this.topics.add(topic.toString());
+        }
+    }
+
+    @Override
+    public synchronized void handleEvent(Event event) {
+
+        GwtEventInfo eventInfo = serialize(event);
+
+        if (events.size() >= MAX_EVENT_COUNT) {
+            events.removeLast();
+        }
+
+        events.push(eventInfo);
+
+        this.notifyAll();
+    }
+
+    private List<GwtEventInfo> getEvents(long fromTimestamp) {
+        LinkedList<GwtEventInfo> result = new LinkedList<GwtEventInfo>();
+
+        Iterator<GwtEventInfo> i = events.iterator();
+
+        while (i.hasNext()) {
+            GwtEventInfo next = i.next();
+            if (Long.parseLong(next.getTimestamp()) <= fromTimestamp) {
+                break;
+            }
+            result.push(next);
+        }
+
+        return result;
+    }
+
+    public void start() {
+        stop();
+
+        Dictionary<String, Object> map = new Hashtable<String, Object>();
+
+        map.put(EventConstants.EVENT_TOPIC, topics.toArray(new String[topics.size()]));
+
+        BundleContext bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
+        registration = bundleContext.registerService(EventHandler.class, this, map);
+    }
+
+    public void stop() {
+        if (registration != null) {
+            registration.unregister();
+            registration = null;
+        }
+    }
+
+    @Override
+    public synchronized List<GwtEventInfo> getNextEvents(String fromTimestamp) {
+        long timestamp = Long.parseLong(fromTimestamp);
+
+        List<GwtEventInfo> result = getEvents(timestamp);
+
+        if (!result.isEmpty()) {
+            return result;
+        }
+
+        try {
+            this.wait(POLL_TIMEOUT_SECONDS * 1000);
+        } catch (InterruptedException e) {
+            return new LinkedList<GwtEventInfo>();
+        }
+
+        return getEvents(timestamp);
+    }
+
+    @Override
+    public synchronized String getLastEventTimestamp() {
+        if (events.isEmpty()) {
+            return "0";
+        }
+        return events.getFirst().getTimestamp();
+    }
+
+    public GwtEventInfo serialize(Event event) {
+        GwtEventInfo result = new GwtEventInfo(event.getTopic());
+
+        for (String property : event.getPropertyNames()) {
+            if ("event".equals(property)) {
+                continue;
+            }
+
+            Object obj = event.getProperty(property);
+            result.set(property, obj != null ? obj.toString() : null);
+        }
+
+        return result;
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/ForwardedEventTopic.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/ForwardedEventTopic.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.shared;
+
+public enum ForwardedEventTopic {
+
+    // This enum defines the subset of events that will be forwarded to the web ui
+    // If you want to forward other events it's enough to define an enum item here
+
+    CLOUD_CONNECTION_STATUS_ESTABLISHED("org/eclipse/kura/cloud/CloudConnectionStatus/ESTABLISHED"),
+    CLOUD_CONNECTION_STATUS_LOST("org/eclipse/kura/cloud/CloudConnectionStatus/LOST"),
+
+    DEPLOYMENT_PACKAGE_INSTALLED("org/eclipse/kura/deployment/agent/INSTALLED"),
+    DEPLOYMENT_PACKAGE_UNINSTALLED("org/eclipse/kura/deployment/agent/UNINSTALLED"),
+
+    BUNDLE_INSTALLED("org/osgi/framework/BundleEvent/INSTALLED"),
+    BUNDLE_STARTED("org/osgi/framework/BundleEvent/STARTED"),
+    BUNDLE_STOPPED("org/osgi/framework/BundleEvent/STOPPED"),
+    BUNDLE_UPDATED("org/osgi/framework/BundleEvent/UPDATED"),
+    BUNDLE_UNINSTALLED("org/osgi/framework/BundleEvent/UNINSTALLED"),
+    BUNDLE_RESOLVED("org/osgi/framework/BundleEvent/RESOLVED"),
+    BUNDLE_UNRESOLVED("org/osgi/framework/BundleEvent/UNRESOLVED");
+
+    private final String topic;
+
+    private ForwardedEventTopic(String topic) {
+        this.topic = topic;
+    }
+
+    @Override
+    public String toString() {
+        return topic;
+    }
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtEventInfo.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtEventInfo.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.shared.model;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class GwtEventInfo extends GwtBaseModel implements Serializable {
+
+    private static final long serialVersionUID = 5806274412665387619L;
+
+    public GwtEventInfo() {
+    }
+
+    public GwtEventInfo(String topic) {
+        set("timestamp", Long.toString(new Date().getTime()));
+        set("topic", topic);
+    }
+
+    public String getTimestamp() {
+        return get("timestamp");
+    }
+
+    public String getTopic() {
+        return get("topic");
+    }
+
+    public String toString() { // TODO remove me
+        return this.data.toString();
+    }
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtEventService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtEventService.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.shared.service;
+
+import java.util.List;
+
+import org.eclipse.kura.web.shared.model.GwtEventInfo;
+
+import com.google.gwt.user.client.rpc.RemoteService;
+import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
+
+@RemoteServiceRelativePath("event")
+public interface GwtEventService extends RemoteService {
+
+    public static final int POLL_TIMEOUT_SECONDS = 30;
+
+    public List<GwtEventInfo> getNextEvents(String fromTimestamp);
+
+    public String getLastEventTimestamp();
+
+}


### PR DESCRIPTION
A subset of the OSGI EventAdmin events is now forwarded to the web ui using long polling.
The subset of events forwarded is defined by the ForwardedEventTopic enum.
The cloud services, bundles, packages and status sections are now refreshed on event.
The icon representing the cloud connection status in the left panel is now updated on event.

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>