### PR TITLE
WireEmitter/Receiver are ConsumerTypeS

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireEmitter.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireEmitter.java
@@ -15,8 +15,6 @@ import org.osgi.service.wireadmin.Producer;
  * The WireEmitter is a marker interface which represents a wire component which
  * is a data producer that can produce values. The produced values can be used
  * by other {@link WireReceiver} components if it is wired with each other.
- *
- * @noimplement This interface is not intended to be implemented by clients.
  */
 public interface WireEmitter extends WireComponent, Producer {
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireReceiver.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireReceiver.java
@@ -15,8 +15,6 @@ import org.osgi.service.wireadmin.Consumer;
  * The WireReceiver interface Represents a wire component which is a data
  * consumer that can receive produced or emitted values from upstream
  * {@link WireEmitter}.
- *
- * @noimplement This interface is not intended to be implemented by clients.
  */
 public interface WireReceiver extends WireComponent, Consumer {
 


### PR DESCRIPTION
The only way an application can consume these types is to
implement them.
An real-world graph will always include domain specific
WireComponentS (WireEmitterS and WireReceiverS) that
must developed by implementing and registering these
interfaces.

Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>