### PR TITLE
Fixed startup scripts and WatchdogService

### DIFF
--- a/kura/distrib/src/main/resources/common/kura.init.raspbian
+++ b/kura/distrib/src/main/resources/common/kura.init.raspbian
@@ -32,6 +32,9 @@ case "$1" in
     start-stop-daemon --stop --quiet --pidfile $pidfile
     RETVAL=$?
     echo "."
+    if [ -f /tmp/watchdog ]; then
+        echo w > `cat /tmp/watchdog`
+    fi
     ;;
   restart)
     $0 stop

--- a/kura/distrib/src/main/resources/common/kura.init.yocto
+++ b/kura/distrib/src/main/resources/common/kura.init.yocto
@@ -28,6 +28,9 @@ case "$1" in
     start-stop-daemon --stop --quiet --pidfile $pidfile
     RETVAL=$?
     echo "."
+    if [ -f /tmp/watchdog ]; then
+        echo w > `cat /tmp/watchdog`
+    fi
     ;;
   restart)
     $0 stop

--- a/kura/distrib/src/main/resources/common/kura.service
+++ b/kura/distrib/src/main/resources/common/kura.service
@@ -4,8 +4,10 @@ Description=Kura
 [Service]
 Type=forking
 ExecStart=/bin/sh INSTALL_DIR/kura/bin/start_kura_background.sh
+ExecStopPost=/bin/sh -c 'if [ -f /tmp/watchdog ]; then echo w > `cat /tmp/watchdog`; fi'
 PIDFile=/var/run/kura.pid
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
-

--- a/kura/org.eclipse.kura.linux.watchdog/src/main/java/org/eclipse/kura/linux/watchdog/WatchdogServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.watchdog/src/main/java/org/eclipse/kura/linux/watchdog/WatchdogServiceImpl.java
@@ -72,10 +72,10 @@ public class WatchdogServiceImpl implements WatchdogService, ConfigurableCompone
         if (this.options.isEnabled()) {
             this.rebootCauseWriter = new RebootCauseFileWriter(this.options.getRebootCauseFilePath());
 
-            try (PrintWriter wdWriter = new PrintWriter(this.options.getWatchdogDevice());) {
+            try (PrintWriter wdWriter = new PrintWriter(this.options.getWatchdogEnabledTemporaryFilePath())) {
                 wdWriter.write(this.options.getWatchdogDevice());
             } catch (IOException e) {
-                logger.error("Unable to write watchdog config file", e);
+                logger.error("Unable to write watchdog enabled temporary file", e);
             }
 
             this.pollTask = this.pollExecutor.scheduleAtFixedRate(() -> {
@@ -202,6 +202,7 @@ public class WatchdogServiceImpl implements WatchdogService, ConfigurableCompone
         // watchdogToStop is used to avoid multiple action executions and kill Kura after a while
         if (!this.watchdogToStop) {
             this.watchdogToStop = true;
+            runCommand("sync");
             runCommand("reboot");
         } else {
             refreshWatchdog();

--- a/kura/org.eclipse.kura.linux.watchdog/src/main/java/org/eclipse/kura/linux/watchdog/WatchdogServiceOptions.java
+++ b/kura/org.eclipse.kura.linux.watchdog/src/main/java/org/eclipse/kura/linux/watchdog/WatchdogServiceOptions.java
@@ -18,10 +18,12 @@ public class WatchdogServiceOptions {
     private static final ConfigurationProperty<Integer> PROPERTY_PING_INTERVAL = new ConfigurationProperty<>(
             "pingInterval", 10000);
     private static final ConfigurationProperty<String> PROPERTY_WD_DEVICE = new ConfigurationProperty<>(
-            "watchdogDevice", "/tmp/watchdog");
+            "watchdogDevice", "/dev/watchdog");
     private static final ConfigurationProperty<String> PROPERTY_REBOOT_CAUSE_FILE_PATH = new ConfigurationProperty<>(
             "rebootCauseFilePath", "/opt/eclipse/kura/data/kura-reboot-cause");
 
+    private static final String WD_ENABLED_TEMPORARY_FILE_PATH = "/tmp/watchdog";
+    
     private Map<String, Object> properties;
 
     public WatchdogServiceOptions(Map<String, Object> properties) {
@@ -44,6 +46,10 @@ public class WatchdogServiceOptions {
         return PROPERTY_REBOOT_CAUSE_FILE_PATH.get(this.properties);
     }
 
+    public String getWatchdogEnabledTemporaryFilePath() {
+    		return WD_ENABLED_TEMPORARY_FILE_PATH;
+    }
+    
     private static class ConfigurationProperty<T> {
 
         private final String key;


### PR DESCRIPTION
This PR takes care of :
- Missing creation of watchdog config file in /tmp when the WatchdogService is enabled
- Added ```sync```command execution before reboot
- Added checkin after stop in init scripts

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>