### PR TITLE
[Testing] Added missing packages to manifest

### DIFF
--- a/kura/test/org.eclipse.kura.internal.driver.s7plc.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.internal.driver.s7plc.test/META-INF/MANIFEST.MF
@@ -7,6 +7,9 @@ Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Fragment-Host: org.eclipse.kura.driver.s7plc.provider
 Import-Package: org.eclipse.kura.core.testutil;version="1.0.0",
+ org.eclipse.kura.driver.binary;version="[1.0.0,2.0.0)",
+ org.eclipse.kura.driver.block;version="[1.0.0,2.0.0)",
+ org.eclipse.kura.driver.block.task;version="[1.0.0,2.0.0)",
  org.junit;version="4.12.0",
  org.junit.runner;version="4.12.0",
  org.junit.runners;version="4.12.0",


### PR DESCRIPTION
PR fixes the likely cause of CI build failures.

Part of #1634.