### PR TITLE
test_sensehat.ledmatrix fix

### DIFF
--- a/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/ledmatrix/FrameBufferTest.java
+++ b/kura/test/org.eclipse.kura.raspberrypi.sensehat.test/src/test/java/org/eclipse/kura/raspberrypi/sensehat/ledmatrix/FrameBufferTest.java
@@ -181,6 +181,9 @@ public class FrameBufferTest {
             Field field = FrameBuffer.class.getDeclaredField("FrameBufferFile");
             field.setAccessible(true);
             field.set(null, new File("target/fb-test.output"));
+            Field graphicsFolderField = FrameBuffer.class.getDeclaredField("graphicsFolder");
+            graphicsFolderField.setAccessible(true);
+            graphicsFolderField.set(null, new File("src/test/resources/"));
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage());
         }


### PR DESCRIPTION
Fix for execution in headless environment.
(Described in #1314)

Signed-off-by: Dario Novakovic <dario.novakovic@comtrade.com>