### PR TITLE
Fixed watchdog service deactivate method

### DIFF
--- a/kura/org.eclipse.kura.linux.watchdog/src/main/java/org/eclipse/kura/linux/watchdog/WatchdogServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.watchdog/src/main/java/org/eclipse/kura/linux/watchdog/WatchdogServiceImpl.java
@@ -64,7 +64,9 @@ public class WatchdogServiceImpl implements WatchdogService, ConfigurableCompone
     protected void deactivate() {
         cancelPollTask();
         shutdownPollExecutor();
-        refreshWatchdog();
+        if (this.configEnabled) {
+            refreshWatchdog();
+        }
     }
 
     public void updated(Map<String, Object> properties) {


### PR DESCRIPTION
When Kura is stopped, the watchdog service triggers the watchdog device even if it is disabled. This causes a system reboot.
This PR fixes the bug adding a condition on the deactivate method.
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>