### PR TITLE
Allow using JMX with default Camel XML router

### DIFF
--- a/kura/org.eclipse.kura.camel.xml/OSGI-INF/metatype/org.eclipse.kura.camel.xml.XmlRouterComponent.xml
+++ b/kura/org.eclipse.kura.camel.xml/OSGI-INF/metatype/org.eclipse.kura.camel.xml.XmlRouterComponent.xml
@@ -43,6 +43,14 @@
             required="false"
             description="JavaScript code which is called when the router is initialized first. The camel context is avaiable in the variable 'camelContext'.|TextArea"/>
 
+        <AD id="disableJmx"
+            name="Disable JMX"
+            type="Boolean"
+            cardinality="1"
+            required="true"
+            default="false"
+            description="Disable the JMX integration for this Camel context"/>
+
     </OCD>
 
     <Designate pid="org.eclipse.kura.camel.xml.XmlRouterComponent">


### PR DESCRIPTION
This change enables the default Camel XML router to activate the JMX
integration. This default is set to "enable JMX". It can be deactivated.

Signed-off-by: Jens Reimann <jreimann@redhat.com>