### PR TITLE
Fix for bind/named service

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxNamed.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxNamed.java
@@ -69,7 +69,7 @@ public class LinuxNamed {
             s_procString = "/usr/sbin/named";
             s_logFileName = "/var/log/named.log";
             s_rfc1912ZonesFilename = "/etc/bind/named.rfc1912.zones";
-        } else if (OS_VERSION.equals(
+        } else if (OS_VERSION.equals(KuraConstants.Fedora_Pi.getImageName()) || OS_VERSION.equals(
                 KuraConstants.Reliagate_20_26.getImageName() + "_" + KuraConstants.Reliagate_20_26.getImageVersion())) {
             s_persistentConfigFileName = "/etc/named.conf";
             s_procString = "named -u named -t";

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxNamed.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxNamed.java
@@ -69,6 +69,12 @@ public class LinuxNamed {
             s_procString = "/usr/sbin/named";
             s_logFileName = "/var/log/named.log";
             s_rfc1912ZonesFilename = "/etc/bind/named.rfc1912.zones";
+        } else if (OS_VERSION.equals(
+                KuraConstants.Reliagate_20_26.getImageName() + "_" + KuraConstants.Reliagate_20_26.getImageVersion())) {
+            s_persistentConfigFileName = "/etc/named.conf";
+            s_procString = "named -u named -t";
+            s_logFileName = "/var/named/data/named.run";
+            s_rfc1912ZonesFilename = "/etc/named.rfc1912.zones";
         } else {
             s_persistentConfigFileName = "/etc/named.conf";
             s_procString = "named -u named -t";
@@ -208,7 +214,9 @@ public class LinuxNamed {
             } else if (OS_VERSION.equals(KuraConstants.ReliaGATE_50_21_Ubuntu.getImageName() + "_"
                     + KuraConstants.ReliaGATE_50_21_Ubuntu.getImageVersion())) {
                 result = LinuxProcessUtil.start("/etc/init.d/bind9 start");
-            } else if (OS_VERSION.equals(KuraConstants.Fedora_Pi.getImageName())) {
+            } else if (OS_VERSION.equals(KuraConstants.Fedora_Pi.getImageName())
+                    || OS_VERSION.equals(KuraConstants.Reliagate_20_26.getImageName() + "_"
+                            + KuraConstants.Reliagate_20_26.getImageVersion())) {
                 result = LinuxProcessUtil.start("/bin/systemctl start named");
             } else {
                 s_logger.info("Linux named enable fallback");
@@ -246,7 +254,9 @@ public class LinuxNamed {
             } else if (OS_VERSION.equals(KuraConstants.ReliaGATE_50_21_Ubuntu.getImageName() + "_"
                     + KuraConstants.ReliaGATE_50_21_Ubuntu.getImageVersion())) {
                 result = LinuxProcessUtil.start("/etc/init.d/bind9 stop");
-            } else if (OS_VERSION.equals(KuraConstants.Fedora_Pi.getImageName())) {
+            } else if (OS_VERSION.equals(KuraConstants.Fedora_Pi.getImageName())
+                    || OS_VERSION.equals(KuraConstants.Reliagate_20_26.getImageName() + "_"
+                            + KuraConstants.Reliagate_20_26.getImageVersion())) {
                 result = LinuxProcessUtil.start("/bin/systemctl stop named");
             } else {
                 result = LinuxProcessUtil.start("/etc/init.d/named stop");

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/KuraConstants.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/KuraConstants.java
@@ -24,6 +24,7 @@ public enum KuraConstants {
     ReliaGATE_50_21_Ubuntu("ubuntu", "14.04", "reliagate-50-21"),
     Reliagate_10_11("yocto", "1.2.1", "reliagate-10-11"),
     Reliagate_20_25("yocto", "1.2.1", "reliagate-20-25"),
+    Reliagate_20_26("rhel", "7.3", "reliagate-20-26"),
     Fedora_Pi("fedora", "2x", "raspberry-pi");
 
     private String m_imageName;


### PR DESCRIPTION
Bind/named service and its configuration files are in different
locations depending on the OS. The modifications on this PR
add the support for different file locations.