### PR TITLE
fix for failed build on hudson

### DIFF
--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.kura.raspberrypi.sensehat.test;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Fragment-Host: org.eclipse.kura.raspberrypi.sensehat
+Fragment-Host: org.eclipse.kura.raspberrypi.sensehat;bundle-version="1.0.2"
 Import-Package: org.eclipse.kura;version="[1.2,2.0)",
  org.eclipse.kura.core.testutil;version="1.0.0",
  org.eclipse.kura.system;version="[1.1,2.0)",


### PR DESCRIPTION
Try to fix broken build on hudson:
```
Missing requirement: org.eclipse.kura.raspberrypi.sensehat.test 1.0.0.qualifier requires 'bundle org.eclipse.kura.raspberrypi.sensehat 0.0.0' but it could not be found
```

Signed-off-by: Dario Novakovic <dario.novakovic@comtrade.com>