### PR TITLE
Added fallback into status bundle.

### DIFF
--- a/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImpl.java
@@ -178,7 +178,9 @@ public class CloudConnectionStatusServiceImpl implements CloudConnectionStatusSe
             if (runnable == null && this.properties.get("led") != null) {
                 runnable = getGpioStatusWorker(status);
             }
-            break;
+            if (runnable != null) {
+                break;
+            }
         case LOG:
             runnable = getLogStatusWorker(status);
             break;
@@ -219,7 +221,7 @@ public class CloudConnectionStatusServiceImpl implements CloudConnectionStatusSe
 
         return createLedRunnable(status, gpioLedManager);
     }
-    
+
     private Runnable createLedRunnable(CloudConnectionStatusEnum status, LedManager linuxLedManager) {
         Runnable runnable;
         switch (status) {

--- a/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImplTest.java
@@ -71,16 +71,6 @@ public class CloudConnectionStatusServiceImplTest {
         assertEquals(1, componentRegistry.size());
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testActivateLinuxLed() throws NoSuchFieldException {
-        // Fails because we don't have that resource available and there are no gpios specified as a fallback option.
-        CloudConnectionStatusServiceImpl service = initCloudConnectionStatusService(
-                "ccs:linux_led:/sys/class/led/led1_green");
-
-        ComponentContext componentContext = mock(ComponentContext.class);
-        service.activate(componentContext);
-    }
-
     @Test
     public void testActivateLinuxGpioLed() throws NoSuchFieldException {
         CloudConnectionStatusServiceImpl service = initCloudConnectionStatusService(
@@ -205,7 +195,7 @@ public class CloudConnectionStatusServiceImplTest {
             assertEquals(selectedStatus, getStatus(service));
         }
     }
-    
+
     @Test
     public void testRegisterStatusesGpio() throws NoSuchFieldException {
         CloudConnectionStatusEnum[] statuses = { CloudConnectionStatusEnum.OFF, CloudConnectionStatusEnum.FAST_BLINKING,
@@ -222,7 +212,7 @@ public class CloudConnectionStatusServiceImplTest {
 
             ComponentContext componentContext = mock(ComponentContext.class);
             service.activate(componentContext);
-            
+
             // Make sure mockComponent is initially not in componentRegistry
             assertFalse(isInComponentRegistry(service, mockComponent));
 


### PR DESCRIPTION
This fallback will set log status logging if the path to the led is wrong and no
gpio fallback is set.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>