### PR TITLE
Integration of PR #1697 in order to prevent possible NPE.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtComponentServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtComponentServiceImpl.java
@@ -109,9 +109,9 @@ public class GwtComponentServiceImpl extends OsgiRemoteServiceServlet implements
             final Set<String> matchingPids = Arrays.stream(context.getServiceReferences((String) null, osgiFilter))
                     .map(reference -> (String) reference.getProperty(KURA_SERVICE_PID)).collect(Collectors.toSet());
             return ServiceLocator
-                    .applyToServiceOptionally(ConfigurationService.class, configurationService -> configurationService
-                            .getComponentConfigurations().stream().filter(config -> matchingPids
-                                    .contains(config.getPid())))
+                    .applyToServiceOptionally(ConfigurationService.class,
+                            configurationService -> configurationService.getComponentConfigurations().stream()
+                                    .filter(config -> matchingPids.contains(config.getPid())))
                     .map(config -> createMetatypeOnlyGwtComponentConfigurationInternal(config)).filter(Objects::nonNull)
                     .collect(Collectors.toList());
         } catch (InvalidSyntaxException e) {
@@ -533,8 +533,10 @@ public class GwtComponentServiceImpl extends OsgiRemoteServiceServlet implements
     private GwtConfigComponent createMetatypeOnlyGwtComponentConfiguration(ComponentConfiguration config)
             throws GwtKuraException {
         final GwtConfigComponent gwtConfig = createMetatypeOnlyGwtComponentConfigurationInternal(config);
-        gwtConfig.setWireComponent(ServiceLocator.applyToServiceOptionally(WireHelperService.class,
-                wireHelperService -> wireHelperService.getServicePid(gwtConfig.getComponentName()) != null));
+        if (gwtConfig != null) {
+            gwtConfig.setWireComponent(ServiceLocator.applyToServiceOptionally(WireHelperService.class,
+                    wireHelperService -> wireHelperService.getServicePid(gwtConfig.getComponentName()) != null));
+        }
         return gwtConfig;
     }
 


### PR DESCRIPTION
NPE could be generated when scanning for component instances.
When, for example, a dp is deleted without killing first a factory instance, scanning of services
could lead to a NPE when analysing the component configuration.
This fix will simply skip those incomplete component configurations.

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>

Closes also #1725