### PR TITLE
Implement Kapua's applicationFramework/applicationFrameworkVersion

### DIFF
--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/message/KuraBirthPayload.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/message/KuraBirthPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kura.core.message;
 
@@ -33,6 +34,8 @@ public class KuraBirthPayload extends KuraPayload {
     private static final String JVM_VERSION = "jvm_version";
     private static final String JVM_PROFILE = "jvm_profile";
     private static final String KURA_VERSION = "kura_version";
+    private static final String APPLICATION_FRAMEWORK = "application_framework";
+    private static final String APPLICATION_FRAMEWORK_VERSION = "application_framework_version";
     private static final String OSGI_FRAMEWORK = "osgi_framework";
     private static final String OSGI_FRAMEWORK_VERSION = "osgi_framework_version";
     private static final String CONNECTION_INTERFACE = "connection_interface";
@@ -43,6 +46,8 @@ public class KuraBirthPayload extends KuraPayload {
     private static final String MODEM_IMSI = "modem_imsi";
     private static final String MODEM_ICCID = "modem_iccid";
     private static final String MODEM_RSSI = "modem_rssi";
+
+    private static final String DEFAULT_APPLICATION_FRAMEWORK = "Kura";
 
     public String getUptime() {
         return (String) getMetric(UPTIME);
@@ -96,8 +101,28 @@ public class KuraBirthPayload extends KuraPayload {
         return (String) getMetric(JVM_PROFILE);
     }
 
+    /**
+     * @deprecated Use {@link #getApplicationFrameworkVersion()}
+     */
+    @Deprecated
     public String getKuraVersion() {
         return (String) getMetric(KURA_VERSION);
+    }
+
+    public String getApplicationFramework() {
+        final String value = (String) getMetric(APPLICATION_FRAMEWORK);
+        if (value != null) {
+            return value;
+        }
+        return DEFAULT_APPLICATION_FRAMEWORK;
+    }
+
+    public String getApplicationFrameworkVersion() {
+        final String value = (String) getMetric(APPLICATION_FRAMEWORK_VERSION);
+        if (value != null) {
+            return value;
+        }
+        return getKuraVersion();
     }
 
     public String getConnectionInterface() {
@@ -154,17 +179,37 @@ public class KuraBirthPayload extends KuraPayload {
 
     @Override
     public String toString() {
-        return "EdcBirthMessage [getUptime()=" + getUptime() + ", getDisplayName()=" + getDisplayName()
-                + ", getModelName()=" + getModelName() + ", getModelId()=" + getModelId() + ", getPartNumber()="
-                + getPartNumber() + ", getSerialNumber()=" + getSerialNumber() + ", getFirmwareVersion()="
-                + getFirmwareVersion() + ", getAvailableProcessors()=" + getAvailableProcessors()
-                + ", getTotalMemory()=" + getTotalMemory() + ", getBiosVersion()=" + getBiosVersion() + ", getOs()="
-                + getOs() + ", getOsVersion()=" + getOsVersion() + ", getOsArch()=" + getOsArch() + ", getJvmName()="
-                + getJvmName() + ", getJvmVersion()=" + getJvmVersion() + ", getJvmProfile()=" + getJvmProfile()
-                + ", getKuraVersion()=" + getKuraVersion() + ", getOsgiFramework()=" + getOsgiFramework()
-                + ", getOsgiFrameworkVersion()=" + getOsgiFrameworkVersion() + ", getConnectionInterface()="
-                + getConnectionInterface() + ", getConnectionIp()=" + getConnectionIp() + ", getAcceptEncoding()="
-                + getAcceptEncoding() + ", getApplicationIdentifiers()=" + getApplicationIdentifiers() + "]";
+        final StringBuilder sb = new StringBuilder("KuraBirthPayload [");
+
+        sb.append("getUptime()=").append(getUptime()).append(", ");
+        sb.append("getDisplayName()=").append(getDisplayName()).append(", ");
+        sb.append("getModelName()=").append(getModelName()).append(", ");
+        sb.append("getModelId()=").append(getModelId()).append(", ");
+        sb.append("getPartNumber()=").append(getPartNumber()).append(", ");
+        sb.append("getSerialNumber()=").append(getSerialNumber()).append(", ");
+        sb.append("getFirmwareVersion()=").append(getFirmwareVersion()).append(", ");
+        sb.append("getAvailableProcessors()=").append(getAvailableProcessors()).append(", ");
+        sb.append("getTotalMemory()=").append(getTotalMemory()).append(", ");
+        sb.append("getBiosVersion()=").append(getBiosVersion()).append(", ");
+        sb.append("getOs()=").append(getOs()).append(", ");
+        sb.append("getOsVersion()=").append(getOsVersion()).append(", ");
+        sb.append("getOsArch()=").append(getOsArch()).append(", ");
+        sb.append("getJvmName()=").append(getJvmName()).append(", ");
+        sb.append("getJvmVersion()=").append(getJvmVersion()).append(", ");
+        sb.append("getJvmProfile()=").append(getJvmProfile()).append(", ");
+        sb.append("getKuraVersion()=").append(getKuraVersion()).append(", ");
+        sb.append("getApplicationFramework()=").append(getApplicationFramework()).append(", ");
+        sb.append("getApplicationFrameworkVersion()=").append(getApplicationFrameworkVersion()).append(", ");
+        sb.append("getOsgiFramework()=").append(getOsgiFramework()).append(", ");
+        sb.append("getOsgiFrameworkVersion()=").append(getOsgiFrameworkVersion()).append(", ");
+        sb.append("getConnectionInterface()=").append(getConnectionInterface()).append(", ");
+        sb.append("getConnectionIp()=").append(getConnectionIp()).append(", ");
+        sb.append("getAcceptEncoding()=").append(getAcceptEncoding()).append(", ");
+        sb.append("getApplicationIdentifiers()=").append(getApplicationIdentifiers());
+
+        sb.append("]");
+
+        return sb.toString();
     }
 
     public static class KuraBirthPayloadBuilder {
@@ -186,6 +231,8 @@ public class KuraBirthPayload extends KuraPayload {
         private String jvmVersion;
         private String jvmProfile;
         private String kuraVersion;
+        private String applicationFramework;
+        private String applicationFrameworkVersion;
         private String connectionInterface;
         private String connectionIp;
         private String acceptEncoding;
@@ -290,7 +337,18 @@ public class KuraBirthPayload extends KuraPayload {
         }
 
         public KuraBirthPayloadBuilder withKuraVersion(String kuraVersion) {
-            this.kuraVersion = kuraVersion;
+            withApplicationFramework(DEFAULT_APPLICATION_FRAMEWORK);
+            withApplicationFrameworkVersion(kuraVersion);
+            return this;
+        }
+
+        public KuraBirthPayloadBuilder withApplicationFramework(String applicationFramework) {
+            this.applicationFramework = applicationFramework;
+            return this;
+        }
+
+        public KuraBirthPayloadBuilder withApplicationFrameworkVersion(String applicationFrameworkVersion) {
+            this.applicationFrameworkVersion = applicationFrameworkVersion;
             return this;
         }
 
@@ -383,6 +441,15 @@ public class KuraBirthPayload extends KuraPayload {
             }
             if (this.kuraVersion != null) {
                 birthPayload.addMetric(KURA_VERSION, this.kuraVersion);
+            }
+            if (this.applicationFramework != null) {
+                birthPayload.addMetric(APPLICATION_FRAMEWORK, this.applicationFramework);
+            } else {
+                birthPayload.addMetric(APPLICATION_FRAMEWORK, DEFAULT_APPLICATION_FRAMEWORK);
+            }
+            if (this.applicationFrameworkVersion != null) {
+                birthPayload.addMetric(KURA_VERSION, this.applicationFrameworkVersion);
+                birthPayload.addMetric(APPLICATION_FRAMEWORK_VERSION, this.applicationFrameworkVersion);
             }
             if (this.connectionInterface != null) {
                 birthPayload.addMetric(CONNECTION_INTERFACE, this.connectionInterface);

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/message/KuraDeviceProfile.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/message/KuraDeviceProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kura.core.message;
 
@@ -38,10 +39,14 @@ public class KuraDeviceProfile {
     private static final String JVM_VERSION = "jvm_version";
     private static final String JVM_PROFILE = "jvm_profile";
     private static final String KURA_VERSION = "kura_version";
+    private static final String APPLICATION_FRAMEWORK = "application_framework";
+    private static final String APPLICATION_FRAMEWORK_VERSION = "application_framework_version";
     private static final String OSGI_FRAMEWORK = "osgi_framework";
     private static final String OSGI_FRAMEWORK_VERSION = "osgi_framework_version";
     private static final String CONNECTION_INTERFACE = "connection_interface";
     private static final String CONNECTION_IP = "connection_ip";
+
+    private static final String DEFAULT_APPLICATION_FRAMEWORK = "Kura";
 
     private String uptime;
     private String displayName;
@@ -59,7 +64,8 @@ public class KuraDeviceProfile {
     private String jvmName;
     private String jvmVersion;
     private String jvmProfile;
-    private String kuraVersion;
+    private String applicationFramework;
+    private String applicationFrameworkVersion;
     private String osgiFramework;
     private String osgiFrameworkVersion;
     private String connectionInterface;
@@ -86,10 +92,19 @@ public class KuraDeviceProfile {
                 props.getProperty(MODEL_ID), props.getProperty(PART_NUMBER), props.getProperty(SERIAL_NUMBER),
                 props.getProperty(FIRMWARE_VERSION), props.getProperty(BIOS_VERSION), props.getProperty(OS),
                 props.getProperty(OS_VERSION), props.getProperty(JVM_NAME), props.getProperty(JVM_VERSION),
-                props.getProperty(JVM_PROFILE), props.getProperty(KURA_VERSION),
-                props.getProperty(CONNECTION_INTERFACE), props.getProperty(CONNECTION_IP),
-                props.getProperty(AVAILABLE_PROCESSORS), props.getProperty(TOTAL_MEMORY), props.getProperty(OS_ARCH),
-                props.getProperty(OSGI_FRAMEWORK), props.getProperty(OSGI_FRAMEWORK_VERSION));
+                props.getProperty(JVM_PROFILE), extractApplicationFramework(props),
+                extractApplicationFrameworkVersion(props), props.getProperty(CONNECTION_INTERFACE),
+                props.getProperty(CONNECTION_IP), props.getProperty(AVAILABLE_PROCESSORS),
+                props.getProperty(TOTAL_MEMORY), props.getProperty(OS_ARCH), props.getProperty(OSGI_FRAMEWORK),
+                props.getProperty(OSGI_FRAMEWORK_VERSION));
+    }
+
+    private static String extractApplicationFramework(Properties props) {
+        return props.getProperty(APPLICATION_FRAMEWORK, DEFAULT_APPLICATION_FRAMEWORK);
+    }
+
+    private static String extractApplicationFrameworkVersion(Properties props) {
+        return props.getProperty(APPLICATION_FRAMEWORK_VERSION, props.getProperty(KURA_VERSION));
     }
 
     /**
@@ -186,7 +201,53 @@ public class KuraDeviceProfile {
             String serialNumber, String firmwareVersion, String biosVersion, String os, String osVersion,
             String jvmName, String jvmVersion, String jvmProfile, String kuraVersion, String connectionInterface,
             String connectionIp) {
-        super();
+        this(uptime, displayName, modelName, modelId, partNumber, serialNumber, firmwareVersion, biosVersion, os,
+                osVersion, jvmName, jvmVersion, jvmProfile, DEFAULT_APPLICATION_FRAMEWORK, kuraVersion,
+                connectionInterface, connectionIp);
+    }
+
+    /**
+     * Creates an KuraDeviceProfile using the values of the supplied parameters.
+     *
+     * @param uptime
+     *            The length of time the unit has been powered on.
+     * @param displayName
+     *            A readable display name for the device.
+     * @param modelName
+     *            The device model name.
+     * @param modelId
+     *            The device model ID.
+     * @param partNumber
+     *            The part number of the device.
+     * @param serialNumber
+     *            The serial number of the device.
+     * @param firmwareVersion
+     *            The version of firmware running on the device.
+     * @param biosVersion
+     *            The version of the BIOS on the device.
+     * @param os
+     *            The name of the operating system
+     * @param osVersion
+     *            The version of the operating system
+     * @param jvmName
+     *            The name of the JVM
+     * @param jvmVersion
+     *            The version of the JVM
+     * @param jvmProfile
+     *            The profile of the JVM
+     * @param applicationFramework
+     *            The application framework
+     * @param applicationFrameworkVersion
+     *            The application framework version
+     * @param connectionInterface
+     *            The name of the interface used to connect to the cloud
+     * @param connectionIp
+     *            The IP address of the interface used to connect to the cloud
+     */
+    public KuraDeviceProfile(String uptime, String displayName, String modelName, String modelId, String partNumber,
+            String serialNumber, String firmwareVersion, String biosVersion, String os, String osVersion,
+            String jvmName, String jvmVersion, String jvmProfile, String applicationFramework,
+            String applicationFrameworkVersion, String connectionInterface, String connectionIp) {
         this.uptime = uptime;
         this.displayName = displayName;
         this.modelName = modelName;
@@ -200,7 +261,8 @@ public class KuraDeviceProfile {
         this.jvmName = jvmName;
         this.jvmVersion = jvmVersion;
         this.jvmProfile = jvmProfile;
-        this.kuraVersion = kuraVersion;
+        this.applicationFramework = applicationFramework;
+        this.applicationFrameworkVersion = applicationFrameworkVersion;
         this.connectionInterface = connectionInterface;
         this.connectionIp = connectionIp;
     }
@@ -256,7 +318,66 @@ public class KuraDeviceProfile {
             String jvmName, String jvmVersion, String jvmProfile, String kuraVersion, String connectionInterface,
             String connectionIp, String availableProcessors, String totalMemory, String osArch, String osgiFramework,
             String osgiFrameworkVersion) {
-        super();
+        this(uptime, displayName, modelName, modelId, partNumber, serialNumber, firmwareVersion, biosVersion, os,
+                osVersion, jvmName, jvmVersion, jvmProfile, DEFAULT_APPLICATION_FRAMEWORK, kuraVersion,
+                connectionInterface, connectionIp, availableProcessors, totalMemory, osArch, osgiFramework,
+                osgiFrameworkVersion);
+    }
+
+    /**
+     * Creates an KuraDeviceProfile using the values of the supplied parameters.
+     *
+     * @param uptime
+     *            The length of time the unit has been powered on.
+     * @param displayName
+     *            A readable display name for the device.
+     * @param modelName
+     *            The device model name.
+     * @param modelId
+     *            The device model ID.
+     * @param partNumber
+     *            The part number of the device.
+     * @param serialNumber
+     *            The serial number of the device.
+     * @param firmwareVersion
+     *            The version of firmware running on the device.
+     * @param biosVersion
+     *            The version of the BIOS on the device.
+     * @param os
+     *            The name of the operating system
+     * @param osVersion
+     *            The version of the operating system
+     * @param jvmName
+     *            The name of the JVM
+     * @param jvmVersion
+     *            The version of the JVM
+     * @param jvmProfile
+     *            The profile of the JVM
+     * @param applicationFramework
+     *            The application framework
+     * @param applicationFrameworkVersion
+     *            The application framework version
+     * @param connectionInterface
+     *            The name of the interface used to connect to the cloud
+     * @param connectionIp
+     *            The IP address of the interface used to connect to the cloud
+     * @param availableProcessors
+     *            The number of available processors for the JVM
+     * @param totalMemory
+     *            The total memory available for the JVM
+     * @param osArch
+     *            The architecture of the JVM (32 or 64)
+     * @param osgiFramework
+     *            The OSGI Framework in use
+     * @param osgiFrameworkVersion
+     *            The version of the OSGI Framework in use
+     */
+    public KuraDeviceProfile(String uptime, String displayName, String modelName, String modelId, String partNumber,
+            String serialNumber, String firmwareVersion, String biosVersion, String os, String osVersion,
+            String jvmName, String jvmVersion, String jvmProfile, String applicationFramework,
+            String applicationFrameworkVersion, String connectionInterface, String connectionIp,
+            String availableProcessors, String totalMemory, String osArch, String osgiFramework,
+            String osgiFrameworkVersion) {
         this.uptime = uptime;
         this.displayName = displayName;
         this.modelName = modelName;
@@ -270,7 +391,8 @@ public class KuraDeviceProfile {
         this.jvmName = jvmName;
         this.jvmVersion = jvmVersion;
         this.jvmProfile = jvmProfile;
-        this.kuraVersion = kuraVersion;
+        this.applicationFramework = applicationFramework;
+        this.applicationFrameworkVersion = applicationFrameworkVersion;
         this.connectionInterface = connectionInterface;
         this.connectionIp = connectionIp;
         setAvailableProcessors(availableProcessors);
@@ -458,8 +580,27 @@ public class KuraDeviceProfile {
      *
      * @return A String representing the Kura version
      */
+    @Deprecated
     public String getKuraVersion() {
-        return this.kuraVersion;
+        return this.applicationFrameworkVersion;
+    }
+
+    /**
+     * Returns the Application Framework.
+     * 
+     * @return A String representing the Application Framework
+     */
+    public String getApplicationFramework() {
+        return this.applicationFramework;
+    }
+
+    /**
+     * Returns the Application Framework version.
+     * 
+     * @return A String representing the Application Framework version
+     */
+    public String getApplicationFrameworkVersion() {
+        return this.applicationFrameworkVersion;
     }
 
     /**


### PR DESCRIPTION
Kapua actually uses two fields for the gateway version called
"application framework" and "application framework version", compared
to the OSGi framework.

This change does implement this information but still allows backwards
compatibility by providing the "kura_version" information.

Signed-off-by: Jens Reimann <jreimann@redhat.com>