### PR TITLE
Fix a possible NPE in the Web UI

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtComponentServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtComponentServiceImpl.java
@@ -1,11 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Contributors:
+ *     Eurotech
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kura.web.server;
 
@@ -466,7 +469,9 @@ public class GwtComponentServiceImpl extends OsgiRemoteServiceServlet implements
 
             for (ComponentConfiguration config : configs) {
                 GwtConfigComponent gwtConfigComponent = createMetatypeOnlyGwtComponentConfiguration(config);
-                gwtConfigs.add(gwtConfigComponent);
+                if (gwtConfigComponent != null) {
+                    gwtConfigs.add(gwtConfigComponent);
+                }
             }
         } catch (Throwable t) {
             KuraExceptionHandler.handle(t);


### PR DESCRIPTION
When, due to some reason, the meta type information is null, it is
still inserted into the list and will cause an NPE later on when the
list is simply processed, assuming that there are only non-null values.

Signed-off-by: Jens Reimann <jreimann@redhat.com>