### PR TITLE
#1067: Tests for org.eclipse.kura.core.cloud

### DIFF
--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudClientImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudClientImpl.java
@@ -108,10 +108,7 @@ public class CloudClientImpl implements CloudClient, CloudClientListener {
     @Override
     public int publish(String deviceId, String appTopic, KuraPayload payload, int qos, boolean retain)
             throws KuraException {
-        boolean isControl = false;
-        String fullTopic = encodeTopic(deviceId, appTopic, isControl);
-        byte[] appPayload = this.cloudServiceImpl.encodePayload(payload);
-        return this.dataService.publish(fullTopic, appPayload, qos, retain, 5);
+        return publish(deviceId, appTopic, payload, qos, retain, 5);
     }
 
     @Override
@@ -124,16 +121,14 @@ public class CloudClientImpl implements CloudClient, CloudClientListener {
     @Override
     public int publish(String deviceId, String appTopic, KuraPayload payload, int qos, boolean retain, int priority)
             throws KuraException {
-        boolean isControl = false;
-        String fullTopic = encodeTopic(deviceId, appTopic, isControl);
         byte[] appPayload = this.cloudServiceImpl.encodePayload(payload);
-        return this.dataService.publish(fullTopic, appPayload, qos, retain, priority);
+        return publish(deviceId, appTopic, appPayload, qos, retain, priority);
     }
 
     @Override
-    public int publish(String topic, byte[] payload, int qos, boolean retain, int priority) throws KuraException {
+    public int publish(String appTopic, byte[] payload, int qos, boolean retain, int priority) throws KuraException {
         CloudServiceOptions options = this.cloudServiceImpl.getCloudServiceOptions();
-        return publish(options.getTopicClientIdToken(), payload, qos, retain, priority);
+        return publish(options.getTopicClientIdToken(), appTopic, payload, qos, retain, priority);
     }
 
     @Override
@@ -145,27 +140,25 @@ public class CloudClientImpl implements CloudClient, CloudClientListener {
     }
 
     @Override
-    public int controlPublish(String topic, KuraPayload payload, int qos, boolean retain, int priority)
+    public int controlPublish(String appTopic, KuraPayload payload, int qos, boolean retain, int priority)
             throws KuraException {
         CloudServiceOptions options = this.cloudServiceImpl.getCloudServiceOptions();
-        return controlPublish(options.getTopicClientIdToken(), topic, payload, qos, retain, priority);
+        return controlPublish(options.getTopicClientIdToken(), appTopic, payload, qos, retain, priority);
     }
 
     @Override
-    public int controlPublish(String deviceId, String topic, KuraPayload payload, int qos, boolean retain, int priority)
+    public int controlPublish(String deviceId, String appTopic, KuraPayload payload, int qos, boolean retain, int priority)
             throws KuraException {
-        boolean isControl = true;
-        String fullTopic = encodeTopic(deviceId, topic, isControl);
         byte[] appPayload = this.cloudServiceImpl.encodePayload(payload);
-        return this.dataService.publish(fullTopic, appPayload, qos, retain, priority);
+        return controlPublish(deviceId, appTopic, appPayload, qos, retain, priority);
     }
 
     @Override
-    public int controlPublish(String deviceId, String topic, byte[] payload, int qos, boolean retain, int priority)
+    public int controlPublish(String deviceId, String appTopic, byte[] payload, int qos, boolean retain, int priority)
             throws KuraException {
         boolean isControl = true;
-        String appTopic = encodeTopic(deviceId, topic, isControl);
-        return this.dataService.publish(appTopic, payload, qos, retain, priority);
+        String fullTopic = encodeTopic(deviceId, appTopic, isControl);
+        return this.dataService.publish(fullTopic, payload, qos, retain, priority);
     }
 
     @Override
@@ -293,7 +286,7 @@ public class CloudClientImpl implements CloudClient, CloudClientListener {
     //
     // ----------------------------------------------------------------
 
-    private String encodeTopic(String deviceId, String topic, boolean isControl) {
+    private String encodeTopic(String deviceId, String appTopic, boolean isControl) {
         CloudServiceOptions options = this.cloudServiceImpl.getCloudServiceOptions();
         StringBuilder sb = new StringBuilder();
         if (isControl) {
@@ -303,8 +296,8 @@ public class CloudClientImpl implements CloudClient, CloudClientListener {
         sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator()).append(deviceId)
                 .append(options.getTopicSeparator()).append(this.applicationId);
 
-        if (topic != null && !topic.isEmpty()) {
-            sb.append(options.getTopicSeparator()).append(topic);
+        if (appTopic != null && !appTopic.isEmpty()) {
+            sb.append(options.getTopicSeparator()).append(appTopic);
         }
 
         return sb.toString();

--- a/kura/test/org.eclipse.kura.core.cloud.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.core.cloud.test/META-INF/MANIFEST.MF
@@ -1,0 +1,18 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.core.cloud.test
+Bundle-SymbolicName: org.eclipse.kura.core.cloud.test;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eclipse Kura
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy
+Import-Package: org.junit;version="4.12.0",
+ org.junit.runners;version="4.12.0",
+ org.slf4j;version="1.6.4",
+ org.eclipse.kura.core.testutil,
+ org.mockito;version="1.10.19",
+ org.mockito.invocation;version="1.10.19",
+ org.mockito.stubbing;version="1.10.19"
+Fragment-Host: org.eclipse.kura.core.cloud;bundle-version="1.1.0"
+

--- a/kura/test/org.eclipse.kura.core.cloud.test/build.properties
+++ b/kura/test/org.eclipse.kura.core.cloud.test/build.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+#
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Eurotech
+#
+
+bin.includes = .,\
+               META-INF/
+source.. = src/main/java/
+additional.bundles = org.eclipse.kura.api,\
+                     slf4j.api,\
+                     slf4j.log4j12

--- a/kura/test/org.eclipse.kura.core.cloud.test/pom.xml
+++ b/kura/test/org.eclipse.kura.core.cloud.test/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2011, 2016 Eurotech and others
+
+     All rights reserved. This program and the accompanying materials
+     are made available under the terms of the Eclipse Public License v1.0
+     which accompanies this distribution, and is available at
+     http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Eurotech
+      Red Hat Inc - fix issue #603
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.kura</groupId>
+		<artifactId>test</artifactId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.kura.core.cloud.test</artifactId>
+	<packaging>eclipse-test-plugin</packaging>
+	<version>1.0.0-SNAPSHOT</version>
+	
+	<properties>
+		<kura.basedir>${project.basedir}/../..</kura.basedir>
+	</properties>
+	
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kura/test/org.eclipse.kura.core.cloud.test/src/test/java/org/eclipse/kura/core/cloud/CloudClientImplTest.java
+++ b/kura/test/org.eclipse.kura.core.cloud.test/src/test/java/org/eclipse/kura/core/cloud/CloudClientImplTest.java
@@ -1,0 +1,513 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.cloud;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.cloud.CloudClientListener;
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.data.DataService;
+import org.eclipse.kura.message.KuraPayload;
+import org.junit.Test;
+
+public class CloudClientImplTest {
+
+    @Test
+    public void testCloudClientImpl() throws NoSuchFieldException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        assertEquals("appId", cloudClient.getApplicationId());
+        assertEquals(mockDataService, (DataService) TestUtil.getFieldValue(cloudClient, "dataService"));
+        assertEquals(mockCloudService, (CloudServiceImpl) TestUtil.getFieldValue(cloudClient, "cloudServiceImpl"));
+        assertNotNull((List<CloudClientListenerAdapter>) TestUtil.getFieldValue(cloudClient, "listeners"));
+    }
+
+    @Test
+    public void testRelease() {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        cloudClient.release();
+        verify(mockCloudService, times(1)).removeCloudClient(cloudClient);
+    }
+
+    @Test
+    public void testAddCloudClientListener() throws NoSuchFieldException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudClientListener mocktListener = mock(CloudClientListener.class);
+        cloudClient.addCloudClientListener(mocktListener);
+
+        List<CloudClientListenerAdapter> listeners = (List<CloudClientListenerAdapter>) TestUtil
+                .getFieldValue(cloudClient, "listeners");
+
+        assertEquals(1, listeners.size());
+        assertEquals(mocktListener, listeners.get(0).getCloudClientListenerAdapted());
+    }
+
+    @Test
+    public void testRemoveCloudClientListener() throws NoSuchFieldException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudClientListener mocktListener = mock(CloudClientListener.class);
+        cloudClient.addCloudClientListener(mocktListener);
+        cloudClient.removeCloudClientListener(mocktListener);
+
+        List<CloudClientListenerAdapter> listeners = (List<CloudClientListenerAdapter>) TestUtil
+                .getFieldValue(cloudClient, "listeners");
+
+        assertEquals(0, listeners.size());
+    }
+
+    @Test
+    public void testIsConnected() {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        doReturn(false).when(mockDataService).isConnected();
+        assertFalse(cloudClient.isConnected());
+
+        doReturn(true).when(mockDataService).isConnected();
+        assertTrue(cloudClient.isConnected());
+    }
+
+    @Test
+    public void testPublishStringKuraPayloadIntBoolean() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Parameters for publish method
+        String appTopic = "appTopic";
+        KuraPayload payload = new KuraPayload();
+        int qos = 0;
+        boolean retain = false;
+
+        // Prepare data service and cloud service mocks
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator());
+        sb.append(options.getTopicClientIdToken()).append(options.getTopicSeparator()).append("appId");
+        sb.append(options.getTopicSeparator()).append(appTopic);
+
+        String fullTopic = sb.toString();
+        byte[] appPayload = { 1, 2, 3 };
+        int priority = 5;
+        int expectedValue = 42;
+
+        doReturn(appPayload).when(mockCloudService).encodePayload(payload);
+        doReturn(expectedValue).when(mockDataService).publish(fullTopic, appPayload, qos, retain, priority);
+
+        // Execute method
+        int value = cloudClient.publish(appTopic, payload, qos, retain);
+        assertEquals(expectedValue, value);
+    }
+
+    @Test
+    public void testPublishStringKuraPayloadIntBooleanInt() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Parameters for publish method
+        String appTopic = "appTopic";
+        KuraPayload payload = new KuraPayload();
+        int qos = 0;
+        boolean retain = false;
+        int priority = 6;
+
+        // Prepare data service and cloud service mocks
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator());
+        sb.append(options.getTopicClientIdToken()).append(options.getTopicSeparator()).append("appId");
+        sb.append(options.getTopicSeparator()).append(appTopic);
+
+        String fullTopic = sb.toString();
+        byte[] appPayload = { 1, 2, 3 };
+        int expectedValue = 42;
+
+        doReturn(appPayload).when(mockCloudService).encodePayload(payload);
+        doReturn(expectedValue).when(mockDataService).publish(fullTopic, appPayload, qos, retain, priority);
+
+        // Execute method
+        int value = cloudClient.publish(appTopic, payload, qos, retain, priority);
+        assertEquals(expectedValue, value);
+    }
+
+    @Test
+    public void testPublishStringByteArrayIntBooleanInt() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Parameters for publish method
+        String appTopic = "appTopic";
+        byte[] payload = { 1, 2, 3 };
+        int qos = 0;
+        boolean retain = false;
+        int priority = 6;
+
+        // Prepare data service mock
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator());
+        sb.append(options.getTopicClientIdToken()).append(options.getTopicSeparator()).append("appId");
+        sb.append(options.getTopicSeparator()).append(appTopic);
+
+        String fullTopic = sb.toString();
+        int expectedValue = 42;
+
+        doReturn(expectedValue).when(mockDataService).publish(fullTopic, payload, qos, retain, priority);
+
+        // Execute method
+        int value = cloudClient.publish(appTopic, payload, qos, retain, priority);
+        assertEquals(expectedValue, value);
+    }
+
+    @Test
+    public void testControlPublishStringKuraPayloadIntBooleanInt() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Parameters for publish method
+        String appTopic = "appTopic";
+        KuraPayload payload = new KuraPayload();
+        int qos = 0;
+        boolean retain = false;
+        int priority = 6;
+
+        // Prepare data service and cloud service mocks
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getTopicControlPrefix()).append(options.getTopicSeparator());
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator());
+        sb.append(options.getTopicClientIdToken()).append(options.getTopicSeparator()).append("appId");
+        sb.append(options.getTopicSeparator()).append(appTopic);
+
+        String fullTopic = sb.toString();
+        byte[] appPayload = { 1, 2, 3 };
+        int expectedValue = 42;
+
+        doReturn(appPayload).when(mockCloudService).encodePayload(payload);
+        doReturn(expectedValue).when(mockDataService).publish(fullTopic, appPayload, qos, retain, priority);
+
+        // Execute method
+        int value = cloudClient.controlPublish(appTopic, payload, qos, retain, priority);
+        assertEquals(expectedValue, value);
+    }
+
+    @Test
+    public void testSubscribeStringInt() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Prepare data service mock
+        String appTopic = "appTopic";
+        int qos = 0;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator());
+        sb.append(options.getTopicClientIdToken()).append(options.getTopicSeparator()).append("appId");
+        sb.append(options.getTopicSeparator()).append(appTopic);
+
+        String fullTopic = sb.toString();
+
+        // Execute method
+        cloudClient.subscribe(appTopic, qos);
+        verify(mockDataService, times(1)).subscribe(fullTopic, qos);
+    }
+
+    @Test
+    public void testControlSubscribeStringInt() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Prepare data service mock
+        String appTopic = "appTopic";
+        int qos = 0;
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getTopicControlPrefix()).append(options.getTopicSeparator());
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator());
+        sb.append(options.getTopicClientIdToken()).append(options.getTopicSeparator()).append("appId");
+        sb.append(options.getTopicSeparator()).append(appTopic);
+
+        String fullTopic = sb.toString();
+
+        // Execute method
+        cloudClient.controlSubscribe(appTopic, qos);
+        verify(mockDataService, times(1)).subscribe(fullTopic, qos);
+    }
+
+    @Test
+    public void testUnsubscribeString() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Prepare data service mock
+        String appTopic = "appTopic";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator());
+        sb.append(options.getTopicClientIdToken()).append(options.getTopicSeparator()).append("appId");
+        sb.append(options.getTopicSeparator()).append(appTopic);
+
+        String fullTopic = sb.toString();
+
+        // Execute method
+        cloudClient.unsubscribe(appTopic);
+        verify(mockDataService, times(1)).unsubscribe(fullTopic);
+    }
+
+    @Test
+    public void testControlUnsubscribeStringString() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Prepare data service mock
+        String appTopic = "appTopic";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(options.getTopicControlPrefix()).append(options.getTopicSeparator());
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator());
+        sb.append(options.getTopicClientIdToken()).append(options.getTopicSeparator()).append("appId");
+        sb.append(options.getTopicSeparator()).append(appTopic);
+
+        String fullTopic = sb.toString();
+
+        // Execute method
+        cloudClient.controlUnsubscribe(appTopic);
+        verify(mockDataService, times(1)).unsubscribe(fullTopic);
+    }
+
+    @Test
+    public void testGetUnpublishedMessageIds() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Prepare data service mock
+        StringBuilder sb = new StringBuilder();
+        sb.append("^(").append("\\$EDC").append(options.getTopicSeparator()).append(")?");
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator()).append(".+");
+        sb.append(options.getTopicSeparator()).append("appId").append("(/.+)?");
+
+        String topicRegex = sb.toString();
+        ArrayList<Integer> expectedMessageIds = new ArrayList<>();
+        expectedMessageIds.add(1);
+        expectedMessageIds.add(2);
+        expectedMessageIds.add(3);
+
+        doReturn(expectedMessageIds).when(mockDataService).getUnpublishedMessageIds(topicRegex);
+
+        // Execute method
+        List<Integer> messageIds = cloudClient.getUnpublishedMessageIds();
+        assertArrayEquals(expectedMessageIds.toArray(), messageIds.toArray());
+    }
+
+    @Test
+    public void testGetInFlightMessageIds() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Prepare data service mock
+        StringBuilder sb = new StringBuilder();
+        sb.append("^(").append("\\$EDC").append(options.getTopicSeparator()).append(")?");
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator()).append(".+");
+        sb.append(options.getTopicSeparator()).append("appId").append("(/.+)?");
+
+        String topicRegex = sb.toString();
+        ArrayList<Integer> expectedMessageIds = new ArrayList<>();
+        expectedMessageIds.add(1);
+        expectedMessageIds.add(2);
+        expectedMessageIds.add(3);
+
+        doReturn(expectedMessageIds).when(mockDataService).getInFlightMessageIds(topicRegex);
+
+        // Execute method
+        List<Integer> messageIds = cloudClient.getInFlightMessageIds();
+        assertArrayEquals(expectedMessageIds.toArray(), messageIds.toArray());
+    }
+
+    @Test
+    public void testGetDroppedInFlightMessageIds() throws KuraException {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudServiceOptions options = new CloudServiceOptions(null, null);
+        doReturn(options).when(mockCloudService).getCloudServiceOptions();
+
+        // Prepare data service mock
+        StringBuilder sb = new StringBuilder();
+        sb.append("^(").append("\\$EDC").append(options.getTopicSeparator()).append(")?");
+        sb.append(options.getTopicAccountToken()).append(options.getTopicSeparator()).append(".+");
+        sb.append(options.getTopicSeparator()).append("appId").append("(/.+)?");
+
+        String topicRegex = sb.toString();
+        ArrayList<Integer> expectedMessageIds = new ArrayList<>();
+        expectedMessageIds.add(1);
+        expectedMessageIds.add(2);
+        expectedMessageIds.add(3);
+
+        doReturn(expectedMessageIds).when(mockDataService).getDroppedInFlightMessageIds(topicRegex);
+
+        // Execute method
+        List<Integer> messageIds = cloudClient.getDroppedInFlightMessageIds();
+        assertArrayEquals(expectedMessageIds.toArray(), messageIds.toArray());
+    }
+
+    @Test
+    public void testOnMessageArrived() {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudClientListener mocktListener = mock(CloudClientListener.class);
+        cloudClient.addCloudClientListener(mocktListener);
+
+        String deviceId = "deviceId";
+        String appTopic = "appTopic";
+        KuraPayload payload = new KuraPayload();
+        int qos = 1;
+        boolean retain = false;
+
+        cloudClient.onMessageArrived(deviceId, appTopic, payload, qos, retain);
+
+        verify(mocktListener, times(1)).onMessageArrived(deviceId, appTopic, payload, qos, retain);
+    }
+
+    @Test
+    public void testOnControlMessageArrived() {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudClientListener mocktListener = mock(CloudClientListener.class);
+        cloudClient.addCloudClientListener(mocktListener);
+
+        String deviceId = "deviceId";
+        String appTopic = "appTopic";
+        KuraPayload payload = new KuraPayload();
+        int qos = 1;
+        boolean retain = false;
+
+        cloudClient.onControlMessageArrived(deviceId, appTopic, payload, qos, retain);
+
+        verify(mocktListener, times(1)).onControlMessageArrived(deviceId, appTopic, payload, qos, retain);
+    }
+
+    @Test
+    public void testOnMessageConfirmed() {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudClientListener mocktListener = mock(CloudClientListener.class);
+        cloudClient.addCloudClientListener(mocktListener);
+
+        int pubId = 1;
+        String appTopic = "appTopic";
+
+        cloudClient.onMessageConfirmed(pubId, appTopic);
+
+        verify(mocktListener, times(1)).onMessageConfirmed(pubId, appTopic);
+    }
+
+    @Test
+    public void testOnMessagePublished() {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudClientListener mocktListener = mock(CloudClientListener.class);
+        cloudClient.addCloudClientListener(mocktListener);
+
+        int pubId = 1;
+        String appTopic = "appTopic";
+
+        cloudClient.onMessagePublished(pubId, appTopic);
+
+        verify(mocktListener, times(1)).onMessagePublished(pubId, appTopic);
+    }
+
+    @Test
+    public void testOnConnectionEstablished() {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudClientListener mocktListener = mock(CloudClientListener.class);
+        cloudClient.addCloudClientListener(mocktListener);
+
+        cloudClient.onConnectionEstablished();
+
+        verify(mocktListener, times(1)).onConnectionEstablished();
+    }
+
+    @Test
+    public void testOnConnectionLost() {
+        DataService mockDataService = mock(DataService.class);
+        CloudServiceImpl mockCloudService = mock(CloudServiceImpl.class);
+        CloudClientImpl cloudClient = new CloudClientImpl("appId", mockDataService, mockCloudService);
+
+        CloudClientListener mocktListener = mock(CloudClientListener.class);
+        cloudClient.addCloudClientListener(mocktListener);
+
+        cloudClient.onConnectionLost();
+
+        verify(mocktListener, times(1)).onConnectionLost();
+    }
+}

--- a/kura/test/org.eclipse.kura.core.cloud.test/src/test/resources/log4j.properties
+++ b/kura/test/org.eclipse.kura.core.cloud.test/src/test/resources/log4j.properties
@@ -1,0 +1,6 @@
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} [%t] %-5p %c{1}:%L - %m%n
+
+log4j.rootLogger=INFO,stdout

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -117,6 +117,7 @@ Copyright (c) 2016 Eurotech and/or its affiliates and others
     <modules>
         <module>org.eclipse.kura.core.certificates.test</module>
         <module>org.eclipse.kura.core.configuration.test</module>
+        <module>org.eclipse.kura.core.cloud.test</module>
         <module>org.eclipse.kura.core.net.test</module>
         <module>org.eclipse.kura.core.status.test</module>
         <module>org.eclipse.kura.core.testutil</module>


### PR DESCRIPTION
- Prepared unit tests for CloudClientImpl.
- Fixed an endless recursion in one of the CloudClientImpl.publish()
  methods (parameter topic was missing).
- Removed some of the code duplication in CloudClientImpl class.

Signed-off-by: Djuro Drljaca <djuro.drljaca@comtrade.com>