### PR TITLE
Fixed firewall init script

### DIFF
--- a/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
@@ -25,4 +25,6 @@ else
     echo "0" > $ipforward_file
 fi
 # source a custom firewall script
-source /etc/init.d/firewall_cust 2> /dev/null
+if [ -f /etc/init.d/firewall_cust ]; then
+    source /etc/init.d/firewall_cust 2> /dev/null
+fi


### PR DESCRIPTION
This PR modifies the firewall init script for the Raspberry Pi 2/3. This will avoid the error from Systemd.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>