### PR TITLE
Partially revert net.wifi breaking change

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiHotspotInfo.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiHotspotInfo.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kura.net.wifi;
 
-import java.util.Set;
+import java.util.EnumSet;
 
 public class WifiHotspotInfo {
 
@@ -21,8 +21,8 @@ public class WifiHotspotInfo {
     private final int channel;
     private final int frequency;
     private final WifiSecurity security;
-    private Set<WifiSecurity> pairCiphers;
-    private Set<WifiSecurity> groupCiphers;
+    private EnumSet<WifiSecurity> pairCiphers;
+    private EnumSet<WifiSecurity> groupCiphers;
 
     public WifiHotspotInfo(String ssid, String macAddress, int signalLevel, int channel, int frequency,
             WifiSecurity security) {
@@ -36,7 +36,7 @@ public class WifiHotspotInfo {
     }
 
     public WifiHotspotInfo(String ssid, String macAddress, int signalLevel, int channel, int frequency,
-            WifiSecurity security, Set<WifiSecurity> pairCiphers, Set<WifiSecurity> groupCiphers) {
+            WifiSecurity security, EnumSet<WifiSecurity> pairCiphers, EnumSet<WifiSecurity> groupCiphers) {
         this(ssid, macAddress, signalLevel, channel, frequency, security);
         this.pairCiphers = pairCiphers;
         this.groupCiphers = groupCiphers;
@@ -66,19 +66,19 @@ public class WifiHotspotInfo {
         return this.security;
     }
 
-    public Set<WifiSecurity> getPairCiphers() {
+    public EnumSet<WifiSecurity> getPairCiphers() {
         return this.pairCiphers;
     }
 
-    public Set<WifiSecurity> getGroupCiphers() {
+    public EnumSet<WifiSecurity> getGroupCiphers() {
         return this.groupCiphers;
     }
 
-    public void setPairCiphers(Set<WifiSecurity> pairCiphers) {
+    public void setPairCiphers(EnumSet<WifiSecurity> pairCiphers) {
         this.pairCiphers = pairCiphers;
     }
 
-    public void setGroupCiphers(Set<WifiSecurity> groupCiphers) {
+    public void setGroupCiphers(EnumSet<WifiSecurity> groupCiphers) {
         this.groupCiphers = groupCiphers;
     }
 


### PR DESCRIPTION
This commit partially revert an API breaking change introduced by 681c285
and specifically part of the refactor of o.e.k.net.wifi.WifiHotspotInfo.
Replacing EnumSet with Set in return types is not backward compatible.

Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>