### PR TITLE
Modified interval check in GwtNetworkServiceImpl.java.

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -345,7 +345,7 @@
 									<groupId>org.eclipse.kura</groupId>
 									<artifactId>org.eclipse.kura.util</artifactId>
 									<version>${org.eclipse.kura.util.version}</version>
-									</artifactItem>
+								</artifactItem>
 								<artifactItem>
 									<groupId>org.eclipse.kura</groupId>
 									<artifactId>org.eclipse.kura.wire.component.provider</artifactId>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -252,7 +252,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
                                         } else {
                                             gwtNetConfig.setIpAddress("");
                                         }
-                                        if (addressConfig.getNetworkPrefixLength() >= 0
+                                        if (addressConfig.getNetworkPrefixLength() > 0
                                                 && addressConfig.getNetworkPrefixLength() <= 32) {
                                             gwtNetConfig.setSubnetMask(NetworkUtil
                                                     .getNetmaskStringForm(addressConfig.getNetworkPrefixLength()));
@@ -723,7 +723,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
     @Override
     public void updateNetInterfaceConfigurations(GwtXSRFToken xsrfToken, GwtNetInterfaceConfig config)
             throws GwtKuraException {
-    	
+
         checkXSRFToken(xsrfToken);
         NetworkAdminService nas = ServiceLocator.getInstance().getService(NetworkAdminService.class);
 
@@ -1564,9 +1564,9 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
 
             // ignore SSID?
             wifiConfig.setIgnoreSSID(gwtWifiConfig.ignoreSSID());
-            
+
             // broadcast SSID
-         	wifiConfig.setBroadcast(!gwtWifiConfig.ignoreSSID());
+            wifiConfig.setBroadcast(!gwtWifiConfig.ignoreSSID());
         }
 
         return wifiConfig;


### PR DESCRIPTION
The interval allowed is now 1-32. If 0 is passed, the internal check will throw an exception.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>