### PR TITLE
Added drag and drop support to the Wire Composer.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WireComponentsAnchorListItem.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WireComponentsAnchorListItem.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui.wires;
 
+import org.eclipse.kura.web.client.util.DragSupport;
+import org.eclipse.kura.web.client.util.DragSupport.DragEvent;
 import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 
@@ -31,17 +33,23 @@ public class WireComponentsAnchorListItem extends AnchorListItem {
         super.setIcon(this.getFactoryIcon());
         super.setText(WiresPanelUi.getFormattedPid(factoryPid));
 
+        DragSupport drag = DragSupport.addIfSupported(this);
+
+        if (drag != null) {
+            drag.setListener(new DragSupport.Listener() {
+
+                @Override
+                public void onDragStart(DragEvent event) {
+                    event.setData("text/plain", WiresPanelUi.FACTORY_PID_DROP_PREFIX + factoryPid);
+                }
+            });
+        }
+
         super.addClickHandler(new ClickHandler() {
 
             @Override
             public void onClick(final ClickEvent event) {
-                if (factoryPid.contains(WiresPanelUi.WIRE_ASSET)) {
-                    WiresPanelUi.driverInstanceForm.setVisible(true);
-                } else {
-                    WiresPanelUi.driverInstanceForm.setVisible(false);
-                }
-                WiresPanelUi.factoryPid.setValue(factoryPid);
-                WiresPanelUi.assetModal.show();
+                WiresPanelUi.showComponentCreationDialog(factoryPid);
                 WireComponentsAnchorListItem.this.setActive(true);
             }
         });

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.ui.xml
@@ -55,7 +55,7 @@
 					</b:Panel>
 				</b:Row>
 				<b:Row>
-					<b:Column size="MD_12,XS_12" b:id="wires-graph" addStyleNames="composer"></b:Column>
+					<b:Column size="MD_12,XS_12" b:id="wires-graph" addStyleNames="composer" ui:field="composer"></b:Column>
 				</b:Row>
 			</b:Column>
 			<b:Column size="MD_2">

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/DragSupport.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/DragSupport.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.web.client.util;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.ui.Widget;
+
+public class DragSupport {
+
+    private Listener listener;
+
+    private DragSupport(Element e) {
+        attachNativeEventHandlers(e);
+    }
+
+    private static native boolean isDragSupported(Element element) /*-{
+                                                                    return element['ondragstart'] !== undefined               
+                                                                    }-*/;
+
+    public static DragSupport addIfSupported(Widget w) {
+        Element domElement = w.getElement();
+        if (!isDragSupported(domElement)) {
+            return null;
+        }
+        return new DragSupport(domElement);
+    }
+
+    private void dispatchDragStart(JavaScriptObject nativeObject) {
+        if (listener == null) {
+            return;
+        }
+        listener.onDragStart(new DragEvent(nativeObject));
+    }
+
+    private native void attachNativeEventHandlers(Element element) /*-{
+                                                                    element.setAttribute('draggable', 'true') 
+                                                                    var self = this
+                                                                    element.addEventListener('dragstart', function (event) {
+                                                                        self.@org.eclipse.kura.web.client.util.DragSupport::dispatchDragStart(Lcom/google/gwt/core/client/JavaScriptObject;)(event.dataTransfer)
+                                                                    })
+                                                                    }-*/;
+
+    public interface Listener {
+
+        public void onDragStart(DragEvent event);
+
+    }
+
+    public void setListener(Listener listener) {
+        this.listener = listener;
+    }
+
+    public static class DragEvent {
+
+        private JavaScriptObject nativeDataTransfer;
+
+        private DragEvent(JavaScriptObject nativeDataTransfer) {
+            this.nativeDataTransfer = nativeDataTransfer;
+        }
+
+        private native void setDataNative(JavaScriptObject nativeObject, String type, String data) /*-{
+                                                                                                   nativeObject.setData(type, data)
+                                                                                                   }-*/;
+
+        public void setData(String type, String data) {
+            setDataNative(nativeDataTransfer, type, data);
+        }
+    }
+}


### PR DESCRIPTION
Adds the support for creating new Wire Components by dragging the corresponding entry from the right menu on the Wire Graph canvas.

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>