### PR TITLE
#779: Unit tests for Modem classes from core.net

### DIFF
--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/modem/ModemInterfaceAddressConfigImpl.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/modem/ModemInterfaceAddressConfigImpl.java
@@ -39,63 +39,36 @@ public class ModemInterfaceAddressConfigImpl extends ModemInterfaceAddressImpl i
     }
 
     @Override
-    public boolean equals(Object obj) {
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((m_configs == null) ? 0 : m_configs.hashCode());
+		return result;
+	}
 
-        if (this == obj) {
-            return true;
-        }
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof ModemInterfaceAddressConfigImpl)) {
+			return false;
+		}
+		if (!super.equals(obj)) {
+			return false;
+		}
+		ModemInterfaceAddressConfigImpl other = (ModemInterfaceAddressConfigImpl) obj;
+		if (m_configs == null) {
+			if (other.m_configs != null) {
+				return false;
+			}
+		} else if (!m_configs.equals(other.m_configs)) {
+			return false;
+		}
+		return true;
+	}
 
-        if (!super.equals(obj)) {
-            return false;
-        }
-
-        if (!(obj instanceof ModemInterfaceAddressConfig)) {
-            return false;
-        }
-
-        ModemInterfaceAddressConfig other = (ModemInterfaceAddressConfig) obj;
-
-        if (!compare(getSignalStrength(), other.getSignalStrength())) {
-            return false;
-        }
-
-        if (!compare(isRoaming(), other.isRoaming())) {
-            return false;
-        }
-
-        if (!compare(getConnectionStatus(), other.getConnectionStatus())) {
-            return false;
-        }
-
-        if (getBytesTransmitted() != other.getBytesTransmitted()) {
-            return false;
-        }
-
-        if (getBytesReceived() != other.getBytesReceived()) {
-            return false;
-        }
-
-        if (!compare(getConnectionType(), other.getConnectionType())) {
-            return false;
-        }
-
-        List<NetConfig> thisNetConfigs = getConfigs();
-        List<NetConfig> otherNetConfigs = other.getConfigs();
-
-        if (thisNetConfigs.size() != otherNetConfigs.size()) {
-            return false;
-        }
-        if (!thisNetConfigs.containsAll(otherNetConfigs)) {
-            return false;
-        }
-        if (!otherNetConfigs.containsAll(thisNetConfigs)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    @Override
+	@Override
     public String toString() {
         if (this.m_configs != null) {
             StringBuffer sb = new StringBuffer();

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/modem/ModemInterfaceAddressImpl.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/modem/ModemInterfaceAddressImpl.java
@@ -94,4 +94,50 @@ public class ModemInterfaceAddressImpl extends NetInterfaceAddressImpl implement
         this.m_connectionType = connectionType;
     }
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (int) (m_bytesReceived ^ (m_bytesReceived >>> 32));
+		result = prime * result + (int) (m_bytesTransmitted ^ (m_bytesTransmitted >>> 32));
+		result = prime * result + ((m_connectionStatus == null) ? 0 : m_connectionStatus.hashCode());
+		result = prime * result + ((m_connectionType == null) ? 0 : m_connectionType.hashCode());
+		result = prime * result + (m_isRoaming ? 1231 : 1237);
+		result = prime * result + m_signalStrength;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof ModemInterfaceAddressImpl)) {
+			return false;
+		}
+		if (!super.equals(obj)) {
+			return false;
+		}
+		ModemInterfaceAddressImpl other = (ModemInterfaceAddressImpl) obj;
+		if (m_bytesReceived != other.m_bytesReceived) {
+			return false;
+		}
+		if (m_bytesTransmitted != other.m_bytesTransmitted) {
+			return false;
+		}
+		if (m_connectionStatus != other.m_connectionStatus) {
+			return false;
+		}
+		if (m_connectionType != other.m_connectionType) {
+			return false;
+		}
+		if (m_isRoaming != other.m_isRoaming) {
+			return false;
+		}
+		if (m_signalStrength != other.m_signalStrength) {
+			return false;
+		}
+		return true;
+	}
+
 }

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/modem/ModemInterfaceAddressConfigImplTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/modem/ModemInterfaceAddressConfigImplTest.java
@@ -1,0 +1,341 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.net.modem;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+
+import org.eclipse.kura.net.IPAddress;
+import org.eclipse.kura.net.NetConfig;
+import org.eclipse.kura.net.NetConfigIP4;
+import org.eclipse.kura.net.NetInterfaceStatus;
+import org.eclipse.kura.net.modem.ModemConnectionStatus;
+import org.eclipse.kura.net.modem.ModemConnectionType;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ModemInterfaceAddressConfigImplTest {
+
+	@Test
+	public void testEqualsObject() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl a = createConfig();
+		assertEquals(a, a);
+
+		ModemInterfaceAddressConfigImpl b = createConfig();
+		assertEquals(a, b);
+
+		a.setNetConfigs(null);
+		b.setNetConfigs(null);
+
+		assertEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentNetConfigs() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl a = createConfig();
+		ModemInterfaceAddressConfigImpl b = createConfig();
+
+		ArrayList<NetConfig> configsA = new ArrayList<>();
+		configsA.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		configsA.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledLAN, true));
+		a.setNetConfigs(configsA);
+
+		ArrayList<NetConfig> configsB = new ArrayList<>();
+		configsB.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		configsB.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		b.setNetConfigs(configsB);
+
+		assertNotEquals(a, b);
+
+		a.setNetConfigs(null);
+		assertNotEquals(a, b);
+
+		a.setNetConfigs(configsA);
+		b.setNetConfigs(null);
+		assertNotEquals(a, b);
+
+		ArrayList<NetConfig> configsA2 = new ArrayList<>();
+		configsA2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		configsA2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		a.setNetConfigs(configsA2);
+
+		ArrayList<NetConfig> configsB2 = new ArrayList<>();
+		configsB2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		b.setNetConfigs(configsB2);
+
+		assertNotEquals(a, b);
+
+		configsB2.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		b.setNetConfigs(configsB2);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentBytesReceived() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl a = createConfig();
+		ModemInterfaceAddressConfigImpl b = createConfig();
+
+		a.setBytesReceived(111);
+		b.setBytesReceived(112);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentBytesTransmitted() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl a = createConfig();
+		ModemInterfaceAddressConfigImpl b = createConfig();
+
+		a.setBytesTransmitted(111);
+		b.setBytesTransmitted(112);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentConnectionStatus() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl a = createConfig();
+		ModemInterfaceAddressConfigImpl b = createConfig();
+
+		a.setConnectionStatus(ModemConnectionStatus.CONNECTED);
+		b.setConnectionStatus(ModemConnectionStatus.DISCONNECTED);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentConnectionType() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl a = createConfig();
+		ModemInterfaceAddressConfigImpl b = createConfig();
+
+		a.setConnectionType(ModemConnectionType.DirectIP);
+		b.setConnectionType(ModemConnectionType.PPP);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentIsRoaming() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl a = createConfig();
+		ModemInterfaceAddressConfigImpl b = createConfig();
+
+		a.setIsRoaming(false);
+		b.setIsRoaming(true);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testEqualsObjectDifferentMode() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl a = createConfig();
+		ModemInterfaceAddressConfigImpl b = createConfig();
+
+		a.setSignalStrength(111);
+		b.setSignalStrength(112);
+
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	public void testModemInterfaceAddressConfigImpl() {
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl();
+
+		assertEquals(0, value.getSignalStrength());
+		assertEquals(false, value.isRoaming());
+		assertNull(value.getConnectionStatus());
+		assertEquals(0, value.getBytesTransmitted());
+		assertEquals(0, value.getBytesReceived());
+		assertEquals(ModemConnectionType.PPP, value.getConnectionType());
+	}
+
+	@Test
+	public void testModemInterfaceAddressConfigImplModemInterfaceAddress() {
+		ModemInterfaceAddressImpl address = new ModemInterfaceAddressImpl();
+		address.setSignalStrength(100);
+		address.setIsRoaming(true);
+		address.setConnectionStatus(ModemConnectionStatus.CONNECTING);
+		address.setBytesTransmitted(200);
+		address.setBytesReceived(300);
+		address.setConnectionType(ModemConnectionType.DirectIP);
+
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl(address);
+
+		assertEquals(100, value.getSignalStrength());
+		assertEquals(true, value.isRoaming());
+		assertEquals(ModemConnectionStatus.CONNECTING, value.getConnectionStatus());
+		assertEquals(200, value.getBytesTransmitted());
+		assertEquals(300, value.getBytesReceived());
+		assertEquals(ModemConnectionType.DirectIP, value.getConnectionType());
+	}
+
+	@Test
+	public void testNetConfigs() {
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl();
+
+		ArrayList<NetConfig> configs = new ArrayList<>();
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledLAN, true));
+		value.setNetConfigs(configs);
+		assertEquals(value.getConfigs(), configs);
+
+		configs = new ArrayList<>();
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+		value.setNetConfigs(configs);
+		assertEquals(value.getConfigs(), configs);
+	}
+
+	@Test
+	public void testToStringNoConfigs() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl value = createConfig();
+		value.setNetConfigs(null);
+
+		String expected = "NetConfig: no configurations";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testToStringEmptyConfigs() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl value = createConfig();
+		value.setNetConfigs(new ArrayList<NetConfig>());
+
+		String expected = "";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testToStringNullConfig() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl value = createConfig();
+
+		ArrayList<NetConfig> configs = new ArrayList<>();
+		configs.add(null);
+		value.setNetConfigs(configs);
+
+		String expected = "NetConfig: null - ";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testToStringWithConfigs() throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl value = createConfig();
+
+		String expected = "NetConfig: NetConfigIP4 [winsServers=[], super.toString()=NetConfigIP"
+				+ " [m_status=netIPv4StatusEnabledLAN, m_autoConnect=true, m_dhcp=false, m_address=null,"
+				+ " m_networkPrefixLength=-1, m_subnetMask=null, m_gateway=null, m_dnsServers=[], m_domains=[],"
+				+ " m_properties={}]] - NetConfig: NetConfigIP4 [winsServers=[], super.toString()=NetConfigIP"
+				+ " [m_status=netIPv4StatusEnabledWAN, m_autoConnect=false, m_dhcp=false, m_address=null,"
+				+ " m_networkPrefixLength=-1, m_subnetMask=null, m_gateway=null, m_dnsServers=[], m_domains=[],"
+				+ " m_properties={}]] - ";
+
+		assertEquals(expected, value.toString());
+	}
+
+	@Test
+	public void testSignalStrength() {
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl();
+
+		value.setSignalStrength(100);
+		assertEquals(100, value.getSignalStrength());
+
+		value.setSignalStrength(200);
+		assertEquals(200, value.getSignalStrength());
+	}
+
+	@Test
+	public void testIsRoaming() {
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl();
+
+		value.setIsRoaming(false);
+		assertEquals(false, value.isRoaming());
+
+		value.setIsRoaming(true);
+		assertEquals(true, value.isRoaming());
+	}
+
+	@Test
+	public void testConnectionStatus() {
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl();
+
+		value.setConnectionStatus(ModemConnectionStatus.CONNECTED);
+		assertEquals(ModemConnectionStatus.CONNECTED, value.getConnectionStatus());
+
+		value.setConnectionStatus(ModemConnectionStatus.DISCONNECTED);
+		assertEquals(ModemConnectionStatus.DISCONNECTED, value.getConnectionStatus());
+	}
+
+	@Test
+	public void testBytesTransmitted() {
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl();
+
+		value.setBytesTransmitted(100);
+		assertEquals(100, value.getBytesTransmitted());
+
+		value.setBytesTransmitted(200);
+		assertEquals(200, value.getBytesTransmitted());
+	}
+
+	@Test
+	public void testBytesReceived() {
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl();
+
+		value.setBytesReceived(100);
+		assertEquals(100, value.getBytesReceived());
+
+		value.setBytesReceived(200);
+		assertEquals(200, value.getBytesReceived());
+	}
+
+	@Test
+	public void testConnectionType() {
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl();
+
+		value.setConnectionType(ModemConnectionType.DirectIP);
+		assertEquals(ModemConnectionType.DirectIP, value.getConnectionType());
+
+		value.setConnectionType(ModemConnectionType.PPP);
+		assertEquals(ModemConnectionType.PPP, value.getConnectionType());
+	}
+
+	private ModemInterfaceAddressConfigImpl createConfig() throws UnknownHostException {
+		ArrayList<IPAddress> dnsServers = new ArrayList<>();
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.1"));
+		dnsServers.add(IPAddress.parseHostAddress("10.0.1.2"));
+
+		ArrayList<NetConfig> configs = new ArrayList<>();
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledLAN, true));
+		configs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusEnabledWAN, false));
+
+		ModemInterfaceAddressConfigImpl value = new ModemInterfaceAddressConfigImpl();
+		value.setAddress(IPAddress.parseHostAddress("10.0.0.100"));
+		value.setBroadcast(IPAddress.parseHostAddress("10.0.0.255"));
+		value.setBytesReceived(100);
+		value.setBytesTransmitted(200);
+		value.setConnectionStatus(ModemConnectionStatus.CONNECTING);
+		value.setConnectionType(ModemConnectionType.DirectIP);
+		value.setDnsServers(dnsServers);
+		value.setGateway(IPAddress.parseHostAddress("10.0.0.1"));
+		value.setIsRoaming(true);
+		value.setNetConfigs(configs);
+		value.setNetmask(IPAddress.parseHostAddress("255.255.255.0"));
+		value.setNetworkPrefixLength((short) 24);
+		value.setSignalStrength(300);
+
+		return value;
+	}
+}

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/modem/ModemInterfaceConfigImplTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/modem/ModemInterfaceConfigImplTest.java
@@ -1,0 +1,262 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.net.modem;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.kura.core.net.util.NetworkUtil;
+import org.eclipse.kura.net.IPAddress;
+import org.eclipse.kura.net.NetInterfaceState;
+import org.eclipse.kura.net.NetInterfaceType;
+import org.eclipse.kura.net.modem.ModemPowerMode;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.eclipse.kura.usb.UsbModemDevice;
+import org.eclipse.kura.usb.UsbNetDevice;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ModemInterfaceConfigImplTest {
+
+	@Test
+	public void testModemInterfaceConfigImplString() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name1");
+		assertEquals("name1", config.getName());
+		assertTrue(config.getNetInterfaceAddresses().isEmpty());
+
+		config = new ModemInterfaceConfigImpl("name2");
+		assertEquals("name2", config.getName());
+		assertTrue(config.getNetInterfaceAddresses().isEmpty());
+	}
+
+	@Test
+	public void testModemInterfaceConfigImplModemInterfaceOfQextendsModemInterfaceAddress()
+			throws UnknownHostException {
+		ModemInterfaceConfigImpl config = createConfig(0);
+
+		assertEquals("ModemInterface", config.getName());
+		assertEquals(1, config.getNetInterfaceAddresses().size());
+	}
+
+	@Test
+	public void testToString1() throws UnknownHostException {
+		ModemInterfaceConfigImpl config = createConfig(0);
+
+		String expected = "name=ModemInterface :: loopback=false :: pointToPoint=false :: virtual=false"
+				+ " :: supportsMulticast=false :: up=false :: mtu=0 :: driver=null :: driverVersion=null :: firmwareVersion=null"
+				+ " :: state=null :: autoConnect=false :: InterfaceAddress=NetConfig: no configurations ";
+
+		assertEquals(expected, config.toString());
+	}
+
+	@Test
+	public void testToString2() throws UnknownHostException {
+		ModemInterfaceConfigImpl config = createConfig(2);
+
+		config.setHardwareAddress(NetworkUtil.macToBytes("12:34:56:78:90:AB"));
+		config.setLoopback(true);
+		config.setPointToPoint(true);
+		config.setVirtual(true);
+		config.setSupportsMulticast(true);
+		config.setUp(true);
+		config.setMTU(42);
+		config.setUsbDevice(new UsbNetDevice("vendorId", "productId", "manufacturerName", "productName", "usbBusNumber",
+				"usbDevicePath", "interfaceName"));
+		config.setDriver("driverName");
+		config.setDriverVersion("driverVersion");
+		config.setFirmwareVersion("firmwareVersion");
+		config.setState(NetInterfaceState.ACTIVATED);
+		config.setAutoConnect(true);
+
+		String expected = "name=ModemInterface :: hardwareAddress=12:34:56:78:90:AB :: loopback=true :: pointToPoint=true"
+				+ " :: virtual=true :: supportsMulticast=true :: up=true :: mtu=42 :: usbDevice=UsbNetDevice"
+				+ " [getInterfaceName()=interfaceName, getVendorId()=vendorId, getProductId()=productId,"
+				+ " getManufacturerName()=manufacturerName, getProductName()=productName, getUsbBusNumber()=usbBusNumber,"
+				+ " getUsbDevicePath()=usbDevicePath, getUsbPort()=usbBusNumber-usbDevicePath] :: driver=driverName"
+				+ " :: driverVersion=driverVersion :: firmwareVersion=firmwareVersion :: state=ACTIVATED :: autoConnect=true"
+				+ " :: InterfaceAddress=NetConfig: no configurations NetConfig: no configurations ";
+
+		assertEquals(expected, config.toString());
+	}
+
+	@Test
+	public void testGetType() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+		assertEquals(NetInterfaceType.MODEM, config.getType());
+	}
+
+	@Test
+	public void testPppNum() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		config.setPppNum(10);
+		assertEquals(10, config.getPppNum());
+
+		config.setPppNum(20);
+		assertEquals(20, config.getPppNum());
+	}
+
+	@Test
+	public void testModemIdentifier() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		config.setModemIdentifier("modemId1");
+		assertEquals("modemId1", config.getModemIdentifier());
+
+		config.setModemIdentifier("modemId2");
+		assertEquals("modemId2", config.getModemIdentifier());
+	}
+
+	@Test
+	public void testModel() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		config.setModel("model1");
+		assertEquals("model1", config.getModel());
+
+		config.setModel("model2");
+		assertEquals("model2", config.getModel());
+	}
+
+	@Test
+	public void testManufacturer() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		config.setManufacturer("manufacturer1");
+		assertEquals("manufacturer1", config.getManufacturer());
+
+		config.setManufacturer("manufacturer2");
+		assertEquals("manufacturer2", config.getManufacturer());
+	}
+
+	@Test
+	public void testSerialNumber() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		config.setSerialNumber("serialNumber1");
+		assertEquals("serialNumber1", config.getSerialNumber());
+
+		config.setSerialNumber("serialNumber2");
+		assertEquals("serialNumber2", config.getSerialNumber());
+	}
+
+	@Test
+	public void testRevisionId() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		String[] rev1 = new String[] { "rev1", "rev2" };
+		config.setRevisionId(rev1);
+		assertArrayEquals(rev1, config.getRevisionId());
+
+		String[] rev2 = new String[] { "rev3", "rev4" };
+		config.setRevisionId(rev2);
+		assertArrayEquals(rev2, config.getRevisionId());
+	}
+
+	@Test
+	public void testTechnologyTypes() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		List<ModemTechnologyType> technologyTypes1 = new ArrayList<>();
+		technologyTypes1.add(ModemTechnologyType.CDMA);
+		technologyTypes1.add(ModemTechnologyType.EVDO);
+		config.setTechnologyTypes(technologyTypes1);
+		assertEquals(technologyTypes1, config.getTechnologyTypes());
+
+		List<ModemTechnologyType> technologyTypes2 = new ArrayList<>();
+		technologyTypes2.add(ModemTechnologyType.GPS);
+		technologyTypes2.add(ModemTechnologyType.GSM_GPRS);
+		config.setTechnologyTypes(technologyTypes2);
+		assertEquals(technologyTypes2, config.getTechnologyTypes());
+	}
+
+	@Test
+	public void testPoweredOn() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		config.setPoweredOn(false);
+		assertEquals(false, config.isPoweredOn());
+
+		config.setPoweredOn(true);
+		assertEquals(true, config.isPoweredOn());
+	}
+
+	@Test
+	public void testPowerMode() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		config.setPowerMode(ModemPowerMode.LOW_POWER);
+		assertEquals(ModemPowerMode.LOW_POWER, config.getPowerMode());
+
+		config.setPowerMode(ModemPowerMode.ONLINE);
+		assertEquals(ModemPowerMode.ONLINE, config.getPowerMode());
+	}
+
+	@Test
+	public void testModemDevice() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		UsbModemDevice modemDevice1 = new UsbModemDevice("vendorId1", "productId1", "manufacturerName1", "productName1",
+				"usbBusNumber1", "usbDevicePath1");
+		config.setModemDevice(modemDevice1);
+		assertEquals(modemDevice1, config.getModemDevice());
+
+		UsbModemDevice modemDevice2 = new UsbModemDevice("vendorId2", "productId2", "manufacturerName2", "productName2",
+				"usbBusNumber2", "usbDevicePath2");
+		config.setModemDevice(modemDevice2);
+		assertEquals(modemDevice2, config.getModemDevice());
+	}
+
+	@Test
+	public void testGpsSupported() {
+		ModemInterfaceConfigImpl config = new ModemInterfaceConfigImpl("name");
+
+		config.setGpsSupported(false);
+		assertEquals(false, config.isGpsSupported());
+
+		config.setGpsSupported(true);
+		assertEquals(true, config.isGpsSupported());
+	}
+
+	ModemInterfaceConfigImpl createConfig(int noOfAddresses) throws UnknownHostException {
+		ModemInterfaceImpl<ModemInterfaceAddressConfigImpl> interfaceImpl = new ModemInterfaceImpl<>(
+				"ModemInterface");
+
+		if (noOfAddresses > 0) {
+			List<ModemInterfaceAddressConfigImpl> interfaceAddresses = new ArrayList<>();
+
+			for (int i = 0; i < noOfAddresses; i++) {
+				String ipAddress = "10.0.0." + Integer.toString(i + 1);
+				ModemInterfaceAddressConfigImpl interfaceAddress = createAddress(ipAddress);
+				interfaceAddresses.add(interfaceAddress);
+			}
+
+			interfaceImpl.setNetInterfaceAddresses(interfaceAddresses);
+		} else {
+			interfaceImpl.setNetInterfaceAddresses(null);
+		}
+
+		return new ModemInterfaceConfigImpl(interfaceImpl);
+	}
+
+	ModemInterfaceAddressConfigImpl createAddress(String ipAddress) throws UnknownHostException {
+		ModemInterfaceAddressConfigImpl interfaceAddress = new ModemInterfaceAddressConfigImpl();
+
+		interfaceAddress.setAddress(IPAddress.parseHostAddress(ipAddress));
+
+		return interfaceAddress;
+	}
+}


### PR DESCRIPTION
- Prepared unit tests for classes ModemInterfaceAddressConfigImpl and
  ModemInterfaceConfigImpl from package org.eclipse.kura.core.net.modem
- Fixed or implemented comparison of classes:
  ModemInterfaceAddressConfigImpl and ModemInterfaceAddressImpl

Signed-off-by: Djuro Drljaca <djuro.drljaca@comtrade.com>