### PR TITLE
Fix debian interface write utility

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/IfcfgConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/IfcfgConfigWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2017 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,6 +17,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Scanner;
@@ -34,13 +36,9 @@ import org.eclipse.kura.net.NetInterfaceAddressConfig;
 import org.eclipse.kura.net.NetInterfaceConfig;
 import org.eclipse.kura.net.NetInterfaceStatus;
 import org.eclipse.kura.net.NetInterfaceType;
-import org.eclipse.kura.net.NetworkAdminService;
 import org.eclipse.kura.net.admin.visitor.linux.util.KuranetConfig;
 import org.eclipse.kura.net.wifi.WifiInterfaceAddressConfig;
 import org.eclipse.kura.net.wifi.WifiMode;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,14 +51,21 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
     private static final String DEBIAN_NET_CONFIGURATION_FILE = "/etc/network/interfaces";
     private static final String DEBIAN_TMP_NET_CONFIGURATION_FILE = "/etc/network/interfaces.tmp";
 
-    private static IfcfgConfigWriter s_instance;
+    private static final String LOCALHOST = "127.0.0.1";
 
-    public static IfcfgConfigWriter getInstance() {
-        if (s_instance == null) {
-            s_instance = new IfcfgConfigWriter();
+    private static IfcfgConfigWriter instance;
+
+    private static List<String> debianInterfaceComandOptions = new ArrayList<>(
+            Arrays.asList("pre-up", "up", "post-up", "pre-down", "down", "post-down"));
+    private static List<String> debianIgnoreInterfaceCommands = new ArrayList<>(
+            Arrays.asList("post-up route del default dev"));
+
+    public static synchronized IfcfgConfigWriter getInstance() {
+        if (instance == null) {
+            instance = new IfcfgConfigWriter();
         }
 
-        return s_instance;
+        return instance;
     }
 
     @Override
@@ -88,11 +93,10 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                 || OS_VERSION.equals(KuraConstants.ReliaGATE_50_21_Ubuntu.getImageName() + "_"
                         + KuraConstants.ReliaGATE_50_21_Ubuntu.getImageVersion())) {
             NetInterfaceType type = netInterfaceConfig.getType();
-            if (type == NetInterfaceType.LOOPBACK || type == NetInterfaceType.ETHERNET
-                    || type == NetInterfaceType.WIFI) {
-                if (configHasChanged(netInterfaceConfig)) {
-                    writeDebianConfig(netInterfaceConfig);
-                }
+            if ((type == NetInterfaceType.LOOPBACK || type == NetInterfaceType.ETHERNET
+                    || type == NetInterfaceType.WIFI) && configHasChanged(netInterfaceConfig)) {
+                writeDebianConfig(netInterfaceConfig);
+
             }
         } else {
             writeRedhatConfig(netInterfaceConfig);
@@ -102,15 +106,15 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
     private void writeRedhatConfig(NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig)
             throws KuraException {
         String interfaceName = netInterfaceConfig.getName();
-        String outputFileName = new StringBuffer().append(REDHAT_NET_CONFIGURATION_DIRECTORY).append("ifcfg-")
+        String outputFileName = new StringBuilder().append(REDHAT_NET_CONFIGURATION_DIRECTORY).append("ifcfg-")
                 .append(interfaceName).toString();
-        String tmpOutputFileName = new StringBuffer().append(REDHAT_NET_CONFIGURATION_DIRECTORY).append("ifcfg-")
+        String tmpOutputFileName = new StringBuilder().append(REDHAT_NET_CONFIGURATION_DIRECTORY).append("ifcfg-")
                 .append(interfaceName).append(".tmp").toString();
         s_logger.debug("Writing config for {}", interfaceName);
 
         NetInterfaceType type = netInterfaceConfig.getType();
         if (type == NetInterfaceType.ETHERNET || type == NetInterfaceType.WIFI || type == NetInterfaceType.LOOPBACK) {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append("# Networking Interface\n");
 
             // DEVICE
@@ -124,8 +128,7 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
 
             List<? extends NetInterfaceAddressConfig> netInterfaceAddressConfigs = netInterfaceConfig
                     .getNetInterfaceAddresses();
-            s_logger.debug(
-                    "There are " + netInterfaceAddressConfigs.size() + " NetInterfaceConfigs in this configuration");
+            s_logger.debug("There are {} NetInterfaceConfigs in this configuration", netInterfaceAddressConfigs.size());
 
             boolean allowWrite = false;
             for (NetInterfaceAddressConfig netInterfaceAddressConfig : netInterfaceAddressConfigs) {
@@ -181,7 +184,7 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
 
                             // DNS
                             List<? extends IPAddress> dnsAddresses = ((NetConfigIP4) netConfig).getDnsServers();
-                            if (dnsAddresses != null && dnsAddresses.size() > 0) {
+                            if (dnsAddresses != null) {
                                 for (int i = 0; i < dnsAddresses.size(); i++) {
                                     IPAddress ipAddr = dnsAddresses.get(i);
                                     if (!(ipAddr.isLoopbackAddress() || ipAddr.isLinkLocalAddress()
@@ -198,7 +201,7 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                         }
                     }
                 } else {
-                    s_logger.debug("netConfigs is null");
+                    s_logger.debug("writeRedhatConfig() :: netConfigs is null");
                 }
 
                 // WIFI
@@ -235,13 +238,14 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                     pw.flush();
                     fos.getFD().sync();
                 } catch (Exception e) {
-                    throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+                    s_logger.error("Failed to write redhat config file", e);
+                    throw KuraException.internalError(e.getMessage());
                 } finally {
                     if (fos != null) {
                         try {
                             fos.close();
                         } catch (IOException ex) {
-                            s_logger.error("I/O Exception while closing BufferedReader!");
+                            s_logger.error("I/O Exception while closing BufferedReader!", ex);
                         }
                     }
                     if (pw != null) {
@@ -263,11 +267,13 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                                             + interfaceName);
                         }
                     } else {
-                        s_logger.info("Not rewriting network interfaces file for " + interfaceName
-                                + " because it is the same");
+                        s_logger.info("Not rewriting network interfaces file for {} because it is the same",
+                                interfaceName);
                     }
                 } catch (IOException e) {
-                    throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+                    s_logger.error("Failed to rename redhat configuration file {} to {} ", tmpFile.getName(),
+                            outputFile.getName(), e);
+                    throw KuraException.internalError(e.getMessage());
                 }
             } else {
                 s_logger.warn("writeNewConfig :: operation is not allowed");
@@ -277,7 +283,7 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
 
     private void writeDebianConfig(NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig)
             throws KuraException {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         File kuraFile = new File(DEBIAN_NET_CONFIGURATION_FILE);
         String iName = netInterfaceConfig.getName();
         boolean appendConfig = true;
@@ -308,7 +314,10 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                                     sb.append(debianWriteUtility(netInterfaceConfig, iName));
 
                                     // remove old config lines from the scanner
-                                    while (scanner.hasNextLine() && !(line = scanner.nextLine()).isEmpty()) {
+                                    while (scanner.hasNextLine() && !(line = scanner.nextLine().trim()).isEmpty()) {
+                                        if (isDebianInterfaceCommandOption(line)) {
+                                            sb.append("\t").append(line).append("\n");
+                                        }
                                     }
                                     sb.append("\n");
                                 } else {
@@ -323,7 +332,8 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                     }
                 }
             } catch (FileNotFoundException e1) {
-                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e1);
+                s_logger.error("Debian config file is not found", e1);
+                throw KuraException.internalError(e1.getMessage());
             } finally {
                 scanner.close();
                 scanner = null;
@@ -350,13 +360,14 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                 pw.flush();
                 fos.getFD().sync();
             } catch (Exception e) {
-                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+                s_logger.error("Failed to write debian configuration file", e);
+                throw KuraException.internalError(e.getMessage());
             } finally {
                 if (fos != null) {
                     try {
                         fos.close();
                     } catch (IOException ex) {
-                        s_logger.error("I/O Exception while closing BufferedReader!");
+                        s_logger.error("I/O Exception while closing BufferedReader!", ex);
                     }
                 }
                 if (pw != null) {
@@ -380,7 +391,9 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                     s_logger.info("Not rewriting network interfaces file because it is the same");
                 }
             } catch (IOException e) {
-                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+                s_logger.error("Failed to rename debian tmp config file {} to {}", tmpFile.getName(), file.getName(),
+                        e);
+                throw KuraException.internalError(e.getMessage());
             }
         }
     }
@@ -390,10 +403,10 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
 
         List<? extends NetInterfaceAddressConfig> netInterfaceAddressConfigs = netInterfaceConfig
                 .getNetInterfaceAddresses();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
-        s_logger.debug(
-                "There are " + netInterfaceAddressConfigs.size() + " NetInterfaceAddressConfigs in this configuration");
+        s_logger.debug("There are {} NetInterfaceAddressConfigs in this configuration",
+                netInterfaceAddressConfigs.size());
 
         for (NetInterfaceAddressConfig netInterfaceAddressConfig : netInterfaceAddressConfigs) {
             List<NetConfig> netConfigs = netInterfaceAddressConfig.getConfigs();
@@ -401,8 +414,7 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
             if (netConfigs != null) {
                 for (NetConfig netConfig : netConfigs) {
                     if (netConfig instanceof NetConfigIP4) {
-                        s_logger.debug(
-                                "Writing netconfig " + netConfig.getClass().toString() + " for " + interfaceName);
+                        s_logger.debug("Writing netconfig {} for {}", netConfig.getClass().toString(), interfaceName);
 
                         // ONBOOT
                         if (((NetConfigIP4) netConfig).isAutoConnect()) {
@@ -452,7 +464,7 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                         } else {
                             // DEFROUTE
                             if (((NetConfigIP4) netConfig).getStatus() == NetInterfaceStatus.netIPv4StatusEnabledLAN) {
-                                sb.append("post-up route del default dev ");
+                                sb.append("\tpost-up route del default dev ");
                                 sb.append(interfaceName);
                                 sb.append("\n");
                             }
@@ -460,36 +472,34 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
 
                         // DNS
                         List<? extends IPAddress> dnsAddresses = ((NetConfigIP4) netConfig).getDnsServers();
-                        if (!dnsAddresses.isEmpty()) {
-                            boolean setDns = false;
-                            for (int i = 0; i < dnsAddresses.size(); i++) {
-                                if (!dnsAddresses.get(i).getHostAddress().equals("127.0.0.1")) {
-                                    if (!setDns) {
-                                        /*
-                                         * IAB:
-                                         * If DNS servers are listed, those entries will be appended to the
-                                         * /etc/resolv.conf
-                                         * file on every ifdown/ifup sequence resulting in multiple entries for the same
-                                         * servers.
-                                         * (Tested on 10-20, 10-10, and Raspberry Pi).
-                                         * Commenting out dns-nameservers in the /etc/network interfaces file allows DNS
-                                         * servers
-                                         * to be picked up by the IfcfgConfigReader and be displayed on the Web UI but
-                                         * the
-                                         * /etc/resolv.conf file will only be updated by Kura.
-                                         */
-                                        sb.append("\t#dns-nameservers ");
-                                        setDns = true;
-                                    }
-                                    sb.append(dnsAddresses.get(i).getHostAddress() + " ");
+                        boolean setDns = false;
+                        for (int i = 0; i < dnsAddresses.size(); i++) {
+                            if (!LOCALHOST.equals(dnsAddresses.get(i).getHostAddress())) {
+                                if (!setDns) {
+                                    /*
+                                     * IAB:
+                                     * If DNS servers are listed, those entries will be appended to the
+                                     * /etc/resolv.conf
+                                     * file on every ifdown/ifup sequence resulting in multiple entries for the same
+                                     * servers.
+                                     * (Tested on 10-20, 10-10, and Raspberry Pi).
+                                     * Commenting out dns-nameservers in the /etc/network interfaces file allows DNS
+                                     * servers
+                                     * to be picked up by the IfcfgConfigReader and be displayed on the Web UI but
+                                     * the
+                                     * /etc/resolv.conf file will only be updated by Kura.
+                                     */
+                                    sb.append("\t#dns-nameservers ");
+                                    setDns = true;
                                 }
+                                sb.append(dnsAddresses.get(i).getHostAddress() + " ");
                             }
-                            sb.append("\n");
                         }
+                        sb.append("\n");
                     }
                 }
             } else {
-                s_logger.debug("netConfigs is null");
+                s_logger.debug("debianWriteUtility() :: netConfigs is null");
             }
 
             // WIFI
@@ -498,6 +508,25 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
             }
         }
         return sb.toString();
+    }
+
+    private boolean isDebianInterfaceCommandOption(String line) {
+        boolean ret = false;
+        for (String debIfaceCmdOp : debianInterfaceComandOptions) {
+            if (line.startsWith(debIfaceCmdOp)) {
+                ret = true;
+                break;
+            }
+        }
+        if (ret) {
+            for (String debIgnoreIfaceCmd : debianIgnoreInterfaceCommands) {
+                if (line.startsWith(debIgnoreIfaceCmd)) {
+                    ret = false;
+                    break;
+                }
+            }
+        }
+        return ret;
     }
 
     public static void writeKuraExtendedConfig(
@@ -509,10 +538,10 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
         List<? extends NetInterfaceAddressConfig> netInterfaceAddressConfigs = netInterfaceConfig
                 .getNetInterfaceAddresses();
 
-        if (netInterfaceAddressConfigs != null && netInterfaceAddressConfigs.size() > 0) {
+        if (netInterfaceAddressConfigs != null) {
             for (NetInterfaceAddressConfig netInterfaceAddressConfig : netInterfaceAddressConfigs) {
                 List<NetConfig> netConfigs = netInterfaceAddressConfig.getConfigs();
-                if (netConfigs != null && netConfigs.size() > 0) {
+                if (netConfigs != null) {
                     for (int i = 0; i < netConfigs.size(); i++) {
                         NetConfig netConfig = netConfigs.get(i);
                         if (netConfig instanceof NetConfigIP4) {
@@ -533,20 +562,16 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
         // set it all
         Properties kuraExtendedProps = KuranetConfig.getProperties();
 
-        if (kuraExtendedProps == null) {
-            s_logger.debug("kuraExtendedProps was null");
-            kuraExtendedProps = new Properties();
-        }
-        StringBuilder sb = new StringBuilder().append("net.interface.").append(netInterfaceConfig.getName())
-                .append(".config.ip4.status");
-        kuraExtendedProps.put(sb.toString(), netInterfaceStatus.toString());
-
         // write it
-        if (kuraExtendedProps != null && !kuraExtendedProps.isEmpty()) {
+        if (!kuraExtendedProps.isEmpty()) {
+            StringBuilder sb = new StringBuilder().append("net.interface.").append(netInterfaceConfig.getName())
+                    .append(".config.ip4.status");
+            kuraExtendedProps.put(sb.toString(), netInterfaceStatus.toString());
             try {
                 KuranetConfig.storeProperties(kuraExtendedProps);
             } catch (IOException e) {
-                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+                s_logger.error("Failed to store properties in the kuranet.conf file.", e);
+                throw KuraException.internalError(e.getMessage());
             }
         }
     }
@@ -557,22 +582,8 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
                     .append(".config.ip4.status");
             KuranetConfig.deleteProperty(sb.toString());
         } catch (IOException e) {
-            throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
-        }
-    }
-
-    private void disableInterface(String interfaceName) {
-        BundleContext bundleContext = FrameworkUtil.getBundle(getClass()).getBundleContext();
-        if (bundleContext != null) {
-            ServiceReference<NetworkAdminService> sr = bundleContext.getServiceReference(NetworkAdminService.class);
-            if (sr != null) {
-                NetworkAdminService nas = bundleContext.getService(sr);
-                try {
-                    nas.disableInterface(interfaceName);
-                } catch (KuraException e) {
-                    s_logger.warn("Could not disable " + interfaceName, e);
-                }
-            }
+            s_logger.error("Failed to remove net.interface..config.ip4.status property from the kuranet.conf file.", e);
+            throw KuraException.internalError(e.getMessage());
         }
     }
 
@@ -623,12 +634,9 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
 
                     // DNS
                     List<? extends IPAddress> dnsAddresses = ((NetConfigIP4) netConfig).getDnsServers();
-                    if (!dnsAddresses.isEmpty()) {
-                        for (int i = 0; i < dnsAddresses.size(); i++) {
-                            if (!dnsAddresses.get(i).getHostAddress().equals("127.0.0.1")) {
-                                props.setProperty("DNS" + Integer.toString(i + 1),
-                                        dnsAddresses.get(i).getHostAddress());
-                            }
+                    for (int i = 0; i < dnsAddresses.size(); i++) {
+                        if (!LOCALHOST.equals(dnsAddresses.get(i).getHostAddress())) {
+                            props.setProperty("DNS" + Integer.toString(i + 1), dnsAddresses.get(i).getHostAddress());
                         }
                     }
                 }
@@ -644,11 +652,9 @@ public class IfcfgConfigWriter implements NetworkConfigurationVisitor {
             throws KuraException {
         Properties oldConfig = IfcfgConfigReader.parseDebianConfigFile(new File(DEBIAN_NET_CONFIGURATION_FILE),
                 netInterfaceConfig.getName());
-        Properties newConfig = parseNetInterfaceAddressConfig(netInterfaceConfig.getNetInterfaceAddresses().get(0));	// FIXME:
-        // assumes
-        // only
-        // one
-        // addressConfig
+
+        // FIXME: assumes only one addressConfig
+        Properties newConfig = parseNetInterfaceAddressConfig(netInterfaceConfig.getNetInterfaceAddresses().get(0));
 
         s_logger.debug("Comparing configs for {}", netInterfaceConfig.getName());
         s_logger.debug("oldProps: {}", oldConfig);

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/util/KuranetConfig.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/util/KuranetConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and others
+ * Copyright (c) 2011, 2017 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -59,7 +59,7 @@ public class KuranetConfig {
     }
 
     public static Properties getProperties() {
-        Properties kuraExtendedProps = null;
+        Properties kuraExtendedProps = new Properties();
 
         s_logger.debug("Getting {}", KURANET_FILENAME);
 
@@ -67,7 +67,6 @@ public class KuranetConfig {
 
         if (kuranetFile.exists()) {
             // found our match so load the properties
-            kuraExtendedProps = new Properties();
             FileInputStream fis = null;
             try {
                 fis = new FileInputStream(kuranetFile);
@@ -91,21 +90,16 @@ public class KuranetConfig {
     }
 
     public static String getProperty(String key) {
-        String value = null;
-
         Properties props = KuranetConfig.getProperties();
-        if (props != null) {
-            value = props.getProperty(key);
-            s_logger.debug("Got property " + key + " :: " + value);
-        }
-
+        String value = props.getProperty(key);
+        s_logger.debug("Got property {} :: {}", key, value);
         return value;
     }
 
     public static void storeProperties(Properties props) throws IOException, KuraException {
         Properties oldProperties = KuranetConfig.getProperties();
 
-        if (oldProperties == null || !oldProperties.equals(props)) {
+        if (!oldProperties.equals(props)) {
             FileOutputStream fos = null;
             try {
                 fos = new FileOutputStream(KURANET_TMP_FILENAME);
@@ -128,7 +122,9 @@ public class KuranetConfig {
                     s_logger.info("Not rewriting kuranet props file because it is the same");
                 }
             } finally {
-                fos.close();
+                if (fos != null) {
+                    fos.close();
+                }
             }
         }
     }
@@ -137,25 +133,18 @@ public class KuranetConfig {
         s_logger.debug("Setting property " + key + " :: " + value);
         Properties properties = KuranetConfig.getProperties();
 
-        if (properties == null) {
-            properties = new Properties();
-        }
-
         properties.setProperty(key, value);
         KuranetConfig.storeProperties(properties);
     }
 
     public static void deleteProperty(String key) throws IOException, KuraException {
         Properties properties = KuranetConfig.getProperties();
-
-        if (properties != null) {
-            if (properties.containsKey(key)) {
-                s_logger.debug("Deleting property {}", key);
-                properties.remove(key);
-                KuranetConfig.storeProperties(properties);
-            } else {
-                s_logger.debug("Property does not exist {}", key);
-            }
+        if (properties.containsKey(key)) {
+            s_logger.debug("Deleting property {}", key);
+            properties.remove(key);
+            KuranetConfig.storeProperties(properties);
+        } else {
+            s_logger.debug("Property does not exist {}", key);
         }
     }
 }


### PR DESCRIPTION
@MMaiero can you review this PR please? I modified write utility for the Debian /etc/network/interfaces file to preserve command options not controlled by Kura (i.e. pre-up, up, post-up, pre-down, down, and post-down) when interface configuration is modified. I also cleaned a few Lint issues that don't require significant code refactoring.