### PR TITLE
Hidden export to CSV buttons from Wires Web UI

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/PropertiesUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/PropertiesUi.ui.xml
@@ -52,6 +52,10 @@
 	.channel-name-form {
 		margin-bottom: 0;
 	}
+	
+	.hidden {
+		display: none;
+	}
 	</ui:style>
 
 	<b:Container fluid="true">
@@ -66,7 +70,7 @@
 										<b:ButtonGroup size="SMALL">
 											<b.html:Strong ui:field="channelTitle">Channels Table</b.html:Strong>
 										</b:ButtonGroup>
-										<b:ButtonGroup size="SMALL" addStyleNames="pull-right">
+										<b:ButtonGroup size="SMALL" addStyleNames="pull-right hidden">
 											<b:Button icon="DOWNLOAD" ui:field="btnDownload">Download Channels</b:Button>
 											<b:Button icon="UPLOAD" ui:field="btnUpload">Upload Channels</b:Button>
 										</b:ButtonGroup>


### PR DESCRIPTION
Hidden the download and upload channels buttons from the Wires Web UI for now, since that feature will not be available in Kura 3.0.0

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>