### PR TITLE
#1163: Tests for org.eclipse.kura.wire.component.provider

### DIFF
--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/timer/Timer.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/timer/Timer.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * The Class Timer represents a Wire Component which triggers a ticking event on
  * every interval as configured. It fires the event on every tick.
  */
-public final class Timer implements WireEmitter, ConfigurableComponent {
+public class Timer implements WireEmitter, ConfigurableComponent {
 
     /** Group Identifier for Quartz Job and Triggers */
     private static final String GROUP_ID = "wires";
@@ -105,7 +105,7 @@ public final class Timer implements WireEmitter, ConfigurableComponent {
         this.wireSupport = this.wireHelperService.newWireSupport(this);
         this.timerOptions = new TimerOptions(properties);
         try {
-            this.scheduler = new StdSchedulerFactory().getScheduler();
+            this.scheduler = createScheduler();
             doUpdate();
         } catch (final SchedulerException e) {
             logger.error(message.schedulerException(), e);
@@ -123,7 +123,7 @@ public final class Timer implements WireEmitter, ConfigurableComponent {
         logger.debug(message.updatingTimer());
         this.timerOptions = new TimerOptions(properties);
         try {
-            this.scheduler = new StdSchedulerFactory().getScheduler();
+            this.scheduler = createScheduler();
             doUpdate();
         } catch (final SchedulerException e) {
             logger.error(message.schedulerException(), e);
@@ -147,6 +147,10 @@ public final class Timer implements WireEmitter, ConfigurableComponent {
             }
         }
         logger.debug(message.deactivatingTimerDone());
+    }
+
+    protected Scheduler createScheduler() throws SchedulerException {
+        return new StdSchedulerFactory().getScheduler();
     }
 
     /**

--- a/kura/test/org.eclipse.kura.wire.component.provider.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/META-INF/MANIFEST.MF
@@ -1,0 +1,17 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.wire.component.provider.test
+Bundle-SymbolicName: org.eclipse.kura.wire.component.provider.test;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eclipse Kura
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy
+Import-Package: org.junit;version="4.12.0",
+ org.junit.runners;version="4.12.0",
+ org.slf4j;version="1.6.4",
+ org.eclipse.kura.core.testutil;version="1.0.0",
+ org.mockito;version="1.10.19",
+ org.mockito.invocation;version="1.10.19",
+ org.mockito.stubbing;version="1.10.19"
+Fragment-Host: org.eclipse.kura.wire.component.provider;bundle-version="1.0.0"

--- a/kura/test/org.eclipse.kura.wire.component.provider.test/build.properties
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/build.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Eurotech
+#
+
+bin.includes = .,\
+               META-INF/
+source.. = src/main/java/
+additional.bundles = org.eclipse.kura.api,\
+                     slf4j.api,\
+                     slf4j.log4j12

--- a/kura/test/org.eclipse.kura.wire.component.provider.test/pom.xml
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
+
+     All rights reserved. This program and the accompanying materials
+     are made available under the terms of the Eclipse Public License v1.0
+     which accompanies this distribution, and is available at
+     http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Eurotech
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.kura</groupId>
+		<artifactId>test</artifactId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.kura.wire.component.provider.test</artifactId>
+	<packaging>eclipse-test-plugin</packaging>
+	<version>1.0.0-SNAPSHOT</version>
+	
+	<properties>
+		<kura.basedir>${project.basedir}/../..</kura.basedir>
+	</properties>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/asset/WireAssetTest.java
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/asset/WireAssetTest.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.internal.wire.asset;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.kura.asset.AssetConfiguration;
+import org.eclipse.kura.asset.Channel;
+import org.eclipse.kura.asset.ChannelType;
+import org.eclipse.kura.configuration.ConfigurationService;
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.driver.Driver;
+import org.eclipse.kura.driver.DriverFlag;
+import org.eclipse.kura.driver.Driver.ConnectionException;
+import org.eclipse.kura.driver.DriverRecord;
+import org.eclipse.kura.driver.DriverStatus;
+import org.eclipse.kura.type.BooleanValue;
+import org.eclipse.kura.type.DataType;
+import org.eclipse.kura.type.LongValue;
+import org.eclipse.kura.type.StringValue;
+import org.eclipse.kura.type.TypedValue;
+import org.eclipse.kura.wire.WireEnvelope;
+import org.eclipse.kura.wire.WireRecord;
+import org.eclipse.kura.wire.WireSupport;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class WireAssetTest {
+
+    @Test
+    public void testOnWireReceive() throws NoSuchFieldException, ConnectionException {
+        Map<String, Object> readChannel1Config = new HashMap<>();
+        readChannel1Config.put("channel.id", 1);
+        Channel readChannel1 = new Channel(1, "readChannel1", ChannelType.READ, DataType.BOOLEAN, readChannel1Config);
+
+        Map<String, Object> writeChannel2Config = new HashMap<>();
+        writeChannel2Config.put("channel.id", 2);
+        Channel writeChannel2 = new Channel(2, "writeChannel2", ChannelType.WRITE, DataType.BOOLEAN,
+                writeChannel2Config);
+
+        Map<Long, Channel> channels = new HashMap<>();
+        channels.put(readChannel1.getId(), readChannel1);
+        channels.put(writeChannel2.getId(), writeChannel2);
+
+        AssetConfiguration assetConfiguration = new AssetConfiguration("description", "driverPid", channels);
+
+        List<WireRecord> writeWireRecords = new ArrayList<>();
+        Map<String, TypedValue<?>> writeWireRecordProperties = new HashMap<>();
+        writeWireRecordProperties.put("writeChannel2_assetName", new StringValue("componentName"));
+        writeWireRecordProperties.put("writeChannel2", new BooleanValue(true));
+        writeWireRecordProperties.put("writeChannel2_channelId", new LongValue(2));
+        WireRecord writeWireRecord = new WireRecord(writeWireRecordProperties);
+        writeWireRecords.add(writeWireRecord);
+
+        WireEnvelope wireEnvelope = new WireEnvelope("pid", writeWireRecords);
+
+        Map<String, Object> assetProperties = new HashMap<>();
+        assetProperties.put(ConfigurationService.KURA_SERVICE_PID, "componentName");
+
+        WireAsset wireAsset = new WireAsset();
+        TestUtil.setFieldValue(wireAsset, "properties", assetProperties);
+        TestUtil.setFieldValue(wireAsset, "assetConfiguration", assetConfiguration);
+
+        Driver mockDriver = mock(Driver.class);
+        wireAsset.setDriver(mockDriver);
+
+        when(mockDriver.read(any())).then(invocation -> {
+            Object[] arguments = invocation.getArguments();
+            assertEquals(1, arguments.length);
+
+            List<DriverRecord> records = (List<DriverRecord>) arguments[0];
+
+            assertEquals(1, records.size());
+
+            DriverRecord record = records.get(0);
+            record.setValue(new BooleanValue(true));
+            record.setTimestamp(42);
+            record.setDriverStatus(new DriverStatus(DriverFlag.READ_SUCCESSFUL));
+
+            return records;
+        });
+
+        when(mockDriver.write(any())).then(invocation -> {
+            Object[] arguments = invocation.getArguments();
+            assertEquals(1, arguments.length);
+
+            List<DriverRecord> records = (List<DriverRecord>) arguments[0];
+
+            assertEquals(1, records.size());
+
+            DriverRecord record = records.get(0);
+            Map<String, Object> channelConfig = record.getChannelConfig();
+            assertEquals((long) 2, channelConfig.get("channel.id"));
+            assertEquals(DataType.BOOLEAN, channelConfig.get("channel.value.type"));
+
+            assertEquals(new BooleanValue(true), record.getValue());
+            
+            record.setTimestamp(111);
+            record.setDriverStatus(new DriverStatus(DriverFlag.WRITE_SUCCESSFUL));
+
+            return records;
+        });
+
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        TestUtil.setFieldValue(wireAsset, "wireSupport", mockWireSupport);
+
+        doAnswer(invocation -> {
+            Object[] arguments = invocation.getArguments();
+            assertEquals(1, arguments.length);
+
+            List<WireRecord> wireRecords = (List<WireRecord>) arguments[0];
+
+            assertEquals(1, wireRecords.size());
+            Map<String, TypedValue<?>> properties = wireRecords.get(0).getProperties();
+
+            assertEquals(4, properties.size());
+            assertEquals(new StringValue("componentName"), properties.get("readChannel1_assetName"));
+            assertEquals(new BooleanValue(true), properties.get("readChannel1"));
+            assertEquals(new LongValue(1), properties.get("readChannel1_channelId"));
+            assertEquals(new LongValue(42), properties.get("readChannel1_timestamp"));
+
+            return null;
+        }).when(mockWireSupport).emit(any());
+
+        wireAsset.onWireReceive(wireEnvelope);
+
+        verify(mockWireSupport).emit(any());
+        verify(mockDriver).read(any());
+        verify(mockDriver).write(any());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/filter/DbWireRecordFilterTest.java
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/filter/DbWireRecordFilterTest.java
@@ -1,0 +1,246 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.internal.wire.filter;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.db.DbService;
+import org.eclipse.kura.internal.wire.common.DbServiceHelper;
+import org.eclipse.kura.wire.WireEnvelope;
+import org.eclipse.kura.wire.WireHelperService;
+import org.eclipse.kura.wire.WireSupport;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.osgi.service.wireadmin.Wire;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class DbWireRecordFilterTest {
+
+    @Test
+    public void testActivateAndUpdated() throws NoSuchFieldException {
+        // Activate
+        DbService mockDbService = mock(DbService.class);
+        
+        WireHelperService mockWireHelperService = mock(WireHelperService.class);
+
+        DbWireRecordFilter filter = new DbWireRecordFilter();
+        filter.bindDbService(mockDbService);
+        filter.bindWireHelperService(mockWireHelperService);
+        
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        when(mockWireHelperService.newWireSupport(filter)).thenReturn(mockWireSupport);
+        
+        int expectedCacheExpirationInterval = 10;
+        String expectedSqlView = "view";
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("cache.expiration.interval", expectedCacheExpirationInterval);
+        properties.put("sql.view", expectedSqlView);
+
+        filter.activate(null, properties);
+        
+        DbWireRecordFilterOptions options = (DbWireRecordFilterOptions) TestUtil.getFieldValue(filter, "options");
+
+        assertEquals(expectedCacheExpirationInterval, options.getCacheExpirationInterval());
+        assertEquals(expectedSqlView, options.getSqlView());
+        
+        DbServiceHelper dbHelper = (DbServiceHelper) TestUtil.getFieldValue(filter, "dbHelper");
+        DbService dbService = (DbService) TestUtil.getFieldValue(dbHelper, "dbService");
+        assertEquals(mockDbService, dbService);
+        
+        verify(mockWireHelperService).newWireSupport(filter);
+        WireSupport wireSupport = (WireSupport) TestUtil.getFieldValue(filter, "wireSupport");
+        assertEquals(mockWireSupport, wireSupport);
+        
+        int cacheExpirationInterval = (int) TestUtil.getFieldValue(filter, "cacheExpirationInterval");
+        assertEquals(expectedCacheExpirationInterval, cacheExpirationInterval);
+        
+        Calendar lastRefreshedTime = (Calendar) TestUtil.getFieldValue(filter, "lastRefreshedTime");
+        Calendar minTime = Calendar.getInstance();
+        minTime.add(Calendar.SECOND, -cacheExpirationInterval);
+        assertTrue(minTime.compareTo(lastRefreshedTime) >= 0);
+        
+        // Updated
+        expectedCacheExpirationInterval = 20;
+        expectedSqlView = "updated view";
+        properties.put("cache.expiration.interval", expectedCacheExpirationInterval);
+        properties.put("sql.view", expectedSqlView);
+        
+        filter.updated(properties);
+        
+        options = (DbWireRecordFilterOptions) TestUtil.getFieldValue(filter, "options");
+
+        assertEquals(expectedCacheExpirationInterval, options.getCacheExpirationInterval());
+        assertEquals(expectedSqlView, options.getSqlView());
+        
+        lastRefreshedTime = (Calendar) TestUtil.getFieldValue(filter, "lastRefreshedTime");
+        minTime = Calendar.getInstance();
+        minTime.add(Calendar.SECOND, -cacheExpirationInterval);
+        assertTrue(minTime.compareTo(lastRefreshedTime) >= 0);
+    }
+
+    @Test
+    public void testConsumersConnected() {
+        DbService mockDbService = mock(DbService.class);
+        
+        WireHelperService mockWireHelperService = mock(WireHelperService.class);
+
+        DbWireRecordFilter filter = new DbWireRecordFilter();
+        filter.bindDbService(mockDbService);
+        filter.bindWireHelperService(mockWireHelperService);
+
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        when(mockWireHelperService.newWireSupport(filter)).thenReturn(mockWireSupport);
+        
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("cache.expiration.interval", 10);
+        properties.put("sql.view", "view");
+
+        filter.activate(null, properties);
+        
+        Wire[] wires = new Wire[2];
+        wires[0] = mock(Wire.class);
+        wires[1] = mock(Wire.class);
+
+        filter.consumersConnected(wires);
+        
+        verify(mockWireSupport).consumersConnected(wires);
+    }
+
+    @Test
+    public void testOnWireReceive() throws SQLException {
+        DbService mockDbService = mock(DbService.class);
+        
+        WireHelperService mockWireHelperService = mock(WireHelperService.class);
+
+        DbWireRecordFilter filter = new DbWireRecordFilter();
+        filter.bindDbService(mockDbService);
+        filter.bindWireHelperService(mockWireHelperService);
+
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        when(mockWireHelperService.newWireSupport(filter)).thenReturn(mockWireSupport);
+        
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("cache.expiration.interval", 10);
+        properties.put("sql.view", "sql command");
+
+        filter.activate(null, properties);
+
+        ResultSetMetaData mockResultSetMetaData = mock(ResultSetMetaData.class);
+        when(mockResultSetMetaData.getColumnCount()).thenReturn(1);
+        when(mockResultSetMetaData.getColumnLabel(1)).thenReturn("data1");
+        
+        ResultSet mockResultSet = mock(ResultSet.class);
+        when(mockResultSet.next()).thenReturn(true).thenReturn(false);
+        when(mockResultSet.getMetaData()).thenReturn(mockResultSetMetaData);
+        when(mockResultSet.getObject(1)).thenReturn(42);
+        
+        Connection mockConnection = mock(Connection.class);
+        when(mockDbService.getConnection()).thenReturn(mockConnection);
+        
+        Statement mockStatement = mock(Statement.class);
+        when(mockStatement.executeQuery("sql command")).thenReturn(mockResultSet);
+        when(mockConnection.createStatement()).thenReturn(mockStatement);
+        
+        WireEnvelope mockWireEnvelope = mock(WireEnvelope.class);
+        filter.onWireReceive(mockWireEnvelope);
+        
+        verify(mockWireSupport).emit(any());
+    }
+    
+    @Test
+    public void testPolled() {
+        DbService mockDbService = mock(DbService.class);
+        
+        WireHelperService mockWireHelperService = mock(WireHelperService.class);
+
+        DbWireRecordFilter filter = new DbWireRecordFilter();
+        filter.bindDbService(mockDbService);
+        filter.bindWireHelperService(mockWireHelperService);
+
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        when(mockWireHelperService.newWireSupport(filter)).thenReturn(mockWireSupport);
+        
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("cache.expiration.interval", 10);
+        properties.put("sql.view", "view");
+
+        filter.activate(null, properties);
+        
+        Wire mockWire = mock(Wire.class);
+        filter.polled(mockWire);
+        
+        verify(mockWireSupport).polled(mockWire);
+    }
+
+    @Test
+    public void testProducersConnected() {
+        DbService mockDbService = mock(DbService.class);
+        
+        WireHelperService mockWireHelperService = mock(WireHelperService.class);
+
+        DbWireRecordFilter filter = new DbWireRecordFilter();
+        filter.bindDbService(mockDbService);
+        filter.bindWireHelperService(mockWireHelperService);
+
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        when(mockWireHelperService.newWireSupport(filter)).thenReturn(mockWireSupport);
+        
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("cache.expiration.interval", 10);
+        properties.put("sql.view", "view");
+
+        filter.activate(null, properties);
+        
+        Wire[] wires = new Wire[2];
+        wires[0] = mock(Wire.class);
+        wires[1] = mock(Wire.class);
+
+        filter.producersConnected(wires);
+        
+        verify(mockWireSupport).producersConnected(wires);
+    }
+
+    @Test
+    public void testUpdatedWireObject() {
+        DbService mockDbService = mock(DbService.class);
+        
+        WireHelperService mockWireHelperService = mock(WireHelperService.class);
+
+        DbWireRecordFilter filter = new DbWireRecordFilter();
+        filter.bindDbService(mockDbService);
+        filter.bindWireHelperService(mockWireHelperService);
+
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        when(mockWireHelperService.newWireSupport(filter)).thenReturn(mockWireSupport);
+        
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("cache.expiration.interval", 10);
+        properties.put("sql.view", "view");
+
+        filter.activate(null, properties);
+        
+        Wire mockWire = mock(Wire.class);
+        filter.updated(mockWire, 42);
+        
+        verify(mockWireSupport).updated(mockWire, 42);
+    }
+
+}

--- a/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/timer/EmitJobTest.java
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/timer/EmitJobTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.internal.wire.timer;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.kura.type.LongValue;
+import org.eclipse.kura.type.TypedValue;
+import org.eclipse.kura.wire.WireRecord;
+import org.eclipse.kura.wire.WireSupport;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class EmitJobTest {
+
+    @Test
+    public void testExecute() throws JobExecutionException {
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        
+        TimerJobDataMap timerJobDataMap = new TimerJobDataMap();
+        timerJobDataMap.putWireSupport(mockWireSupport);
+
+        JobDetail mockJobDetail = mock(JobDetail.class);
+        when(mockJobDetail.getJobDataMap()).thenReturn(timerJobDataMap);
+        
+        JobExecutionContext mockJobExecutionContext = mock(JobExecutionContext.class);
+        when(mockJobExecutionContext.getJobDetail()).thenReturn(mockJobDetail);
+
+        long startTime = new Date().getTime();
+        
+        doAnswer(invocation -> {
+            Object[] arguments = invocation.getArguments();
+            assertEquals(1, arguments.length);
+
+            List<WireRecord> wireRecords = (List<WireRecord>) arguments[0];
+
+            assertEquals(1, wireRecords.size());
+            Map<String, TypedValue<?>> properties = wireRecords.get(0).getProperties();
+
+            long endTime = new Date().getTime();
+            
+            assertEquals(1, properties.size());
+            
+            LongValue timerTime = (LongValue) properties.get("TIMER");
+            
+            // Make sure timer time is between start and end of the test
+            assertTrue(startTime <= timerTime.getValue());
+            assertTrue(timerTime.getValue() <= endTime);
+
+            return null;
+        }).when(mockWireSupport).emit(any());
+        
+        EmitJob job = new EmitJob();
+        
+        job.execute(mockJobExecutionContext);
+
+        verify(mockWireSupport).emit(any());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/timer/TimerTest.java
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/timer/TimerTest.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.internal.wire.timer;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.wire.WireHelperService;
+import org.eclipse.kura.wire.WireSupport;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerContext;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.impl.triggers.CronTriggerImpl;
+import org.quartz.impl.triggers.SimpleTriggerImpl;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TimerTest {
+
+    @Test
+    public void testActivateSimple() throws SchedulerException, NoSuchFieldException {
+        WireHelperService mockWireHelperService = mock(WireHelperService.class);
+        Scheduler mockScheduler = mock(Scheduler.class);
+        
+        Timer timer = new Timer() {
+            
+            @Override
+            protected Scheduler createScheduler() throws SchedulerException {
+                return mockScheduler;
+            }
+        };
+        
+        timer.bindWireHelperService(mockWireHelperService);
+
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        when(mockWireHelperService.newWireSupport(timer)).thenReturn(mockWireSupport);
+
+        String expectedType = "SIMPLE";
+        int expectedInterval = 3;
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("type", expectedType);
+        properties.put("simple.interval", expectedInterval);
+        
+        doAnswer(invocation -> {
+            Object[] arguments = invocation.getArguments();
+
+            assertEquals(2, arguments.length);
+
+            JobDetail job = (JobDetail) arguments[0];
+            Trigger trigger = (Trigger) arguments[1];
+            
+            assertTrue(job.getJobDataMap() instanceof TimerJobDataMap);
+            assertTrue(trigger instanceof SimpleTriggerImpl);
+            
+            SimpleTriggerImpl simpleTriggerImpl = (SimpleTriggerImpl) trigger;
+            assertEquals((long) expectedInterval * 1000, simpleTriggerImpl.getRepeatInterval());
+            
+            return null;
+        }).when(mockScheduler).scheduleJob(any(), any());
+        
+        timer.activate(null, properties);
+
+        assertEquals(mockWireSupport, TestUtil.getFieldValue(timer, "wireSupport"));
+        
+        TimerOptions timerOptions = (TimerOptions) TestUtil.getFieldValue(timer, "timerOptions");
+        assertEquals(expectedType, timerOptions.getType());
+        assertEquals(expectedInterval, timerOptions.getSimpleInterval());
+
+        assertEquals(mockScheduler, TestUtil.getFieldValue(timer, "scheduler"));
+        assertNotNull(TestUtil.getFieldValue(timer, "jobKey"));
+        
+        verify(mockScheduler).start();
+        verify(mockScheduler).scheduleJob(any(), any());
+    }
+
+    @Test
+    public void testActivateCron() throws SchedulerException, NoSuchFieldException {
+        WireHelperService mockWireHelperService = mock(WireHelperService.class);
+        Scheduler mockScheduler = mock(Scheduler.class);
+        
+        Timer timer = new Timer() {
+            
+            @Override
+            protected Scheduler createScheduler() throws SchedulerException {
+                return mockScheduler;
+            }
+        };
+        
+        timer.bindWireHelperService(mockWireHelperService);
+
+        WireSupport mockWireSupport = mock(WireSupport.class);
+        when(mockWireHelperService.newWireSupport(timer)).thenReturn(mockWireSupport);
+        
+        SchedulerContext mockSchedulerContext = mock(SchedulerContext.class);
+        when(mockScheduler.getContext()).thenReturn(mockSchedulerContext);
+
+        String expectedType = "CRON";
+        String expectedCronExpression = "0 15 10 ? * *";
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("type", expectedType);
+        properties.put("cron.interval", expectedCronExpression);
+        
+        doAnswer(invocation -> {
+            Object[] arguments = invocation.getArguments();
+
+            assertEquals(2, arguments.length);
+
+            JobDetail job = (JobDetail) arguments[0];
+            Trigger trigger = (Trigger) arguments[1];
+            
+            assertTrue(job.getJobDataMap() instanceof TimerJobDataMap);
+            assertTrue(trigger instanceof CronTriggerImpl);
+            
+            CronTriggerImpl simpleTriggerImpl = (CronTriggerImpl) trigger;
+            assertEquals(expectedCronExpression, simpleTriggerImpl.getCronExpression());
+            
+            return null;
+        }).when(mockScheduler).scheduleJob(any(), any());
+        
+        timer.activate(null, properties);
+
+        assertEquals(mockWireSupport, TestUtil.getFieldValue(timer, "wireSupport"));
+        
+        TimerOptions timerOptions = (TimerOptions) TestUtil.getFieldValue(timer, "timerOptions");
+        assertEquals(expectedType, timerOptions.getType());
+        assertEquals(expectedCronExpression, timerOptions.getCronExpression());
+
+        assertEquals(mockScheduler, TestUtil.getFieldValue(timer, "scheduler"));
+        assertNotNull(TestUtil.getFieldValue(timer, "jobKey"));
+        
+        verify(mockScheduler).getContext();
+        verify(mockSchedulerContext).put("wireSupport", mockWireSupport);
+        verify(mockScheduler).start();
+        verify(mockScheduler).scheduleJob(any(), any());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/resources/log4j.properties
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/resources/log4j.properties
@@ -1,0 +1,6 @@
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} [%t] %-5p %c{1}:%L - %m%n
+
+log4j.rootLogger=INFO,stdout

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -126,5 +126,6 @@ Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
         <module>org.eclipse.kura.core.system.test</module>
         <module>org.eclipse.kura.core.testutil</module>
         <module>org.eclipse.kura.internal.wire.test</module>
+        <module>org.eclipse.kura.wire.component.provider.test</module>
     </modules>
 </project>


### PR DESCRIPTION
- Prepared unit tests for WireAsset, DbWireRecordFilter, EmitJob and
  Timer classes.
- Changed Timer class so that it is possible to unit test it.

Signed-off-by: Djuro Drljaca <djuro.drljaca@comtrade.com>