### PR TITLE
Set the connect.retry-interval minimum value in metatype to 1.

### DIFF
--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -33,8 +33,8 @@
             cardinality="0" 
             required="true"
             default="60"
-            min="0"
-            description="Frequency in seconds to retry a connection of the Data Publishers after a disconnect (0 to disable)."/>
+            min="1"
+            description="Frequency in seconds to retry a connection of the Data Publishers after a disconnect (Minimum value 1)."/>
             
         <AD id="enable.recovery.on.connection.failure"
             name="enable.recovery.on.connection.failure"


### PR DESCRIPTION
This should prevent the IllegalArgumentException in the startConnectionMonitorTask
and the continuous component activations during a reboot.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>

Closes #1556 