### PR TITLE
Activate maven batch mode by default and reduce console log

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright (c) 2016 Red Hat and/or its affiliates
+# Copyright (c) 2016 Red Hat and others
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -12,7 +12,13 @@
 #     Red Hat - Initial API and implementation
 #
 
-[ -z "$RUN_TESTS" ] && MAVEN_PROPS="-Dmaven.test.skip=true"
+# activate batch mode by default
+
+MAVEN_PROPS="-B"
+
+# allow running tests
+
+[ -z "$RUN_TESTS" ] && MAVEN_PROPS="$MAVEN_PROPS -Dmaven.test.skip=true"
 
 mvn "$@" -f target-platform/pom.xml clean install $MAVEN_PROPS &&
 mvn "$@" -f kura/manifest_pom.xml clean install $MAVEN_PROPS &&


### PR DESCRIPTION
This change does activate the maven batch mode which will stop printing out download progress on the console which will then reduce the console output. That is helpful for CI builds like Hudson/Jenkins or Travis and reduced the log size a lot.

Signed-off-by: Jens Reimann <jreimann@redhat.com>