### PR TITLE
Defines /tmp/.kura as a folder that has not to be cleaned.

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -354,6 +354,8 @@ fi]]>
                         prefix="${build.output.name}/install" />
 			<zipfileset file="src/main/resources/common/monitrc.raspbian"
                         prefix="${build.output.name}/install" />
+            <zipfileset file="src/main/resources/${build.name}/kura-tmpfiles.conf"
+                        prefix="${build.output.name}/install" />
 
 
 			<zipfileset file="src/main/resources/common/logrotate.conf"

--- a/kura/distrib/src/main/resources/fedorapi/kura-tmpfiles.conf
+++ b/kura/distrib/src/main/resources/fedorapi/kura-tmpfiles.conf
@@ -1,0 +1,3 @@
+# Kura specific file. Do not edit!
+
+x /tmp/.kura

--- a/kura/distrib/src/main/resources/fedorapi/kura_install.sh
+++ b/kura/distrib/src/main/resources/fedorapi/kura_install.sh
@@ -99,3 +99,6 @@ if [ ! -d /etc/logrotate.d/ ]; then
     mkdir -p /etc/logrotate.d/
 fi
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
+
+# Setup tmpfiles.d
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /usr/lib/tmpfiles.d/kura.conf


### PR DESCRIPTION
This set of changes tries to prevent the cleanup that periodically fedora-based
systems can perform in the /tmp folder. This cleanup, in particular, can break
kura removing the .kura folder and files while the framework is running.

This PR closes #912 and #904. 

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>