### PR TITLE
Soved issue with fillPropertiesFromConfiguration GwtServerUtil

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -328,13 +328,13 @@ public final class GwtServerUtil {
         if (backupCC == null) {
             properties.putAll(config.getProperties());
             for (final GwtConfigParameter gwtConfigParam : config.getParameters()) {
-                properties.put(gwtConfigParam.getName(), getUserDefinedObject(gwtConfigParam, null));
+                properties.put(gwtConfigParam.getId(), getUserDefinedObject(gwtConfigParam, null));
             }
         } else {
             final Map<String, Object> backupConfigProp = backupCC.getConfigurationProperties();
             for (final GwtConfigParameter gwtConfigParam : config.getParameters()) {
                 final Map<String, Object> currentConfigProp = currentCC.getConfigurationProperties();
-                properties.put(gwtConfigParam.getName(),
+                properties.put(gwtConfigParam.getId(),
                         getUserDefinedObject(gwtConfigParam, currentConfigProp.get(gwtConfigParam.getName())));
             }
 


### PR DESCRIPTION
It was taken the name value instead of the id.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>

Closes #1661
As a side note, I believe we should try to uniform the update code to reduce duplication and issues like this: wires update takes a completely different path than, for example, the usual Service configuration update.