### PR TITLE
Fixed validation for the 'DNS Servers' field to allow to enter multip…

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabTcpIpUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabTcpIpUi.java
@@ -547,6 +547,31 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
             @Override
             public void onChange(ChangeEvent event) {
                 setDirty(true);
+                
+                if (TabTcpIpUi.this.dns.getText().trim().length() == 0) {
+        			TabTcpIpUi.this.groupDns.setValidationState(ValidationState.NONE);
+        			TabTcpIpUi.this.helpDns.setText("");
+            		return;
+        		}
+        
+        		String regex = "[\\s,;\\n\\t]+";
+        		String[] aDnsServers = TabTcpIpUi.this.dns.getText().trim().split(regex);
+        		boolean validDnsList = true;
+        		for (String dnsEntry : aDnsServers) {
+        			if ((dnsEntry.length() > 0) && !dnsEntry.matches(FieldType.IPv4_ADDRESS.getRegex())) {
+        				validDnsList = false;
+        				break;
+        			}
+        		}
+        		if (!validDnsList) {
+        			TabTcpIpUi.this.groupDns.setValidationState(ValidationState.ERROR);
+                    TabTcpIpUi.this.helpDns.setText(MSGS.netIPv4InvalidAddress());
+        		} else {
+        			TabTcpIpUi.this.groupDns.setValidationState(ValidationState.NONE);
+                    TabTcpIpUi.this.helpDns.setText("");
+        		}
+                
+        		/*
                 if (!TabTcpIpUi.this.dns.getText().trim().matches(FieldType.IPv4_ADDRESS.getRegex())
                         && TabTcpIpUi.this.dns.getText().trim().length() > 0) {
                     TabTcpIpUi.this.groupDns.setValidationState(ValidationState.ERROR);
@@ -555,6 +580,7 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
                     TabTcpIpUi.this.groupDns.setValidationState(ValidationState.NONE);
                     TabTcpIpUi.this.helpDns.setText("");
                 }
+                */
             }
         });
 
@@ -706,23 +732,34 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
                     this.subnet.setEnabled(false);
                     this.gateway.setEnabled(false);
                     this.renew.setEnabled(true);
+                    if (this.status.getSelectedValue().equals(IPV4_STATUS_WAN_MESSAGE)) {
+                    	this.dns.setEnabled(true);
+                    	this.search.setEnabled(true);
+                    } else {
+                    	this.dns.setEnabled(false);
+                    	this.search.setEnabled(false);
+                    }
                 } else {
                     this.ip.setEnabled(true);
                     this.subnet.setEnabled(true);
-                    this.gateway.setEnabled(true);
+                    //this.gateway.setEnabled(true);
 
                     if (this.status.getSelectedValue().equals(IPV4_STATUS_WAN_MESSAGE)) {
-                        // enable gateway field
                         this.gateway.setEnabled(true);
+                        this.dns.setEnabled(true);
+                        this.search.setEnabled(true);
                     } else {
                         this.gateway.setText("");
                         this.gateway.setEnabled(false);
+                        this.dns.setEnabled(false);
+                        this.search.setEnabled(false);
                     }
                     this.renew.setEnabled(false);
                 }
+                /*
                 this.dns.setEnabled(true);
                 this.search.setEnabled(true);
-
+				*/
             }
         }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -316,16 +316,13 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
                                     StringBuffer sb = new StringBuffer();
                                     List<IP4Address> dnsServers = ((NetConfigIP4) netConfig).getDnsServers();
                                     if (dnsServers != null && !dnsServers.isEmpty()) {
-                                        String sep = "";
                                         for (IP4Address dnsServer : dnsServers) {
                                             if (!dnsServer.getHostAddress().equals("127.0.0.1")) {
-                                                sb.append(sep).append(dnsServer.getHostAddress());
-                                                sep = "\n";
+                                                sb.append(' ').append(dnsServer.getHostAddress());
                                             }
                                         }
-
                                         s_logger.debug("DNS Servers: {}", sb);
-                                        gwtNetConfig.setDnsServers(sb.toString());
+                                        gwtNetConfig.setDnsServers(sb.toString().trim());
                                     } else {
                                         s_logger.debug("DNS Servers: [empty String]");
                                         gwtNetConfig.setDnsServers("");
@@ -726,6 +723,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
     @Override
     public void updateNetInterfaceConfigurations(GwtXSRFToken xsrfToken, GwtNetInterfaceConfig config)
             throws GwtKuraException {
+    	
         checkXSRFToken(xsrfToken);
         NetworkAdminService nas = ServiceLocator.getInstance().getService(NetworkAdminService.class);
 


### PR DESCRIPTION
@cdealti I have fixed validation for the 'DNS Servers' field to allow to enter multiple DNS servers. I've also made changes to disable 'DNS Servers' and 'Search Domains' fields if interface is configured as LAN. I did it because in the DnsMonitorServiceImpl DNS servers are added for WAN interfaces only which I think is correct. Please validate.

Signed-off-by: ibinshtok <ilya.binshtok@eurotech.com>