### PR TITLE
Set security level to low

### DIFF
--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/BluetoothLe.java
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/BluetoothLe.java
@@ -430,8 +430,8 @@ public class BluetoothLe implements ConfigurableComponent, CloudClientListener, 
                 logger.info("Connecting to TiSensorTag...");
                 this.connected = myTiSensorTag.connect(this.iname);
                 if (this.connected) {
-                    logger.info("Set security level to high.");
-                    myTiSensorTag.setSecurityLevel(BluetoothGattSecurityLevel.HIGH);
+                    logger.info("Set security level to low.");
+                    myTiSensorTag.setSecurityLevel(BluetoothGattSecurityLevel.LOW);
                     logger.info("Security Level : " + myTiSensorTag.getSecurityLevel().toString());
                 }
             } else {


### PR DESCRIPTION
In the SensortTag example, the security level has to be set to low. If set to high, gatttool will drop the connection with the device at the first request.
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>