### PR TITLE
Added functionality to allow adding Wire Components after removing one

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtComponentService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtComponentService.java
@@ -1,10 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *  Eurotech
+ *  Amit Kumar Mondal
  *
  *******************************************************************************/
 package org.eclipse.kura.web.shared.service;
@@ -146,6 +150,8 @@ public interface GwtComponentService extends RemoteService {
             throws GwtKuraException;
     
     public List<String> findFactoryComponents(GwtXSRFToken xsrfToken) throws GwtKuraException;
+    
+    public boolean updateProperties(GwtXSRFToken xsrfToken, String pid, Map<String, Object> properties) throws GwtKuraException;
 
     public GwtConfigComponent findWireComponentConfigurationFromPid(GwtXSRFToken xsrfToken, String pid,
             String factoryPid, Map<String, Object> extraProps) throws GwtKuraException;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtWireService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtWireService.java
@@ -33,6 +33,21 @@ import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 public interface GwtWireService extends RemoteService {
 
     /**
+     * This is a Wire Component OSGi Property that denotes that the Wire Component has been
+     * deleted visually from the Wire Graph. This property will only be present if
+     * and only if the Wire Component is removed visually from the Wire Graph. This
+     * does not signify that the Wire Component is eligible for permanent removal
+     * from OSGi runtime. This OSGi service property has been introduced to optimize
+     * creation of new Wire Components in the Wire Graph. A possible scenario is when
+     * the user removes a Wire Component with a name set to <b>A</b> and adds same type of
+     * Wire Component with the same name <b>A</b>. In case of this, the previous Wire Component
+     * is updated with this OSGi service property and eventually while saving the entire
+     * Wire Graph, the new configuration of the new Wire Component will be captured and will
+     * update the old Wire Component that has been updated with this property.
+     */
+    public static final String DELETED_WIRE_COMPONENT = "deletedfromWireGraph";
+
+    /**
      * Retrieves all the registered driver instances.
      *
      * @param xsrfToken

--- a/kura/org.eclipse.kura.web2/src/main/webapp/kura_wires.js
+++ b/kura/org.eclipse.kura.web2/src/main/webapp/kura_wires.js
@@ -291,7 +291,7 @@ var kuraWires = (function() {
 					x : x,
 					y : y,
 				};
-				createComponent(compConfig);
+				createComponent(compConfig, false);
 			}
 			createExisitingWires();
 		}
@@ -438,10 +438,10 @@ var kuraWires = (function() {
 		}
 	}
 
-	/*
-	 * / Create a new component
+	/**
+	 * Create a new component
 	 */
-	function createComponent(comp) {
+	function createComponent(comp, flag) {
 
 		if (comp.name === "") {
 			comp.name = comp.pid;
@@ -557,12 +557,16 @@ var kuraWires = (function() {
 			xPos = 300;
 			yPos = 300;
 		}
-
+		
+		if (flag) {
+			selectedElement = rect;
+			jsniUpdateSelection(comp.name, comp.fPid);
+		}
 		return rect.attributes.id;
 	}
 
-	/*
-	 * / Event Functions
+	/**
+	 * Event Functions
 	 */
 	function saveConfig() {
 		graphToSave = prepareJsonFromGraph();
@@ -666,7 +670,7 @@ var kuraWires = (function() {
 			if (i != -1) {
 				elementsContainerTemp.splice(i, 1);
 			}
-			jsniUpdateSelection("", "");
+			jsniUpdateSelection(pid, "");
 			if (clientConfig.wireComponentsJson.length !== "0") {
 				isComponentDeleted = true;
 			}
@@ -699,10 +703,6 @@ var kuraWires = (function() {
 	}
 
 	function createNewComponent() {
-		if (isComponentDeleted) {
-			jsniShowAddNotAllowedModal();
-			return;
-		}
 		var newComp;
 		// Determine whether component can be producer, consumer, or both
 		fPid = $("#factoryPid").val();
@@ -760,7 +760,7 @@ var kuraWires = (function() {
 			jsniDeactivateNavPils();
 			toggleDeleteGraphButton(false);
 			// Create the new component and store information in array
-			createComponent(newComp);
+			createComponent(newComp, true);
 			$("#componentName").val('');
 			$("#driverPids").val('--- Select Driver ---');
 			$("#factoryPid").val('');


### PR DESCRIPTION
This allows adding Wire Components of same names to the Wire Graph even
after removing a Wire Component of the same name. This does not require
saving the Wire Graph before adding new Wire Components.

Fixes #1121 