### PR TITLE
Modified jvm dependency.

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -1413,7 +1413,7 @@
 			<id>raspberry-pi</id>
 			<properties>
 				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw,
-					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, openjdk-8-jre-headless</project.raspbian.dependencies>
+					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, java8-runtime-headless | java8-runtime</project.raspbian.dependencies>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1518,7 +1518,7 @@
 		<profile>
 			<id>raspberry-pi-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, openjdk-8-jre-headless</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, java8-runtime-headless | java8-runtime</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1613,7 +1613,7 @@
 			<id>raspberry-pi-bplus</id>
 			<properties>
 				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw,
-					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, openjdk-8-jre-headless</project.raspbian.dependencies>
+					dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, java8-runtime-headless | java8-runtime</project.raspbian.dependencies>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1718,7 +1718,7 @@
 		<profile>
 			<id>raspberry-pi-bplus-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, openjdk-8-jre-headless</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, java8-runtime-headless | java8-runtime</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1813,7 +1813,7 @@
 		<profile>
 			<id>raspberry-pi-2-3</id>
 			<properties>
-				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw, dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, openjdk-8-jre-headless</project.raspbian.dependencies>
+				<project.raspbian.dependencies>hostapd, isc-dhcp-server, iw, dos2unix, bind9, unzip, ethtool, telnet, wireless-tools, java8-runtime-headless | java8-runtime</project.raspbian.dependencies>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->
@@ -1909,7 +1909,7 @@
 		<profile>
 			<id>raspberry-pi-2-3-nn</id>
 			<properties>
-				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, openjdk-8-jre-headless</project.raspbian.dependencies.nn>
+				<project.raspbian.dependencies.nn>dos2unix, unzip, telnet, java8-runtime-headless | java8-runtime</project.raspbian.dependencies.nn>
 <!--
 				<kura.install.dir>/opt/eclipse</kura.install.dir>
 -->


### PR DESCRIPTION
With this change, there is no more the requirement to install the openjdk jvm.
With the new dependency, if the oracle jvm is already installed (like in raspbian)
it will not more required to install the openjdk jvm.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>