### PR TITLE
Added custom auth request command for Ublox modems

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
 import org.eclipse.kura.linux.net.modem.UsbModemDriver;
-import org.eclipse.kura.net.admin.modem.hspa.HspaModemConfigGenerator;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxConfigGenerator;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxModemFactory;
 import org.eclipse.kura.net.admin.modem.sierra.usb598.SierraUsb598ConfigGenerator;
@@ -27,6 +26,7 @@ import org.eclipse.kura.net.admin.modem.telit.he910.TelitHe910ModemFactory;
 import org.eclipse.kura.net.admin.modem.telit.le910.TelitLe910ModemFactory;
 import org.eclipse.kura.net.admin.modem.telit.le910v2.TelitLe910v2ConfigGenerator;
 import org.eclipse.kura.net.admin.modem.telit.le910v2.TelitLe910v2ModemFactory;
+import org.eclipse.kura.net.admin.modem.ublox.generic.UbloxModemConfigGenerator;
 import org.eclipse.kura.net.admin.modem.ublox.generic.UbloxModemFactory;
 
 public class SupportedUsbModemsFactoryInfo {
@@ -44,7 +44,7 @@ public class SupportedUsbModemsFactoryInfo {
         Sierra_MC8775(SupportedUsbModemInfo.Sierra_MC8775, SierraMc87xxModemFactory.class, SierraMc87xxConfigGenerator.class),
         Sierra_MC8790(SupportedUsbModemInfo.Sierra_MC8790, SierraMc87xxModemFactory.class, SierraMc87xxConfigGenerator.class),
         Sierra_USB598(SupportedUsbModemInfo.Sierra_USB598, SierraUsb598ModemFactory.class, SierraUsb598ConfigGenerator.class),
-        Ublox_SARA_U2(SupportedUsbModemInfo.Ublox_SARA_U2, UbloxModemFactory.class, HspaModemConfigGenerator.class);
+        Ublox_SARA_U2(SupportedUsbModemInfo.Ublox_SARA_U2, UbloxModemFactory.class, UbloxModemConfigGenerator.class);
 
         private final SupportedUsbModemInfo m_usbModemInfo;
         private final Class<? extends CellularModemFactory> m_factoryClass;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/ublox/generic/UbloxModemAtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/ublox/generic/UbloxModemAtCommands.java
@@ -14,7 +14,8 @@ package org.eclipse.kura.net.admin.modem.ublox.generic;
 
 public enum UbloxModemAtCommands {
 
-    getGprsSessionDataVolume("at+ugcntrd\r\n");
+    getGprsSessionDataVolume("at+ugcntrd\r\n"),
+    getAuthentificationRequest("at+uauthreq");
 
     private String m_command;
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/ublox/generic/UbloxModemConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/ublox/generic/UbloxModemConfigGenerator.java
@@ -1,0 +1,186 @@
+package org.eclipse.kura.net.admin.modem.ublox.generic;
+
+import org.eclipse.kura.configuration.Password;
+import org.eclipse.kura.net.admin.modem.ModemPppConfigGenerator;
+import org.eclipse.kura.net.admin.modem.PppPeer;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModemAtCommands;
+import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangePair;
+import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangeScript;
+import org.eclipse.kura.net.modem.ModemConfig;
+import org.eclipse.kura.net.modem.ModemConfig.AuthType;
+import org.eclipse.kura.net.modem.ModemConfig.PdpType;
+
+public class UbloxModemConfigGenerator implements ModemPppConfigGenerator {
+
+    @Override
+    public PppPeer getPppPeer(String deviceId, ModemConfig modemConfig, String logFile, String connectScript,
+            String disconnectScript) {
+
+        PppPeer pppPeer = new PppPeer();
+
+        // default values
+        pppPeer.setBaudRate(115200);
+        pppPeer.setEnableDebug(true);
+        pppPeer.setUseModemControlLines(true);
+        pppPeer.setUseRtsCtsFlowControl(false);
+        pppPeer.setLockSerialDevice(true);
+        pppPeer.setPeerMustAuthenticateItself(false);
+        pppPeer.setPeerToSupplyLocalIP(true);
+        pppPeer.setAddDefaultRoute(true);
+        pppPeer.setUsePeerDns(true);
+        pppPeer.setAllowProxyArps(false);
+        pppPeer.setAllowVanJacobsonTcpIpHdrCompression(false);
+        pppPeer.setAllowVanJacobsonConnectionIDCompression(false);
+        pppPeer.setAllowBsdCompression(false);
+        pppPeer.setAllowDeflateCompression(false);
+        pppPeer.setAllowMagic(false);
+        pppPeer.setConnectDelay(1000);
+        pppPeer.setLcpEchoInterval(0);
+
+        // other config
+        pppPeer.setLogfile(logFile);
+        pppPeer.setProvider(deviceId);
+        pppPeer.setPppUnitNumber(modemConfig.getPppNumber());
+        pppPeer.setConnectScript(connectScript);
+        pppPeer.setDisconnectScript(disconnectScript);
+        pppPeer.setApn(modemConfig.getApn());
+        pppPeer.setAuthType(modemConfig.getAuthType());
+        pppPeer.setUsername(modemConfig.getUsername());
+        pppPeer.setPassword(modemConfig.getPasswordAsPassword());
+        pppPeer.setDialString(modemConfig.getDialString());
+        pppPeer.setPersist(modemConfig.isPersist());
+        pppPeer.setMaxFail(modemConfig.getMaxFail());
+        pppPeer.setIdleTime(modemConfig.getIdle());
+        pppPeer.setActiveFilter(modemConfig.getActiveFilter());
+        pppPeer.setLcpEchoInterval(modemConfig.getLcpEchoInterval());
+        pppPeer.setLcpEchoFailure(modemConfig.getLcpEchoFailure());
+
+        return pppPeer;
+    }
+
+    @Override
+    public ModemXchangeScript getConnectScript(ModemConfig modemConfig) {
+        int pdpPid = 1;
+        String apn = "";
+        String dialString = "";
+        AuthType authType = AuthType.NONE;
+        String username = "";
+        Password password = null;
+
+        if (modemConfig != null) {
+            apn = modemConfig.getApn();
+            dialString = modemConfig.getDialString();
+            authType = modemConfig.getAuthType();
+            username = modemConfig.getUsername();
+            password = modemConfig.getPasswordAsPassword();
+        }
+
+        ModemXchangeScript modemXchange = new ModemXchangeScript();
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"ERROR\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ath\"", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"AT\"", "OK"));
+        if (!authType.equals(AuthType.NONE)) {
+            modemXchange.addmodemXchangePair(
+                    new ModemXchangePair(formAuthRequest(pdpPid, authType, username, password), "OK"));
+        }
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formPDPcontext(pdpPid, PdpType.IP, apn), "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\d\\d\\d\"", "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formDialString(dialString), "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\c\"", "CONNECT"));
+
+        return modemXchange;
+    }
+
+    @Override
+    public ModemXchangeScript getDisconnectScript(ModemConfig modemConfig) {
+
+        ModemXchangeScript modemXchange = new ModemXchangeScript();
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("BREAK", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ATH\"", "\"\""));
+
+        return modemXchange;
+    }
+
+    /*
+     * This method forms dial string
+     */
+    private String formDialString(String dialString) {
+        StringBuffer buf = new StringBuffer();
+        buf.append('"');
+        if (dialString != null) {
+            buf.append(dialString);
+        }
+        buf.append('"');
+        return buf.toString();
+    }
+
+    /*
+     * This method forms PDP context
+     * (e.g. AT+CGDCONT=<pid>,<pdp_type>,<apn>)
+     */
+    private String formPDPcontext(int pdpPid, PdpType pdpType, String apn) {
+
+        StringBuffer pdpcontext = new StringBuffer(HspaModemAtCommands.pdpContext.getCommand());
+        pdpcontext.append('=');
+        pdpcontext.append(pdpPid);
+        pdpcontext.append(',');
+        pdpcontext.append('"');
+        pdpcontext.append(pdpType.toString());
+        pdpcontext.append('"');
+        pdpcontext.append(',');
+        pdpcontext.append('"');
+        if (apn != null) {
+            pdpcontext.append(apn);
+        }
+        pdpcontext.append('"');
+
+        return pdpcontext.toString();
+    }
+
+    /*
+     * This method forms the Authentication Request
+     * (e.g. AT+UAUTHREQ=<pdpPid>,<authType>,<username>,<password>)
+     */
+    private String formAuthRequest(int pdpPid, AuthType authType, String username, Password password) {
+
+        int auth = 3;
+        if (authType.equals(AuthType.NONE)) {
+            auth = 0;
+        } else if (authType.equals(AuthType.PAP)) {
+            auth = 1;
+        }
+        if (authType.equals(AuthType.CHAP)) {
+            auth = 2;
+        }
+        if (authType.equals(AuthType.AUTO)) {
+            auth = 3;
+        }
+
+        StringBuilder authReq = new StringBuilder(UbloxModemAtCommands.getAuthentificationRequest.getCommand());
+        authReq.append('=');
+        authReq.append(pdpPid);
+        authReq.append(',');
+        authReq.append(auth);
+        authReq.append(',');
+        authReq.append('"');
+        authReq.append(username);
+        authReq.append('"');
+        authReq.append(',');
+        authReq.append('"');
+        authReq.append(password.getPassword());
+        authReq.append('"');
+
+        return authReq.toString();
+    }
+
+}


### PR DESCRIPTION
This PR adds the UAUTHREQ command for UBlox modems. The command is needed when an APN requires PAP/CHAP authentification.
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>