### PR TITLE
Changed deb dependency requiring java 8.

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -1039,7 +1039,7 @@
 			<id>beaglebone</id>
 			<properties>
 				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw,
-					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies>
+					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, oracle-java8-installer</project.raspbian.dependencies>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1155,7 +1155,7 @@
 		<profile>
 			<id>beaglebone-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, oracle-java8-installer</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1252,7 +1252,7 @@
 			<id>raspberry-pi</id>
 			<properties>
 				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw,
-					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies>
+					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, openjdk-8-jre-headless</project.raspbian.dependencies>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1357,7 +1357,7 @@
 		<profile>
 			<id>raspberry-pi-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, openjdk-8-jre-headless</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1452,7 +1452,7 @@
 			<id>raspberry-pi-bplus</id>
 			<properties>
 				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw,
-					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies>
+					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, openjdk-8-jre-headless</project.raspbian.dependencies>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1557,7 +1557,7 @@
 		<profile>
 			<id>raspberry-pi-bplus-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, openjdk-8-jre-headless</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1652,7 +1652,7 @@
 		<profile>
 			<id>raspberry-pi-2-3</id>
 			<properties>
-				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw, dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies>
+				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw, dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, openjdk-8-jre-headless</project.raspbian.dependencies>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1748,7 +1748,7 @@
 		<profile>
 			<id>raspberry-pi-2-3-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, default-jre-headless | java7-runtime-headless</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, openjdk-8-jre-headless</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->


### PR DESCRIPTION
Beaglebone will require oracle java 8 VM.
Raspbian devices will require openjdk 8 headless vm.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>