### PR TITLE
#1111: Tests for org.eclipse.kura.core.ssl

### DIFF
--- a/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.eclipse.kura.core
 Bundle-SymbolicName: org.eclipse.kura.core;singleton:=true
 Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Eclipse Kura
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.kura.core.linux.util; version="1.1.0", org.eclipse.kura.core.util; version="1.1.0"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SSLSocketFactoryWrapper.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SSLSocketFactoryWrapper.java
@@ -36,8 +36,6 @@ public class SSLSocketFactoryWrapper extends SSLSocketFactory {
 
     private static final Logger s_logger = LoggerFactory.getLogger(SSLSocketFactoryWrapper.class);
 
-    private static final String CANNOT_ENABLE_SSL_ENDPOINT_IDENTIFICATION_JAVA7 = "Cannot enable SSL Endpoint Identification as it requires Java7";
-
     private final String ciphers;
     private final Boolean hostnameVerification;
     private final SSLSocketFactory sslsf;
@@ -113,26 +111,11 @@ public class SSLSocketFactoryWrapper extends SSLSocketFactory {
             sslParams.setProtocols(protocols.toArray(new String[protocols.size()]));
 
             // enable server verification
-            // to keep the code compatible with Java6,
-            // test if the SSLParameters class has the
-            // setEndpointIdentificationAlgorithm method
-            Class<SSLParameters> clSSLParameters = SSLParameters.class;
-            try {
-                Method m = clSSLParameters.getMethod("setEndpointIdentificationAlgorithm", String.class);
-                if (m != null && this.hostnameVerification) {
-                    m.invoke(sslParams, "HTTPS");
-                    s_logger.info("SSL Endpoint Identification enabled.");
-                }
-            } catch (NoSuchMethodException e) {
-                s_logger.warn(CANNOT_ENABLE_SSL_ENDPOINT_IDENTIFICATION_JAVA7, e);
-            } catch (IllegalArgumentException e) {
-                s_logger.warn(CANNOT_ENABLE_SSL_ENDPOINT_IDENTIFICATION_JAVA7, e);
-            } catch (IllegalAccessException e) {
-                s_logger.warn(CANNOT_ENABLE_SSL_ENDPOINT_IDENTIFICATION_JAVA7, e);
-            } catch (InvocationTargetException e) {
-                s_logger.warn(CANNOT_ENABLE_SSL_ENDPOINT_IDENTIFICATION_JAVA7, e);
+            if (this.hostnameVerification) {
+                sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+                s_logger.info("SSL Endpoint Identification enabled.");
             }
-
+            
             // Adjust the supported ciphers.
             if (this.ciphers != null && !this.ciphers.isEmpty()) {
                 String[] arrCiphers = this.ciphers.split(",");

--- a/kura/test/org.eclipse.kura.core.ssl.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.core.ssl.test/META-INF/MANIFEST.MF
@@ -1,0 +1,17 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.core.ssl.test
+Bundle-SymbolicName: org.eclipse.kura.core.ssl.test;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eclipse Kura
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy
+Import-Package: org.junit;version="4.12.0",
+ org.junit.runners;version="4.12.0",
+ org.slf4j;version="1.6.4",
+ org.eclipse.kura.core.testutil,
+ org.mockito;version="1.10.19",
+ org.mockito.invocation;version="1.10.19",
+ org.mockito.stubbing;version="1.10.19"
+Fragment-Host: org.eclipse.kura.core;bundle-version="1.0.11"

--- a/kura/test/org.eclipse.kura.core.ssl.test/build.properties
+++ b/kura/test/org.eclipse.kura.core.ssl.test/build.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+#
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Eurotech
+#
+
+bin.includes = .,\
+               META-INF/
+source.. = src/main/java/
+additional.bundles = org.eclipse.kura.api,\
+                     slf4j.api,\
+                     slf4j.log4j12

--- a/kura/test/org.eclipse.kura.core.ssl.test/pom.xml
+++ b/kura/test/org.eclipse.kura.core.ssl.test/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2011, 2016 Eurotech and others
+
+     All rights reserved. This program and the accompanying materials
+     are made available under the terms of the Eclipse Public License v1.0
+     which accompanies this distribution, and is available at
+     http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Eurotech
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.kura</groupId>
+		<artifactId>test</artifactId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.kura.core.ssl.test</artifactId>
+	<packaging>eclipse-test-plugin</packaging>
+	<version>1.0.0-SNAPSHOT</version>
+	
+	<properties>
+		<kura.basedir>${project.basedir}/../..</kura.basedir>
+	</properties>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kura/test/org.eclipse.kura.core.ssl.test/src/test/java/org/eclipse/kura/core/ssl/ConnectionSslOptionsTest.java
+++ b/kura/test/org.eclipse.kura.core.ssl.test/src/test/java/org/eclipse/kura/core/ssl/ConnectionSslOptionsTest.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.ssl;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.eclipse.kura.ssl.SslManagerServiceOptions;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ConnectionSslOptionsTest {
+
+    @Test
+    public void testConnectionSslOptions() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        assertEquals(serviceOptions, sslOptions.getSslManagerOpts());
+    }
+
+    @Test
+    public void testSetProtocolNull() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslProtocol()).thenReturn("p1");
+        sslOptions.setProtocol(null);
+        assertEquals("p1", sslOptions.getProtocol());
+    }
+
+    @Test
+    public void testSetProtocolEmpty() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslProtocol()).thenReturn("p2");
+        sslOptions.setProtocol("");
+        assertEquals("p2", sslOptions.getProtocol());
+    }
+
+    @Test
+    public void testSetProtocolWhitespace() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslProtocol()).thenReturn("p3");
+        sslOptions.setProtocol(" \t\r\b\f");
+        assertEquals("p3", sslOptions.getProtocol());
+    }
+
+    @Test
+    public void testSetProtocolNonEmpty() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        sslOptions.setProtocol("p4");
+        assertEquals("p4", sslOptions.getProtocol());
+    }
+
+    @Test
+    public void testSetCiphersNull() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslCiphers()).thenReturn("c1");
+        sslOptions.setCiphers(null);
+        assertEquals("c1", sslOptions.getCiphers());
+    }
+
+    @Test
+    public void testSetCiphersEmpty() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslCiphers()).thenReturn("c2");
+        sslOptions.setCiphers("");
+        assertEquals("c2", sslOptions.getCiphers());
+    }
+
+    @Test
+    public void testSetCiphersWhitespace() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslCiphers()).thenReturn("c3");
+        sslOptions.setCiphers(" \t\r\b\f");
+        assertEquals("c3", sslOptions.getCiphers());
+    }
+
+    @Test
+    public void testSetCiphersNonEmpty() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        sslOptions.setCiphers("c4");
+
+        assertEquals("c4", sslOptions.getCiphers());
+    }
+
+    @Test
+    public void testSetTrustStoreNull() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslKeyStore()).thenReturn("ts1");
+        sslOptions.setTrustStore(null);
+        assertEquals("ts1", sslOptions.getTrustStore());
+    }
+
+    @Test
+    public void testSetTrustStoreEmpty() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslKeyStore()).thenReturn("ts2");
+        sslOptions.setTrustStore("");
+        assertEquals("ts2", sslOptions.getTrustStore());
+    }
+
+    @Test
+    public void testSetTrustStoreWhitespace() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslKeyStore()).thenReturn("ts3");
+        sslOptions.setTrustStore(" \t\r\b\f");
+
+        assertEquals("ts3", sslOptions.getTrustStore());
+    }
+
+    @Test
+    public void testSetTrustStoreNonEmpty() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        sslOptions.setTrustStore("ts4");
+        assertEquals("ts4", sslOptions.getTrustStore());
+    }
+
+    @Test
+    public void testSetKeyStoreNull() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslKeyStore()).thenReturn("ks1");
+        sslOptions.setKeyStore(null);
+        assertEquals("ks1", sslOptions.getKeyStore());
+    }
+
+    @Test
+    public void testSetKeyStoreEmpty() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslKeyStore()).thenReturn("ks2");
+        sslOptions.setKeyStore("");
+        assertEquals("ks2", sslOptions.getKeyStore());
+    }
+
+    @Test
+    public void testSetKeyStoreWhitespace() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        when(serviceOptions.getSslKeyStore()).thenReturn("ks3");
+        sslOptions.setKeyStore(" \t\r\b\f");
+        assertEquals("ks3", sslOptions.getKeyStore());
+    }
+
+    @Test
+    public void testSetKeyStoreNonEmpty() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        sslOptions.setKeyStore("ks4");
+        assertEquals("ks4", sslOptions.getKeyStore());
+    }
+
+    @Test
+    public void testSetKeyStorePassword() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        char[] password = "keyStorePassword".toCharArray();
+        sslOptions.setKeyStorePassword(password);
+        assertArrayEquals(password, sslOptions.getKeyStorePassword());
+    }
+
+    @Test
+    public void testSetAlias() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        sslOptions.setAlias("alias");
+        assertEquals("alias", sslOptions.getAlias());
+    }
+
+    @Test
+    public void testSetHostnameVerification() {
+        SslManagerServiceOptions serviceOptions = mock(SslManagerServiceOptions.class);
+        ConnectionSslOptions sslOptions = new ConnectionSslOptions(serviceOptions);
+
+        sslOptions.setHostnameVerification(true);
+        assertEquals(true, sslOptions.getHostnameVerification());
+
+        sslOptions.setHostnameVerification(false);
+        assertEquals(false, sslOptions.getHostnameVerification());
+    }
+}

--- a/kura/test/org.eclipse.kura.core.ssl.test/src/test/java/org/eclipse/kura/core/ssl/SSLSocketFactoryWrapperTest.java
+++ b/kura/test/org.eclipse.kura.core.ssl.test/src/test/java/org/eclipse/kura/core/ssl/SSLSocketFactoryWrapperTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.core.ssl;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.net.Socket;
+
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class SSLSocketFactoryWrapperTest {
+
+    @Test
+    public void testSSLSocketFactoryWrapper() throws NoSuchFieldException {
+        SSLSocketFactory factory = mock(SSLSocketFactory.class);
+        SSLSocketFactoryWrapper wrapper = new SSLSocketFactoryWrapper(factory, "ciphers", false);
+
+        assertEquals(factory, (SSLSocketFactory) TestUtil.getFieldValue(wrapper, "sslsf"));
+        assertEquals("ciphers", (String) TestUtil.getFieldValue(wrapper, "ciphers"));
+        assertEquals(false, (Boolean) TestUtil.getFieldValue(wrapper, "hostnameVerification"));
+    }
+
+    @Test
+    public void testGetDefaultCipherSuites() {
+        SSLSocketFactory factory = mock(SSLSocketFactory.class);
+        SSLSocketFactoryWrapper wrapper = new SSLSocketFactoryWrapper(factory, "ciphers", false);
+
+        String[] defaultCipherSuites = { "cipher1", "cipher2" };
+        when(factory.getDefaultCipherSuites()).thenReturn(defaultCipherSuites);
+
+        assertArrayEquals(defaultCipherSuites, wrapper.getDefaultCipherSuites());
+    }
+
+    @Test
+    public void testGetSupportedCipherSuites() {
+        SSLSocketFactory factory = mock(SSLSocketFactory.class);
+        SSLSocketFactoryWrapper wrapper = new SSLSocketFactoryWrapper(factory, "ciphers", false);
+
+        String[] sSupportedCipherSuites = { "cipher1", "cipher2" };
+        when(factory.getSupportedCipherSuites()).thenReturn(sSupportedCipherSuites);
+
+        assertArrayEquals(sSupportedCipherSuites, wrapper.getSupportedCipherSuites());
+    }
+
+    @Test
+    public void testCreateSocket() throws IOException {
+        SSLSocketFactory factory = mock(SSLSocketFactory.class);
+        SSLSocketFactoryWrapper wrapper = new SSLSocketFactoryWrapper(factory,
+                "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256", true);
+
+        SSLSocket socket = (SSLSocket) SSLSocketFactory.getDefault().createSocket();
+        socket.setEnabledProtocols(new String[] { "TLSv1.1", "SSLv2Hello", "TLSv1.2" });
+        when(factory.createSocket()).thenReturn(socket);
+
+        Socket resultSocket = wrapper.createSocket();
+        assertTrue(resultSocket instanceof SSLSocket);
+
+        SSLParameters resultParameters = ((SSLSocket) resultSocket).getSSLParameters();
+        String[] expectedProtocols = { "TLSv1.1", "TLSv1.2" };
+        String[] expectedCiphers = { "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256" };
+        assertArrayEquals(expectedProtocols, resultParameters.getProtocols());
+        assertEquals("HTTPS", resultParameters.getEndpointIdentificationAlgorithm());
+        assertArrayEquals(expectedCiphers, resultParameters.getCipherSuites());
+
+        assertTrue(resultSocket.getTcpNoDelay());
+    }
+}

--- a/kura/test/org.eclipse.kura.core.ssl.test/src/test/resources/log4j.properties
+++ b/kura/test/org.eclipse.kura.core.ssl.test/src/test/resources/log4j.properties
@@ -1,0 +1,6 @@
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} [%t] %-5p %c{1}:%L - %m%n
+
+log4j.rootLogger=INFO,stdout

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -119,6 +119,7 @@ Copyright (c) 2016 Eurotech and/or its affiliates and others
         <module>org.eclipse.kura.core.configuration.test</module>
         <module>org.eclipse.kura.core.cloud.test</module>
         <module>org.eclipse.kura.core.net.test</module>
+        <module>org.eclipse.kura.core.ssl.test</module>
         <module>org.eclipse.kura.core.status.test</module>
         <module>org.eclipse.kura.core.testutil</module>
     </modules>


### PR DESCRIPTION
- Increased BREE from Java 1.6 to Java 1.8 in bundle
  org.eclipse.kura.core
- Removed checking for Java 1.6 in
  SSLSocketFactoryWrapper.updateSSLParameters() method
- Prepared unit tests for ConnectionSslOptions and
  SSLSocketFactoryWrapper classes.

Signed-off-by: Djuro Drljaca <djuro.drljaca@comtrade.com>