### PR TITLE
First integration of Travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,10 @@ jobs:
   include:
     - stage: Main-build
       script:
+        - rm -rf $HOME/.m2/repository/org/eclipse
         - $M2_HOME/bin/mvn -B -f target-platform/pom.xml clean install
-        - $M2_HOME/bin/mvn -B -f kura/pom.xml clean install 
-    - stage: distrib-examples-and-tests
+        - $M2_HOME/bin/mvn -B -f kura/pom.xml clean install -DskipTests
+    - stage: distrib-examples-tests-karaf
       script: $M2_HOME/bin/mvn -f kura/distrib/pom.xml clean install
     - # stage name not required, will continue to use the previous
       script:
@@ -43,3 +44,5 @@ jobs:
       - $M2_HOME/bin/mvn -f kura/examples/pom.xml clean install
     - # stage name not required, will continue to use the previous 
       script: $M2_HOME/bin/mvn -f kura/test/pom.xml clean install
+    - # stage name not required, will continue to use the previous
+      script: $M2_HOME/bin/mvn -f karaf/pom.xml clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ sudo: false
 jdk:
   - oraclejdk8
 
+cache:
+  directories:
+  - $HOME/.m2
+  - kura/target-definition
+
 before_script:
   - echo ==== Setting up toolchain.xml ====
   - ls /usr/lib/jvm
@@ -15,7 +20,7 @@ before_script:
   - cd maven ; tar --strip-components 1 -xzf ../maven.tar.gz ; cd ..
   - chmod a+x maven/bin/mvn
   - export M2_HOME=$PWD/maven
-  - export PATH=$PWD/maven/bin:${PATH}
+  - export PATH=${M2_HOME}/maven/bin:${PATH}
   - hash -r
 
 addons:
@@ -24,4 +29,17 @@ addons:
       - dos2unix
       - oracle-java8-installer
 
-script: RUN_TESTS=true ./build-all.sh -Pbree -Dgwt.draftCompile=true -Dgwt.compiler.optimizationLevel=0 -Praspberry-pi-2-3
+jobs:
+  include:
+    - stage: Main-build
+      script:
+        - $M2_HOME/bin/mvn -B -f target-platform/pom.xml clean install
+        - $M2_HOME/bin/mvn -B -f kura/pom.xml clean install 
+    - stage: distrib-examples-and-tests
+      script: $M2_HOME/bin/mvn -f kura/distrib/pom.xml clean install
+    - # stage name not required, will continue to use the previous
+      script:
+      - $M2_HOME/bin/mvn -f kura/org.eclipse.kura-p2/pom.xml clean install 
+      - $M2_HOME/bin/mvn -f kura/examples/pom.xml clean install
+    - # stage name not required, will continue to use the previous 
+      script: $M2_HOME/bin/mvn -f kura/test/pom.xml clean install

--- a/build-all.sh
+++ b/build-all.sh
@@ -25,6 +25,6 @@ mvn "$@" -f target-platform/pom.xml clean install $MAVEN_PROPS &&
 mvn "$@" -f kura/pom.xml clean install $MAVEN_PROPS &&
 mvn "$@" -f kura/distrib/pom.xml clean install $MAVEN_PROPS &&
 mvn "$@" -f kura/examples/pom.xml clean install $MAVEN_PROPS &&
-mvn "$@" -f kura/maven-central clean install $MAVEN_PROPS -Pweb &&
+mvn "$@" -f kura/maven-central clean install $MAVEN_PROPS &&
 mvn "$@" -f karaf/pom.xml clean install $MAVEN_PROPS
 

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -638,7 +638,7 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<plugin>
+                <plugin>
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-packaging-plugin</artifactId>
                     <version>${tycho-version}</version>

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -88,7 +88,6 @@
 						</goals>
 						<configuration>
 							<files>
-								<file>${basedir}/build.properties</file>
 								<file>${basedir}/config/kura.build.properties</file>
 								<file>${kura.basedir}/../../target-platform/config/kura.target-platform.build.properties</file>
 							</files>
@@ -639,6 +638,15 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-packaging-plugin</artifactId>
+                    <version>${tycho-version}</version>
+                    <configuration>
+                        <strictVersions>true</strictVersions>
+                        <format>${kura.build.version}</format>
+                    </configuration>
+                </plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings
 					only. It has no influence on the Maven build itself. -->
 				<plugin>

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -280,9 +280,6 @@ fi]]>
 		<!-- Populate parameters -->
 		<copy file="src/main/resources/${build.name}/kura_install.sh"
               tofile="${project.build.directory}/${build.output.name}/kura_install.sh" />
-		<copy file="src/main/resources/common/kura.init.wrl"
-              tofile="${project.build.directory}/${build.output.name}/kura.init.wrl"
-              failonerror="false" />
 		<copy file="src/main/resources/common/kura.init.yocto"
               tofile="${project.build.directory}/${build.output.name}/kura.init.yocto"
               failonerror="false" />
@@ -293,7 +290,6 @@ fi]]>
               tofile="${project.build.directory}/${build.output.name}/kura.service"
         	  failonerror="false" />
 		<replaceregexp file="${project.build.directory}/${build.output.name}/kura_install.sh" match="INSTALL_DIR=.*" replace="INSTALL_DIR=${kura.install.dir}" />
-		<replaceregexp file="${project.build.directory}/${build.output.name}/kura.init.wrl" match="INSTALL_DIR=.*" replace="INSTALL_DIR=${kura.install.dir}" />
 		<replaceregexp file="${project.build.directory}/${build.output.name}/kura.init.yocto" match="INSTALL_DIR=.*" replace="INSTALL_DIR=${kura.install.dir}" />
 		<replaceregexp file="${project.build.directory}/${build.output.name}/kura.init.raspbian" match="INSTALL_DIR=.*" replace="INSTALL_DIR=${kura.install.dir}" />
 		<replaceregexp file="${project.build.directory}/${build.output.name}/kura.service" match="INSTALL_DIR" replace="${kura.install.dir}" />
@@ -321,8 +317,6 @@ fi]]>
 			<zipfileset file="src/main/resources/${build.name}/kuranet.conf"
                         prefix="${build.output.name}/install/" />
 
-			<zipfileset file="${project.build.directory}/${build.output.name}/kura.init.wrl"
-                        prefix="${build.output.name}/install" />
 			<zipfileset file="${project.build.directory}/${build.output.name}/kura.init.yocto"
                         prefix="${build.output.name}/install" />
 			<zipfileset file="${project.build.directory}/${build.output.name}/kura.init.raspbian"

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -209,6 +209,17 @@
 				<module>tools</module>
 			</modules>
 		</profile>
+        <profile>
+            <id>tests</id>
+            <activation>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <modules>
+                <module>test</module>
+            </modules>
+        </profile>
 		
 		<profile>
 			<id>web</id>

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -69,7 +69,6 @@
         <module>org.eclipse.kura.wire.provider</module>
         <module>features</module>
         <module>emulator</module>
-        <module>test</module>
 
         <!-- final p2 repository -->
         <module>org.eclipse.kura-p2</module>


### PR DESCRIPTION
Splitted kura build in two parts: Kura core first; distrib, example and tests in parallel
Added plugin to populate kura.build.version.
Removed stale wrl references in ant file.
Caching target-definition folder.
Build org.eclipse.kura-p2 before examples.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>

Closes #1479