### PR TITLE
Included missing .data folder creation instructions.

### DIFF
--- a/kura/distrib/src/main/resources/beaglebone-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/beaglebone-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2014 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -23,6 +23,11 @@ chmod +x ${INSTALL_DIR}/kura/bin/*.sh
 
 #set up runlevels to start/stop Kura by default
 update-rc.d kura defaults
+
+# setup snapshot_0 recovery folder
+if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
+    mkdir ${INSTALL_DIR}/kura/.data
+fi
 
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf

--- a/kura/distrib/src/main/resources/intel-edison-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-edison-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2014 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -72,6 +72,11 @@ cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 sed -i 's/ps ax/ps/g' ${INSTALL_DIR}/kura/bin/start_kura.sh
 sed -i 's/ps ax/ps/g' ${INSTALL_DIR}/kura/bin/start_kura_background.sh
 sed -i 's/ps ax/ps/g' ${INSTALL_DIR}/kura/bin/start_kura_debug.sh
+
+# setup snapshot_0 recovery folder
+if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
+    mkdir ${INSTALL_DIR}/kura/.data
+fi
 
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/.data/.recoverDefaultConfig.sh

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2014 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -23,6 +23,11 @@ chmod +x ${INSTALL_DIR}/kura/bin/*.sh
 
 #set up runlevels to start/stop Kura by default
 update-rc.d kura defaults
+
+# setup snapshot_0 recovery folder
+if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
+    mkdir ${INSTALL_DIR}/kura/.data
+fi
 
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf

--- a/kura/distrib/src/main/resources/raspberry-pi-bplus-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-bplus-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2014 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -27,6 +27,11 @@ update-rc.d kura defaults
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
+
+# setup snapshot_0 recovery folder
+if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
+    mkdir ${INSTALL_DIR}/kura/.data
+fi
 
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/.data/.recoverDefaultConfig.sh

--- a/kura/distrib/src/main/resources/raspberry-pi-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2014 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -27,6 +27,11 @@ update-rc.d kura defaults
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
+
+# setup snapshot_0 recovery folder
+if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
+    mkdir ${INSTALL_DIR}/kura/.data
+fi
 
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/.data/.recoverDefaultConfig.sh


### PR DESCRIPTION
The fix is applied to kura_install.sh scripts for all nn profiles.

Closes #941 

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>