### PR TITLE
Add a Kura on Karaf emulator launcher

### DIFF
--- a/karaf/emulator-instance/pom.xml
+++ b/karaf/emulator-instance/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>emulator-instance</artifactId>
     <packaging>karaf-assembly</packaging>
-    <name>Local Karaf emulator assembly</name>
+    <name>Eclipse Kura :: Karaf :: Emulator</name>
 
     <dependencies>
         <dependency>
@@ -20,29 +20,32 @@
             <version>${karaf.version}</version>
             <type>kar</type>
         </dependency>
+        
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>framework</artifactId>
             <version>${karaf.version}</version>
             <classifier>features</classifier>
             <type>xml</type>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>standard</artifactId>
             <version>${karaf.version}</version>
             <classifier>features</classifier>
             <type>xml</type>
-            <scope>runtime</scope>
+            <scope>compile</scope>
         </dependency>
+        
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>spring</artifactId>
             <version>${karaf.version}</version>
             <classifier>features</classifier>
             <type>xml</type>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -93,6 +96,10 @@
                     <startLevel>80</startLevel>
                     <aggregateFeatures>false</aggregateFeatures>
                     <addTransitiveFeatures>false</addTransitiveFeatures>
+
+                    <startupFeatures>
+                        <feature>eventadmin</feature>
+                    </startupFeatures>
 
                     <installedFeatures>
                         <feature>wrapper</feature>

--- a/kura/setups/launchers/Apache Karaf Emulator.launch
+++ b/kura/setups/launchers/Apache Karaf Emulator.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="exec:java"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value="run"/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="true"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:karaf}/emulator-instance"/>
+</launchConfiguration>


### PR DESCRIPTION
This change does add a simple launch configuration for running
Kura on Karaf. It also fixes an issue of Karaf reloading the shell
by installing the eventadmin first.

Signed-off-by: Jens Reimann <jreimann@redhat.com>