### PR TITLE
Add a docker file for building Kura on Karaf

### DIFF
--- a/karaf/features/kura-core/src/main/feature/feature.xml
+++ b/karaf/features/kura-core/src/main/feature/feature.xml
@@ -18,6 +18,7 @@
         <feature dependency="true">kura-runtime</feature>
         
         <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.api/${org.eclipse.kura.api.version}</bundle>
+        
         <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.core/${org.eclipse.kura.core.version}</bundle>
         <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.core.cloud/${org.eclipse.kura.core.cloud.version}</bundle>
         <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.core.comm/${org.eclipse.kura.core.comm.version}</bundle>
@@ -25,7 +26,16 @@
         <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.core.crypto/${org.eclipse.kura.core.crypto.version}</bundle>
         <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.core.net/${org.eclipse.kura.core.net.version}</bundle>
         <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.core.status/${org.eclipse.kura.core.status.version}</bundle>
+        
         <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.deployment.agent/${org.eclipse.kura.deployment.agent.version}</bundle>
+        
+        <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.localization/${org.eclipse.kura.localization.version}</bundle>
+        <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.localization.resources/${org.eclipse.kura.localization.resources.version}</bundle>
+        
+        <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.util/${org.eclipse.kura.util.version}</bundle>
+        
+        <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.asset.provider/${org.eclipse.kura.asset.provider.version}</bundle>
+        <bundle start-level="80">mvn:org.eclipse.kura/org.eclipse.kura.wire.provider/${org.eclipse.kura.wire.provider.version}</bundle>
     </feature>
     
     <feature name="kura-camel" version="${project.version}" description="Eclipse Kura :: Apache Camel components">

--- a/karaf/features/kura-runtime/src/main/feature/feature.xml
+++ b/karaf/features/kura-runtime/src/main/feature/feature.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <features
     xmlns="http://karaf.apache.org/xmlns/features/v1.4.0"
-	name="kura-runtime"
+    name="kura-runtime"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0">
+    xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0">
 
-	<feature name="kura-runtime">
-		<bundle dependency="true">mvn:commons-io/commons-io/2.4</bundle>
-		<bundle dependency="true">mvn:org.osgi/org.osgi.service.repository/1.1.0</bundle>
-        
+    <feature name="kura-runtime">
+        <bundle dependency="true">mvn:commons-io/commons-io/2.4</bundle>
+        <bundle dependency="true">mvn:org.osgi/org.osgi.service.repository/1.1.0</bundle>
+        <bundle dependency="true">mvn:com.eclipsesource.minimal-json/minimal-json/0.9.4</bundle>
+
+        <bundle dependency="true">mvn:org.apache.felix/org.apache.felix.gogo.runtime/0.10.0</bundle>
+
         <feature dependency="true">scr</feature>
         <feature dependency="true">eventadmin</feature>
-	</feature>
+    </feature>
 
 </features>

--- a/karaf/features/kura-web/pom.xml
+++ b/karaf/features/kura-web/pom.xml
@@ -52,27 +52,6 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.eclipse.kura</groupId>
-			<artifactId>org.eclipse.kura.web2</artifactId>
-			<version>2.0.2-SNAPSHOT</version>
-			<type>jar</type>
-			<exclusions>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.osgi</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.gwtbootstrap3</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-
 	</dependencies>
 
 	<build>
@@ -90,6 +69,7 @@
 						<configuration>
 							<descriptors>
 								<descriptor>mvn:org.apache.karaf.features/framework/${karaf.version}/xml/features</descriptor>
+								<descriptor>mvn:org.apache.karaf.features/standard/${karaf.version}/xml/features</descriptor>
 								<descriptor>mvn:org.eclipse.kura.karaf/kura-runtime/${project.version}/xml/features</descriptor>
 								<descriptor>mvn:org.eclipse.kura.karaf/kura-core/${project.version}/xml/features</descriptor>
 								<descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
@@ -101,8 +81,7 @@
 							</framework>
 							<ignoreMissingConditions>true</ignoreMissingConditions>
 							<features>
-								<feature>scr</feature>
-								<feature>eventadmin</feature>
+								<feature>kura-web</feature>
 							</features>
 						</configuration>
 					</execution>

--- a/karaf/features/kura-web/src/main/feature/feature.xml
+++ b/karaf/features/kura-web/src/main/feature/feature.xml
@@ -5,15 +5,19 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0 http://karaf.apache.org/xmlns/features/v1.4.0"
     >
+    
     <feature name="kura-web">
+    
         <feature dependency="true">webconsole</feature>
         <feature dependency="true">kura-core</feature>
+        
         <bundle dependency="true">mvn:commons-fileupload/commons-fileupload/1.2.2</bundle>
         <bundle dependency="true">mvn:commons-net/commons-net/3.1</bundle>
         <bundle dependency="true">mvn:commons-io/commons-io/2.4</bundle>
         
+        <bundle>mvn:com.gwt/com.gwt.user/${com.gwt.user.version}</bundle>
+        
         <bundle>mvn:org.eclipse.kura/org.eclipse.kura.web2/${org.eclipse.kura.web2.version}</bundle>
         
-        <bundle>mvn:com.gwt/com.gwt.user/${com.gwt.user.version}</bundle>
     </feature>
 </features>

--- a/kura/docker/karaf-emulator/Dockerfile
+++ b/kura/docker/karaf-emulator/Dockerfile
@@ -1,0 +1,23 @@
+FROM fedora:24
+
+MAINTAINER Jens Reimann <jreimann@redhat.com>
+
+LABEL Description="This is an emulator instance of Eclipse Kura"
+
+ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0
+
+COPY . /kura
+RUN dnf -y install git java-1.8.0-openjdk-devel maven && \
+    cd /kura && ./build-all.sh -Pspeedup -Pnot-existing && \
+    cd /kura/karaf && mvn clean install && \
+    cd /kura/karaf/deployment/fragments && mvn clean install && \
+    cd /kura/karaf/deployment/targets/docker-emulator-fedora && mvn clean install && \
+    dnf remove -y git java-1.8.0-openjdk-devel maven && \
+    dnf install -y jre-1.8.0-openjdk-headless && \
+    dnf install -y /kura/karaf/deployment/targets/docker-emulator-fedora/target/*.rpm && \
+    rm -Rf /kura /root/.m2 && dnf -y clean all
+
+EXPOSE 8181
+
+ENTRYPOINT ["/opt/eclipse/kura/bin/karaf"]
+CMD ["console"]

--- a/kura/docker/karaf-emulator/Dockerfile
+++ b/kura/docker/karaf-emulator/Dockerfile
@@ -4,10 +4,13 @@ MAINTAINER Jens Reimann <jreimann@redhat.com>
 
 LABEL Description="This is an emulator instance of Eclipse Kura"
 
+ARG GIT_REPO=https://github.com/eclipse/kura.git
+ARG GIT_BRANCH=develop
+
 ENV JAVA_HOME=/usr/lib/jvm/jre-1.8.0
 
-COPY . /kura
 RUN dnf -y install git java-1.8.0-openjdk-devel maven && \
+    git clone "$GIT_REPO" -b "$GIT_BRANCH"&& \
     cd /kura && ./build-all.sh -Pspeedup -Pnot-existing && \
     cd /kura/karaf && mvn clean install && \
     cd /kura/karaf/deployment/fragments && mvn clean install && \

--- a/kura/docker/karaf-emulator/README.md
+++ b/kura/docker/karaf-emulator/README.md
@@ -7,9 +7,19 @@ This is a docker image of the Eclipse Kura emulator running on Apache Karaf.
 Build this docker image by executing:
 
     sudo docker build -t kura-emulator -f kura/docker/karaf-emulator/Dockerfile github.com/eclipse/kura#develop
-    
+
 ## Starting
 
 Start the emulator with:
 
-    sudo docker run -ti kura-emulator
+    sudo docker run -ti -p 8181:8181 kura-emulator
+
+## Using
+
+Navigate your web browser to:
+
+ * http://localhost:8181 – For the Kura Web UI (credentials: admin/admin)
+ * http://localhost:8181/system/console – For the Kura Web UI (credentials: karaf/karaf)
+
+**Warning**: Do not use the Karaf Web UI to edit Kura configuration. This will break the Kura configuration. 
+

--- a/kura/docker/karaf-emulator/README.md
+++ b/kura/docker/karaf-emulator/README.md
@@ -1,0 +1,15 @@
+# Eclipse Kura emulator based on Apache Karaf
+
+This is a docker image of the Eclipse Kura emulator running on Apache Karaf.
+
+## Building
+
+Build this docker image by executing:
+
+    sudo docker build -t kura-emulator -f kura/docker/karaf-emulator/Dockerfile github.com/eclipse/kura#develop
+    
+## Starting
+
+Start the emulator with:
+
+    sudo docker run -ti kura-emulator

--- a/kura/docker/karaf-emulator/README.md
+++ b/kura/docker/karaf-emulator/README.md
@@ -6,7 +6,11 @@ This is a docker image of the Eclipse Kura emulator running on Apache Karaf.
 
 Build this docker image by executing:
 
-    sudo docker build -t kura-emulator -f kura/docker/karaf-emulator/Dockerfile github.com/eclipse/kura#develop
+    sudo docker build -t kura-emulator github.com/eclipse/kura#develop:kura/docker/karaf-emulator
+
+If you want to build a different repository or branch:
+
+    sudo docker build -t kura-emulator --build-arg GIT_REPO=https://github.com/ctron/kura --build-arg GIT_BRANCH=feature/karaf_docker_1 github.com/ctron/kura#feature/karaf_docker_1:kura/docker/karaf-emulator
 
 ## Starting
 


### PR DESCRIPTION
This change adds a dockerfile for building Kura on Karaf inside a docker container and provide a Kura emulator instance running on Apache Karaf.

It also fixes a few issues introduced by the Kura Wires PR.