### PR TITLE
#1096: Tests for org.eclipse.kura.core.util

### DIFF
--- a/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.kura.core;singleton:=true
 Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.kura.core.linux.util; version="1.1.0", org.eclipse.kura.core.util; version="1.1.0"
+Export-Package: org.eclipse.kura.core.linux.util; version="1.1.0", org.eclipse.kura.core.util; version="1.1.1"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.crypto,

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/util/ValidationUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/util/ValidationUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,11 +23,11 @@ public class ValidationUtil {
     }
 
     /**
-     * Throws an EdcIllegalNullArgumentException if the string value for the specified argument is empty or null.
+     * Throws an KuraException if the string value for the specified argument is empty, null, or whitespace.
      * 
      * @param obj
      * @param argumentName
-     * @throws EdcIllegalNullArgumentException
+     * @throws KuraException
      */
     public static void notEmptyOrNull(String value, String argumentName) throws KuraException {
         if (value == null || value.trim().length() == 0) {
@@ -36,11 +36,11 @@ public class ValidationUtil {
     }
 
     /**
-     * Throws an EdcIllegalNullArgumentException if the value for the specified argument is null.
+     * Throws an KuraException if the value for the specified argument is null.
      * 
      * @param obj
      * @param argumentName
-     * @throws EdcIllegalNullArgumentException
+     * @throws KuraException
      */
     public static void notNegative(int value, String argumentName) throws KuraException {
         if (value < 0) {
@@ -49,11 +49,11 @@ public class ValidationUtil {
     }
 
     /**
-     * Throws an EdcIllegalNullArgumentException if the value for the specified argument is null.
+     * Throws an KuraException if the value for the specified argument is null.
      * 
      * @param obj
      * @param argumentName
-     * @throws EdcIllegalNullArgumentException
+     * @throws KuraException
      */
     public static void notNegative(short value, String argumentName) throws KuraException {
         if (value < 0) {
@@ -62,11 +62,11 @@ public class ValidationUtil {
     }
 
     /**
-     * Throws an EdcIllegalNullArgumentException if the value for the specified argument is null.
+     * Throws an KuraException if the value for the specified argument is null.
      * 
      * @param obj
      * @param argumentName
-     * @throws EdcIllegalNullArgumentException
+     * @throws KuraException
      */
     public static void notNegative(long value, String argumentName) throws KuraException {
         if (value < 0) {

--- a/kura/test/org.eclipse.kura.core.util.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.core.util.test/META-INF/MANIFEST.MF
@@ -1,0 +1,15 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.core.util.test
+Bundle-SymbolicName: org.eclipse.kura.core.util.test;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eclipse Kura
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy
+Import-Package: org.junit;version="4.12.0",
+ org.junit.runners;version="4.12.0",
+ org.slf4j;version="1.6.4",
+ org.eclipse.kura.core.testutil,
+ org.apache.commons.io;version="[2.4.0,3.0.0)"
+Fragment-Host: org.eclipse.kura.core;bundle-version="1.0.11"

--- a/kura/test/org.eclipse.kura.core.util.test/build.properties
+++ b/kura/test/org.eclipse.kura.core.util.test/build.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2017 Eurotech and/or its affiliates
+#
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Eurotech
+#
+
+bin.includes = .,\
+               META-INF/
+source.. = src/main/java/
+additional.bundles = org.eclipse.kura.api,\
+                     slf4j.api,\
+                     slf4j.log4j12,\
+                     log4j

--- a/kura/test/org.eclipse.kura.core.util.test/pom.xml
+++ b/kura/test/org.eclipse.kura.core.util.test/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017 Eurotech and others
+
+     All rights reserved. This program and the accompanying materials
+     are made available under the terms of the Eclipse Public License v1.0
+     which accompanies this distribution, and is available at
+     http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Eurotech
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.kura</groupId>
+		<artifactId>test</artifactId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.kura.core.util.test</artifactId>
+	<packaging>eclipse-test-plugin</packaging>
+	<version>1.0.0-SNAPSHOT</version>
+	
+	<properties>
+		<kura.basedir>${project.basedir}/../..</kura.basedir>
+	</properties>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kura/test/org.eclipse.kura.core.util.test/src/test/java/org/eclipse/kura/core/util/NetUtilTest.java
+++ b/kura/test/org.eclipse.kura.core.util.test/src/test/java/org/eclipse/kura/core/util/NetUtilTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class NetUtilTest {
+
+	@Test
+	public void testHardwareAddressToString() {
+		byte[] input = {0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB};
+		String result = NetUtil.hardwareAddressToString(input);
+		assertEquals("01:23:45:67:89:AB", result);
+	}
+
+	@Test
+	public void testHardwareAddressToStringNull() {
+		byte[] input = null;
+		String result = NetUtil.hardwareAddressToString(input);
+		assertEquals("N/A", result);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHardwareAddressToStringEmptyValue() {
+		NetUtil.hardwareAddressToString(new byte[]{});
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHardwareAddressToStringNotEnoughElements() {
+		byte[] input = {0x01, 0x23, 0x45, 0x67, (byte) 0x89};
+		NetUtil.hardwareAddressToString(input);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHardwareAddressToStringTooManyElements() {
+		byte[] input = {0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB, 0x42};
+		NetUtil.hardwareAddressToString(input);
+	}
+
+	@Test
+	public void testHardwareAddressToBytes() {
+		byte[] result = NetUtil.hardwareAddressToBytes("01:23:45:67:89:AB");
+		byte[] expected = {0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xAB};
+		assertArrayEquals(expected, result);
+	}
+
+	@Test
+	public void testHardwareAddressToBytesNullOrEmpty() {
+		byte[] expected = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+		byte[] result = NetUtil.hardwareAddressToBytes(null);
+		assertArrayEquals(expected, result);
+
+		result = NetUtil.hardwareAddressToBytes("");
+		assertArrayEquals(expected, result);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHardwareAddressToBytesInvalidValue1() {
+		NetUtil.hardwareAddressToBytes("g1:23:45:67:89:AB");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHardwareAddressToBytesInvalidValue2() {
+		NetUtil.hardwareAddressToBytes("01::45:67:89:AB");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHardwareAddressToBytesInvalidValueNotEnoughElements() {
+		NetUtil.hardwareAddressToBytes("01:23:45:67:89");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHardwareAddressToBytesTooManyElements() {
+		NetUtil.hardwareAddressToBytes("01:23:45:67:89:AB:42");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testHardwareAddressToBytesOutOfRangeValue() {
+		NetUtil.hardwareAddressToBytes("101:23:45:67:89:AB");
+	}
+}

--- a/kura/test/org.eclipse.kura.core.util.test/src/test/java/org/eclipse/kura/core/util/ProcessUtilTest.java
+++ b/kura/test/org.eclipse.kura.core.util.test/src/test/java/org/eclipse/kura/core/util/ProcessUtilTest.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.util;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ProcessUtilTest {
+	private static final String TEMP_SCRIPT_FILE_PATH = "/tmp/kura_test_script_ProcessUtilTest";
+
+	@Test
+	public void testExecString() throws Exception {
+		int[] values = new int[]{0, 1, 2};
+		String command = "/bin/sh " + TEMP_SCRIPT_FILE_PATH;
+		File file = new File(TEMP_SCRIPT_FILE_PATH);
+		file.deleteOnExit();
+
+		for (int value : values) {
+			String stdout;
+			String stderr;
+			int errorCode = -1;
+
+			try {
+				try (PrintWriter out = new PrintWriter(file)) {
+					out.println("echo stdout");
+					out.println("echo stderr 1>&2");
+					out.println("exit " + value);
+				}
+
+				SafeProcess process = ProcessUtil.exec(command);
+
+				errorCode = process.exitValue();
+				stdout = IOUtils.toString(process.getInputStream(),
+						StandardCharsets.UTF_8);
+				stderr = IOUtils.toString(process.getErrorStream(),
+						StandardCharsets.UTF_8);
+			} catch (Exception e) {
+				throw e;
+			} finally {
+				file.delete();
+			}
+
+			assertEquals(value, errorCode);
+			assertEquals("stdout\n", stdout);
+			assertEquals("stderr\n", stderr);
+		}
+	}
+
+	@Test
+	public void testExecStringArray() throws Exception {
+		int[] values = new int[]{0, 1, 2};
+		String[] commandArray = {"/bin/sh", TEMP_SCRIPT_FILE_PATH};
+		File file = new File(TEMP_SCRIPT_FILE_PATH);
+		file.deleteOnExit();
+
+		for (int value : values) {
+			String stdout;
+			String stderr;
+			int errorCode = -1;
+
+			try {
+				try (PrintWriter out = new PrintWriter(file)) {
+					out.println("echo stdout");
+					out.println("echo stderr 1>&2");
+					out.println("exit " + value);
+				}
+
+				SafeProcess process = ProcessUtil.exec(commandArray);
+
+				errorCode = process.exitValue();
+				stdout = IOUtils.toString(process.getInputStream(),
+						StandardCharsets.UTF_8);
+				stderr = IOUtils.toString(process.getErrorStream(),
+						StandardCharsets.UTF_8);
+			} catch (Exception e) {
+				throw e;
+			} finally {
+				file.delete();
+			}
+
+			assertEquals(value, errorCode);
+			assertEquals("stdout\n", stdout);
+			assertEquals("stderr\n", stderr);
+		}
+	}
+
+	@Test
+	public void testDestroy() throws Exception {
+		// First execute the process
+		String[] commandArray = {"/bin/sh", TEMP_SCRIPT_FILE_PATH};
+		File file = new File(TEMP_SCRIPT_FILE_PATH);
+		file.deleteOnExit();
+
+		SafeProcess process;
+
+		try {
+			try (PrintWriter out = new PrintWriter(file)) {
+				out.println("echo stdout");
+				out.println("echo stderr 1>&2");
+				out.println("exit 0");
+			}
+
+			process = ProcessUtil.exec(commandArray);
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			file.delete();
+		}
+
+		String stdout = IOUtils.toString(process.getInputStream(),
+				StandardCharsets.UTF_8);
+		String stderr = IOUtils.toString(process.getErrorStream(),
+				StandardCharsets.UTF_8);
+
+		assertEquals("stdout\n", stdout);
+		assertEquals("stderr\n", stderr);
+
+		// Then destroy it 
+		ProcessUtil.destroy(process);
+
+		assertNull(TestUtil.getFieldValue(process, "m_inBytes"));
+		assertNull(TestUtil.getFieldValue(process, "m_errBytes"));
+		assertNull(TestUtil.getFieldValue(process, "m_process"));
+	}
+}

--- a/kura/test/org.eclipse.kura.core.util.test/src/test/java/org/eclipse/kura/core/util/SafeProcessTest.java
+++ b/kura/test/org.eclipse.kura.core.util.test/src/test/java/org/eclipse/kura/core/util/SafeProcessTest.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.util;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class SafeProcessTest {
+	private static final String TEMP_SCRIPT_FILE_PATH = "/tmp/kura_test_script_SafeProcessTest";
+
+	@Test
+	public void testExec() throws Exception {
+		int[] values = new int[]{0, 1, 2};
+		String[] commandArray = {"/bin/sh", TEMP_SCRIPT_FILE_PATH};
+		File file = new File(TEMP_SCRIPT_FILE_PATH);
+		file.deleteOnExit();
+
+		for (int expectedErrorCode : values) {
+			String stdout;
+			String stderr;
+			int errorCode = -1;
+
+			try {
+				try (PrintWriter out = new PrintWriter(file)) {
+					out.println("echo stdout");
+					out.println("echo stderr 1>&2");
+					out.println("exit " + expectedErrorCode);
+				}
+
+				SafeProcess process = new SafeProcess();
+				process.exec(commandArray);
+
+				errorCode = process.exitValue();
+				stdout = IOUtils.toString(process.getInputStream(),
+						StandardCharsets.UTF_8);
+				stderr = IOUtils.toString(process.getErrorStream(),
+						StandardCharsets.UTF_8);
+			} catch (Exception e) {
+				throw e;
+			} finally {
+				file.delete();
+			}
+
+			assertEquals(expectedErrorCode, errorCode);
+			assertEquals("stdout\n", stdout);
+			assertEquals("stderr\n", stderr);
+		}
+	}
+
+	@Test
+	public void testDestroy() throws Exception {
+		// First execute the process
+		String[] commandArray = {"/bin/sh", TEMP_SCRIPT_FILE_PATH};
+		File file = new File(TEMP_SCRIPT_FILE_PATH);
+		file.deleteOnExit();
+
+		SafeProcess process = new SafeProcess();
+
+		try {
+			try (PrintWriter out = new PrintWriter(file)) {
+				out.println("echo stdout");
+				out.println("echo stderr 1>&2");
+				out.println("exit 0");
+			}
+
+			process.exec(commandArray);
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			file.delete();
+		}
+
+		String stdout = IOUtils.toString(process.getInputStream(),
+				StandardCharsets.UTF_8);
+		String stderr = IOUtils.toString(process.getErrorStream(),
+				StandardCharsets.UTF_8);
+
+		assertEquals("stdout\n", stdout);
+		assertEquals("stderr\n", stderr);
+
+		// Then destroy it 
+		process.destroy();
+
+		assertNull(TestUtil.getFieldValue(process, "m_inBytes"));
+		assertNull(TestUtil.getFieldValue(process, "m_errBytes"));
+		assertNull(TestUtil.getFieldValue(process, "m_process"));
+	}
+}

--- a/kura/test/org.eclipse.kura.core.util.test/src/test/java/org/eclipse/kura/core/util/ValidationUtilTest.java
+++ b/kura/test/org.eclipse.kura.core.util.test/src/test/java/org/eclipse/kura/core/util/ValidationUtilTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.util;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.kura.KuraException;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ValidationUtilTest {
+
+	@Test
+	public void testNotNullWithObject() throws KuraException {
+		Object value = new Object();
+		ValidationUtil.notNull(value, "value");
+	}
+
+	@Test(expected = KuraException.class)
+	public void testNotNullWithNullObject() throws KuraException {
+		Object value = null;
+		ValidationUtil.notNull(value, "value");
+	}
+
+	@Test
+	public void testNotEmptyOrNullWithNonEmptyString() throws KuraException {
+		String value = "xyz";
+		ValidationUtil.notEmptyOrNull(value, "value");
+	}
+
+	@Test(expected = KuraException.class)
+	public void testNotEmptyOrNullWithNullString() throws KuraException {
+		String value = null;
+		ValidationUtil.notEmptyOrNull(value, "value");
+	}
+
+	@Test(expected = KuraException.class)
+	public void testNotEmptyOrNullWithEmptyString() throws KuraException {
+		String value = "";
+		ValidationUtil.notEmptyOrNull(value, "value");
+	}
+
+	@Test(expected = KuraException.class)
+	public void testNotEmptyOrNullWithWhitespace() throws KuraException {
+		String value = " \t\n\r\f";
+		ValidationUtil.notEmptyOrNull(value, "value");
+	}
+
+	@Test
+	public void testNotNegativeIntStringWithZero() throws KuraException {
+		int value = 0;
+		ValidationUtil.notNegative(value, "value");
+	}
+
+	@Test
+	public void testNotNegativeIntStringWithPositive() throws KuraException {
+		int value = 1;
+		ValidationUtil.notNegative(value, "value");
+	}
+
+	@Test(expected = KuraException.class)
+	public void testNotNegativeIntStringWithNegative() throws KuraException {
+		int value = -1;
+		ValidationUtil.notNegative(value, "value");
+	}
+
+	@Test
+	public void testNotNegativeShortStringWithZero() throws KuraException {
+		short value = 0;
+		ValidationUtil.notNegative(value, "value");
+	}
+
+	@Test
+	public void testNotNegativeShortStringWithPositive() throws KuraException {
+		short value = 1;
+		ValidationUtil.notNegative(value, "value");
+	}
+
+	@Test(expected = KuraException.class)
+	public void testNotNegativeShortStringWithNegative() throws KuraException {
+		short value = -1;
+		ValidationUtil.notNegative(value, "value");
+	}
+
+	@Test
+	public void testNotNegativeLongStringWithZero() throws KuraException {
+		long value = 0;
+		ValidationUtil.notNegative(value, "value");
+	}
+
+	@Test
+	public void testNotNegativeLongStringWithPositive() throws KuraException {
+		long value = 1;
+		ValidationUtil.notNegative(value, "value");
+	}
+
+	@Test(expected = KuraException.class)
+	public void testNotNegativeLongStringWithNegative() throws KuraException {
+		long value = -1;
+		ValidationUtil.notNegative(value, "value");
+	}
+}

--- a/kura/test/org.eclipse.kura.core.util.test/src/test/resources/log4j.properties
+++ b/kura/test/org.eclipse.kura.core.util.test/src/test/resources/log4j.properties
@@ -1,0 +1,6 @@
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} [%t] %-5p %c{1}:%L - %m%n
+
+log4j.rootLogger=INFO,stdout

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -125,5 +125,6 @@ Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
         <module>org.eclipse.kura.core.status.test</module>
         <module>org.eclipse.kura.core.system.test</module>
         <module>org.eclipse.kura.core.testutil</module>
+        <module>org.eclipse.kura.core.util.test</module>
     </modules>
 </project>


### PR DESCRIPTION
- Prepared unit tests for NetUtil, ProcessUtil, SafeProcess, and
  ValidationUtil classes.
- Improved input validation and conversion of hardware address from and
  to string in methods hardwareAddressToString() and
  hardwareAddressToBytes().
- Fixed some comments in ValidationUtil class. It was referencing
  EdcIllegalNullArgumentException instead of KuraException. Also
  documentation of notEmptyOrNull() method was extended to note that the
  exception is thrown also in case the input value contains only
  whitespace characters.
- Increased BREE from Java 1.6 to Java 1.8

Signed-off-by: Djuro Drljaca <djuro.drljaca@comtrade.com>