### PR TITLE
Revert working directory ignored in CMD-V1

### DIFF
--- a/kura/distrib/RELEASE_NOTES.txt
+++ b/kura/distrib/RELEASE_NOTES.txt
@@ -48,6 +48,7 @@ Bug Fixes :
     * #1585: [Messaging] Share cloud connection with external applications
     * #1575: [Watchdog Service] Write the last reboot cause to a persistent file
     * #1564: [MqttDataTransport] wss connections without hostname verification do not work
+    * #1558: CommandCloudApp doesn't use received working directory parameter
     * #1556: connect.retry-interval=0 causes DataService activation failure
     * #1541: Add support for polling to GPIO example
     * #1531: Create "Drivers and Assets" tab


### PR DESCRIPTION
This fixes #1558 by partially reverting commit 1c577d8.
With that commit the working directory specified in the CMD-V1 EXEC request is ignored.
It was introdouced as a workaround to support the Windows port where the cloud platform
always send /tmp as the working directory.
As there's no Windows port and the right thing to do is fixing the cloud platform
the old behavior is restored.

Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>