### PR TITLE
Fix iptables-restore run in background

### DIFF
--- a/kura/distrib/src/main/resources/beaglebone/firewall.init
+++ b/kura/distrib/src/main/resources/beaglebone/firewall.init
@@ -12,7 +12,7 @@
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
-iptables-restore < $iptables_config_file &
+iptables-restore < $iptables_config_file
 while IFS='' read -r line || [[ -n "$line" ]]; do
     if [[ $line =~ "-A FORWARD" ]]; then
 	enable_ipforwarding=true

--- a/kura/distrib/src/main/resources/fedora25/firewall.init
+++ b/kura/distrib/src/main/resources/fedora25/firewall.init
@@ -3,7 +3,7 @@
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
-iptables-restore < $iptables_config_file &
+iptables-restore < $iptables_config_file
 while IFS='' read -r line || [[ -n "$line" ]]; do
     if [[ $line =~ "-A FORWARD" ]]; then
 	enable_ipforwarding=true

--- a/kura/distrib/src/main/resources/intel-edison/firewall.init
+++ b/kura/distrib/src/main/resources/intel-edison/firewall.init
@@ -3,7 +3,7 @@
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
-iptables-restore < $iptables_config_file &
+iptables-restore < $iptables_config_file
 while IFS='' read -r line || [[ -n "$line" ]]; do
     if [[ $line =~ "-A FORWARD" ]]; then
 	enable_ipforwarding=true

--- a/kura/distrib/src/main/resources/pcengines-apu/firewall.init
+++ b/kura/distrib/src/main/resources/pcengines-apu/firewall.init
@@ -13,7 +13,7 @@
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
-iptables-restore < $iptables_config_file &
+iptables-restore < $iptables_config_file
 while IFS='' read -r line || [[ -n "$line" ]]; do
     if [[ $line =~ "-A FORWARD" ]]; then
 	enable_ipforwarding=true

--- a/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
@@ -12,7 +12,7 @@
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
-iptables-restore < $iptables_config_file &
+iptables-restore < $iptables_config_file
 while IFS='' read -r line || [[ -n "$line" ]]; do
     if [[ $line =~ "-A FORWARD" ]]; then
 	enable_ipforwarding=true

--- a/kura/distrib/src/main/resources/raspberry-pi-bplus/firewall.init
+++ b/kura/distrib/src/main/resources/raspberry-pi-bplus/firewall.init
@@ -12,7 +12,7 @@
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
-iptables-restore < $iptables_config_file &
+iptables-restore < $iptables_config_file
 while IFS='' read -r line || [[ -n "$line" ]]; do
     if [[ $line =~ "-A FORWARD" ]]; then
 	enable_ipforwarding=true

--- a/kura/distrib/src/main/resources/raspberry-pi/firewall.init
+++ b/kura/distrib/src/main/resources/raspberry-pi/firewall.init
@@ -12,7 +12,7 @@
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
-iptables-restore < $iptables_config_file &
+iptables-restore < $iptables_config_file
 while IFS='' read -r line || [[ -n "$line" ]]; do
     if [[ $line =~ "-A FORWARD" ]]; then
 	enable_ipforwarding=true


### PR DESCRIPTION
In the firewall init script iptables-restore is run in background.
This is not usually a problem unless the firewall_cust script
exists.
In this case the firewall init script will create iptable
rules concurrently often leading to a state where some
rules are missing.

Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>