### PR TITLE
First set of changes to reduce Travis build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ addons:
     packages:
       - dos2unix
 
-script: RUN_TESTS=true ./build-all.sh -Pbree
+script: RUN_TESTS=true ./build-all.sh -Pbree -Dgwt.draftCompile=true -Dgwt.compiler.optimizationLevel=0
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ addons:
     packages:
       - dos2unix
 
-script: RUN_TESTS=true ./build-all.sh -Pbree -Dgwt.draftCompile=true -Dgwt.compiler.optimizationLevel=0
+script: RUN_TESTS=true ./build-all.sh -Pbree -Dgwt.draftCompile=true -Dgwt.compiler.optimizationLevel=0 -Praspberry-pi-2-3
 
 


### PR DESCRIPTION
The changes include:

- Reduce the number of permutations in the web2 project via a system property (.travis.yml)

- Build only a single distrib profile (.travis.yml) - raspberry-pi-2-3

Related to issue #1465 