### PR TITLE
Applied minor changes to db store and filter.

### DIFF
--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/filter/DbWireRecordFilter.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/filter/DbWireRecordFilter.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -252,9 +253,13 @@ public final class DbWireRecordFilter implements WireEmitter, WireReceiver, Conf
             refreshCachedRecords();
         }
 
+        List<WireRecord> result;
         if (nonNull(this.lastRecords)) {
-            this.wireSupport.emit(this.lastRecords);
+            result = Collections.unmodifiableList(this.lastRecords);
+        } else {
+            result = Collections.unmodifiableList(new ArrayList<WireRecord>());
         }
+        this.wireSupport.emit(result);
     }
 
     private void refreshCachedRecords() {

--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/store/DbWireRecordStore.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/store/DbWireRecordStore.java
@@ -171,6 +171,9 @@ public final class DbWireRecordStore implements WireEmitter, WireReceiver, Confi
         this.wireRecordStoreOptions = new DbWireRecordStoreOptions(properties);
         this.dbHelper = DbServiceHelper.of(this.dbService);
         this.wireSupport = this.wireHelperService.newWireSupport(this);
+
+        final String tableName = this.wireRecordStoreOptions.getTableName();
+        reconcileDB(tableName);
         logger.debug(message.activatingStoreDone());
     }
 
@@ -183,6 +186,9 @@ public final class DbWireRecordStore implements WireEmitter, WireReceiver, Confi
     public void updated(final Map<String, Object> properties) {
         logger.debug(message.updatingStore() + properties);
         this.wireRecordStoreOptions = new DbWireRecordStoreOptions(properties);
+
+        final String tableName = this.wireRecordStoreOptions.getTableName();
+        reconcileDB(tableName);
         logger.debug(message.updatingStoreDone());
     }
 
@@ -352,7 +358,23 @@ public final class DbWireRecordStore implements WireEmitter, WireReceiver, Confi
                 reconcileColumns(tableName, wireRecord);
             }
         } catch (final SQLException ee) {
-            logger.error(message.errorStoring() + ee);
+            logger.error(message.errorStoring(), ee);
+        }
+    }
+
+    /**
+     * Tries to reconcile the database.
+     *
+     * @param tableName
+     *            the table name in the database that needs to be reconciled.
+     */
+    private void reconcileDB(final String tableName) {
+        try {
+            if (nonNull(tableName) && !tableName.isEmpty()) {
+                reconcileTable(tableName);
+            }
+        } catch (final SQLException ee) {
+            logger.error(message.errorStoring(), ee);
         }
     }
 


### PR DESCRIPTION
Db store wire component now reconciles the tables at activation or update.
DB filter emits an empty message in case the query fails.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>