### PR TITLE
First implementation of prepared reads for Asset and Driver

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/asset/Asset.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/asset/Asset.java
@@ -72,6 +72,25 @@ public interface Asset {
     public List<AssetRecord> read(List<Long> channelIds) throws KuraException;
 
     /**
+     * Performs a read on all READ or READ_WRITE channels that are defined on this asset and returns
+     * the result as a list of {@link AssetRecord} instances.
+     * 
+     * @see Asset#read(List)
+     *
+     * @throws KuraRuntimeException
+     *             if the method is not implemented by the asset then specific
+     *             error code {@code KuraErrorCode#OPERATION_NOT_SUPPORTED}
+     *             needs to be set in the thrown {@link KuraRuntimeException}
+     * @throws KuraException
+     *             if the connection to the asset was interrupted, then error
+     *             code {@code KuraErrorCode#CONNECTION_FAILED} needs to be set
+     *             in the thrown {@link KuraException}.
+     * @return the list of asset records which comprises the currently read
+     *         value in case of success or the reason of failure
+     */
+    public List<AssetRecord> readAllChannels() throws KuraException;
+
+    /**
      * Registers asset listener for the provided channel name for a monitor
      * operation on it.
      *

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/driver/Driver.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/driver/Driver.java
@@ -211,4 +211,26 @@ public interface Driver {
      */
     public List<DriverRecord> write(List<DriverRecord> records) throws ConnectionException;
 
+    /**
+     * This method allows the driver to perform protocol specific optimizations in order to accelerate the execution of
+     * batches of read requests having the same channel configuration.
+     * The result of this optimization will be returned by the driver as a {@link PreparedRead} instance that can be
+     * used to perform the requests.
+     * In order to improve efficiency a driver should validate the channel configuration of the provided channels during
+     * this method call.
+     * It is also permitted to the implementation of the {@link PreparedRead#execute()} and
+     * {@link PreparedRead#getDriverRecords()} methods to return the same {@link DriverRecord} instances provided as an
+     * argument to this method.
+     * If the validation of the channel configuration fails for some channels, the driver must not throw an exception
+     * but it is required to return driver records with proper error flags set as a result of the
+     * {@link PreparedRead#execute()} call.
+     * 
+     * @see PreparedRead
+     * @param records
+     *            The list of driver records that represent the request to be optimized.
+     * @return The {@link PreparedRead} instance
+     * @throws NullPointerException
+     *             if the provided list is null
+     */
+    public PreparedRead prepareRead(List<DriverRecord> records);
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/driver/PreparedRead.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/driver/PreparedRead.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Eurotech
+ */
+package org.eclipse.kura.driver;
+
+import java.util.List;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.driver.Driver.ConnectionException;
+
+/**
+ * This interface represents an optimized request that can be performed by a driver.
+ * Implementations of this interface are returned by a driver as a result of
+ * a call to the {@link Driver#prepareRead(java.util.List)} method.
+ * 
+ * @see Driver#prepareRead(java.util.List)
+ */
+public interface PreparedRead extends AutoCloseable {
+
+    /**
+     * Performs the optimized read request described by this {@link PreparedRead} instance.
+     * In order to improve efficiency this method can return the same {@link DriverRecord} instances that were supplied
+     * as arguments to the {@link Driver#prepareRead(List)} call that created this {@link PreparedRead}.
+     * The returned records should not be modified while a valid (not closed) {@link PreparedRead} holds a
+     * reference to them, otherwise unpredictable behavior can occur.
+     * 
+     * @return the result of the request as a list of {@link DriverRecord} instances.
+     * @throws KuraException
+     *             if the provided {@link PreparedRead} is not valid (for example if it has been closed)
+     * @throws ConnectionException
+     *             if the connection to the field device is interrupted
+     */
+    public List<DriverRecord> execute() throws ConnectionException, KuraException;
+
+    /**
+     * Returns the list of driver records associated with this prepared read.
+     * In order to improve efficiency this method can return the same {@link DriverRecord} instances that were supplied
+     * as arguments to the {@link Driver#prepareRead(List)} call that created this {@link PreparedRead}.
+     * The returned records should not be modified while a valid (not closed) {@link PreparedRead} holds a
+     * reference to them, otherwise unpredictable behavior can occur.
+     * 
+     * @return The list of driver records associated with this prepared read.
+     */
+    public List<DriverRecord> getDriverRecords();
+}

--- a/kura/org.eclipse.kura.driver.opcua.localization/src/main/java/org/eclipse/kura/driver/opcua/localization/OpcUaMessages.java
+++ b/kura/org.eclipse.kura.driver.opcua.localization/src/main/java/org/eclipse/kura/driver/opcua/localization/OpcUaMessages.java
@@ -84,6 +84,9 @@ public interface OpcUaMessages {
     @En("Driver Record cannot be null")
     public String recordNonNull();
 
+    @En("Driver Record list cannot be null")
+    public String recordListNonNull();
+
     @En("Updating OPC-UA Driver.....")
     public String updating();
 
@@ -116,4 +119,5 @@ public interface OpcUaMessages {
 
     @En("Operation Result Variant cannot be null")
     public String errorNullVariant();
+
 }

--- a/kura/org.eclipse.kura.driver.opcua.provider/src/main/java/org/eclipse/kura/internal/driver/opcua/OpcUaDriver.java
+++ b/kura/org.eclipse.kura.driver.opcua.provider/src/main/java/org/eclipse/kura/internal/driver/opcua/OpcUaDriver.java
@@ -25,6 +25,7 @@ import static org.eclipse.kura.driver.DriverFlag.WRITE_FAILURE;
 import static org.eclipse.kura.driver.DriverFlag.WRITE_SUCCESSFUL;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -42,6 +43,7 @@ import org.eclipse.kura.driver.ChannelDescriptor;
 import org.eclipse.kura.driver.Driver;
 import org.eclipse.kura.driver.DriverRecord;
 import org.eclipse.kura.driver.DriverStatus;
+import org.eclipse.kura.driver.PreparedRead;
 import org.eclipse.kura.driver.listener.DriverListener;
 import org.eclipse.kura.driver.opcua.localization.OpcUaMessages;
 import org.eclipse.kura.localization.LocalizationAdapter;
@@ -81,7 +83,6 @@ import io.netty.util.internal.StringUtil;
  * the driver connection specific properties are enlisted in
  * {@link OpcUaOptions}
  *
- * @see Asset
  * @see Driver
  * @see OpcUaOptions
  * @see OpcUaChannelDescriptor
@@ -310,6 +311,34 @@ public final class OpcUaDriver implements Driver {
         }
     }
 
+    private void runReadRequest(OpcUaRequestInfo requestInfo) {
+        DriverRecord record = requestInfo.driverRecord;
+        final NodeId nodeId = new NodeId(requestInfo.nodeNamespaceIndex, requestInfo.nodeId);
+        final VariableNode node = this.client.getAddressSpace().createVariableNode(nodeId);
+        Object readResult = null;
+        try {
+            logger.debug("reading: ns={};s={}..", requestInfo.nodeNamespaceIndex, requestInfo.nodeId);
+            readResult = extractValue(runSafe(node.readValue()));
+            logger.debug("Read Successful");
+        } catch (final Exception e) {
+            record.setDriverStatus(new DriverStatus(READ_FAILURE, message.readFailed(), e));
+            record.setTimestamp(System.currentTimeMillis());
+            logger.warn(message.readFailed(), e);
+            return;
+        }
+
+        final Optional<TypedValue<?>> typedValue = this.getTypedValue(requestInfo.dataType, readResult);
+        if (!typedValue.isPresent()) {
+            record.setDriverStatus(new DriverStatus(DRIVER_ERROR_CHANNEL_VALUE_TYPE_CONVERSION_EXCEPTION,
+                    message.errorValueTypeConversion(), null));
+            record.setTimestamp(System.currentTimeMillis());
+            return;
+        }
+        record.setValue(typedValue.get());
+        record.setDriverStatus(new DriverStatus(READ_SUCCESSFUL));
+        record.setTimestamp(System.currentTimeMillis());
+    }
+
     /** {@inheritDoc} */
     @Override
     public List<DriverRecord> read(final List<DriverRecord> records) throws ConnectionException {
@@ -320,32 +349,7 @@ public final class OpcUaDriver implements Driver {
             this.connect();
         }
         for (final DriverRecord record : records) {
-            OpcUaRequestInfo.extract(record).ifPresent(requestInfo -> {
-                final NodeId nodeId = new NodeId(requestInfo.nodeNamespaceIndex, requestInfo.nodeId);
-                final VariableNode node = this.client.getAddressSpace().createVariableNode(nodeId);
-                Object readResult = null;
-                try {
-                    logger.debug("reading: ns={};s={}..", requestInfo.nodeNamespaceIndex, requestInfo.nodeId);
-                    readResult = extractValue(runSafe(node.readValue()));
-                    logger.debug("Read Successful");
-                } catch (final Exception e) {
-                    record.setDriverStatus(new DriverStatus(READ_FAILURE, message.readFailed(), e));
-                    record.setTimestamp(System.currentTimeMillis());
-                    logger.warn(message.readFailed(), e);
-                    return;
-                }
-
-                final Optional<TypedValue<?>> typedValue = this.getTypedValue(requestInfo.dataType, readResult);
-                if (!typedValue.isPresent()) {
-                    record.setDriverStatus(new DriverStatus(DRIVER_ERROR_CHANNEL_VALUE_TYPE_CONVERSION_EXCEPTION,
-                            message.errorValueTypeConversion(), null));
-                    record.setTimestamp(System.currentTimeMillis());
-                    return;
-                }
-                record.setValue(typedValue.get());
-                record.setDriverStatus(new DriverStatus(READ_SUCCESSFUL));
-                record.setTimestamp(System.currentTimeMillis());
-            });
+            OpcUaRequestInfo.extract(record).ifPresent(this::runReadRequest);
         }
         return Collections.unmodifiableList(records);
     }
@@ -394,6 +398,24 @@ public final class OpcUaDriver implements Driver {
         logger.debug(message.updatingDone());
     }
 
+    private void runWriteRequest(OpcUaRequestInfo requestInfo) {
+        DriverRecord record = requestInfo.driverRecord;
+        final TypedValue<?> value = record.getValue();
+        final NodeId nodeId = new NodeId(requestInfo.nodeNamespaceIndex, requestInfo.nodeId);
+        final VariableNode node = this.client.getAddressSpace().createVariableNode(nodeId);
+        final DataValue newValue = new DataValue(new Variant(value.getValue()));
+        try {
+            logger.debug("writing: {} to ns={};s={}..", value, requestInfo.nodeNamespaceIndex, requestInfo.nodeId);
+            checkStatus(runSafe(node.writeValue(newValue)));
+            record.setDriverStatus(new DriverStatus(WRITE_SUCCESSFUL));
+            logger.debug("Write Successful");
+        } catch (final Exception e) {
+            record.setDriverStatus(new DriverStatus(WRITE_FAILURE, message.writeFailed(), e));
+            logger.warn(message.writeFailed(), e);
+        }
+        record.setTimestamp(System.currentTimeMillis());
+    }
+
     /** {@inheritDoc} */
     @Override
     public List<DriverRecord> write(final List<DriverRecord> records) throws ConnectionException {
@@ -404,23 +426,7 @@ public final class OpcUaDriver implements Driver {
             this.connect();
         }
         for (final DriverRecord record : records) {
-            OpcUaRequestInfo.extract(record).ifPresent((requestInfo) -> {
-                final TypedValue<?> value = record.getValue();
-                final NodeId nodeId = new NodeId(requestInfo.nodeNamespaceIndex, requestInfo.nodeId);
-                final VariableNode node = this.client.getAddressSpace().createVariableNode(nodeId);
-                final DataValue newValue = new DataValue(new Variant(value.getValue()));
-                try {
-                    logger.debug("writing: {} to ns={};s={}..", value, requestInfo.nodeNamespaceIndex,
-                            requestInfo.nodeId);
-                    checkStatus(runSafe(node.writeValue(newValue)));
-                    record.setDriverStatus(new DriverStatus(WRITE_SUCCESSFUL));
-                    logger.debug("Write Successful");
-                } catch (final Exception e) {
-                    record.setDriverStatus(new DriverStatus(WRITE_FAILURE, message.writeFailed(), e));
-                    logger.warn(message.writeFailed(), e);
-                }
-                record.setTimestamp(System.currentTimeMillis());
-            });
+            OpcUaRequestInfo.extract(record).ifPresent(this::runWriteRequest);
         }
         return Collections.unmodifiableList(records);
     }
@@ -430,11 +436,14 @@ public final class OpcUaDriver implements Driver {
         private final DataType dataType;
         private final int nodeNamespaceIndex;
         private final String nodeId;
+        private final DriverRecord driverRecord;
 
-        public OpcUaRequestInfo(final DataType dataType, final int nodeNamespaceIndex, final String nodeId) {
+        public OpcUaRequestInfo(final DriverRecord driverRecord, final DataType dataType, final int nodeNamespaceIndex,
+                final String nodeId) {
             this.dataType = dataType;
             this.nodeNamespaceIndex = nodeNamespaceIndex;
             this.nodeId = nodeId;
+            this.driverRecord = driverRecord;
         }
 
         private static void fail(final DriverRecord record, final String message) {
@@ -468,7 +477,52 @@ public final class OpcUaDriver implements Driver {
                 return Optional.empty();
             }
 
-            return Optional.of(new OpcUaRequestInfo(dataType, nodeNamespaceIndex, nodeId));
+            return Optional.of(new OpcUaRequestInfo(record, dataType, nodeNamespaceIndex, nodeId));
+        }
+    }
+
+    @Override
+    public PreparedRead prepareRead(List<DriverRecord> driverRecords) {
+        requireNonNull(driverRecords, message.recordListNonNull());
+
+        OpcUaPreparedRead preparedRead = new OpcUaPreparedRead();
+        preparedRead.driverRecords = driverRecords;
+
+        for (DriverRecord record : driverRecords) {
+            OpcUaRequestInfo.extract(record).ifPresent(preparedRead.requestInfos::add);
+        }
+        return preparedRead;
+    }
+
+    private class OpcUaPreparedRead implements PreparedRead {
+
+        private List<OpcUaRequestInfo> requestInfos = new ArrayList<OpcUaRequestInfo>();
+        private volatile List<DriverRecord> driverRecords;
+
+        @Override
+        public synchronized List<DriverRecord> execute() throws ConnectionException {
+            if (OpcUaDriver.this.isBusy.get()) {
+                throw new ConnectionException(message.errorDriverBusy());
+            }
+            if (OpcUaDriver.this.client == null) {
+                OpcUaDriver.this.connect();
+            }
+
+            for (OpcUaRequestInfo requestInfo : requestInfos) {
+                OpcUaDriver.this.runReadRequest(requestInfo);
+            }
+
+            return Collections.unmodifiableList(driverRecords);
+        }
+
+        @Override
+        public List<DriverRecord> getDriverRecords() {
+            return Collections.unmodifiableList(driverRecords);
+        }
+
+        @Override
+        public void close() {
+            // TODO Auto-generated method stub
         }
     }
 }

--- a/kura/org.eclipse.kura.localization.resources/src/main/java/org/eclipse/kura/localization/resources/AssetMessages.java
+++ b/kura/org.eclipse.kura.localization.resources/src/main/java/org/eclipse/kura/localization/resources/AssetMessages.java
@@ -284,4 +284,10 @@ public interface AssetMessages {
     @En("Writing to channels...Done")
     public String writingDone();
 
+    @En("Failed to prepare read")
+    public String errorPreparingRead();
+
+    @En("Failed close prepared read")
+    public String errorClosingPreparingRead();
+
 }


### PR DESCRIPTION
This PR proposes a first implementation of prepared reads for Asset and Driver.

See #1206 

Modified Asset and Driver APIs to add support for prepared reads.
Adapted the OPCUA driver to use the new API.
WireAssets now always use prepared reads.

This is a breaking change, drivers that use the previous API will no longer work after this is merged.

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>