### PR TITLE
JUnit tests org.eclipse.kura.raspberrypi.sensehat

### DIFF
--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/META-INF/MANIFEST.MF
@@ -1,0 +1,23 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.raspberrypi.sensehat.test
+Bundle-SymbolicName: org.eclipse.kura.raspberrypi.sensehat.test;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eclipse Kura
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Fragment-Host: org.eclipse.kura.raspberrypi.sensehat
+Import-Package: org.eclipse.kura;version="[1.2,2.0)",
+ org.eclipse.kura.core.testutil;version="1.0.0",
+ org.eclipse.kura.system;version="[1.1,2.0)",
+ org.junit;version="4.12.0",
+ org.junit.runner;version="4.12.0",
+ org.junit.runners;version="4.12.0",
+ org.mockito;version="1.10.19",
+ org.mockito.invocation;version="1.10.19",
+ org.mockito.stubbing;version="1.10.19",
+ org.osgi.framework;version="1.7",
+ org.osgi.service.cm;version="1.4",
+ org.osgi.service.component;version="1.2",
+ org.slf4j;version="1.6.4",
+ org.apache.log4j
+Bundle-ActivationPolicy: lazy

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/build.properties
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/build.properties
@@ -1,0 +1,18 @@
+################################################################################
+# Copyright (c) 2017 Eurotech and/or its affiliates and others
+#
+#   All rights reserved. This program and the accompanying materials
+#   are made available under the terms of the Eclipse Public License v1.0
+#   which accompanies this distribution, and is available at
+#   http://www.eclipse.org/legal/epl-v10.html
+################################################################################
+
+output.. = target/classes/
+source.. = src/main/java/
+bin.includes = META-INF/,\
+               .
+additional.bundles = org.eclipse.kura.api,\
+                     slf4j.api,\
+                     slf4j.log4j12,\
+                     org.junit
+                  

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/pom.xml
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2017 Eurotech and others
+
+     All rights reserved. This program and the accompanying materials
+     are made available under the terms of the Eclipse Public License v1.0
+     which accompanies this distribution, and is available at
+     http://www.eclipse.org/legal/epl-v10.html
+
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.kura</groupId>
+        <artifactId>test</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>org.eclipse.kura.raspberrypi.sensehat.test</artifactId>
+    <packaging>eclipse-test-plugin</packaging>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <kura.basedir>${project.basedir}/../..</kura.basedir>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                </configuration>
+            </plugin>
+            
+        </plugins>
+    </build>
+</project>

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/HTS221Test.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/HTS221Test.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.raspberrypi.sensehat.sensors;
+
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.CTRL_REG1;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.HUMIDITY_H_REG;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.HUMIDITY_L_REG;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.TEMP_H_REG;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.TEMP_L_REG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices.DummyDevice;
+import org.junit.Test;
+
+public class HTS221Test {
+
+    @Test
+    public void testGetHumiditySensor() {
+        HTS221 hts221 = HTS221.getHumiditySensor(1, 2, 1, 1);
+        assertNotNull("HTS221 not created", hts221);
+    }
+
+    @Test
+    public void testInitDevice() {
+        HTS221 hts221 = HTS221.getHumiditySensor(1, 2, 1, 1);
+        boolean result = hts221.initDevice();
+        assertTrue("HTS221 not inited", result);
+    }
+
+    @Test
+    public void testCloseDevice() throws NoSuchFieldException {
+        HTS221 hts221 = HTS221.getHumiditySensor(1, 2, 1, 1);
+        hts221.initDevice();
+        assertNotNull(hts221);
+        KuraI2CDevice humidityI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(hts221, "humidityI2CDevice");
+        assertNotNull(humidityI2CDevice);
+        HTS221.closeDevice();
+        HTS221 closedHummiditySensor = (HTS221) TestUtil.getFieldValue(hts221, "humiditySensor");
+        KuraI2CDevice closedHummidityI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(hts221, "humidityI2CDevice");
+        assertNull(closedHummiditySensor);
+        assertNull(closedHummidityI2CDevice);
+    }
+
+    @Test
+    public void testGetHumidity() throws NoSuchFieldException {
+        HTS221 hts221 = HTS221.getHumiditySensor(1, 2, 1, 1);
+        boolean result = hts221.initDevice();
+        float humidity = hts221.getHumidity();
+        float mh = (float) TestUtil.getFieldValue(hts221, "mh");
+        float qh = (float) TestUtil.getFieldValue(hts221, "qh");
+        assertTrue(mh * (HUMIDITY_H_REG << 8 | HUMIDITY_L_REG) + qh == humidity);
+
+    }
+
+    @Test
+    public void testGetTemperature() throws NoSuchFieldException {
+        HTS221 hts221 = HTS221.getHumiditySensor(1, 2, 1, 1);
+        boolean result = hts221.initDevice();
+        float temperature = hts221.getTemperature();
+        float mt = (float) TestUtil.getFieldValue(hts221, "mt");
+        float qt = (float) TestUtil.getFieldValue(hts221, "qt");
+        assertTrue(mt * (TEMP_H_REG << 8 | TEMP_L_REG) + qt == temperature);
+    }
+
+    @Test
+    public void testIsHumidityReady() {
+        HTS221 hts221 = HTS221.getHumiditySensor(1, 2, 1, 1);
+        hts221.initDevice();
+        boolean result = hts221.isHumidityReady();
+        assertTrue("Humidity not ready", result);
+
+    }
+
+    @Test
+    public void testIsTemperatureReady() {
+        HTS221 hts221 = HTS221.getHumiditySensor(1, 2, 1, 1);
+        hts221.initDevice();
+        boolean result = hts221.isTemperatureReady();
+        assertTrue("Temperature not ready", result);
+    }
+
+    @Test
+    public void testRead() {
+        // we test by writing to the simualted device register the same value as the register address
+        // and then we expect the same value
+        HTS221 hts221 = HTS221.getHumiditySensor(1, 2, 1, 1);
+        hts221.initDevice();
+        int val = HTS221.read(CTRL_REG1);
+        assertEquals("Sensor reading not as expected", CTRL_REG1, val);
+    }
+
+    @Test
+    public void testWrite() throws NoSuchFieldException {
+        HTS221 hts221 = HTS221.getHumiditySensor(1, 2, 1, 1);
+        hts221.initDevice();
+        HTS221.write(0, new byte[] { 50 });
+        KuraI2CDevice humidityI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(hts221, "humidityI2CDevice");
+        DummyDevice dummyyDevice = (DummyDevice) TestUtil.getFieldValue(humidityI2CDevice, "device");
+        int registerValue = (int) TestUtil.getFieldValue(dummyyDevice, "register");
+        assertEquals("Sensor writing not as expected", 50, registerValue);
+    }
+
+}

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/KuraI2CDevice.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/KuraI2CDevice.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.raspberrypi.sensehat.sensors;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices.DummyDevice;
+import org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices.HTS221DummyDevice;
+import org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices.LPS25HDummyDevice;
+import org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices.LSM9DS1TAccDummyyDevice;
+import org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices.LSM9DS1TMagDummyyDevice;
+
+public class KuraI2CDevice {
+
+    private int bus;
+    private int address;
+    private int addressSize;
+    private int frequency;
+
+    private DummyDevice device;
+
+    public KuraI2CDevice(int bus, int address, int addressSize, int frequency) {
+        this.bus = bus;
+        this.address = address;
+        this.addressSize = addressSize;
+        this.frequency = frequency;
+        switch (address) {
+        case LPS25HDummyDevice.ID:
+            device = new LPS25HDummyDevice();
+            break;
+        case HTS221DummyDevice.ID:
+            device = new HTS221DummyDevice();
+            break;
+        case LSM9DS1TMagDummyyDevice.ID:
+            device = new LSM9DS1TMagDummyyDevice();
+            break;
+        case LSM9DS1TAccDummyyDevice.ID:
+            device = new LSM9DS1TAccDummyyDevice();
+            break;
+        }
+    }
+
+    public int read() throws IOException {
+        return device.read();
+    }
+
+    public void write(int value) throws IOException {
+        device.write(value);
+    }
+
+    public void write(int register, int size, ByteBuffer value) throws IOException {
+        device.write(register, size, value);
+    }
+
+    public void beginTransaction() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void endTransaction() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    public void close() throws IOException {
+        device.close();
+    }
+
+    public boolean isOpen() {
+        return device.isOpen();
+    }
+
+}

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/LPS25HTest.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/LPS25HTest.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.raspberrypi.sensehat.sensors;
+
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.PRESS_OUT_H;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.PRESS_OUT_L;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.PRESS_OUT_XL;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.TEMP_OUT_H;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.TEMP_OUT_L;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices.DummyDevice;
+import org.junit.Test;
+
+public class LPS25HTest {
+
+    @Test
+    public void testGetPressureSensor() {
+        LPS25H lps25h = LPS25H.getPressureSensor(1, 1, 1, 1);
+        assertNotNull("LPS25H not created", lps25h);
+    }
+
+    @Test
+    public void testRead() {
+        // we test by writing to the simualted device register the same value as the register address
+        // and then we expect the same value
+        LPS25H lps25h = LPS25H.getPressureSensor(1, 1, 1, 1);
+        lps25h.initDevice();
+        int val = LPS25H.read(TEMP_OUT_H);
+        assertEquals("Sensor reading not as expected", TEMP_OUT_H, val);
+    }
+
+    @Test
+    public void testWrite() throws NoSuchFieldException {
+        LPS25H lps25h = LPS25H.getPressureSensor(1, 1, 1, 1);
+        lps25h.initDevice();
+        LPS25H.write(0, new byte[] { 50 });
+        KuraI2CDevice pressureI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lps25h, "pressureI2CDevice");
+        DummyDevice dummyyDevice = (DummyDevice) TestUtil.getFieldValue(pressureI2CDevice, "device");
+        int registerValue = (int) TestUtil.getFieldValue(dummyyDevice, "register");
+        assertEquals("Sensor writing not as expected", 50, registerValue);
+    }
+
+    @Test
+    public void testInitDevice() {
+        LPS25H lps25h = LPS25H.getPressureSensor(1, 1, 1, 1);
+        boolean result = lps25h.initDevice();
+        assertTrue("Device not inited", result);
+    }
+
+    @Test
+    public void testCloseDevice() throws NoSuchFieldException {
+        LPS25H lps25h = LPS25H.getPressureSensor(1, 1, 1, 1);
+        KuraI2CDevice pressureI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lps25h, "pressureI2CDevice");
+        lps25h.initDevice();
+        assertNotNull(lps25h);
+        assertNotNull(pressureI2CDevice);
+        LPS25H.closeDevice();
+        LPS25H closedPressureSensor = (LPS25H) TestUtil.getFieldValue(lps25h, "pressureSensor");
+        KuraI2CDevice closedPressureI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lps25h, "pressureI2CDevice");
+        assertNull(closedPressureSensor);
+        assertNull(closedPressureI2CDevice);
+    }
+
+    @Test
+    public void testGetPressure() {
+        LPS25H lps25h = LPS25H.getPressureSensor(1, 1, 1, 1);
+        lps25h.initDevice();
+        float pressure = lps25h.getPressure();
+        // simulate reading device registers using the same values that are sent as commands
+        assertTrue((PRESS_OUT_H << 16 | PRESS_OUT_L << 8 | PRESS_OUT_XL) / 4096F == pressure);
+    }
+
+    @Test
+    public void testGetTemperature() {
+        LPS25H lps25h = LPS25H.getPressureSensor(1, 1, 1, 1);
+        lps25h.initDevice();
+        float temperaure = lps25h.getTemperature();
+        // simulate reading device registers using the same values that are sent as commands
+        assertTrue(42.5F + (TEMP_OUT_H << 8 | TEMP_OUT_L << 0) / 480F == temperaure);
+    }
+
+}

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/LSM9DS1Test.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/LSM9DS1Test.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.raspberrypi.sensehat.sensors;
+
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.ACC_DEVICE;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.CTRL_REG1_G;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.CTRL_REG2_M;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.MAG_DEVICE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices.DummyDevice;
+import org.junit.Test;
+
+public class LSM9DS1Test {
+
+    @Test
+    public void testGetIMUSensor() {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        assertNotNull("LSM9DS1 not created", lsm9ds1);
+    }
+
+    @Test
+    public void testInitDevice() {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        boolean result = lsm9ds1.initDevice(true, true, true);
+        assertTrue("LSM9DS1 not inited", result);
+    }
+
+    @Test
+    public void testCloseDevice() throws NoSuchFieldException {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        lsm9ds1.initDevice(true, true, true);
+        KuraI2CDevice accI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "accI2CDevice");
+        KuraI2CDevice magI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "magI2CDevice");
+        assertNotNull(lsm9ds1);
+        assertNotNull(accI2CDevice);
+        assertNotNull(magI2CDevice);
+        LSM9DS1.closeDevice();
+        LSM9DS1 sensor = (LSM9DS1) TestUtil.getFieldValue(lsm9ds1, "imuSensor");
+        KuraI2CDevice closedAccDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "accI2CDevice");
+        KuraI2CDevice closedMagDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "magI2CDevice");
+        assertNull(sensor);
+        assertNull(closedAccDevice);
+        assertNull(closedMagDevice);
+    }
+
+    @Test
+    public void testRead() throws KuraException {
+        // we test by writing to the simulated device register the same value as the register address
+        // and then we expect the same value
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        lsm9ds1.initDevice(true, true, true);
+        int val = LSM9DS1.read(ACC_DEVICE, CTRL_REG1_G);
+        assertEquals("Sensor reading not as expected", CTRL_REG1_G, val);
+        int magval = LSM9DS1.read(MAG_DEVICE, CTRL_REG2_M);
+        assertEquals("Sensor reading not as expected", CTRL_REG2_M, magval);
+    }
+
+    @Test
+    public void testWrite() throws NoSuchFieldException, KuraException {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        lsm9ds1.initDevice(true, true, true);
+        LSM9DS1.write(ACC_DEVICE, 0, new byte[] { 22 });
+        LSM9DS1.write(MAG_DEVICE, 0, new byte[] { 33 });
+        KuraI2CDevice accI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "accI2CDevice");
+        DummyDevice accSensor = (DummyDevice) TestUtil.getFieldValue(accI2CDevice, "device");
+        KuraI2CDevice magI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "accI2CDevice");
+        DummyDevice magSensor = (DummyDevice) TestUtil.getFieldValue(accI2CDevice, "device");
+        int accValue = (int) TestUtil.getFieldValue(accSensor, "register");
+        assertEquals("Sensor writing not as expected", 22, accValue);
+        int magValue = (int) TestUtil.getFieldValue(magSensor, "register");
+        assertEquals("Sensor writing not as expected", 22, magValue);
+    }
+
+    @Test
+    public void testGetCompassRaw() {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        float[] compasRaw = lsm9ds1.getCompassRaw();
+        float[] expected = new float[] { 9.692838F, -17.843777F, -21.380009F };
+        assertTrue(Arrays.equals(expected, compasRaw));
+    }
+
+    @Test
+    public void testGetGyroscopeRaw() {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        float[] gyroRaw = lsm9ds1.getGyroscopeRaw();
+        float[] expected = new float[] { -0.024642F, -0.020255F, 0.011905F };
+        assertTrue(Arrays.equals(expected, gyroRaw));
+    }
+
+    @Test
+    public void testGetAccelerometerRaw() {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        float[] accelerometerRaw = lsm9ds1.getAccelerometerRaw();
+        float[] expected = new float[] { -0.16921997F, -0.17315522F, 0.17095335F };
+        assertTrue(Arrays.equals(expected, accelerometerRaw));
+    }
+
+    @Test
+    public void testEnableAccelerometer() throws NoSuchFieldException {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        LSM9DS1.enableAccelerometer();
+        KuraI2CDevice accI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "accI2CDevice");
+        DummyDevice dummyyDevice = (DummyDevice) TestUtil.getFieldValue(accI2CDevice, "device");
+        int registerValue = (int) TestUtil.getFieldValue(dummyyDevice, "register");
+        assertEquals(0x7B, registerValue);
+    }
+
+    @Test
+    public void testDisableAccelerometer() throws NoSuchFieldException {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        LSM9DS1.disableAccelerometer();
+        KuraI2CDevice accI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "accI2CDevice");
+        DummyDevice dummyyDevice = (DummyDevice) TestUtil.getFieldValue(accI2CDevice, "device");
+        int registerValue = (int) TestUtil.getFieldValue(dummyyDevice, "register");
+        assertEquals(0x0, registerValue);
+    }
+
+    @Test
+    public void testEnableGyroscope() throws NoSuchFieldException {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        LSM9DS1.enableGyroscope();
+        int gyroSampleRate = (int) TestUtil.getFieldValue(lsm9ds1, "gyroSampleRate");
+        assertEquals(119, gyroSampleRate);
+        KuraI2CDevice accI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "accI2CDevice");
+        DummyDevice dummyyDevice = (DummyDevice) TestUtil.getFieldValue(accI2CDevice, "device");
+        int registerValue = (int) TestUtil.getFieldValue(dummyyDevice, "register");
+        assertEquals(0x44, registerValue);
+    }
+
+    @Test
+    public void testDisableGyroscope() throws NoSuchFieldException {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        LSM9DS1.disableGyroscope();
+        KuraI2CDevice accI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "accI2CDevice");
+        DummyDevice dummyyDevice = (DummyDevice) TestUtil.getFieldValue(accI2CDevice, "device");
+        int registerValue = (int) TestUtil.getFieldValue(dummyyDevice, "register");
+        assertEquals(16, registerValue);
+    }
+
+    @Test
+    public void testEnableMagnetometer() throws NoSuchFieldException {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        LSM9DS1.enableMagnetometer();
+        KuraI2CDevice magI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "magI2CDevice");
+        DummyDevice dummyyDevice = (DummyDevice) TestUtil.getFieldValue(magI2CDevice, "device");
+        int registerValue = (int) TestUtil.getFieldValue(dummyyDevice, "register");
+        assertEquals(0x0, registerValue);
+    }
+
+    @Test
+    public void testDisableMagnetometer() throws NoSuchFieldException {
+        LSM9DS1 lsm9ds1 = LSM9DS1.getIMUSensor(1, 3, 4, 1, 1);
+        LSM9DS1.disableMagnetometer();
+        KuraI2CDevice magI2CDevice = (KuraI2CDevice) TestUtil.getFieldValue(lsm9ds1, "magI2CDevice");
+        DummyDevice dummyyDevice = (DummyDevice) TestUtil.getFieldValue(magI2CDevice, "device");
+        int registerValue = (int) TestUtil.getFieldValue(dummyyDevice, "register");
+        assertEquals(0x3, registerValue);
+    }
+
+}

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/DummyDevice.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/DummyDevice.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+package org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public abstract class DummyDevice {
+
+    protected boolean open;
+    protected int register = -1;
+
+    public abstract int read();
+
+    public void write(int value) throws IOException {
+        register = value;
+    }
+
+    public void write(int register, int size, ByteBuffer value) throws IOException {
+        if (value.array().length == 4) {
+            this.register = value.getInt() & 0xFF;
+        } else {
+            this.register = value.get() & 0xFF;
+        }
+    }
+
+    public void close() throws IOException {
+        open = false;
+    }
+
+    public boolean isOpen() {
+        return open;
+    }
+
+}

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/HTS221DummyDevice.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/HTS221DummyDevice.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+package org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices;
+
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.CTRL_REG1;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.H0_T0_OUT_H;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.H0_T0_OUT_L;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.H0_rH_x2;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.H1_T0_OUT_H;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.H1_T0_OUT_L;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.H1_rH_x2;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.HUMIDITY_H_REG;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.HUMIDITY_L_REG;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.STATUS_REG;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.T0_OUT_H;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.T0_OUT_L;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.T0_T1_msb;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.T0_degC_x8;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.T1_OUT_H;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.T1_OUT_L;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.T1_degC_x8;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.TEMP_H_REG;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.TEMP_L_REG;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.WHO_AM_I;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.HTS221.WHO_AM_I_ID;
+
+import java.util.Random;
+
+public class HTS221DummyDevice extends DummyDevice {
+
+    public static final int ID = 2;
+
+    private Random rnd = new Random();
+
+    @Override
+    public int read() {
+        switch (register) {
+        case STATUS_REG:
+            return 3;  // temparature (bit 1) and humiditiy (bit 2) ready
+        case WHO_AM_I:
+            return WHO_AM_I_ID;
+        case HUMIDITY_H_REG:   // we can return any value, returning the same for the simplicity
+        case HUMIDITY_L_REG:
+        case TEMP_H_REG:
+        case TEMP_L_REG:
+        case CTRL_REG1:
+            return register;
+        case H0_rH_x2:  // random values are OK for calibration
+        case H1_rH_x2:
+        case T0_T1_msb:
+        case T0_degC_x8:
+        case T1_degC_x8:
+        case H0_T0_OUT_H:
+        case H0_T0_OUT_L:
+        case H1_T0_OUT_H:
+        case H1_T0_OUT_L:
+        case T0_OUT_H:
+        case T0_OUT_L:
+        case T1_OUT_H:
+        case T1_OUT_L:
+            byte[] rndVal = new byte[1];
+            rnd.nextBytes(rndVal);
+            return rndVal[0];
+        default:
+            return 0;
+        }
+    }
+
+}

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/LPS25HDummyDevice.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/LPS25HDummyDevice.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices;
+
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.PRESS_OUT_H;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.PRESS_OUT_L;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.PRESS_OUT_XL;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.TEMP_OUT_H;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.TEMP_OUT_L;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.WHO_AM_I;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LPS25H.WHO_AM_I_ID;
+
+public class LPS25HDummyDevice extends DummyDevice {
+
+    public static final int ID = 1;
+
+    @Override
+    public int read() {
+        switch (register) {
+        case WHO_AM_I:
+            return WHO_AM_I_ID;
+        case PRESS_OUT_L:   // we can return any value, returning the same for the simplicity
+        case PRESS_OUT_H:
+        case PRESS_OUT_XL:
+        case TEMP_OUT_L:
+        case TEMP_OUT_H:
+            return register;
+        default:
+            return 0;
+        }
+    }
+
+}

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/LSM9DS1TAccDummyyDevice.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/LSM9DS1TAccDummyyDevice.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices;
+
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.CTRL_REG1_G;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.CTRL_REG6_XL;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_X_H_G;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_X_H_XL;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_X_L_G;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_X_L_XL;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Y_H_G;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Y_H_XL;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Y_L_G;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Y_L_XL;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Z_H_G;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Z_H_XL;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Z_L_G;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Z_L_XL;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.WHO_AM_I_AG_ID;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.WHO_AM_I_XG;
+
+public class LSM9DS1TAccDummyyDevice extends DummyDevice {
+
+    public static final int ID = 3;
+
+    @Override
+    public int read() {
+        switch (register) {
+        case WHO_AM_I_XG:
+            return WHO_AM_I_AG_ID;
+        case CTRL_REG1_G:  // we can return any value, returning the same for the simplicity
+        case CTRL_REG6_XL:
+            return register;
+        case OUT_X_L_XL:
+        case OUT_Y_L_XL:
+        case OUT_Z_L_XL:
+        case OUT_X_L_G:
+        case OUT_Y_L_G:
+        case OUT_Z_L_G:
+            return -10;
+        case OUT_X_H_XL:
+        case OUT_Y_H_XL:
+        case OUT_Z_H_XL:
+        case OUT_X_H_G:
+        case OUT_Y_H_G:
+        case OUT_Z_H_G:
+            return 10;
+        default:
+            return 0;
+        }
+    }
+
+}

--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/LSM9DS1TMagDummyyDevice.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/sensors/dummydevices/LSM9DS1TMagDummyyDevice.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.raspberrypi.sensehat.sensors.dummydevices;
+
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.CTRL_REG2_M;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_X_H_M;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_X_L_M;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Y_H_M;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Y_L_M;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Z_H_M;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.OUT_Z_L_M;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.WHO_AM_I_M;
+import static org.eclipse.kura.raspberrypi.sensehat.sensors.LSM9DS1.WHO_AM_I_M_ID;
+
+public class LSM9DS1TMagDummyyDevice extends DummyDevice {
+
+    public static final int ID = 4;
+
+    @Override
+    public int read() {
+        switch (register) {
+        case WHO_AM_I_M:
+            return WHO_AM_I_M_ID;
+        case CTRL_REG2_M:
+            return register;
+        case OUT_X_L_M:
+        case OUT_Y_L_M:
+        case OUT_Z_L_M:
+            return -10;
+        case OUT_X_H_M:
+        case OUT_Y_H_M:
+        case OUT_Z_H_M:
+            return 10;
+        default:
+            return 0;
+        }
+    }
+
+}

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -129,5 +129,6 @@ Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
         <module>org.eclipse.kura.internal.wire.test</module>
         <module>org.eclipse.kura.wire.component.provider.test</module>
         <module>org.eclipse.kura.stress.test</module>
+        <module>org.eclipse.kura.raspberrypi.sensehat.test</module>
     </modules>
 </project>


### PR DESCRIPTION
Created unit tests for sensors.
Created dummy device to simulate HW devices.

KuraI2CDevice.class replaces real implementation of the same name 
because it comes first in the class path when tests are run.
Devices are simulated with dummy implementation which returns
and stores values using the "register" variable.

Signed-off-by: Dario Novakovic <dario.novakovic@comtrade.com>