### PR TITLE
Implemented a check on MqttException type in connection monitor.

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates
+ * Copyright (c) 2017 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -116,7 +116,7 @@ public class DataServiceOptions {
         return (int) this.properties.getOrDefault(RATE_LIMIT_BURST_SIZE_PROP_NAME, RATE_LIMIT_BURST_SIZE_DEFAULT);
     }
 
-    long getRateLimitTimeUnit() throws IllegalArgumentException {
+    long getRateLimitTimeUnit() {
         String timeUnitString = (String) properties.getOrDefault(RATE_LIMIT_TIME_UNIT_PROP_NAME,
                 RATE_LIMIT_TIME_UNIT_DEFAULT);
         TimeUnit timeUnit;


### PR DESCRIPTION
If the exception is due to REASON_CODE_FAILED_AUTHENTICATION, REASON_CODE_INVALID_CLIENT_ID
or REASON_CODE_NOT_AUTHORIZED, the checkin is done because a reboot cannot solve
the issue.

Applied cleanup profile, corrected date in copyright and removed an unneeded throws.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>