### PR TITLE
Filter functionality on WireRecord associated properties

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireHelperService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireHelperService.java
@@ -86,7 +86,7 @@ public interface WireHelperService {
      *
      * @param emitterPid
      *            the {@link WireEmitter} {@code ConfigurationService#KURA_SERVICE_PID}
-     * @return the collection of existent {@link WireConfiguration} instances
+     * @return the collection of existent {@link WireConfiguration} instances or empty
      * @throws NullPointerException
      *             if the argument is null
      */
@@ -98,7 +98,7 @@ public interface WireHelperService {
      *
      * @param receiverPid
      *            the {@link WireReceiver} {@code ConfigurationService#KURA_SERVICE_PID}
-     * @return the collection of existent {@link WireConfiguration} instances
+     * @return the collection of existent {@link WireConfiguration} instances or empty
      * @throws NullPointerException
      *             if the argument is null
      */

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireHelperService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireHelperService.java
@@ -128,11 +128,13 @@ public interface WireHelperService {
     public boolean isReceiver(final String wireComponentPid);
 
     /**
-     * Returns a Wire Support instance of the provided wire component
+     * Returns a {@link WireSupport} instance of the provided {@link WireComponent}
+     * instance
      *
      * @param wireComponent
-     *            the wire component
-     * @return the wire support instance
+     *            the {@link WireComponent}
+     *            instance
+     * @return the {@link WireSupport} instance
      * @throws NullPointerException
      *             if the argument is null
      */

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireHelperService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireHelperService.java
@@ -13,8 +13,11 @@
  *******************************************************************************/
 package org.eclipse.kura.wire;
 
+import java.util.Optional;
+import java.util.Set;
+
 /**
- * The interface WireHelperService is an service utility API to provide quick
+ * The interface {@link WireHelperService} is an service utility API to provide quick
  * and necessary operations for Kura Wires topology.
  *
  * @noimplement This interface is not intended to be implemented by clients.
@@ -61,6 +64,45 @@ public interface WireHelperService {
      *             if the argument is null
      */
     public String getServicePid(final WireComponent wireComponent);
+
+    /**
+     * Retrieves the created {@link WireConfiguration} instance
+     *
+     * @param emitterPid
+     *            the {@link WireEmitter} {@code ConfigurationService#KURA_SERVICE_PID}
+     * @param receiverPid
+     *            the {@link WireReceiver} {@code ConfigurationService#KURA_SERVICE_PID}
+     * @return an {@link Optional} with the existent {@link WireConfiguration} instance if
+     *         existent {@link WireConfiguration} instance is {@code non-null}, otherwise
+     *         an empty {@link Optional}
+     * @throws NullPointerException
+     *             if any of the arguments is null
+     */
+    public Optional<WireConfiguration> getWireConfiguration(String emitterPid, String receiverPid);
+
+    /**
+     * Retrieves the created {@link WireConfiguration} instances associated with the
+     * provided {@link WireEmitter} {@code ConfigurationService#KURA_SERVICE_PID}
+     *
+     * @param emitterPid
+     *            the {@link WireEmitter} {@code ConfigurationService#KURA_SERVICE_PID}
+     * @return the collection of existent {@link WireConfiguration} instances
+     * @throws NullPointerException
+     *             if the argument is null
+     */
+    public Set<WireConfiguration> getWireConfigurationsByEmitterPid(String emitterPid);
+
+    /**
+     * Retrieves the created {@link WireConfiguration} instances associated with the
+     * provided {@link WireReceiver} {@code ConfigurationService#KURA_SERVICE_PID}
+     *
+     * @param receiverPid
+     *            the {@link WireReceiver} {@code ConfigurationService#KURA_SERVICE_PID}
+     * @return the collection of existent {@link WireConfiguration} instances
+     * @throws NullPointerException
+     *             if the argument is null
+     */
+    public Set<WireConfiguration> getWireConfigurationsByReceiverPid(String receiverPid);
 
     /**
      * Checks whether the provided Wire Component PID belongs to a Wire Emitter

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireRecord.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireRecord.java
@@ -24,8 +24,8 @@ import org.eclipse.kura.annotation.ThreadSafe;
 import org.eclipse.kura.type.TypedValue;
 
 /**
- * The Class WireRecord represents a record to be transmitted during wire
- * communication between wire emitter and wire receiver
+ * The Class {@link WireRecord} represents a record to be transmitted during wire
+ * communication between {@link WireEmitter} and {@link WireReceiver}
  *
  * @noextend This class is not intended to be extended by clients.
  */
@@ -43,9 +43,8 @@ public class WireRecord {
      * @throws NullPointerException
      *             if any of the argument is null
      */
-    public WireRecord(Map<String, TypedValue<?>> properties) {
+    public WireRecord(final Map<String, TypedValue<?>> properties) {
         requireNonNull(properties, "Properties cannot be null");
-
         this.properties = new HashMap<>(properties);
     }
 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireSupport.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireSupport.java
@@ -36,9 +36,23 @@ public interface WireSupport extends Producer, Consumer {
      * Emit the provided {@link WireRecord}s
      *
      * @param wireRecords
-     *            a List of {@link WireRecord} objects that will be sent to the receiver.
+     *            a list of {@link WireRecord} objects that will be sent to the receiver.
      * @throws NullPointerException
      *             if the argument is null
      */
     public void emit(List<WireRecord> wireRecords);
+
+    /**
+     * Filters out the keys from the associated properties of provided {@link WireRecord}s
+     * that matches the provided filter
+     *
+     * @param wireRecords
+     *            the list of {@link WireRecord}s
+     * @param filter
+     *            the filter to match
+     * @return the list of {@link WireRecord}s containing the filtered peroperties
+     * @throws NullPointerException
+     *             if any of the arguments is null
+     */
+    public List<WireRecord> filter(List<WireRecord> wireRecords, String filter);
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireSupport.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireSupport.java
@@ -19,9 +19,9 @@ import org.osgi.service.wireadmin.Consumer;
 import org.osgi.service.wireadmin.Producer;
 
 /**
- * The interface WireSupport is responsible for managing incoming as well as
- * outgoing wires of the contained Wire Component. This is also used to perform
- * wire related operations for instance, emit and receive {@link WireRecord}s.
+ * The interface {@link WireSupport} is responsible for managing incoming as well as
+ * outgoing wires of the contained {@link WireComponent}. This is also used to perform
+ * wire related operations for instance, emit, filter and receive {@link WireRecord}s.
  *
  * @noimplement This interface is not intended to be implemented by clients.
  */
@@ -36,7 +36,8 @@ public interface WireSupport extends Producer, Consumer {
      * Emit the provided {@link WireRecord}s
      *
      * @param wireRecords
-     *            a list of {@link WireRecord} objects that will be sent to the receiver.
+     *            a list of {@link WireRecord} objects that will be emitted to
+     *            the connected {@link WireReceiver} instance
      * @throws NullPointerException
      *             if the argument is null
      */

--- a/kura/org.eclipse.kura.localization.resources/src/main/java/org/eclipse/kura/localization/resources/WireMessages.java
+++ b/kura/org.eclipse.kura.localization.resources/src/main/java/org/eclipse/kura/localization/resources/WireMessages.java
@@ -40,6 +40,12 @@ public interface WireMessages {
     @En("Activating DB Wire Record Filter...Done")
     public String activatingFilterDone();
 
+    @En("Activating Wire Helper Service...")
+    public String activatingHelperService();
+
+    @En("Activating Wire Helper Service...Done")
+    public String activatingHelperServiceDone();
+
     @En("Activating Logger Wire Component...")
     public String activatingLogger();
 
@@ -201,6 +207,12 @@ public interface WireMessages {
 
     @En("Dectivating DB Wire Record Filter...Done")
     public String deactivatingFilterDone();
+
+    @En("Deactivating Wire Helper Service...")
+    public String deactivatingHelperService();
+
+    @En("Deactivating Wire Helper Service...Done")
+    public String deactivatingHelperServiceDone();
 
     @En("Deactivating Logger Wire Component...")
     public String deactivatingLogger();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
@@ -90,6 +90,17 @@ public class WiresPanelUi extends Composite {
     static Button btnAssetModalYes;
     @UiField
     static Button btnAssetModalNo;
+    
+    @UiField
+    static Modal filterModal;
+    @UiField
+    static Button btnFilterModalYes;
+    @UiField
+    static Button btnFilterModalNo;
+    @UiField
+    static FormLabel regexFilterText;
+    @UiField
+    static TextBox regexFilterInput;
 
     @UiField
     static Modal saveGraphModal;
@@ -217,6 +228,8 @@ public class WiresPanelUi extends Composite {
         exportJSNIshowCycleExistenceError();
         exportJSNImakeUiDirty();
         exportJSNIDeactivateNavPils();
+        exportJSNIShowFilterModal();
+        exportJSNIHideFilterModal();
     }
 
     private String getFactoryPidFromDropUrl(String dropUrl) {
@@ -252,9 +265,10 @@ public class WiresPanelUi extends Composite {
         }
     }
 
-    private native void createComponentNative() /*-{
-                                                          parent.window.kuraWires.createNewComponent()
-                                                          }-*/;
+    private native void createComponentNative() 
+    /*-{
+    parent.window.kuraWires.createNewComponent()
+    }-*/;
 
     private void createComponent(final String pid) {
         EntryClassUi.showWaitModal();
@@ -636,6 +650,20 @@ public class WiresPanelUi extends Composite {
     @org.eclipse.kura.web.client.ui.wires.WiresPanelUi::jsniMakeUiDirty()
     );
     }-*/;
+    
+    private static native void exportJSNIShowFilterModal()
+    /*-{
+    parent.window.jsniShowFilterModal = $entry(
+    @org.eclipse.kura.web.client.ui.wires.WiresPanelUi::jsniShowFilterModal(Ljava/lang/String;)
+    );
+    }-*/;
+    
+    private static native void exportJSNIHideFilterModal()
+    /*-{
+    parent.window.jsniHideFilterModal = $entry(
+    @org.eclipse.kura.web.client.ui.wires.WiresPanelUi::jsniHideFilterModal()
+    );
+    }-*/;
 
     private static native void exportJSNIshowCycleExistenceError()
     /*-{
@@ -693,6 +721,18 @@ public class WiresPanelUi extends Composite {
         WiresPanelUi.errorAlertText.setText(MSGS.wiresComponentNameAlreadyUsed(pid));
         WiresPanelUi.errorModal.show();
         assetModal.hide();
+    }
+    
+    public static void jsniShowFilterModal(final String filter) {
+        WiresPanelUi.regexFilterText.setText(MSGS.wiresRegularExpression());
+        WiresPanelUi.regexFilterInput.setText(filter);
+        WiresPanelUi.btnFilterModalYes.setText(MSGS.apply());
+        WiresPanelUi.btnFilterModalNo.setText(MSGS.cancelButton());
+        WiresPanelUi.filterModal.show();
+    }
+    
+    public static void jsniHideFilterModal() {
+        WiresPanelUi.filterModal.hide();
     }
 
     public static void jsniUpdateSelection(final String pid, final String factoryPid) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.ui.xml
@@ -1,6 +1,5 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <!--
-
     Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
 
      All rights reserved. This program and the accompanying materials
@@ -8,6 +7,9 @@
      which accompanies this distribution, and is available at
      http://www.eclipse.org/legal/epl-v10.html
      
+     Contributors:
+	  Eurotech
+	  Amit Kumar Mondal
 -->
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
 	xmlns:b="urn:import:org.gwtbootstrap3.client.ui" xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
@@ -108,6 +110,26 @@
                 <b:Button b:id="btn-create-comp-cancel" icon="REMOVE" type="PRIMARY" dataDismiss="MODAL" ui:field="btnAssetModalNo"/>
 				<b:Button icon="SAVE" type="PRIMARY" b:id="btn-create-comp"
 					ui:field="btnAssetModalYes"/>
+			</b:ModalFooter>
+		</b:Modal>
+		<b:Modal closable="true" fade="true" dataBackdrop="STATIC"
+			dataKeyboard="true" b:id="filter-modal" ui:field="filterModal">
+			<b:ModalHeader addStyleNames="{style.asset-comp-modal-header}"/>
+			<b:ModalBody addStyleNames="{style.asset-comp-modal-body}">
+				<b:Form>
+					<b:FormGroup>
+						<b:FormLabel for="regexFilter" addStyleNames="col-md-4" ui:field="regexFilterText"/>
+						<g:FlowPanel addStyleNames="col-md-8">
+							<b:TextBox ui:field="regexFilterInput" b:id="regexFilterInput" allowBlank="true"
+								autoComplete="false"/>
+						</g:FlowPanel>
+					</b:FormGroup>
+				</b:Form>
+			</b:ModalBody>
+			<b:ModalFooter>
+                <b:Button addStyleNames="fa fa-times" b:id="btn-save-filter-cancel" type="PRIMARY" dataDismiss="MODAL" ui:field="btnFilterModalNo"/>
+				<b:Button addStyleNames="fa fa-check" type="PRIMARY" b:id="btn-save-filter"
+					ui:field="btnFilterModalYes"/>
 			</b:ModalFooter>
 		</b:Modal>
 		<b:Modal closable="true" fade="true" dataBackdrop="STATIC"

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtWireServiceUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtWireServiceUtil.java
@@ -1,10 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *  Eurotech
+ *  Amit Kumar Mondal
  *
  *******************************************************************************/
 package org.eclipse.kura.web.server.util;
@@ -36,12 +40,12 @@ import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 
 /**
- * The Class GwtWireServiceUtil.
+ * The Utility class required for Wires Canvas
  */
 public final class GwtWireServiceUtil {
 
     /**
-     * Instantiates a new gwt wire service util.
+     * Constructor
      */
     private GwtWireServiceUtil() {
         // static factory methods container
@@ -103,7 +107,7 @@ public final class GwtWireServiceUtil {
             final ServiceReference<?>[] refs = bundleContext.getServiceReferences(clazz, filter);
             return refs == null ? new ServiceReference[0] : refs;
         } catch (final InvalidSyntaxException ise) {
-            throw new KuraRuntimeException(KuraErrorCode.INTERNAL_ERROR, ise);
+            throw new KuraRuntimeException(KuraErrorCode.CONFIGURATION_ERROR, ise);
         }
     }
 
@@ -154,7 +158,7 @@ public final class GwtWireServiceUtil {
      */
     public static List<String> getWireComponents() throws GwtKuraException {
         final WireHelperService helperService = ServiceLocator.getInstance().getService(WireHelperService.class);
-        final List<String> list = new ArrayList<String>();
+        final List<String> list = new ArrayList<>();
         final BundleContext context = FrameworkUtil.getBundle(GwtWireServiceUtil.class).getBundleContext();
         final ServiceReference<?>[] refs = getServiceReferences(context, WireComponent.class.getName(), null);
         for (final ServiceReference<?> ref : refs) {
@@ -208,7 +212,7 @@ public final class GwtWireServiceUtil {
      */
     public static List<WireConfiguration> getWireConfigurationsByEmitterPid(final String pid) throws GwtKuraException {
         final WireService wireService = ServiceLocator.getInstance().getService(WireService.class);
-        final List<WireConfiguration> wireConfs = new ArrayList<WireConfiguration>();
+        final List<WireConfiguration> wireConfs = new ArrayList<>();
         for (final WireConfiguration wireConf : wireService.getWireConfigurations()) {
             final String emitterPid = wireConf.getEmitterPid();
             if (emitterPid.equalsIgnoreCase(pid)) {
@@ -229,7 +233,7 @@ public final class GwtWireServiceUtil {
      */
     public static List<WireConfiguration> getWireConfigurationsByReceiverPid(final String pid) throws GwtKuraException {
         final WireService wireService = ServiceLocator.getInstance().getService(WireService.class);
-        final List<WireConfiguration> wireConfs = new ArrayList<WireConfiguration>();
+        final List<WireConfiguration> wireConfs = new ArrayList<>();
         for (final WireConfiguration wireConf : wireService.getWireConfigurations()) {
             final String receiverPid = wireConf.getReceiverPid();
             if (receiverPid.equalsIgnoreCase(pid)) {
@@ -247,14 +251,17 @@ public final class GwtWireServiceUtil {
      * @return the wire configurations from JSON
      */
     public static List<GwtWireConfiguration> getWireConfigurationsFromJson(final JsonObject json) {
-        final List<GwtWireConfiguration> list = new ArrayList<GwtWireConfiguration>();
+        final List<GwtWireConfiguration> list = new ArrayList<>();
         for (int i = 0; i < json.size(); i++) {
             final JsonObject jsonObject = json.get(String.valueOf(i)).asObject();
             final String emitter = jsonObject.getString("producer", null);
             final String receiver = jsonObject.getString("consumer", null);
+            final String filter = jsonObject.getString("filter", null);
             final GwtWireConfiguration configuration = new GwtWireConfiguration();
             configuration.setEmitterPid(emitter);
             configuration.setReceiverPid(receiver);
+            configuration.setFilter(filter);
+
             list.add(configuration);
         }
         return list;
@@ -272,7 +279,8 @@ public final class GwtWireServiceUtil {
         int i = 0;
         for (final GwtWireConfiguration wcConf : list) {
             final JsonObject wireConf = Json.object();
-            wireConf.add("emitter", wcConf.getEmitterPid()).add("receiver", wcConf.getReceiverPid());
+            wireConf.add("emitter", wcConf.getEmitterPid()).add("receiver", wcConf.getReceiverPid()).add("filter",
+                    wcConf.getFilter());
             wireConfigs.add(String.valueOf(i++), wireConf);
         }
         wireConfigs.add("length", String.valueOf(i));

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtWireConfiguration.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtWireConfiguration.java
@@ -1,11 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
+ *  Contributors:
+ *     Eurotech
+ *     Amit Kumar Mondal
+ *
  *******************************************************************************/
 package org.eclipse.kura.web.shared.model;
 
@@ -21,8 +25,8 @@ public final class GwtWireConfiguration extends GwtBaseModel implements Serializ
     private static final long serialVersionUID = 3573302888192836657L;
 
     private String emitterPid;
-
     private String receiverPid;
+    private String filter;
 
     public String getEmitterPid() {
         return this.emitterPid;
@@ -32,12 +36,20 @@ public final class GwtWireConfiguration extends GwtBaseModel implements Serializ
         return this.receiverPid;
     }
 
+    public String getFilter() {
+        return this.filter;
+    }
+
     public void setEmitterPid(final String emitterPid) {
         this.emitterPid = emitterPid;
     }
 
     public void setReceiverPid(final String receiverPid) {
         this.receiverPid = receiverPid;
+    }
+
+    public void setFilter(final String filter) {
+        this.filter = filter;
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -5,7 +5,10 @@
 #  are made available under the terms of the Eclipse Public License v1.0
 #  which accompanies this distribution, and is available at
 #  http://www.eclipse.org/legal/epl-v10.html
-#
+#  
+#  Contributors:
+#   Eurotech
+#   Amit Kumar Mondal
 #
 
 yesButton=Yes
@@ -503,6 +506,7 @@ wiresComponentName=Component Name
 wiresComponentNamePlaceholder=Please enter an user friendly name
 wiresComponentDeleteAlert=Are you sure you want to delete the selected Wire Component instance?
 wiresGraphDeleteAlert=Are you sure you want to delete the complete Wire Graph?
+wiresRegularExpression=Regular Expression
 
 servicesComponentFactorySelectorIdle=--- Select Component ---
 servicesComponentFactoryNew=New Factory Component

--- a/kura/org.eclipse.kura.wire.helper.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.wire.helper.provider/META-INF/MANIFEST.MF
@@ -11,12 +11,15 @@ Import-Package: org.eclipse.kura;version="[1.2,2.0)",
  org.eclipse.kura.configuration;version="[1.1,1.2)",
  org.eclipse.kura.localization;version="[1.0,2.0)",
  org.eclipse.kura.localization.resources;version="[1.0,2.0)",
+ org.eclipse.kura.type;version="[1.0,2.0)",
  org.eclipse.kura.util.base;version="[1.0,2.0)",
  org.eclipse.kura.util.collection;version="[1.0,2.0)",
  org.eclipse.kura.util.service;version="[1.0,2.0)",
  org.eclipse.kura.wire;version="[1.0,1.1)",
  org.osgi.framework;version="[1.7.0,2.0.0)",
  org.osgi.service.event;version="1.3.0",
- org.osgi.service.wireadmin;version="1.0.1"
+ org.osgi.service.wireadmin;version="1.0.1",
+ org.osgi.util.tracker;version="1.5.1",
+ org.slf4j;version="1.6.4"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/kura/org.eclipse.kura.wire.helper.provider/OSGI-INF/WireHelperService.xml
+++ b/kura/org.eclipse.kura.wire.helper.provider/OSGI-INF/WireHelperService.xml
@@ -26,4 +26,10 @@
    	          name="EventAdmin" 
    	          policy="static" 
    	          unbind="unbindEventAdmin"/>
+   <reference bind="bindWireService" 
+   	          cardinality="1..1" 
+   	          interface="org.eclipse.kura.wire.WireService" 
+   	          name="WireService" 
+   	          policy="static" 
+   	          unbind="unbindWireService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.helper.provider/OSGI-INF/WireHelperService.xml
+++ b/kura/org.eclipse.kura.wire.helper.provider/OSGI-INF/WireHelperService.xml
@@ -12,9 +12,11 @@
      	Amit Kumar Mondal
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
-    name="org.eclipse.kura.wire.WireHelperService" 
-    enabled="true" 
-    immediate="false">
+			activate="activate" 
+			deactivate="deactivate" 
+			enabled="true" 
+			immediate="false" 
+			name="org.eclipse.kura.wire.WireHelperService">
    <implementation class="org.eclipse.kura.internal.wire.helper.WireHelperServiceImpl"/>
    <property name="service.pid" value="org.eclipse.kura.wire.WireHelperService"/>
    <service>
@@ -26,10 +28,4 @@
    	          name="EventAdmin" 
    	          policy="static" 
    	          unbind="unbindEventAdmin"/>
-   <reference bind="bindWireService" 
-   	          cardinality="1..1" 
-   	          interface="org.eclipse.kura.wire.WireService" 
-   	          name="WireService" 
-   	          policy="static" 
-   	          unbind="unbindWireService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireServiceCommandProvider.java
+++ b/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireServiceCommandProvider.java
@@ -10,7 +10,7 @@
  *     Eurotech
  *     Red Hat Inc
  *     Amit Kumar Mondal
- *     
+ *
  *******************************************************************************/
 package org.eclipse.kura.internal.wire;
 
@@ -62,8 +62,10 @@ public final class WireServiceCommandProvider {
      */
     @Descriptor("Creates a Wire Configuration between the provided Emitter and Receiver")
     public void createWire(@Descriptor("Emitter PID") final String emitterPid,
-            @Descriptor("Receiver PID") final String receiverPid) throws KuraException {
-        this.wireService.createWireConfiguration(emitterPid, receiverPid);
+            @Descriptor("Receiver PID") final String receiverPid, @Descriptor("Filter") final String filter)
+            throws KuraException {
+        final WireConfiguration wireConfiguration = this.wireService.createWireConfiguration(emitterPid, receiverPid);
+        wireConfiguration.setFilter(filter);
     }
 
     /**
@@ -98,9 +100,8 @@ public final class WireServiceCommandProvider {
         final Set<WireConfiguration> configs = this.wireService.getWireConfigurations();
         int i = 0;
         for (final WireConfiguration config : configs) {
-            System.out.format("%d. Emitter PID ===> %s  Receiver PID ===> %s%n", i, config.getEmitterPid(),
-                    config.getReceiverPid());
-            i++;
+            System.out.format("%d. Emitter PID ===> %s  Receiver PID ===> %s  Filter ===> %s%n", ++i,
+                    config.getEmitterPid(), config.getReceiverPid(), config.getFilter());
         }
         System.out.println("===========================================================");
     }

--- a/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireServiceImpl.java
@@ -230,13 +230,7 @@ public final class WireServiceImpl implements SelfConfiguringComponent, WireServ
      */
     synchronized void createWires() {
         logger.debug(message.creatingWires());
-        final List<WireConfiguration> cloned = CollectionUtil.newArrayList();
-        for (final WireConfiguration wc : this.wireConfigs) {
-            final WireConfiguration wireConf = new WireConfiguration(wc.getEmitterPid(), wc.getReceiverPid());
-            wireConf.setFilter(wc.getFilter());
-            cloned.add(wireConf);
-        }
-        for (final WireConfiguration wireConfig : cloned) {
+        for (final WireConfiguration wireConfig : this.wireConfigs) {
             final String emitterPid = wireConfig.getEmitterPid();
             final String receiverPid = wireConfig.getReceiverPid();
 
@@ -246,9 +240,9 @@ public final class WireServiceImpl implements SelfConfiguringComponent, WireServ
             if (emitterFound && receiverFound) {
                 logger.info(message.creatingWire(emitterPid, receiverPid));
                 createConfiguration(wireConfig, emitterPid, receiverPid);
-                logger.info(message.creatingWiresDone());
             }
         }
+        logger.debug(message.creatingWiresDone());
     }
 
     /**


### PR DESCRIPTION
Proposal for #1211

This is a proposal PR and it introduces the filter functionality to the `WireRecord` associated properties. It filters keys based on regular expression.

The idea is that users can associate regular expression filter to the created wires either from Composer UI canvas or from Gogo Shell. The user can double click on the created wire in the `WireGraph` which will pop up a dialog box asking for regular expression filter. The UI changes have not been incorporated. On the other hand, I have added the necessary changes to the Gogo Shell commands to associate filter to `WireConfigurations`.

According to the Kura Wires Model,

Kura Wires delegates the requests to `WireAdmin` which internally manages a registry of created `Wires` and `WireAdmin` service pushes the data from the created `Wires` to the connected `Consumers` (`Consumer` and `Producer` are fixed terminologies in `WireAdmin`).

So, if we go for a Filter Wire Component, it will be as follows:

`Timer ----> Wire Admin ----> Filter Wire Component ----> Wire Admin ----> Logger`

On the other hand, according to this proposal,

`Timer ----> Wire Admin ----> Logger`

`--->` This signifies the data flow

1. The filtering mechanism occurs at the wire level and hence it does not incur multiple calls to `WireAdmin` to filter the `WireRecord` associated properties. 
2. In addition, in future we can also provide other `Filter Wire Components` to filter using `LDAP filter`, `DSL based filter` etc.

**Easy Testing Procedure**:

1. Add several properties of your choice in the map in `EmitJob.java` (in `Timer`)
2. Create a `Timer` instance (`T`) from the canvas
3. Create a `Logger` instance (`L`) from the canvas
4. execute `createWire T L \\wA\\w*` in console (syntax: `createWire emitterPid receiverPid filter`)