### PR TITLE
Modified web2 bundle packaging.

### DIFF
--- a/kura/org.eclipse.kura.web2/pom.xml
+++ b/kura/org.eclipse.kura.web2/pom.xml
@@ -97,7 +97,7 @@
 				<configuration>
 					<additionalFileSets>
 						<fileSet>
-							<directory>www</directory>
+							<directory>src/main/webapp</directory>
 							<prefix>www/</prefix>
 							<excludes>
 								<exclude>**/WEB-INF/**</exclude>


### PR DESCRIPTION
The previous packaging used the www link that causes troubles when trying to
unpack the jar file.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>