### PR TITLE
Modified aes decrypt.

### DIFF
--- a/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
+++ b/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
@@ -53,7 +53,7 @@ public class CryptoServiceImpl implements CryptoService {
     public void setSystemService(SystemService systemService) {
         this.m_systemService = systemService;
     }
-    
+
     public void unsetSystemService(SystemService systemService) {
         this.m_systemService = null;
     }
@@ -105,7 +105,7 @@ public class CryptoServiceImpl implements CryptoService {
 
         }
 
-        if (convertedData != null) {
+        if (convertedData != null && convertedData instanceof byte[]) {
             return (byte[]) convertedData;
         }
         return null;
@@ -170,6 +170,9 @@ public class CryptoServiceImpl implements CryptoService {
             c.init(Cipher.DECRYPT_MODE, key);
             String internalStringValue = new String(encryptedValue);
             byte[] decodedValue = base64Decode(internalStringValue);
+            if (encryptedValue.length > 0 && decodedValue.length == 0) {
+                throw new KuraException(KuraErrorCode.DECODER_ERROR);
+            }
             byte[] decryptedBytes = c.doFinal(decodedValue);
             String decryptedValue = new String(decryptedBytes);
             return decryptedValue.toCharArray();


### PR DESCRIPTION
The change is defined in order to throw an exception if a string with a length >0
passed to the base64decode method returns an empty array.

Closes #901 

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>