### PR TITLE
Fix can bus ids

### DIFF
--- a/kura/org.eclipse.kura.protocol.can/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.protocol.can/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Import-Package: org.eclipse.kura;version="[1.0,2.0)",
  org.osgi.service.event;version="1.3.0",
  org.osgi.service.io,
  org.slf4j;version="1.6.4"
-Export-Package: org.eclipse.kura.protocol.can;version="1.0.0"
+Export-Package: org.eclipse.kura.protocol.can;version="1.1.0"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,

--- a/kura/org.eclipse.kura.protocol.can/src/main/java/org/eclipse/kura/protocol/can/CanConnectionService.java
+++ b/kura/org.eclipse.kura.protocol.can/src/main/java/org/eclipse/kura/protocol/can/CanConnectionService.java
@@ -22,6 +22,20 @@ import org.eclipse.kura.KuraException;
 public interface CanConnectionService {
 
     /**
+     * Establishes a RAW CAN socket connection
+     * 
+     * @throws IOException
+     */
+    public void connectCanSocket() throws IOException;
+    
+    /**
+     * Disconnects a CAN socket connection
+     * 
+     * @throws IOException
+     */
+    public void disconnectCanSocket() throws IOException;
+    
+    /**
      * Sends an array of bytes on a CAN socket
      *
      * @param ifName
@@ -50,5 +64,5 @@ public interface CanConnectionService {
      * @throws KuraException
      * @throws IOException
      */
-    public CanMessage receiveCanMessage(int can_id, int can_mask) throws KuraException, IOException;
+    public CanMessage receiveCanMessage(int can_id, int can_mask) throws IOException;
 }

--- a/kura/org.eclipse.kura.protocol.can/src/main/java/org/eclipse/kura/protocol/can/CanConnectionServiceImpl.java
+++ b/kura/org.eclipse.kura.protocol.can/src/main/java/org/eclipse/kura/protocol/can/CanConnectionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,7 +15,6 @@ import java.io.IOException;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
-import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,62 +27,69 @@ import de.entropia.can.CanSocket.Mode;
 public class CanConnectionServiceImpl implements CanConnectionService {
 
     private static final Logger s_logger = LoggerFactory.getLogger(CanConnectionServiceImpl.class);
+    
+    private CanSocket socket = null;
 
-    protected void activate(ComponentContext componentContext) {
+    protected void activate() {
         s_logger.info("activating CanConnectionService");
     }
 
-    protected void deactivate(ComponentContext componentContext) {
+    protected void deactivate() {
+        if (this.socket != null) {
+            try {
+                this.socket.close();
+            } catch (IOException e) {
+                s_logger.error("Error closing CAN socket");
+            }
+        }
     }
 
+    @Override
+    public void connectCanSocket() throws IOException {
+        this.socket = new CanSocket(Mode.RAW);
+        this.socket.setLoopbackMode(false);
+        this.socket.bind(CanSocket.CAN_ALL_INTERFACES);
+    }
+    
+    @Override
+    public void disconnectCanSocket() throws IOException {
+        if (this.socket != null) {
+            this.socket.close();
+        }
+    }
+    
     @Override
     public void sendCanMessage(String ifName, int canId, byte[] message) throws KuraException, IOException {
         if (message.length > 8) {
             throw new KuraException(KuraErrorCode.INTERNAL_ERROR, "CAN send : Incorrect frame length");
         }
 
-        CanSocket socket = null;
         try {
-            socket = new CanSocket(Mode.RAW);
-            socket.setLoopbackMode(false);
-            CanInterface canif = new CanInterface(socket, ifName);
+            CanInterface canif = new CanInterface(this.socket, ifName);
             socket.bind(canif);
             socket.send(new CanFrame(canif, new CanId(canId), message));
-            // s_logger.debug("message sent on " + ifName);
         } catch (IOException e) {
             s_logger.error("Error on CanSocket in sendCanMessage: {}", e.getMessage());
             throw e;
-        } finally {
-            if (socket != null) {
-                socket.close();
-            }
         }
     }
 
     @Override
-    public CanMessage receiveCanMessage(int can_id, int can_mask) throws KuraException, IOException {
-        CanSocket socket = null;
+    public CanMessage receiveCanMessage(int canId, int canMask) throws IOException {
         try {
-            socket = new CanSocket(Mode.RAW);
-            socket.setLoopbackMode(false);
-            socket.bind(CanSocket.CAN_ALL_INTERFACES);
-            if (can_id >= 0) {
-                socket.setCanFilter(can_id, can_mask);
+            if (canId >= 0) {
+                this.socket.setCanFilter(canId, canMask);
             }
-            CanFrame cf = socket.recv();
+            CanFrame cf = this.socket.recv();
             CanId ci = cf.getCanId();
-            // s_logger.debug(cf.toString());
+
             CanMessage cm = new CanMessage();
-            cm.setCanId(ci.getCanId_SFF());
+            cm.setCanId(ci.getCanId_EFF());
             cm.setData(cf.getData());
             return cm;
         } catch (IOException e) {
             s_logger.error("Error on CanSocket in receiveCanMessage: {}", e.getMessage());
             throw e;
-        } finally {
-            if (socket != null) {
-                socket.close();
-            }
         }
     }
 


### PR DESCRIPTION
This commit adds support for CAN frames with 29-bit IDs. It also
adds methods for opening/closing the underlying socket connection.
Opening/closing the socket for each read/write caused frames to be
missed in high data rate scenarios.

@pierrepitiot Can you please review?