### PR TITLE
Fix net.admin tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ before_script:
   - export PATH=$PWD/maven/bin:${PATH}
   - hash -r
 
+addons:
+  apt:
+    packages:
+      - dos2unix
+
 script: RUN_TESTS=true ./build-all.sh -Pbree
 
 


### PR DESCRIPTION
net.admin tests are failing on Travis due to missing dos2unix.
Install the dos2unix package.