### PR TITLE
Removed Karaf dependency from examples.

### DIFF
--- a/karaf/deployment/targets/pom.xml
+++ b/karaf/deployment/targets/pom.xml
@@ -121,9 +121,6 @@
                     </bootFeatures>
                     <installedFeatures>
                         <feature>wrapper</feature>
-                        <feature>kura-example-publisher</feature>
-                        <feature>kura-example-camel-aggregation</feature>
-                        <feature>kura-example-camel-quickstart</feature>
                     </installedFeatures>
 
                     <javase>1.8</javase>

--- a/karaf/features/kura-core/pom.xml
+++ b/karaf/features/kura-core/pom.xml
@@ -69,10 +69,6 @@
                             <features>
                                 <feature>kura-core</feature>
                                 <feature>kura-camel</feature>
-
-                                <feature>kura-example-publisher</feature>
-                                <feature>kura-example-camel-aggregation</feature>
-                                <feature>kura-example-camel-quickstart</feature>
                             </features>
                         </configuration>
                     </execution>

--- a/karaf/features/kura-core/src/main/feature/feature.xml
+++ b/karaf/features/kura-core/src/main/feature/feature.xml
@@ -47,26 +47,4 @@
         <bundle>mvn:org.eclipse.kura/org.eclipse.kura.camel/${org.eclipse.kura.camel.version}</bundle>
         <bundle>mvn:org.eclipse.kura/org.eclipse.kura.camel.cloud.factory/${org.eclipse.kura.camel.cloud.factory.version}</bundle>
     </feature>
-
-    <!-- Examples -->
-
-    <feature name="kura-example-publisher" version="${project.version}" description="Eclipse Kura Examples :: Publisher">
-        <feature dependency="true">kura-core</feature>
-
-        <bundle>mvn:org.eclipse.kura/org.eclipse.kura.example.publisher/${org.eclipse.kura.example.publisher.version}</bundle>
-    </feature>
-
-    <feature name="kura-example-camel-aggregation" version="${project.version}" description="Eclipse Kura Examples :: Camel :: Aggregation">
-        <feature dependency="true">kura-core</feature>
-        <feature dependency="true">kura-camel</feature>
-
-        <bundle>mvn:org.eclipse.kura/org.eclipse.kura.example.camel.aggregation/${org.eclipse.kura.example.camel.aggregation.version}</bundle>
-    </feature>
-
-    <feature name="kura-example-camel-quickstart" version="${project.version}" description="Eclipse Kura Examples :: Camel :: Quickstart">
-        <feature dependency="true">kura-core</feature>
-        <feature dependency="true">kura-camel</feature>
-
-        <bundle>mvn:org.eclipse.kura/org.eclipse.kura.example.camel.quickstart/${org.eclipse.kura.example.camel.quickstart.version}</bundle>
-    </feature>
 </features>


### PR DESCRIPTION
Signed-off-by: MMaiero <matteo.maiero@eurotech.com>

This will solve current Travis issue due to the parallel building.
When pushed to maven central, the examples could be retrieved from there.
