### PR TITLE
#779: Unit tests for Wifi classes from core.net

### DIFF
--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/WifiAccessPointImpl.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/WifiAccessPointImpl.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kura.core.net;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -116,7 +117,7 @@ public class WifiAccessPointImpl implements WifiAccessPoint {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("ssid=").append(this.ssid);
-        if (this.hardwareAddress != null && this.hardwareAddress.length > 0) {
+        if (this.hardwareAddress != null && this.hardwareAddress.length == 6) {
             sb.append(" :: hardwareAddress=").append(NetworkUtil.macToString(this.hardwareAddress));
         }
         sb.append(" :: frequency=").append(this.frequency).append(" :: mode=").append(this.mode);
@@ -141,4 +142,82 @@ public class WifiAccessPointImpl implements WifiAccessPoint {
         }
         return sb.toString();
     }
+    
+    @Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((bitrate == null) ? 0 : bitrate.hashCode());
+		result = prime * result + ((capabilities == null) ? 0 : capabilities.hashCode());
+		result = prime * result + (int) (frequency ^ (frequency >>> 32));
+		result = prime * result + Arrays.hashCode(hardwareAddress);
+		result = prime * result + ((mode == null) ? 0 : mode.hashCode());
+		result = prime * result + ((rsnSecurity == null) ? 0 : rsnSecurity.hashCode());
+		result = prime * result + ((ssid == null) ? 0 : ssid.hashCode());
+		result = prime * result + strength;
+		result = prime * result + ((wpaSecurity == null) ? 0 : wpaSecurity.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof WifiAccessPointImpl)) {
+			return false;
+		}
+		WifiAccessPointImpl other = (WifiAccessPointImpl) obj;
+		if (bitrate == null) {
+			if (other.bitrate != null) {
+				return false;
+			}
+		} else if (!bitrate.equals(other.bitrate)) {
+			return false;
+		}
+		if (capabilities == null) {
+			if (other.capabilities != null) {
+				return false;
+			}
+		} else if (!capabilities.equals(other.capabilities)) {
+			return false;
+		}
+		if (frequency != other.frequency) {
+			return false;
+		}
+		if (!Arrays.equals(hardwareAddress, other.hardwareAddress)) {
+			return false;
+		}
+		if (mode != other.mode) {
+			return false;
+		}
+		if (rsnSecurity == null) {
+			if (other.rsnSecurity != null) {
+				return false;
+			}
+		} else if (!rsnSecurity.equals(other.rsnSecurity)) {
+			return false;
+		}
+		if (ssid == null) {
+			if (other.ssid != null) {
+				return false;
+			}
+		} else if (!ssid.equals(other.ssid)) {
+			return false;
+		}
+		if (strength != other.strength) {
+			return false;
+		}
+		if (wpaSecurity == null) {
+			if (other.wpaSecurity != null) {
+				return false;
+			}
+		} else if (!wpaSecurity.equals(other.wpaSecurity)) {
+			return false;
+		}
+		return true;
+	}
 }

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/WifiInterfaceAddressConfigImpl.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/WifiInterfaceAddressConfigImpl.java
@@ -55,20 +55,17 @@ public class WifiInterfaceAddressConfigImpl extends WifiInterfaceAddressImpl imp
 
         WifiInterfaceAddressConfig other = (WifiInterfaceAddressConfig) obj;
 
-        if (!compare(getMode(), other.getMode())) {
-            return false;
-        }
-
-        if (getBitrate() != other.getBitrate()) {
-            return false;
-        }
-
-        if (!compare(getWifiAccessPoint(), other.getWifiAccessPoint())) {
-            return false;
-        }
-
         List<NetConfig> thisNetConfigs = getConfigs();
         List<NetConfig> otherNetConfigs = other.getConfigs();
+
+        if ((thisNetConfigs == null) && (otherNetConfigs == null)) {
+        	// Both configurations are null
+        	return true;
+        }
+        else if ((thisNetConfigs == null) || (otherNetConfigs == null)) {
+        	// One configuration is null but the other one is not, so a null pointer exception would be thrown below!
+            return false;
+        }
 
         if (thisNetConfigs.size() != otherNetConfigs.size()) {
             return false;

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/WifiAccessPointImplTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/WifiAccessPointImplTest.java
@@ -1,0 +1,497 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.net;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+
+import org.eclipse.kura.core.net.util.NetworkUtil;
+import org.eclipse.kura.net.wifi.WifiMode;
+import org.eclipse.kura.net.wifi.WifiSecurity;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class WifiAccessPointImplTest {
+
+	@Test
+	public void testWifiAccessPointImpl() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		assertEquals("ssid", ap.getSSID());
+		assertNull(ap.getHardwareAddress());
+		assertEquals(0, ap.getFrequency());
+		assertNull(ap.getMode());
+		assertNull(ap.getBitrate());
+		assertEquals(0, ap.getStrength());
+		assertNull(ap.getWpaSecurity());
+		assertNull(ap.getRsnSecurity());
+		assertNull(ap.getCapabilities());
+	}
+
+	@Test
+	public void testGetSSID() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid1");
+		assertEquals("ssid1", ap1.getSSID());
+
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid2");
+		assertEquals("ssid2", ap2.getSSID());
+
+		WifiAccessPointImpl ap3 = new WifiAccessPointImpl(null);
+		assertNull(ap3.getSSID());
+	}
+
+	@Test
+	public void testHardwareAddress() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		byte[] mac1 = NetworkUtil.macToBytes("12:34:56:78:90:AB");
+		ap.setHardwareAddress(mac1);
+		assertArrayEquals(mac1, ap.getHardwareAddress());
+
+		byte[] mac2 = NetworkUtil.macToBytes("11:22:33:44:55:66");
+		ap.setHardwareAddress(mac2);
+		assertArrayEquals(mac2, ap.getHardwareAddress());
+	}
+
+	@Test
+	public void testFrequency() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setFrequency(42);
+		assertEquals(42, ap.getFrequency());
+
+		ap.setFrequency(100);
+		assertEquals(100, ap.getFrequency());
+	}
+
+	@Test
+	public void testMode() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setMode(WifiMode.ADHOC);
+		assertEquals(WifiMode.ADHOC, ap.getMode());
+
+		ap.setMode(WifiMode.INFRA);
+		assertEquals(WifiMode.INFRA, ap.getMode());
+	}
+
+	@Test
+	public void testBitrate() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ArrayList<Long> bitrate1 = new ArrayList<>();
+		bitrate1.add((long) 1);
+		bitrate1.add((long) 2);
+
+		ap.setBitrate(bitrate1);
+		assertEquals(bitrate1, ap.getBitrate());
+
+		ArrayList<Long> bitrate2 = new ArrayList<>();
+		bitrate2.add((long) 3);
+		bitrate2.add((long) 4);
+
+		ap.setBitrate(bitrate2);
+		assertEquals(bitrate2, ap.getBitrate());
+	}
+
+	@Test
+	public void testStrength() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setStrength(42);
+		assertEquals(42, ap.getStrength());
+
+		ap.setStrength(100);
+		assertEquals(100, ap.getStrength());
+	}
+
+	@Test
+	public void testWpaSecurity() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		EnumSet<WifiSecurity> ws1 = EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_TKIP);
+		ap.setWpaSecurity(ws1);
+		assertEquals(ws1, ap.getWpaSecurity());
+
+		EnumSet<WifiSecurity> ws2 = EnumSet.of(WifiSecurity.GROUP_WEP104, WifiSecurity.GROUP_WEP40);
+		ap.setWpaSecurity(ws2);
+		assertEquals(ws2, ap.getWpaSecurity());
+	}
+
+	@Test
+	public void testRsnSecurity() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		EnumSet<WifiSecurity> rs1 = EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_TKIP);
+		ap.setRsnSecurity(rs1);
+		assertEquals(rs1, ap.getRsnSecurity());
+
+		EnumSet<WifiSecurity> rs2 = EnumSet.of(WifiSecurity.GROUP_WEP104, WifiSecurity.GROUP_WEP40);
+		ap.setRsnSecurity(rs2);
+		assertEquals(rs2, ap.getRsnSecurity());
+	}
+
+	@Test
+	public void testCapabilities() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ArrayList<String> capabilities1 = new ArrayList<>();
+		capabilities1.add("a");
+		capabilities1.add("b");
+
+		ap.setCapabilities(capabilities1);
+		assertEquals(capabilities1, ap.getCapabilities());
+
+		ArrayList<String> capabilities2 = new ArrayList<>();
+		capabilities2.add("c");
+		capabilities2.add("d");
+
+		ap.setCapabilities(capabilities2);
+		assertEquals(capabilities2, ap.getCapabilities());
+	}
+
+	@Test
+	public void testToStringJustSSID() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		String expected = "ssid=ssid :: frequency=0 :: mode=null :: strength=0";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithHardwareAddress() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		byte[] mac = NetworkUtil.macToBytes("12:34:56:78:90:AB");
+
+		ap.setHardwareAddress(mac);
+
+		String expected = "ssid=ssid :: hardwareAddress=12:34:56:78:90:AB :: frequency=0 :: mode=null :: strength=0";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithFrequency() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setFrequency(42);
+
+		String expected = "ssid=ssid :: frequency=42 :: mode=null :: strength=0";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithMode() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setMode(WifiMode.ADHOC);
+
+		String expected = "ssid=ssid :: frequency=0 :: mode=ADHOC :: strength=0";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithBitrate() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ArrayList<Long> bitrate = new ArrayList<Long>();
+		bitrate.add((long) 1);
+		bitrate.add((long) 2);
+
+		ap.setBitrate(bitrate);
+
+		String expected = "ssid=ssid :: frequency=0 :: mode=null :: bitrate=1 2  :: strength=0";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithEmptyBitrate() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ArrayList<Long> bitrate = new ArrayList<>();
+		ap.setBitrate(bitrate);
+
+		String expected = "ssid=ssid :: frequency=0 :: mode=null :: strength=0";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithStrength() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setStrength(42);
+
+		String expected = "ssid=ssid :: frequency=0 :: mode=null :: strength=42";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithWpaSecurity() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setWpaSecurity(EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_TKIP));
+
+		String expected = "ssid=ssid :: frequency=0 :: mode=null :: strength=0 :: wpaSecurity=GROUP_TKIP GROUP_CCMP ";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithEmptyWpaSecurity() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setWpaSecurity(EnumSet.noneOf(WifiSecurity.class));
+
+		String expected = "ssid=ssid :: frequency=0 :: mode=null :: strength=0";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithRsnSecurity() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setRsnSecurity(EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_TKIP));
+
+		String expected = "ssid=ssid :: frequency=0 :: mode=null :: strength=0 :: rsnSecurity=GROUP_TKIP GROUP_CCMP ";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithEmptyRsnSecurity() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		ap.setRsnSecurity(EnumSet.noneOf(WifiSecurity.class));
+
+		String expected = "ssid=ssid :: frequency=0 :: mode=null :: strength=0";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testToStringWithAllFields() {
+		WifiAccessPointImpl ap = createWifiAccessPoint();
+
+		String expected = "ssid=ssid :: hardwareAddress=12:34:56:78:90:AB :: frequency=42 :: mode=ADHOC"
+				+ " :: bitrate=1 2  :: strength=42 :: wpaSecurity=GROUP_TKIP GROUP_CCMP "
+				+ " :: rsnSecurity=GROUP_TKIP GROUP_CCMP ";
+
+		assertEquals(expected, ap.toString());
+	}
+
+	@Test
+	public void testEqualsObject() {
+		WifiAccessPointImpl ap1 = createWifiAccessPoint();
+		assertEquals(ap1, ap1);
+
+		WifiAccessPointImpl ap2 = createWifiAccessPoint();
+		assertEquals(ap1, ap2);
+
+		ap1 = new WifiAccessPointImpl("ssid");
+		ap2 = new WifiAccessPointImpl("ssid");
+		assertEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsWithNull() {
+		WifiAccessPointImpl ap1 = createWifiAccessPoint();
+		WifiAccessPointImpl ap2 = null;
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsUnexpectedType() {
+		WifiAccessPointImpl ap1 = createWifiAccessPoint();
+		String str = "";
+
+		assertNotEquals(ap1, str);
+	}
+
+	@Test
+	public void testEqualsDifferentSSID() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid1");
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid2");
+
+		assertNotEquals(ap1, ap2);
+
+		ap1 = new WifiAccessPointImpl(null);
+
+		assertNotEquals(ap1, ap2);
+
+		ap1.setStrength(42);
+		ap2 = new WifiAccessPointImpl(null);
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsDifferentHardwareAddress() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid");
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid");
+
+		byte[] mac1 = NetworkUtil.macToBytes("12:34:56:78:90:AB");
+		byte[] mac2 = NetworkUtil.macToBytes("11:22:33:44:55:66");
+
+		ap1.setHardwareAddress(mac1);
+		ap2.setHardwareAddress(mac2);
+
+		assertNotEquals(ap1, ap2);
+
+		ap1.setHardwareAddress(null);
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsDifferentFrequency() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid");
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid");
+
+		ap1.setFrequency(42);
+		ap2.setFrequency(100);
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsDifferentMode() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid");
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid");
+
+		ap1.setMode(WifiMode.ADHOC);
+		ap2.setMode(WifiMode.INFRA);
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsDifferentBitrate() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid");
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid");
+
+		ArrayList<Long> bitrate1 = new ArrayList<>();
+		bitrate1.add((long) 1);
+		bitrate1.add((long) 2);
+
+		ArrayList<Long> bitrate2 = new ArrayList<>();
+		bitrate2.add((long) 3);
+		bitrate2.add((long) 4);
+
+		ap1.setBitrate(bitrate1);
+		ap2.setBitrate(bitrate2);
+
+		assertNotEquals(ap1, ap2);
+
+		ap1.setBitrate(null);
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsDifferentStrength() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid");
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid");
+
+		ap1.setStrength(42);
+		ap2.setStrength(100);
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsDifferentWpaSecurity() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid");
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid");
+
+		ap1.setWpaSecurity(EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_TKIP));
+		ap2.setWpaSecurity(EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_WEP104));
+
+		assertNotEquals(ap1, ap2);
+
+		ap1.setWpaSecurity(null);
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsDifferentRsnSecurity() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid");
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid");
+
+		ap1.setRsnSecurity(EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_TKIP));
+		ap2.setRsnSecurity(EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_WEP104));
+
+		assertNotEquals(ap1, ap2);
+
+		ap1.setRsnSecurity(null);
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	@Test
+	public void testEqualsDifferentCapabilities() {
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid");
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid");
+
+		ArrayList<String> capabilities1 = new ArrayList<>();
+		capabilities1.add("a");
+		capabilities1.add("b");
+
+		ArrayList<String> capabilities2 = new ArrayList<>();
+		capabilities2.add("c");
+		capabilities2.add("d");
+
+		ap1.setCapabilities(capabilities1);
+		ap2.setCapabilities(capabilities2);
+
+		assertNotEquals(ap1, ap2);
+
+		ap1.setCapabilities(null);
+
+		assertNotEquals(ap1, ap2);
+	}
+
+	WifiAccessPointImpl createWifiAccessPoint() {
+		WifiAccessPointImpl ap = new WifiAccessPointImpl("ssid");
+
+		byte[] mac = NetworkUtil.macToBytes("12:34:56:78:90:AB");
+
+		ArrayList<Long> bitrate = new ArrayList<>();
+		bitrate.add((long) 1);
+		bitrate.add((long) 2);
+
+		ArrayList<String> capabilities = new ArrayList<>();
+		capabilities.add("a");
+		capabilities.add("b");
+
+		ap.setHardwareAddress(mac);
+		ap.setFrequency(42);
+		ap.setMode(WifiMode.ADHOC);
+		ap.setBitrate(bitrate);
+		ap.setStrength(42);
+		ap.setWpaSecurity(EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_TKIP));
+		ap.setRsnSecurity(EnumSet.of(WifiSecurity.GROUP_CCMP, WifiSecurity.GROUP_TKIP));
+		ap.setCapabilities(capabilities);
+
+		return ap;
+	}
+}

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/WifiInterfaceAddressConfigImplTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/WifiInterfaceAddressConfigImplTest.java
@@ -1,0 +1,311 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.net;
+
+import static org.junit.Assert.*;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+
+import org.eclipse.kura.net.IPAddress;
+import org.eclipse.kura.net.NetConfig;
+import org.eclipse.kura.net.NetConfigIP4;
+import org.eclipse.kura.net.NetInterfaceStatus;
+import org.eclipse.kura.net.wifi.WifiMode;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class WifiInterfaceAddressConfigImplTest {
+
+	@Test
+	public void testEqualsObject() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl a = createConfig();
+		assertEquals(a, a);
+
+		WifiInterfaceAddressConfigImpl b = createConfig();
+		assertEquals(a, b);
+
+		a.setNetConfigs(null);
+		b.setNetConfigs(null);
+
+		assertEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentNetConfigs() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl a = createConfig();
+		WifiInterfaceAddressConfigImpl b = createConfig();
+
+		ArrayList<NetConfig> configsA = new ArrayList<>();
+		configsA.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledLAN, true));
+		configsA.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		a.setNetConfigs(configsA);
+
+		ArrayList<NetConfig> configsB = new ArrayList<>();
+		configsB.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		configsB.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		b.setNetConfigs(configsB);
+
+		assertNotEquals(a, b);
+
+		a.setNetConfigs(null);
+		assertNotEquals(a, b);
+
+		a.setNetConfigs(configsA);
+		b.setNetConfigs(null);
+		assertNotEquals(a, b);
+
+		ArrayList<NetConfig> configsA2 = new ArrayList<>();
+		configsA2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		configsA2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		a.setNetConfigs(configsA2);
+
+		ArrayList<NetConfig> configsB2 = new ArrayList<>();
+		configsB2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		b.setNetConfigs(configsB2);
+
+		assertNotEquals(a, b);
+
+		configsB2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		b.setNetConfigs(configsB2);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentMode() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl a = createConfig();
+		WifiInterfaceAddressConfigImpl b = createConfig();
+
+		a.setMode(WifiMode.ADHOC);
+		b.setMode(WifiMode.INFRA);
+
+		assertNotEquals(a, b);
+
+		a.setMode(null);
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentBitrate() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl a = createConfig();
+		WifiInterfaceAddressConfigImpl b = createConfig();
+
+		a.setBitrate(42);
+		b.setBitrate(100);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentWifiAccessPoint() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl a = createConfig();
+		WifiInterfaceAddressConfigImpl b = createConfig();
+
+		a.setWifiAccessPoint(new WifiAccessPointImpl("ssid1"));
+		b.setWifiAccessPoint(new WifiAccessPointImpl("ssid2"));
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectWifiInterfaceAddress() {
+		WifiInterfaceAddressImpl a = new WifiInterfaceAddressImpl();
+		NetInterfaceAddressImpl b = new NetInterfaceAddressImpl();
+
+		assertNotEquals(a, b);
+
+		b.setNetworkPrefixLength((short) 24);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectWifiInterfaceAddressConfig() {
+		WifiInterfaceAddressConfigImpl a = new WifiInterfaceAddressConfigImpl();
+		WifiInterfaceAddressImpl b = new WifiInterfaceAddressImpl();
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testWifiInterfaceAddressConfigImpl() {
+		WifiInterfaceAddressConfigImpl value = new WifiInterfaceAddressConfigImpl();
+
+		assertNull(value.getMode());
+		assertEquals(0, value.getBitrate());
+		assertNull(value.getWifiAccessPoint());
+		assertNull(value.getAddress());
+		assertEquals(0, value.getNetworkPrefixLength());
+		assertNull(value.getNetmask());
+		assertNull(value.getGateway());
+		assertNull(value.getBroadcast());
+		assertNull(value.getDnsServers());
+	}
+
+	@Test
+	public void testWifiInterfaceAddressConfigImplWifiInterfaceAddress() throws UnknownHostException {
+		ArrayList<IPAddress> dnsServers = new ArrayList<>();
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.1"));
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.2"));
+
+		WifiAccessPointImpl wifiAccessPoint = new WifiAccessPointImpl("ssid");
+
+		WifiInterfaceAddressImpl address = new WifiInterfaceAddressImpl();
+		address.setAddress(IPAddress.parseHostAddress("10.0.0.100"));
+		address.setBitrate(42);
+		address.setBroadcast(IPAddress.parseHostAddress("10.0.0.255"));
+		address.setDnsServers(dnsServers);
+		address.setGateway(IPAddress.parseHostAddress("10.0.0.1"));
+		address.setMode(WifiMode.MASTER);
+		address.setNetmask(IPAddress.parseHostAddress("255.255.255.0"));
+		address.setNetworkPrefixLength((short) 24);
+		address.setWifiAccessPoint(wifiAccessPoint);
+
+		WifiInterfaceAddressConfigImpl value = new WifiInterfaceAddressConfigImpl(address);
+
+		assertEquals(WifiMode.MASTER, value.getMode());
+		assertEquals(42, value.getBitrate());
+		assertEquals(wifiAccessPoint, value.getWifiAccessPoint());
+		assertEquals(IPAddress.parseHostAddress("10.0.0.100"), value.getAddress());
+		assertEquals(24, value.getNetworkPrefixLength());
+		assertEquals(IPAddress.parseHostAddress("255.255.255.0"), value.getNetmask());
+		assertEquals(IPAddress.parseHostAddress("10.0.0.1"), value.getGateway());
+		assertEquals(IPAddress.parseHostAddress("10.0.0.255"), value.getBroadcast());
+		assertEquals(dnsServers, value.getDnsServers());
+	}
+
+	@Test
+	public void testNetConfigs() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl value = createConfig();
+
+		ArrayList<NetConfig> configs = new ArrayList<>();
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledLAN, true));
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		value.setNetConfigs(configs);
+		assertEquals(value.getConfigs(), configs);
+
+		configs = new ArrayList<>();
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		value.setNetConfigs(configs);
+		assertEquals(value.getConfigs(), configs);
+	}
+
+	@Test
+	public void testToStringNoConfigs() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl value = createConfig();
+		value.setNetConfigs(null);
+
+		String expected = "NetConfig: no configurations";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testToStringEmptyConfigs() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl value = createConfig();
+		value.setNetConfigs(new ArrayList<NetConfig>());
+
+		String expected = "";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testToStringNullConfig() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl value = createConfig();
+
+		ArrayList<NetConfig> configs = new ArrayList<>();
+		configs.add(null);
+		value.setNetConfigs(configs);
+
+		String expected = "NetConfig: null - ";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testToStringWithConfigs() throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl value = createConfig();
+
+		String expected = "NetConfig: NetConfigIP4 [winsServers=[], super.toString()=NetConfigIP"
+				+ " [m_status=netIPv4StatusEnabledLAN, m_autoConnect=true, m_dhcp=false, m_address=null,"
+				+ " m_networkPrefixLength=-1, m_subnetMask=null, m_gateway=null, m_dnsServers=[], m_domains=[],"
+				+ " m_properties={}]] - NetConfig: NetConfigIP4 [winsServers=[], super.toString()=NetConfigIP"
+				+ " [m_status=netIPv4StatusEnabledWAN, m_autoConnect=false, m_dhcp=false, m_address=null,"
+				+ " m_networkPrefixLength=-1, m_subnetMask=null, m_gateway=null, m_dnsServers=[], m_domains=[],"
+				+ " m_properties={}]] - ";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testMode() {
+		WifiInterfaceAddressConfigImpl value = new WifiInterfaceAddressConfigImpl();
+
+		value.setMode(WifiMode.ADHOC);
+		assertEquals(WifiMode.ADHOC, value.getMode());
+
+		value.setMode(WifiMode.INFRA);
+		assertEquals(WifiMode.INFRA, value.getMode());
+	}
+
+	@Test
+	public void testBitrate() {
+		WifiInterfaceAddressConfigImpl value = new WifiInterfaceAddressConfigImpl();
+
+		value.setBitrate(42);
+		assertEquals(42, value.getBitrate());
+
+		value.setBitrate(100);
+		assertEquals(100, value.getBitrate());
+	}
+
+	@Test
+	public void testWifiAccessPoint() {
+		WifiInterfaceAddressConfigImpl value = new WifiInterfaceAddressConfigImpl();
+
+		WifiAccessPointImpl ap1 = new WifiAccessPointImpl("ssid1");
+		value.setWifiAccessPoint(ap1);
+		assertEquals(ap1, value.getWifiAccessPoint());
+
+		WifiAccessPointImpl ap2 = new WifiAccessPointImpl("ssid2");
+		value.setWifiAccessPoint(ap2);
+		assertEquals(ap2, value.getWifiAccessPoint());
+	}
+
+	private WifiInterfaceAddressConfigImpl createConfig() throws UnknownHostException {
+		ArrayList<IPAddress> dnsServers = new ArrayList<IPAddress>();
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.1"));
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.2"));
+
+		ArrayList<NetConfig> configs = new ArrayList<NetConfig>();
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledLAN, true));
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+
+		WifiAccessPointImpl wifiAccessPoint = new WifiAccessPointImpl("ssid");
+
+		WifiInterfaceAddressConfigImpl value = new WifiInterfaceAddressConfigImpl();
+		value.setAddress(IPAddress.parseHostAddress("10.0.0.100"));
+		value.setBitrate(42);
+		value.setBroadcast(IPAddress.parseHostAddress("10.0.0.255"));
+		value.setDnsServers(dnsServers);
+		value.setGateway(IPAddress.parseHostAddress("10.0.0.1"));
+		value.setMode(WifiMode.MASTER);
+		value.setNetConfigs(configs);
+		value.setNetmask(IPAddress.parseHostAddress("255.255.255.0"));
+		value.setNetworkPrefixLength((short) 24);
+		value.setWifiAccessPoint(wifiAccessPoint);
+
+		return value;
+	}
+}

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/WifiInterfaceConfigImplTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/WifiInterfaceConfigImplTest.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.net;
+
+import static org.junit.Assert.*;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.eclipse.kura.core.net.util.NetworkUtil;
+import org.eclipse.kura.net.IPAddress;
+import org.eclipse.kura.net.NetInterfaceState;
+import org.eclipse.kura.net.NetInterfaceType;
+import org.eclipse.kura.net.wifi.WifiInterface.Capability;
+import org.eclipse.kura.usb.UsbNetDevice;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class WifiInterfaceConfigImplTest {
+
+	@Test
+	public void testWifiInterfaceConfigImplString() {
+		WifiInterfaceConfigImpl config = new WifiInterfaceConfigImpl("name1");
+		assertEquals("name1", config.getName());
+		assertTrue(config.getNetInterfaceAddresses().isEmpty());
+
+		config = new WifiInterfaceConfigImpl("name2");
+		assertEquals("name2", config.getName());
+		assertTrue(config.getNetInterfaceAddresses().isEmpty());
+	}
+
+	@Test
+	public void testWifiInterfaceConfigImplWifiInterfaceOfQextendsWifiInterfaceEmptyAddress()
+			throws UnknownHostException {
+		WifiInterfaceConfigImpl config = createConfig(0);
+
+		assertEquals("wifiInterface", config.getName());
+		assertEquals(1, config.getNetInterfaceAddresses().size());
+	}
+
+	@Test
+	public void testWifiInterfaceConfigImplWifiInterfaceOfQextendsWifiInterfaceAddressNonEmptyAddress()
+			throws UnknownHostException {
+		WifiInterfaceConfigImpl config = createConfig(2);
+
+		assertEquals("wifiInterface", config.getName());
+		assertEquals(2, config.getNetInterfaceAddresses().size());
+
+		assertEquals(createAddress("10.0.0.1"), config.getNetInterfaceAddresses().get(0));
+		assertEquals(createAddress("10.0.0.2"), config.getNetInterfaceAddresses().get(1));
+	}
+
+	@Test
+	public void testToString1() throws UnknownHostException {
+		WifiInterfaceConfigImpl config = createConfig(0);
+
+		String expected = "name=wifiInterface :: loopback=false :: pointToPoint=false :: virtual=false"
+				+ " :: supportsMulticast=false :: up=false :: mtu=0 :: driver=null :: driverVersion=null"
+				+ " :: firmwareVersion=null :: state=null :: autoConnect=false"
+				+ " :: InterfaceAddress=NetConfig: no configurations  :: capabilities=null";
+
+		assertEquals(expected, config.toString());
+	}
+
+	@Test
+	public void testToString2() throws UnknownHostException {
+		WifiInterfaceConfigImpl config = createConfig(2);
+
+		config.setHardwareAddress(NetworkUtil.macToBytes("12:34:56:78:90:AB"));
+		config.setLoopback(true);
+		config.setPointToPoint(true);
+		config.setVirtual(true);
+		config.setSupportsMulticast(true);
+		config.setUp(true);
+		config.setMTU(42);
+		config.setUsbDevice(new UsbNetDevice("vendorId", "productId", "manufacturerName", "productName", "usbBusNumber",
+				"usbDevicePath", "interfaceName"));
+		config.setDriver("driverName");
+		config.setDriverVersion("driverVersion");
+		config.setFirmwareVersion("firmwareVersion");
+		config.setState(NetInterfaceState.ACTIVATED);
+		config.setAutoConnect(true);
+
+		config.setCapabilities(EnumSet.of(Capability.WPA, Capability.CIPHER_WEP40));
+
+		String expected = "name=wifiInterface :: hardwareAddress=12:34:56:78:90:AB :: loopback=true :: pointToPoint=true"
+				+ " :: virtual=true :: supportsMulticast=true :: up=true :: mtu=42 :: usbDevice=UsbNetDevice"
+				+ " [getInterfaceName()=interfaceName, getVendorId()=vendorId, getProductId()=productId,"
+				+ " getManufacturerName()=manufacturerName, getProductName()=productName, getUsbBusNumber()=usbBusNumber,"
+				+ " getUsbDevicePath()=usbDevicePath, getUsbPort()=usbBusNumber-usbDevicePath] :: driver=driverName"
+				+ " :: driverVersion=driverVersion :: firmwareVersion=firmwareVersion :: state=ACTIVATED"
+				+ " :: autoConnect=true :: InterfaceAddress=NetConfig: no configurations NetConfig: no configurations "
+				+ " :: capabilities=CIPHER_WEP40 WPA ";
+
+		assertEquals(expected, config.toString());
+	}
+
+	@Test
+	public void testGetType() {
+		WifiInterfaceConfigImpl config = new WifiInterfaceConfigImpl("name");
+		assertEquals(NetInterfaceType.WIFI, config.getType());
+	}
+
+	@Test
+	public void testCapabilities() {
+		WifiInterfaceConfigImpl config = new WifiInterfaceConfigImpl("name");
+
+		EnumSet<Capability> expected = EnumSet.of(Capability.WPA, Capability.CIPHER_WEP40);
+		config.setCapabilities(expected);
+		assertEquals(expected, config.getCapabilities());
+
+		expected = EnumSet.of(Capability.CIPHER_WEP104, Capability.CIPHER_TKIP);
+		config.setCapabilities(expected);
+		assertEquals(expected, config.getCapabilities());
+	}
+
+	WifiInterfaceConfigImpl createConfig(int noOfAddresses) throws UnknownHostException {
+		WifiInterfaceImpl<WifiInterfaceAddressConfigImpl> interfaceImpl = new WifiInterfaceImpl<>(
+				"wifiInterface");
+
+		if (noOfAddresses > 0) {
+			List<WifiInterfaceAddressConfigImpl> interfaceAddresses = new ArrayList<>();
+
+			for (int i = 0; i < noOfAddresses; i++) {
+				String ipAddress = "10.0.0." + Integer.toString(i + 1);
+				WifiInterfaceAddressConfigImpl interfaceAddress = createAddress(ipAddress);
+				interfaceAddresses.add(interfaceAddress);
+			}
+
+			interfaceImpl.setNetInterfaceAddresses(interfaceAddresses);
+		} else {
+			interfaceImpl.setNetInterfaceAddresses(null);
+		}
+
+		return new WifiInterfaceConfigImpl(interfaceImpl);
+	}
+
+	WifiInterfaceAddressConfigImpl createAddress(String ipAddress) throws UnknownHostException {
+		WifiInterfaceAddressConfigImpl interfaceAddress = new WifiInterfaceAddressConfigImpl();
+
+		interfaceAddress.setAddress(IPAddress.parseHostAddress(ipAddress));
+
+		return interfaceAddress;
+	}
+}


### PR DESCRIPTION
- Prepared unit tests for classes WifiAccessPointImpl,
  WifiInterfaceAddressConfigImpl and WifiInterfaceConfigImpl from
  package org.eclipse.kura.core.net
- Fixed or implemented comparison of classes: WifiAccessPointImpl,
  WifiInterfaceAddressConfigImpl

Signed-off-by: Djuro Drljaca <djuro.drljaca@comtrade.com>