### PR TITLE
Fix the implementation of the Kura wires commands

### DIFF
--- a/kura/org.eclipse.kura.wire.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.wire.provider/META-INF/MANIFEST.MF
@@ -19,7 +19,6 @@ Import-Package: org.eclipse.kura;version="[1.2,2.0)",
  org.eclipse.kura.util.collection;version="[1.0,2.0)",
  org.eclipse.kura.util.service;version="[1.0,2.0)",
  org.eclipse.kura.wire;version="[1.0,1.1)",
- org.eclipse.osgi.framework.console;version="1.1.0",
  org.osgi.framework;version="[1.7.0,2.0.0)",
  org.osgi.service.component;version="1.2.0",
  org.osgi.service.event;version="1.3.0",
@@ -29,3 +28,4 @@ Import-Package: org.eclipse.kura;version="[1.2,2.0)",
  org.slf4j;version="1.6.4"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
+Require-Bundle: org.apache.felix.gogo.runtime;bundle-version="0.10.0"

--- a/kura/org.eclipse.kura.wire.provider/OSGI-INF/WireServiceCommandComponent.xml
+++ b/kura/org.eclipse.kura.wire.provider/OSGI-INF/WireServiceCommandComponent.xml
@@ -6,18 +6,27 @@
      are made available under the terms of the Eclipse Public License v1.0
      which accompanies this distribution, and is available at
      http://www.eclipse.org/legal/epl-v10.html
+     
+     Contributors:
+         Eurotech and/or its affiliates
+         Red Hat Inc
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
     name="org.eclipse.kura.wire.WireServiceCommand"
     enabled="true">
    <implementation class="org.eclipse.kura.internal.wire.WireServiceCommandProvider"/>
-   <service>
-      <provide interface="org.eclipse.osgi.framework.console.CommandProvider"/>
-   </service>
    <reference bind="bindWireService" 
    	          cardinality="1..1" 
    	          interface="org.eclipse.kura.wire.WireService" 
    	          name="WireService" 
    	          policy="static" 
    	          unbind="unbindWireService"/>
+   <service>
+      <provide interface="org.eclipse.kura.internal.wire.WireServiceCommandProvider"/>
+   </service>
+   <property name="osgi.command.scope" type="String" value="kura"/>
+   <property name="osgi.command.function" type="String">createWire
+deleteWire
+listWires
+   </property>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.provider/pom.xml
+++ b/kura/org.eclipse.kura.wire.provider/pom.xml
@@ -6,6 +6,10 @@
      are made available under the terms of the Eclipse Public License v1.0
      which accompanies this distribution, and is available at
      http://www.eclipse.org/legal/epl-v10.html
+     
+     Contributors:
+         Eurotech and/or its affiliates
+         Red Hat Inc
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireServiceCommandProvider.java
+++ b/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireServiceCommandProvider.java
@@ -5,32 +5,25 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
+ * Contributors:
+ *     Eurotech and/or its affiliates
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kura.internal.wire;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 
+import org.apache.felix.service.command.Descriptor;
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.Preconditions;
-import org.eclipse.kura.localization.LocalizationAdapter;
-import org.eclipse.kura.localization.resources.WireMessages;
-import org.eclipse.kura.util.base.ThrowableUtil;
 import org.eclipse.kura.wire.WireConfiguration;
 import org.eclipse.kura.wire.WireService;
-import org.eclipse.osgi.framework.console.CommandInterpreter;
-import org.eclipse.osgi.framework.console.CommandProvider;
 
 /**
  * Provides Gogo Shell commands to create, delete Wire Configurations and list
  * the available ones
  */
-public final class WireServiceCommandProvider implements CommandProvider {
-
-    /** Localization Resource */
-    private static final WireMessages s_message = LocalizationAdapter.adapt(WireMessages.class);
+public final class WireServiceCommandProvider {
 
     /** The Wire Service. */
     private volatile WireService wireService;
@@ -39,52 +32,31 @@ public final class WireServiceCommandProvider implements CommandProvider {
      * The command {@code createWire} creates a Wire Configuration between the
      * provided emitter PID and receiver PID
      *
-     * @param ci
-     *            the console interpreter
+     * @throws KuraException
+     *             In case of an errror
      */
-    public void _createWire(final CommandInterpreter ci) {
-        final String argument = ci.nextArgument();
-        if (argument == null) {
-            ci.println("Usage: createWire <emitterPid>----<receiverPid>");
-        }
-        final List<String> pids = this.getPids(argument);
-        if (pids.isEmpty() || (pids.size() != 2)) {
-            ci.println("The format is wrongly provided");
-            ci.println("Usage: createWire <emitterPid>----<receiverPid>");
-        }
-        final String emitterPid = pids.get(0);
-        final String receiverPid = pids.get(1);
-        try {
-            this.wireService.createWireConfiguration(emitterPid, receiverPid);
-        } catch (final KuraException e) {
-            ci.println("Exception occurred ==> " + ThrowableUtil.stackTraceAsString(e));
-        }
+    @Descriptor("Creates a Wire Configuration between the provided emitter and receiver")
+    public void createWire(@Descriptor("Emitter PID") String emitterPid, @Descriptor("Receiver PID") String receiverPid)
+            throws KuraException {
+        this.wireService.createWireConfiguration(emitterPid, receiverPid);
     }
 
     /**
      * The command {@code deleteWire} delete existing Wire Configuration between
      * the provided emitter PID and receiver PID
-     *
-     * @param ci
-     *            the console interpreter
+     * 
+     * @param emitterPid
+     *            the emitter PID
+     * @param receiverPid
+     *            the receiver PID
      */
-    public void _deleteWire(final CommandInterpreter ci) {
-        final String argument = ci.nextArgument();
-        if (argument == null) {
-            ci.println("Usage: deleteWire <emitterPid>----<receiverPid>");
-        }
-        final List<String> pids = this.getPids(argument);
-        if (pids.isEmpty() || (pids.size() != 2)) {
-            ci.println("The format is wrongly provided");
-            ci.println("Usage: deleteWire <emitterPid>----<receiverPid>");
-        }
-        final String emitterPid = pids.get(0);
-        final String receiverPid = pids.get(1);
+    @Descriptor("Deletes the already created Wire Configuration between the provided emitter and receiver")
+    public void deleteWire(@Descriptor("Emitter PID") String emitterPid,
+            @Descriptor("Receiver PID") String receiverPid) {
         for (final WireConfiguration configuration : this.wireService.getWireConfigurations()) {
             if (configuration.getEmitterPid().equals(emitterPid)
                     && configuration.getReceiverPid().equals(receiverPid)) {
                 this.wireService.deleteWireConfiguration(configuration);
-                return;
             }
         }
     }
@@ -95,16 +67,17 @@ public final class WireServiceCommandProvider implements CommandProvider {
      * @param ci
      *            the console interpreter
      */
-    public void _listWires(final CommandInterpreter ci) {
-        ci.println("=================== Wire Configurations ===================");
+    @Descriptor("List all created Wire Configurations")
+    public void listWires() {
+        System.out.println("=================== Wire Configurations ===================");
         final Set<WireConfiguration> configs = this.wireService.getWireConfigurations();
         int i = 0;
         for (final WireConfiguration config : configs) {
-            ci.println(new StringBuilder().append(i++).append(".").append(" ").append("Emitter PID ===>").append(" ")
-                    .append(config.getEmitterPid()).append("  ").append("Receiver PID ===>").append(" ")
-                    .append(config.getReceiverPid()).toString());
+            System.out.format("%d. Emitter PID ===> %s  Receiver PID ===> %s%n", i, config.getEmitterPid(),
+                    config.getReceiverPid());
+            i++;
         }
-        ci.println("===========================================================");
+        System.out.println("===========================================================");
     }
 
     /**
@@ -117,28 +90,6 @@ public final class WireServiceCommandProvider implements CommandProvider {
         if (this.wireService == null) {
             this.wireService = wireHelperService;
         }
-    }
-
-    /** Shows the Help Option for this command */
-    @Override
-    public String getHelp() {
-        return "---Wire Service---\n"
-                + "\tcreateWire <emitterPid>----<receiverPid> - Creates a Wire Configuration between the provided emitter and receiver\n"
-                + "\tlistWires - list all created Wire Configurations\n"
-                + "\tdeleteWire <emitterPid>----<receiverPid> - Deletes the already created Wire Configuration between the provided emitter and receiver\n";
-    }
-
-    /**
-     * Retrieves the emitter and receiver PIDs from the provided param
-     *
-     * @param param
-     *            the param in the format of {@code emitterPid----receiverPid}
-     * @return the list containing the emitter and receiver PID
-     */
-    private List<String> getPids(final String param) {
-        Preconditions.checkNull(param, s_message.stringNonNull());
-        final String delimiter = "----";
-        return Arrays.asList(param.split(delimiter));
     }
 
     /**


### PR DESCRIPTION
Contrary to the javadoc of the Wires commands this implementation does
not use the Gogo shell but the old, legacy, deprecated Equinox console.

However this does break the compatibility with Karaf.

Signed-off-by: Jens Reimann <jreimann@redhat.com>