### PR TITLE
Updated apply button behavior.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/CloudServices/CloudServiceConfigurationUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/CloudServices/CloudServiceConfigurationUi.java
@@ -59,7 +59,7 @@ public class CloudServiceConfigurationUi extends AbstractServicesUi {
     }
 
     private Modal modal;
-    private final GwtConfigComponent originalConfig;
+    private GwtConfigComponent originalConfig;
 
     @UiField
     Button applyConnectionEdit;
@@ -229,6 +229,7 @@ public class CloudServiceConfigurationUi extends AbstractServicesUi {
                                         CloudServiceConfigurationUi.this.applyConnectionEdit.setEnabled(false);
                                         CloudServiceConfigurationUi.this.resetConnectionEdit.setEnabled(false);
                                         setDirty(false);
+                                        originalConfig = CloudServiceConfigurationUi.this.m_configurableComponent;
                                         EntryClassUi.hideWaitModal();
                                     }
                                 });

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.java
@@ -63,8 +63,9 @@ public class ServicesUi extends AbstractServicesUi {
     private final GwtComponentServiceAsync gwtComponentService = GWT.create(GwtComponentService.class);
     private final GwtSecurityTokenServiceAsync gwtXSRFService = GWT.create(GwtSecurityTokenService.class);
 
-    private boolean dirty, initialized;
-    private final GwtConfigComponent originalConfig;
+    private boolean dirty;
+    private boolean initialized;
+    private GwtConfigComponent originalConfig;
 
     NavPills menu;
     PanelBody content;
@@ -183,7 +184,7 @@ public class ServicesUi extends AbstractServicesUi {
             footer.add(group);
             this.modal.add(footer);
             this.modal.show();
-        }                   // end is dirty
+        }
     }
 
     // TODO: Separate render methods for each type (ex: Boolean, String,
@@ -291,6 +292,7 @@ public class ServicesUi extends AbstractServicesUi {
                                         ServicesUi.this.apply.setEnabled(false);
                                         ServicesUi.this.reset.setEnabled(false);
                                         setDirty(false);
+                                        originalConfig = ServicesUi.this.m_configurableComponent;
                                         ServicesUi.this.entryClass.initServicesTree();
                                         EntryClassUi.hideWaitModal();
                                     }
@@ -314,14 +316,11 @@ public class ServicesUi extends AbstractServicesUi {
                 footer.add(group);
                 this.modal.add(footer);
                 this.modal.show();
-
-                // ----
-
-            }                   // end isDirty()
+            }
         } else {
             errorLogger.log(Level.SEVERE, "Device configuration error!");
             this.incompleteFieldsModal.show();
-        }                   // end else isValid
+        }
     }
 
     private GwtConfigComponent getUpdatedConfiguration() {


### PR DESCRIPTION
When pressing apply, now the original configuration variable used for the reset
is updated with the new component configuration. In this way, a consequent reset
will not restore the stating configuration, but the updated one.

Some cleanups of unuseful comments.

Closes #895 

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>