### PR TITLE
Changes to prevent exception of wires panel refresh.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
@@ -456,10 +456,7 @@ public class WiresPanelUi extends Composite {
             currentSelection = item;
             WiresPanelUi.propertiesPanelBody.add(WiresPanelUi.propertiesUi);
         } else {
-            WiresPanelUi.propertiesPanelBody.clear();
-            propertiesPanelHeader.setText(MSGS.wiresNoComponentSelected());
-            WiresPanelUi.propertiesPanel.setVisible(false);
-            currentSelection = null;
+            deselectComponent();
         }
     }
 
@@ -746,7 +743,7 @@ public class WiresPanelUi extends Composite {
                 if (currentSelection != null && WiresPanelUi.propertiesUi != null) {
                     WiresPanelUi.propertiesUi.getUpdatedConfiguration();
                 }
-                gwtWireService.updateWireConfiguration(token, obj, configs, new AsyncCallback<GwtWiresConfiguration>() {
+                gwtWireService.updateWireConfiguration(token, obj, configs, new AsyncCallback<Void>() {
 
                     @Override
                     public void onFailure(final Throwable caught) {
@@ -755,8 +752,7 @@ public class WiresPanelUi extends Composite {
                     }
 
                     @Override
-                    public void onSuccess(final GwtWiresConfiguration result) {
-                        internalLoad(result);
+                    public void onSuccess(final Void result) {
                         EntryClassUi.hideWaitModal();
                         setDirty(false);
                         if (configs != null && !configs.isEmpty()) {
@@ -765,12 +761,20 @@ public class WiresPanelUi extends Composite {
                         if (propertiesUis != null && !propertiesUis.isEmpty()) {
                             propertiesUis.clear();
                         }
+                        deselectComponent();
                     }
                 });
             }
         });
 
         return 0;
+    }
+
+    private static void deselectComponent() {
+        WiresPanelUi.propertiesPanelBody.clear();
+        propertiesPanelHeader.setText(MSGS.wiresNoComponentSelected());
+        WiresPanelUi.propertiesPanel.setVisible(false);
+        currentSelection = null;
     }
 
     public static native void resetDeleteComponentState()

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtWireServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtWireServiceImpl.java
@@ -377,9 +377,8 @@ public final class GwtWireServiceImpl extends OsgiRemoteServiceServlet implement
     /** {@inheritDoc} */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
-    public GwtWiresConfiguration updateWireConfiguration(final GwtXSRFToken xsrfToken,
-            final String newJsonConfiguration, final Map<String, GwtConfigComponent> configurations)
-                    throws GwtKuraException {
+    public void updateWireConfiguration(final GwtXSRFToken xsrfToken, final String newJsonConfiguration,
+            final Map<String, GwtConfigComponent> configurations) throws GwtKuraException {
         this.checkXSRFToken(xsrfToken);
 
         // TODO: refactor this method: split and simplify code
@@ -518,7 +517,6 @@ public final class GwtWireServiceImpl extends OsgiRemoteServiceServlet implement
         } catch (final InvalidSyntaxException exception) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, exception);
         }
-        return getWiresConfigurationInternal();
     }
 
     private List<String> deleteWireComponents(JsonObject jWireGraph, final ConfigurationService configService,

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtWireService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtWireService.java
@@ -105,11 +105,10 @@ public interface GwtWireService extends RemoteService {
      *            the new configuration to update
      * @param configurations
      *            the configurations
-     * @return the updated {@link GwtWiresConfiguration} instance
      * @throws GwtKuraException
      *             if the associated instance is not updated
      */
-    public GwtWiresConfiguration updateWireConfiguration(GwtXSRFToken xsrfToken, String newJsonConfiguration,
+    public void updateWireConfiguration(GwtXSRFToken xsrfToken, String newJsonConfiguration,
             Map<String, GwtConfigComponent> configurations) throws GwtKuraException;
 
     /**

--- a/kura/org.eclipse.kura.web2/src/main/webapp/kura_wires.js
+++ b/kura/org.eclipse.kura.web2/src/main/webapp/kura_wires.js
@@ -100,7 +100,7 @@ var kuraWires = (function() {
 			eventSource = new EventSource("/sse?session=" + eventSourceSessionId);
 			eventSource.onmessage = function(event) {
 				_.each(graph.getElements(), function(c) {
-					if (c.attributes.pid === event.data) {
+					if (c.attributes.label === event.data) {
 						fireTransition(c);
 					}
 				});

--- a/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireComponentTrackerCustomizer.java
+++ b/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireComponentTrackerCustomizer.java
@@ -16,6 +16,7 @@ package org.eclipse.kura.internal.wire;
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_PID;
 
+import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.kura.localization.LocalizationAdapter;
@@ -151,7 +152,9 @@ final class WireComponentTrackerCustomizer implements ServiceTrackerCustomizer<W
      */
     private void removeWireComponent(final String pid) {
         requireNonNull(pid, message.pidNonNull());
-        for (final WireConfiguration wireConfiguration : this.wireService.getWireConfigurations()) {
+        Iterator<WireConfiguration> wireConfigsIterator = this.wireService.getWireConfigurations().iterator();
+        while (wireConfigsIterator.hasNext()) {
+            final WireConfiguration wireConfiguration = wireConfigsIterator.next();
             if (wireConfiguration.getWire() != null && (pid.equals(wireConfiguration.getEmitterPid())
                     || pid.equals(wireConfiguration.getReceiverPid()))) {
                 this.wireService.deleteWireConfiguration(wireConfiguration);


### PR DESCRIPTION
It can happen that, with heavy components, the getWiresConfigurationInternal() invocation
at the end of updateWireConfiguration() determines an internal error, probably due to a refresh
when the component is not effectively up and running.
The changes try to prevent this refresh, as not really needed.
Small change in WireComponentTrackerCustomizer.java to try to prevent a ConcurrentModificationException.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>