### PR TITLE
Show the service description as well

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -47,7 +47,6 @@ import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Column;
 import org.gwtbootstrap3.client.ui.FormLabel;
-import org.gwtbootstrap3.client.ui.Heading;
 import org.gwtbootstrap3.client.ui.Icon;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.Modal;
@@ -57,6 +56,7 @@ import org.gwtbootstrap3.client.ui.ModalHeader;
 import org.gwtbootstrap3.client.ui.NavPills;
 import org.gwtbootstrap3.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.PanelBody;
+import org.gwtbootstrap3.client.ui.PanelHeader;
 import org.gwtbootstrap3.client.ui.Row;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.gwtbootstrap3.client.ui.TextBox;
@@ -102,7 +102,7 @@ public class EntryClassUi extends Composite {
     @UiField
     Strong errorAlertText;
     @UiField
-    Heading contentPanelHeader;
+    PanelHeader contentPanelHeader;
     @UiField
     PanelBody contentPanelBody;
     @UiField
@@ -161,6 +161,8 @@ public class EntryClassUi extends Composite {
     Column sidenav;
     @UiField
     Panel sidenavOverlay;
+    @UiField
+    Label serviceDescription;
 
     private static final Messages MSGS = GWT.create(Messages.class);
     private static final Logger logger = Logger.getLogger(EntryClassUi.class.getSimpleName());
@@ -737,7 +739,7 @@ public class EntryClassUi extends Composite {
 
     private void setHeader(final String title, final String subTitle) {
         this.contentPanelHeader.setText(title);
-        this.contentPanelHeader.setSubText(subTitle != null ? subTitle : "");
+        this.serviceDescription.setText(subTitle != null ? subTitle : "");
     }
 
     public void render(GwtConfigComponent item) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -9,7 +9,7 @@
  * Contributors:
  *  Eurotech
  *  Amit Kumar Mondal
- *
+ *  Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui;
 
@@ -47,6 +47,7 @@ import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Column;
 import org.gwtbootstrap3.client.ui.FormLabel;
+import org.gwtbootstrap3.client.ui.Heading;
 import org.gwtbootstrap3.client.ui.Icon;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.Modal;
@@ -56,7 +57,6 @@ import org.gwtbootstrap3.client.ui.ModalHeader;
 import org.gwtbootstrap3.client.ui.NavPills;
 import org.gwtbootstrap3.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.PanelBody;
-import org.gwtbootstrap3.client.ui.PanelHeader;
 import org.gwtbootstrap3.client.ui.Row;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.gwtbootstrap3.client.ui.TextBox;
@@ -102,7 +102,7 @@ public class EntryClassUi extends Composite {
     @UiField
     Strong errorAlertText;
     @UiField
-    PanelHeader contentPanelHeader;
+    Heading contentPanelHeader;
     @UiField
     PanelBody contentPanelBody;
     @UiField
@@ -306,7 +306,14 @@ public class EntryClassUi extends Composite {
                         if (EntryClassUi.this.modal != null) {
                             EntryClassUi.this.modal.hide();
                         }
-                        EntryClassUi.this.showStatusPanel();
+                        EntryClassUi.this.setSelectedAnchorListItem(EntryClassUi.this.status);
+                        EntryClassUi.this.contentPanel.setVisible(true);
+                        setHeader("Status", null);
+                        EntryClassUi.this.contentPanelBody.clear();
+                        EntryClassUi.this.contentPanelBody.add(EntryClassUi.this.statusBinder);
+                        EntryClassUi.this.statusBinder.setSession(EntryClassUi.this.currentSession);
+                        EntryClassUi.this.statusBinder.setParent(instanceReference);
+                        EntryClassUi.this.statusBinder.loadStatusData();
                     }
                 });
 
@@ -329,7 +336,7 @@ public class EntryClassUi extends Composite {
                         }
                         EntryClassUi.this.setSelectedAnchorListItem(EntryClassUi.this.device);
                         EntryClassUi.this.contentPanel.setVisible(true);
-                        EntryClassUi.this.contentPanelHeader.setText(MSGS.device());
+                        setHeader(MSGS.device(), null);
                         EntryClassUi.this.contentPanelBody.clear();
                         EntryClassUi.this.contentPanelBody.add(EntryClassUi.this.deviceBinder);
                         EntryClassUi.this.deviceBinder.setSession(EntryClassUi.this.currentSession);
@@ -356,7 +363,7 @@ public class EntryClassUi extends Composite {
                             }
                             EntryClassUi.this.setSelectedAnchorListItem(EntryClassUi.this.network);
                             EntryClassUi.this.contentPanel.setVisible(true);
-                            EntryClassUi.this.contentPanelHeader.setText(MSGS.network());
+                            setHeader(MSGS.network(), null);
                             EntryClassUi.this.contentPanelBody.clear();
                             EntryClassUi.this.contentPanelBody.add(EntryClassUi.this.networkBinder);
                             EntryClassUi.this.networkBinder.setSession(EntryClassUi.this.currentSession);
@@ -384,7 +391,7 @@ public class EntryClassUi extends Composite {
                             }
                             EntryClassUi.this.setSelectedAnchorListItem(EntryClassUi.this.firewall);
                             EntryClassUi.this.contentPanel.setVisible(true);
-                            EntryClassUi.this.contentPanelHeader.setText(MSGS.firewall());
+                            setHeader(MSGS.firewall(), null);
                             EntryClassUi.this.contentPanelBody.clear();
                             EntryClassUi.this.contentPanelBody.add(EntryClassUi.this.firewallBinder);
                             EntryClassUi.this.firewallBinder.initFirewallPanel();
@@ -410,7 +417,7 @@ public class EntryClassUi extends Composite {
                         }
                         EntryClassUi.this.setSelectedAnchorListItem(EntryClassUi.this.packages);
                         EntryClassUi.this.contentPanel.setVisible(true);
-                        EntryClassUi.this.contentPanelHeader.setText(MSGS.packages());
+                        setHeader(MSGS.packages(), null);
                         EntryClassUi.this.contentPanelBody.clear();
                         EntryClassUi.this.contentPanelBody.add(EntryClassUi.this.packagesBinder);
                         EntryClassUi.this.packagesBinder.setSession(EntryClassUi.this.currentSession);
@@ -437,7 +444,7 @@ public class EntryClassUi extends Composite {
                         }
                         EntryClassUi.this.setSelectedAnchorListItem(EntryClassUi.this.settings);
                         EntryClassUi.this.contentPanel.setVisible(true);
-                        EntryClassUi.this.contentPanelHeader.setText(MSGS.settings());
+                        setHeader(MSGS.settings(), null);
                         EntryClassUi.this.contentPanelBody.clear();
                         EntryClassUi.this.contentPanelBody.add(EntryClassUi.this.settingsBinder);
                         EntryClassUi.this.settingsBinder.setSession(EntryClassUi.this.currentSession);
@@ -463,7 +470,7 @@ public class EntryClassUi extends Composite {
                         }
                         EntryClassUi.this.setSelectedAnchorListItem(EntryClassUi.this.cloudServices);
                         EntryClassUi.this.contentPanel.setVisible(true);
-                        EntryClassUi.this.contentPanelHeader.setText(MSGS.cloudServices());
+                        setHeader(MSGS.cloudServices(), null);
                         EntryClassUi.this.contentPanelBody.clear();
                         EntryClassUi.this.contentPanelBody.add(EntryClassUi.this.cloudServicesBinder);
                         EntryClassUi.this.cloudServicesBinder.refresh();
@@ -489,7 +496,7 @@ public class EntryClassUi extends Composite {
                         }
                         EntryClassUi.this.setSelectedAnchorListItem(EntryClassUi.this.wires);
                         EntryClassUi.this.contentPanel.setVisible(true);
-                        EntryClassUi.this.contentPanelHeader.setText(MSGS.wires());
+                        setHeader(MSGS.wires(), null);
                         EntryClassUi.this.contentPanelBody.clear();
                         EntryClassUi.this.contentPanelBody.add(EntryClassUi.this.wiresBinder);
                         EntryClassUi.this.wiresBinder.load();
@@ -728,14 +735,21 @@ public class EntryClassUi extends Composite {
         });
     }
 
+    private void setHeader(final String title, final String subTitle) {
+        this.contentPanelHeader.setText(title);
+        this.contentPanelHeader.setSubText(subTitle != null ? subTitle : "");
+    }
+
     public void render(GwtConfigComponent item) {
         // Do everything Content Panel related in ServicesUi
         this.contentPanelBody.clear();
         this.servicesUi = new ServicesUi(item, this);
         this.contentPanel.setVisible(true);
+
         if (item != null) {
-            this.contentPanelHeader.setText(item.getComponentName());
+            setHeader(item.getComponentName(), item.getComponentDescription());
         }
+
         this.contentPanelBody.add(this.servicesUi);
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -215,9 +215,10 @@
                             <b:Row addStyleNames='content-wrapper'>
                                 <b:Column size="MD_10">
                                     <b:Panel ui:field="contentPanel" addStyleNames="content-panel">
-                                        <b:PanelHeader>
-                                            <b:Heading ui:field="contentPanelHeader" size="H3" />
-                                        </b:PanelHeader>
+                                        <b:PanelHeader ui:field="contentPanelHeader" addStyleNames="{style.content-panel-header}" />
+                                        <b:Row>
+                                             <g:Label ui:field="serviceDescription" />
+                                        </b:Row>
                                         <b:PanelBody ui:field="contentPanelBody" addStyleNames="{style.content-panel-body}">
                                         </b:PanelBody>
                                     </b:Panel>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -4,10 +4,14 @@
 
     Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
 
-     All rights reserved. This program and the accompanying materials
-     are made available under the terms of the Eclipse Public License v1.0
-     which accompanies this distribution, and is available at
-     http://www.eclipse.org/legal/epl-v10.html	
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech
+        Red Hat Inc
 
 -->
 
@@ -211,7 +215,8 @@
                             <b:Row addStyleNames='content-wrapper'>
                                 <b:Column size="MD_10">
                                     <b:Panel ui:field="contentPanel" addStyleNames="content-panel">
-                                        <b:PanelHeader ui:field="contentPanelHeader" addStyleNames="{style.content-panel-header}">
+                                        <b:PanelHeader>
+                                            <b:Heading ui:field="contentPanelHeader" size="H3" />
                                         </b:PanelHeader>
                                         <b:PanelBody ui:field="contentPanelBody" addStyleNames="{style.content-panel-body}">
                                         </b:PanelBody>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesAnchorListItem.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesAnchorListItem.java
@@ -9,8 +9,7 @@
  * Contributors:
  *  Eurotech
  *  Amit Kumar Mondal
- *  Red Hat
- *  
+ *  Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui;
 
@@ -62,6 +61,11 @@ public class ServicesAnchorListItem extends AnchorListItem {
         } else {
             super.setIcon(icon);
             super.setText(this.item.getComponentName());
+        }
+
+        final String description = service.getComponentDescription();
+        if (description != null && !description.isEmpty()) {
+            super.setTitle(description);
         }
 
         super.addClickHandler(new ClickHandler() {


### PR DESCRIPTION
This change does show the service description as well as the
service name. In the menu on the left this is done by using the
title attribute, in the panel heading it uses bootstraps sub-title
feature.