### PR TITLE
Applied changes to wire publisher.

### DIFF
--- a/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.CloudPublisher.xml
+++ b/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.CloudPublisher.xml
@@ -26,7 +26,7 @@
             type="String"
             cardinality="0"
             required="true"
-            default="APP"
+            default="W1"
             description="Application topic prefix to be used when publishing messages.">
         </AD>
 
@@ -35,7 +35,7 @@
             type="String"
             cardinality="0"
             required="true"
-            default="EVENT"
+            default="A1/$assetName"
             description="Application portion of the topic to be used when publishing messages.">
         </AD>
         

--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/asset/WireAsset.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/asset/WireAsset.java
@@ -306,6 +306,12 @@ public final class WireAsset extends BaseAsset implements WireEmitter, WireRecei
         }
 
         final Map<String, TypedValue<?>> wireRecordProperties = new HashMap<>();
+        try {
+            wireRecordProperties.put(ASSET_NAME, TypedValues.newStringValue(getKuraServicePid()));
+        } catch (KuraException e) {
+            logger.error(message.configurationNonNull(), e);
+        }
+
         for (final AssetRecord assetRecord : assetRecords) {
             final AssetStatus assetStatus = assetRecord.getAssetStatus();
             final AssetFlag assetFlag = assetStatus.getAssetFlag();
@@ -320,13 +326,6 @@ public final class WireAsset extends BaseAsset implements WireEmitter, WireRecei
             }
 
             wireRecordProperties.put(channelName, typedValue);
-
-            try {
-                wireRecordProperties.put(channelName + PROPERTY_SEPARATOR + ASSET_NAME,
-                        TypedValues.newStringValue(getKuraServicePid()));
-            } catch (KuraException e) {
-                logger.error(message.configurationNonNull(), e);
-            }
 
             wireRecordProperties.put(channelName + PROPERTY_SEPARATOR + TIMESTAMP,
                     TypedValues.newLongValue(assetRecord.getTimestamp()));

--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherOptions.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherOptions.java
@@ -50,7 +50,7 @@ final class CloudPublisherOptions {
     private static final String DEFAULT_CLOUD_SERVICE_PID = "org.eclipse.kura.cloud.CloudService";
 
     /** The Constant application to perform (either publish or subscribe). */
-    private static final String DEFAULT_APPLICATION = "PUB";
+    private static final String DEFAULT_APPLICATION = "W1";
 
     private static final boolean DEFAULT_CONTROL_MESSAGE = false;
 
@@ -62,7 +62,7 @@ final class CloudPublisherOptions {
     private static final boolean DEFAULT_RETAIN = false;
 
     /** The Constant denoting default MQTT topic. */
-    private static final String DEFAULT_TOPIC = "EVENT";
+    private static final String DEFAULT_TOPIC = "A1/$assetName";
 
     private final Map<String, Object> properties;
 

--- a/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/asset/WireAssetTest.java
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/asset/WireAssetTest.java
@@ -130,7 +130,7 @@ public class WireAssetTest {
             Map<String, TypedValue<?>> properties = wireRecords.get(0).getProperties();
 
             assertEquals(3, properties.size());
-            assertEquals(new StringValue("componentName"), properties.get("readChannel1_assetName"));
+            assertEquals(new StringValue("componentName"), properties.get("assetName"));
             assertEquals(new BooleanValue(true), properties.get("readChannel1"));
             assertEquals(new LongValue(42), properties.get("readChannel1_timestamp"));
 


### PR DESCRIPTION
Fixed the topic in comp. properties.
Defined code to perform the string substitution when the assetName property
is provided.
Modified the WireAsset in order to provide only one entry in WireEnvelope where
the asset name is specified.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>