### PR TITLE
Bluetooth: fixed bug on gatttool and example refactor

### DIFF
--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag.tinyb/OSGI-INF/metatype/org.eclipse.kura.example.ble.tisensortag.tinyb.BluetoothLe.xml
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag.tinyb/OSGI-INF/metatype/org.eclipse.kura.example.ble.tisensortag.tinyb.BluetoothLe.xml
@@ -128,6 +128,14 @@
             required="true"
             default="false"
             description="Switch on the buzzer."/>
+            
+         <AD id="discoverServicesAndCharacteristics"
+            name="discoverServicesAndCharacteristics"
+            type="Boolean"
+            cardinality="0"
+            required="true"
+            default="false"
+            description="Perform a discovery of GATT services and characteristics."/>
                         
         <AD id="publishTopic"  
             name="publishTopic"

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag.tinyb/src/main/java/org/eclipse/kura/example/ble/tisensortag/tinyb/BluetoothLe.java
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag.tinyb/src/main/java/org/eclipse/kura/example/ble/tisensortag/tinyb/BluetoothLe.java
@@ -263,8 +263,10 @@ public class BluetoothLe implements ConfigurableComponent {
                     payload.addMetric("Type", "CC2541");
                 }
 
-                doServicesDiscovery(myTiSensorTag);
-                doCharacteristicsDiscovery(myTiSensorTag);
+                if (this.options.isEnableServicesDiscovery()) {
+                    doServicesDiscovery(myTiSensorTag);
+                    doCharacteristicsDiscovery(myTiSensorTag);
+                }
 
                 payload.addMetric("Firmware", myTiSensorTag.getFirmareRevision());
 

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag/OSGI-INF/metatype/org.eclipse.kura.example.ble.tisensortag.BluetoothLe.xml
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag/OSGI-INF/metatype/org.eclipse.kura.example.ble.tisensortag.BluetoothLe.xml
@@ -131,7 +131,15 @@
             required="true"
             default="false"
             description="Switch on the buzzer."/>
-                        
+
+         <AD id="discoverServicesAndCharacteristics"
+            name="discoverServicesAndCharacteristics"
+            type="Boolean"
+            cardinality="0"
+            required="true"
+            default="false"
+            description="Perform a discovery of GATT services and characteristics."/>
+                                    
         <AD id="publishTopic"  
             name="publishTopic"
             type="String"

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/BluetoothLe.java
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/BluetoothLe.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -24,12 +26,10 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.bluetooth.BluetoothAdapter;
 import org.eclipse.kura.bluetooth.BluetoothDevice;
 import org.eclipse.kura.bluetooth.BluetoothGattCharacteristic;
-import org.eclipse.kura.bluetooth.BluetoothGattSecurityLevel;
 import org.eclipse.kura.bluetooth.BluetoothGattService;
 import org.eclipse.kura.bluetooth.BluetoothLeScanListener;
 import org.eclipse.kura.bluetooth.BluetoothService;
 import org.eclipse.kura.cloud.CloudClient;
-import org.eclipse.kura.cloud.CloudClientListener;
 import org.eclipse.kura.cloud.CloudService;
 import org.eclipse.kura.configuration.ConfigurableComponent;
 import org.eclipse.kura.message.KuraPayload;
@@ -38,55 +38,24 @@ import org.osgi.service.component.ComponentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BluetoothLe implements ConfigurableComponent, CloudClientListener, BluetoothLeScanListener {
+public class BluetoothLe implements ConfigurableComponent, BluetoothLeScanListener, TiSensorTagNotificationListener {
 
     private static final Logger logger = LoggerFactory.getLogger(BluetoothLe.class);
 
-    private final String APP_ID = "BLE_APP_V1";
-    private final String PROPERTY_SCAN = "scan_enable";
-    private final String PROPERTY_SCANTIME = "scan_time";
-    private final String PROPERTY_PERIOD = "period";
-    private final String PROPERTY_TEMP = "enableTermometer";
-    private final String PROPERTY_ACC = "enableAccelerometer";
-    private final String PROPERTY_HUM = "enableHygrometer";
-    private final String PROPERTY_MAG = "enableMagnetometer";
-    private final String PROPERTY_PRES = "enableBarometer";
-    private final String PROPERTY_GYRO = "enableGyroscope";
-    private final String PROPERTY_OPTO = "enableLuxometer";
-    private final String PROPERTY_BUTTONS = "enableButtons";
-    private final String PROPERTY_REDLED = "switchOnRedLed";
-    private final String PROPERTY_GREENLED = "switchOnGreenLed";
-    private final String PROPERTY_BUZZER = "switchOnBuzzer";
-    private final String PROPERTY_TOPIC = "publishTopic";
-    private final String PROPERTY_INAME = "iname";
+    private static final String APP_ID = "BLE_APP_V1";
+
+    private static final String INTERRUPTED_EX = "Interrupted Exception";
 
     private CloudService cloudService;
-    private static CloudClient cloudClient;
+    private CloudClient cloudClient;
     private List<TiSensorTag> tiSensorTagList;
     private BluetoothService bluetoothService;
     private BluetoothAdapter bluetoothAdapter;
-    private List<BluetoothGattService> bluetoothGattServices;
     private ScheduledExecutorService worker;
     private ScheduledFuture<?> handle;
-
-    private int period = 10;
-    private int scantime = 5;
-    private static String topic = "data";
     private long startTime;
-    private boolean connected = false;
-    private String iname = "hci0";
-    private boolean enableScan = false;
-    private boolean enableTemp = false;
-    private boolean enableAcc = false;
-    private boolean enableHum = false;
-    private boolean enableMag = false;
-    private boolean enablePres = false;
-    private boolean enableGyro = false;
-    private boolean enableOpto = false;
-    private boolean enableButtons = false;
-    private boolean enableRedLed = false;
-    private boolean enableGreenLed = false;
-    private boolean enableBuzzer = false;
+
+    private BluetoothLeOptions options;
 
     public void setCloudService(CloudService cloudService) {
         this.cloudService = cloudService;
@@ -112,72 +81,56 @@ public class BluetoothLe implements ConfigurableComponent, CloudClientListener, 
     protected void activate(ComponentContext context, Map<String, Object> properties) {
         logger.info("Activating BluetoothLe example...");
 
-        readProperties(properties);
-
-        this.tiSensorTagList = new ArrayList<TiSensorTag>();
-
         try {
-            cloudClient = this.cloudService.newCloudClient(this.APP_ID);
-            cloudClient.addCloudClientListener(this);
-        } catch (KuraException e1) {
-            logger.error("Error starting component", e1);
-            throw new ComponentException(e1);
+            this.cloudClient = this.cloudService.newCloudClient(APP_ID);
+        } catch (KuraException e) {
+            logger.error("Error starting component", e);
+            throw new ComponentException(e);
         }
 
-        if (this.enableScan) {
-
-            this.worker = Executors.newSingleThreadScheduledExecutor();
-
-            try {
-
-                // Get Bluetooth adapter and ensure it is enabled
-                this.bluetoothAdapter = this.bluetoothService.getBluetoothAdapter(this.iname);
-                if (this.bluetoothAdapter != null) {
-                    logger.info("Bluetooth adapter interface => " + this.iname);
-                    logger.info("Bluetooth adapter address => " + this.bluetoothAdapter.getAddress());
-                    logger.info("Bluetooth adapter le enabled => " + this.bluetoothAdapter.isLeReady());
-
-                    if (!this.bluetoothAdapter.isEnabled()) {
-                        logger.info("Enabling bluetooth adapter...");
-                        this.bluetoothAdapter.enable();
-                        logger.info("Bluetooth adapter address => " + this.bluetoothAdapter.getAddress());
-                    }
-                    this.startTime = 0;
-                    this.connected = false;
-                    this.handle = this.worker.scheduleAtFixedRate(new Runnable() {
-
-                        @Override
-                        public void run() {
-                            checkScan();
-                        }
-                    }, 0, 1, TimeUnit.SECONDS);
-                } else {
-                    logger.warn("No Bluetooth adapter found ...");
-                }
-            } catch (Exception e) {
-                logger.error("Error starting component", e);
-                throw new ComponentException(e);
-            }
-        }
+        this.tiSensorTagList = new CopyOnWriteArrayList<>(new ArrayList<>());
+        doUpdate(properties);
+        logger.debug("Updating Bluetooth Service... Done.");
     }
 
     protected void deactivate(ComponentContext context) {
 
+        doDeactivate();
+
+        // Releasing the CloudApplicationClient
+        logger.info("Releasing CloudApplicationClient for {}...", APP_ID);
+        if (this.cloudClient != null) {
+            this.cloudClient.release();
+        }
+
+        logger.debug("Deactivating BluetoothLe... Done.");
+    }
+
+    protected void updated(Map<String, Object> properties) {
+
+        doDeactivate();
+        doUpdate(properties);
+        logger.debug("Updating Bluetooth Service... Done.");
+    }
+
+    private void doDeactivate() {
         logger.debug("Deactivating BluetoothLe...");
         if (this.bluetoothAdapter != null && this.bluetoothAdapter.isScanning()) {
-            logger.debug("m_bluetoothAdapter.isScanning");
             this.bluetoothAdapter.killLeScan();
         }
 
         // disconnect SensorTags
         for (TiSensorTag tiSensorTag : this.tiSensorTagList) {
-            if (tiSensorTag != null) {
+            if (tiSensorTag != null && tiSensorTag.isConnected()) {
+                if (this.options.isEnableButtons()) {
+                    tiSensorTag.disableKeysNotifications();
+                }
                 tiSensorTag.disconnect();
             }
         }
         this.tiSensorTagList.clear();
 
-        // cancel a current worker handle if one if active
+        // cancel a current worker handle if one is active
         if (this.handle != null) {
             this.handle.cancel(true);
         }
@@ -189,83 +142,31 @@ public class BluetoothLe implements ConfigurableComponent, CloudClientListener, 
 
         // cancel bluetoothAdapter
         this.bluetoothAdapter = null;
-
-        // Releasing the CloudApplicationClient
-        logger.info("Releasing CloudApplicationClient for {}...", this.APP_ID);
-        if (cloudClient != null) {
-            cloudClient.release();
-        }
-
-        logger.debug("Deactivating BluetoothLe... Done.");
     }
 
-    protected void updated(Map<String, Object> properties) {
+    private void doUpdate(Map<String, Object> properties) {
 
-        readProperties(properties);
+        this.options = new BluetoothLeOptions(properties);
+        this.startTime = 0;
+        if (this.options.isEnableScan()) {
+            // re-create the worker
+            this.worker = Executors.newSingleThreadScheduledExecutor();
 
-        try {
-            logger.debug("Deactivating BluetoothLe...");
-            if (this.bluetoothAdapter != null && this.bluetoothAdapter.isScanning()) {
-                logger.debug("m_bluetoothAdapter.isScanning");
-                this.bluetoothAdapter.killLeScan();
-            }
-
-            // disconnect SensorTags
-            for (TiSensorTag tiSensorTag : this.tiSensorTagList) {
-                if (tiSensorTag != null) {
-                    tiSensorTag.disconnect();
+            // Get Bluetooth adapter and ensure it is enabled
+            this.bluetoothAdapter = this.bluetoothService.getBluetoothAdapter(this.options.getIname());
+            if (this.bluetoothAdapter != null) {
+                logger.info("Bluetooth adapter interface => {}", this.options.getIname());
+                if (!this.bluetoothAdapter.isEnabled()) {
+                    logger.info("Enabling bluetooth adapter...");
+                    this.bluetoothAdapter.enable();
                 }
+                logger.info("Bluetooth adapter address => {}", this.bluetoothAdapter.getAddress());
+
+                this.handle = this.worker.scheduleAtFixedRate(this::performScan, 0, 1, TimeUnit.SECONDS);
+            } else {
+                logger.info("Bluetooth adapter {} not found.", this.options.getIname());
             }
-            this.tiSensorTagList.clear();
-
-            // cancel a current worker handle if one is active
-            if (this.handle != null) {
-                this.handle.cancel(true);
-            }
-
-            // shutting down the worker and cleaning up the properties
-            if (this.worker != null) {
-                this.worker.shutdown();
-            }
-
-            // cancel bluetoothAdapter
-            this.bluetoothAdapter = null;
-
-            if (this.enableScan) {
-                // re-create the worker
-                this.worker = Executors.newSingleThreadScheduledExecutor();
-
-                // Get Bluetooth adapter and ensure it is enabled
-                this.bluetoothAdapter = this.bluetoothService.getBluetoothAdapter(this.iname);
-                if (this.bluetoothAdapter != null) {
-                    logger.info("Bluetooth adapter interface => " + this.iname);
-                    logger.info("Bluetooth adapter address => " + this.bluetoothAdapter.getAddress());
-                    logger.info("Bluetooth adapter le enabled => " + this.bluetoothAdapter.isLeReady());
-
-                    if (!this.bluetoothAdapter.isEnabled()) {
-                        logger.info("Enabling bluetooth adapter...");
-                        this.bluetoothAdapter.enable();
-                        logger.info("Bluetooth adapter address => " + this.bluetoothAdapter.getAddress());
-                    }
-                    this.startTime = 0;
-                    this.connected = false;
-                    this.handle = this.worker.scheduleAtFixedRate(new Runnable() {
-
-                        @Override
-                        public void run() {
-                            checkScan();
-                        }
-                    }, 0, 1, TimeUnit.SECONDS);
-                } else {
-                    logger.warn("No Bluetooth adapter found ...");
-                }
-            }
-        } catch (Exception e) {
-            logger.error("Error starting component", e);
-            throw new ComponentException(e);
         }
-
-        logger.debug("Updating Bluetooth Service... Done.");
     }
 
     // --------------------------------------------------------------------
@@ -274,16 +175,16 @@ public class BluetoothLe implements ConfigurableComponent, CloudClientListener, 
     //
     // --------------------------------------------------------------------
 
-    void checkScan() {
+    void performScan() {
 
         // Scan for devices
         if (this.bluetoothAdapter.isScanning()) {
             logger.info("m_bluetoothAdapter.isScanning");
-            if (System.currentTimeMillis() - this.startTime >= this.scantime * 1000) {
+            if (System.currentTimeMillis() - this.startTime >= this.options.getScantime() * 1000) {
                 this.bluetoothAdapter.killLeScan();
             }
         } else {
-            if (System.currentTimeMillis() - this.startTime >= this.period * 1000) {
+            if (System.currentTimeMillis() - this.startTime >= this.options.getPeriod() * 1000) {
                 logger.info("startLeScan");
                 this.bluetoothAdapter.startLeScan(this);
                 this.startTime = System.currentTimeMillis();
@@ -298,29 +199,29 @@ public class BluetoothLe implements ConfigurableComponent, CloudClientListener, 
     //
     // --------------------------------------------------------------------
 
-    protected static void doPublishKeys(String address, Object key) {
+    @Override
+    public void notify(String address, Map<String, Object> values) {
         KuraPayload payload = new KuraPayload();
         payload.setTimestamp(new Date());
-        payload.addMetric("key", key);
+        for (Entry<String, Object> entry : values.entrySet()) {
+            payload.addMetric(entry.getKey(), entry.getValue());
+        }
         try {
-            cloudClient.publish(topic + "/" + address + "/keys", payload, 0, false);
-        } catch (Exception e) {
+            cloudClient.publish(this.options.getTopic() + "/" + address, payload, 0, false);
+        } catch (KuraException e) {
             logger.error("Can't publish message, " + "keys", e);
         }
 
     }
 
-    @SuppressWarnings("unused")
     private void doServicesDiscovery(TiSensorTag tiSensorTag) {
         logger.info("Starting services discovery...");
-        this.bluetoothGattServices = tiSensorTag.discoverServices();
-        for (BluetoothGattService bgs : this.bluetoothGattServices) {
+        for (BluetoothGattService bgs : tiSensorTag.discoverServices()) {
             logger.info(
                     "Service UUID: " + bgs.getUuid() + "  :  " + bgs.getStartHandle() + "  :  " + bgs.getEndHandle());
         }
     }
 
-    @SuppressWarnings("unused")
     private void doCharacteristicsDiscovery(TiSensorTag tiSensorTag) {
         List<BluetoothGattCharacteristic> lbgc = tiSensorTag.getCharacteristics("0x0001", "0x0100");
         for (BluetoothGattCharacteristic bgc : lbgc) {
@@ -329,65 +230,24 @@ public class BluetoothLe implements ConfigurableComponent, CloudClientListener, 
         }
     }
 
-    private boolean searchSensorTagList(String address) {
-
+    private boolean isSensorTagInList(String address) {
+        boolean found = false;
         for (TiSensorTag tiSensorTag : this.tiSensorTagList) {
             if (tiSensorTag.getBluetoothDevice().getAdress().equals(address)) {
-                return true;
+                found = true;
+                break;
             }
         }
-        return false;
+        return found;
     }
 
-    private void readProperties(Map<String, Object> properties) {
-        if (properties != null) {
-            if (properties.get(this.PROPERTY_SCAN) != null) {
-                this.enableScan = (Boolean) properties.get(this.PROPERTY_SCAN);
-            }
-            if (properties.get(this.PROPERTY_SCANTIME) != null) {
-                this.scantime = (Integer) properties.get(this.PROPERTY_SCANTIME);
-            }
-            if (properties.get(this.PROPERTY_PERIOD) != null) {
-                this.period = (Integer) properties.get(this.PROPERTY_PERIOD);
-            }
-            if (properties.get(this.PROPERTY_TEMP) != null) {
-                this.enableTemp = (Boolean) properties.get(this.PROPERTY_TEMP);
-            }
-            if (properties.get(this.PROPERTY_ACC) != null) {
-                this.enableAcc = (Boolean) properties.get(this.PROPERTY_ACC);
-            }
-            if (properties.get(this.PROPERTY_HUM) != null) {
-                this.enableHum = (Boolean) properties.get(this.PROPERTY_HUM);
-            }
-            if (properties.get(this.PROPERTY_MAG) != null) {
-                this.enableMag = (Boolean) properties.get(this.PROPERTY_MAG);
-            }
-            if (properties.get(this.PROPERTY_PRES) != null) {
-                this.enablePres = (Boolean) properties.get(this.PROPERTY_PRES);
-            }
-            if (properties.get(this.PROPERTY_GYRO) != null) {
-                this.enableGyro = (Boolean) properties.get(this.PROPERTY_GYRO);
-            }
-            if (properties.get(this.PROPERTY_OPTO) != null) {
-                this.enableOpto = (Boolean) properties.get(this.PROPERTY_OPTO);
-            }
-            if (properties.get(this.PROPERTY_BUTTONS) != null) {
-                this.enableButtons = (Boolean) properties.get(this.PROPERTY_BUTTONS);
-            }
-            if (properties.get(this.PROPERTY_REDLED) != null) {
-                this.enableRedLed = (Boolean) properties.get(this.PROPERTY_REDLED);
-            }
-            if (properties.get(this.PROPERTY_GREENLED) != null) {
-                this.enableGreenLed = (Boolean) properties.get(this.PROPERTY_GREENLED);
-            }
-            if (properties.get(this.PROPERTY_BUZZER) != null) {
-                this.enableBuzzer = (Boolean) properties.get(this.PROPERTY_BUZZER);
-            }
-            if (properties.get(this.PROPERTY_TOPIC) != null) {
-                topic = (String) properties.get(this.PROPERTY_TOPIC);
-            }
-            if (properties.get(this.PROPERTY_INAME) != null) {
-                this.iname = (String) properties.get(this.PROPERTY_INAME);
+    private void filterDevices(List<BluetoothDevice> devices) {
+        // Scan for TI SensorTag
+        for (BluetoothDevice bluetoothDevice : devices) {
+            logger.info("Address {} Name {}", bluetoothDevice.getAdress(), bluetoothDevice.getName());
+
+            if (bluetoothDevice.getName().contains("SensorTag") && !isSensorTagInList(bluetoothDevice.getAdress())) {
+                this.tiSensorTagList.add(new TiSensorTag(bluetoothDevice));
             }
         }
     }
@@ -406,211 +266,79 @@ public class BluetoothLe implements ConfigurableComponent, CloudClientListener, 
     @Override
     public void onScanResults(List<BluetoothDevice> scanResults) {
 
-        // Scan for TI SensorTag
-        for (BluetoothDevice bluetoothDevice : scanResults) {
-            logger.info("Address " + bluetoothDevice.getAdress() + " Name " + bluetoothDevice.getName());
-
-            if (bluetoothDevice.getName().contains("SensorTag")) {
-                logger.info("TI SensorTag " + bluetoothDevice.getAdress() + " found.");
-                if (!searchSensorTagList(bluetoothDevice.getAdress())) {
-                    TiSensorTag tiSensorTag = new TiSensorTag(bluetoothDevice);
-                    this.tiSensorTagList.add(tiSensorTag);
-                }
-            } else {
-                logger.info("Found device = " + bluetoothDevice.getAdress());
-            }
-        }
-
-        logger.debug("Found " + this.tiSensorTagList.size() + " SensorTags");
+        filterDevices(scanResults);
 
         // connect to TiSensorTags
         for (TiSensorTag myTiSensorTag : this.tiSensorTagList) {
-
             if (!myTiSensorTag.isConnected()) {
-                logger.info("Connecting to TiSensorTag...");
-                this.connected = myTiSensorTag.connect(this.iname);
-                if (this.connected) {
-                    logger.info("Set security level to low.");
-                    myTiSensorTag.setSecurityLevel(BluetoothGattSecurityLevel.LOW);
-                    logger.info("Security Level : " + myTiSensorTag.getSecurityLevel().toString());
-                }
-            } else {
-                logger.info("TiSensorTag already connected!");
-                this.connected = true;
+                logger.info("Connecting to TiSensorTag {}...", myTiSensorTag.getBluetoothDevice().getAdress());
+                myTiSensorTag.connect(this.options.getIname());
             }
 
-            if (this.connected) {
-
+            if (myTiSensorTag.isConnected()) {
                 KuraPayload payload = new KuraPayload();
                 payload.setTimestamp(new Date());
-                if (myTiSensorTag.getCC2650()) {
+                if (myTiSensorTag.isCC2650()) {
                     payload.addMetric("Type", "CC2650");
                 } else {
                     payload.addMetric("Type", "CC2541");
                 }
 
-                // Test
-                // doServicesDiscovery(myTiSensorTag);
-                // doCharacteristicsDiscovery(myTiSensorTag);
-
-                myTiSensorTag.setFirmwareRevision(myTiSensorTag.firmwareRevision());
-
-                if (this.enableTemp) {
-                    myTiSensorTag.enableTermometer();
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    double[] temperatures = myTiSensorTag.readTemperature();
-
-                    logger.info("Ambient: " + temperatures[0] + " Target: " + temperatures[1]);
-
-                    payload.addMetric("Ambient", temperatures[0]);
-                    payload.addMetric("Target", temperatures[1]);
+                if (this.options.isEnableServicesDiscovery()) {
+                    doServicesDiscovery(myTiSensorTag);
+                    doCharacteristicsDiscovery(myTiSensorTag);
                 }
 
-                if (this.enableAcc) {
-                    if (myTiSensorTag.getCC2650()) {
-                        // Reduce period to 500ms (for a bug on SensorTag firmware :-)) and enable accelerometer with
-                        // range 8g
-                        myTiSensorTag.setAccelerometerPeriod("32");
-                        myTiSensorTag.enableAccelerometer("3802");
-                    } else {
-                        myTiSensorTag.enableAccelerometer("01");
-                    }
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        logger.error("Interrupted Exception", e);
-                    }
-                    double[] acceleration = myTiSensorTag.readAcceleration();
+                payload.addMetric("Firmware", myTiSensorTag.getFirmareRevision());
 
-                    logger.info(
-                            "Acc X: " + acceleration[0] + " Acc Y: " + acceleration[1] + " Acc Z: " + acceleration[2]);
-
-                    payload.addMetric("Acceleration X", acceleration[0]);
-                    payload.addMetric("Acceleration Y", acceleration[1]);
-                    payload.addMetric("Acceleration Z", acceleration[2]);
+                if (this.options.isEnableTemp()) {
+                    readTemperature(myTiSensorTag, payload);
                 }
 
-                if (this.enableHum) {
-                    myTiSensorTag.enableHygrometer();
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        logger.error("Interrupted Exception", e);
-                    }
-
-                    float humidity = myTiSensorTag.readHumidity();
-                    logger.info("Humidity: " + humidity);
-
-                    payload.addMetric("Humidity", humidity);
+                if (this.options.isEnableAcc()) {
+                    readAcceleration(myTiSensorTag, payload);
                 }
 
-                if (this.enableMag) {
-                    // Reduce period to 500ms (for a bug on SensorTag firmware :-)) and enable magnetometer
-                    myTiSensorTag.setMagnetometerPeriod("32");
-                    if (myTiSensorTag.getCC2650()) {
-                        myTiSensorTag.enableMagnetometer("4000");
-                    } else {
-                        myTiSensorTag.enableMagnetometer("");
-                    }
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        logger.error("Interrupted Exception", e);
-                    }
-                    float[] magneticField = myTiSensorTag.readMagneticField();
-
-                    logger.info("Mag X: " + magneticField[0] + " Mag Y: " + magneticField[1] + " Mag Z: "
-                            + magneticField[2]);
-
-                    payload.addMetric("Magnetic X", magneticField[0]);
-                    payload.addMetric("Magnetic Y", magneticField[1]);
-                    payload.addMetric("Magnetic Z", magneticField[2]);
-
+                if (this.options.isEnableHum()) {
+                    readHumidity(myTiSensorTag, payload);
                 }
 
-                if (this.enablePres) {
-                    // Calibrate pressure sensor
-                    myTiSensorTag.calibrateBarometer();
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        logger.error("Interrupted Exception", e);
-                    }
-                    myTiSensorTag.readCalibrationBarometer();
-
-                    // Read pressure
-                    myTiSensorTag.enableBarometer();
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        logger.error("Interrupted Exception", e);
-                    }
-                    double pressure = myTiSensorTag.readPressure();
-
-                    logger.info("Pre : " + pressure);
-
-                    payload.addMetric("Pressure", pressure);
+                if (this.options.isEnableMag()) {
+                    readMagneticField(myTiSensorTag, payload);
                 }
 
-                if (this.enableGyro) {
-                    if (myTiSensorTag.getCC2650()) {
-                        // Reduce period to 500ms (for a bug on SensorTag firmware :-)) and enable gyroscope
-                        myTiSensorTag.setGyroscopePeriod("32");
-                        myTiSensorTag.enableGyroscope("0700");
-                    } else {
-                        myTiSensorTag.enableGyroscope("07");
-                    }
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        logger.error("Interrupted Exception", e);
-                    }
-                    float[] gyroscope = myTiSensorTag.readGyroscope();
-
-                    logger.info("Gyro X: " + gyroscope[0] + " Gyro Y: " + gyroscope[1] + " Gyro Z: " + gyroscope[2]);
-
-                    payload.addMetric("Gyro X", gyroscope[0]);
-                    payload.addMetric("Gyro Y", gyroscope[1]);
-                    payload.addMetric("Gyro Z", gyroscope[2]);
-
+                if (this.options.isEnablePres()) {
+                    readPressure(myTiSensorTag, payload);
                 }
 
-                if (this.enableOpto) {
-                    myTiSensorTag.enableLuxometer();
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        logger.error("Interrupted Exception", e);
-                    }
-
-                    double light = myTiSensorTag.readLight();
-                    logger.info("Light: " + light);
-
-                    payload.addMetric("Light", light);
+                if (this.options.isEnableGyro()) {
+                    readOrientation(myTiSensorTag, payload);
                 }
 
-                if (this.enableButtons) {
+                if (this.options.isEnableOpto()) {
+                    readLight(myTiSensorTag, payload);
+                }
+
+                if (this.options.isEnableButtons()) {
                     // For buttons only enable notifications
-                    myTiSensorTag.enableKeysNotification();
+                    myTiSensorTag.enableKeysNotifications(this);
+                } else {
+                    myTiSensorTag.disableKeysNotifications();
                 }
 
-                if (this.enableRedLed) {
+                if (this.options.isEnableRedLed()) {
                     myTiSensorTag.switchOnRedLed();
                 } else {
                     myTiSensorTag.switchOffRedLed();
                 }
 
-                if (this.enableGreenLed) {
+                if (this.options.isEnableGreenLed()) {
                     myTiSensorTag.switchOnGreenLed();
                 } else {
                     myTiSensorTag.switchOffGreenLed();
                 }
 
-                if (this.enableBuzzer) {
+                if (this.options.isEnableBuzzer()) {
                     myTiSensorTag.switchOnBuzzer();
                 } else {
                     myTiSensorTag.switchOffBuzzer();
@@ -618,56 +346,131 @@ public class BluetoothLe implements ConfigurableComponent, CloudClientListener, 
 
                 myTiSensorTag.enableIOService();
 
-                try {
-                    // Publish only if there are metrics to be published!
-                    if (!payload.metricNames().isEmpty()) {
-                        cloudClient.publish(topic + "/" + myTiSensorTag.getBluetoothDevice().getAdress(), payload, 0,
-                                false);
+                // Publish only if there are metrics to be published!
+                if (!payload.metricNames().isEmpty()) {
+                    try {
+                        this.cloudClient.publish(
+                                this.options.getTopic() + "/" + myTiSensorTag.getBluetoothDevice().getAdress(), payload,
+                                0, false);
+                    } catch (KuraException e) {
+                        logger.error("Publish message failed", e);
                     }
-                } catch (Exception e) {
-                    logger.error("Interrupted Exception", e);
                 }
+
             } else {
-                logger.info("Cannot connect to TI SensorTag " + myTiSensorTag.getBluetoothDevice().getAdress() + ".");
+                logger.warn("Cannot connect to TI SensorTag {}.", myTiSensorTag.getBluetoothDevice().getAdress());
             }
 
         }
-
     }
 
-    // --------------------------------------------------------------------
-    //
-    // CloudClientListener APIs
-    //
-    // --------------------------------------------------------------------
-    @Override
-    public void onControlMessageArrived(String deviceId, String appTopic, KuraPayload msg, int qos, boolean retain) {
+    private void readLight(TiSensorTag myTiSensorTag, KuraPayload payload) {
+        myTiSensorTag.enableLuxometer();
+        waitFor(1000);
 
+        double light = myTiSensorTag.readLight();
+        logger.info("Light: {}", light);
+
+        payload.addMetric("Light", light);
     }
 
-    @Override
-    public void onMessageArrived(String deviceId, String appTopic, KuraPayload msg, int qos, boolean retain) {
+    private void readOrientation(TiSensorTag myTiSensorTag, KuraPayload payload) {
+        if (myTiSensorTag.isCC2650()) {
+            // Reduce period to 500ms (for a bug on SensorTag firmware :-)) and enable gyroscope
+            myTiSensorTag.setGyroscopePeriod("32");
+            myTiSensorTag.enableGyroscope("0700");
+        } else {
+            myTiSensorTag.enableGyroscope("07");
+        }
+        waitFor(1000);
+        float[] gyroscope = myTiSensorTag.readGyroscope();
 
+        logger.info("Gyro X: {} Gyro Y: {} Gyro Z: {}", gyroscope[0], gyroscope[1], gyroscope[2]);
+
+        payload.addMetric("Gyro X", gyroscope[0]);
+        payload.addMetric("Gyro Y", gyroscope[1]);
+        payload.addMetric("Gyro Z", gyroscope[2]);
     }
 
-    @Override
-    public void onConnectionLost() {
+    private void readPressure(TiSensorTag myTiSensorTag, KuraPayload payload) {
+        // Calibrate pressure sensor
+        myTiSensorTag.calibrateBarometer();
+        waitFor(1000);
 
+        // Read pressure
+        myTiSensorTag.enableBarometer();
+        waitFor(1000);
+        double pressure = myTiSensorTag.readPressure();
+
+        logger.info("Pre: {}", pressure);
+
+        payload.addMetric("Pressure", pressure);
     }
 
-    @Override
-    public void onConnectionEstablished() {
+    private void readMagneticField(TiSensorTag myTiSensorTag, KuraPayload payload) {
+        // Reduce period to 500ms (for a bug on SensorTag firmware :-)) and enable magnetometer
+        myTiSensorTag.setMagnetometerPeriod("32");
+        if (myTiSensorTag.isCC2650()) {
+            myTiSensorTag.enableMagnetometer("4000");
+        } else {
+            myTiSensorTag.enableMagnetometer("");
+        }
+        waitFor(1000);
+        float[] magneticField = myTiSensorTag.readMagneticField();
 
+        logger.info("Mag X: {} Mag Y: {} Mag Z: {}", magneticField[0], magneticField[1], magneticField[2]);
+
+        payload.addMetric("Magnetic X", magneticField[0]);
+        payload.addMetric("Magnetic Y", magneticField[1]);
+        payload.addMetric("Magnetic Z", magneticField[2]);
     }
 
-    @Override
-    public void onMessageConfirmed(int messageId, String appTopic) {
+    private void readHumidity(TiSensorTag myTiSensorTag, KuraPayload payload) {
+        myTiSensorTag.enableHygrometer();
+        waitFor(1000);
 
+        float humidity = myTiSensorTag.readHumidity();
+        logger.info("Humidity: {}", humidity);
+
+        payload.addMetric("Humidity", humidity);
     }
 
-    @Override
-    public void onMessagePublished(int messageId, String appTopic) {
+    private void readAcceleration(TiSensorTag myTiSensorTag, KuraPayload payload) {
+        // Reduce period to 500ms (for a bug on SensorTag firmware :-)) and enable accelerometer with
+        // range 8g
+        myTiSensorTag.setAccelerometerPeriod("32");
+        if (myTiSensorTag.isCC2650()) {
+            myTiSensorTag.enableAccelerometer("3802");
+        } else {
+            myTiSensorTag.enableAccelerometer("01");
+        }
+        waitFor(1000);
+        double[] acceleration = myTiSensorTag.readAcceleration();
 
+        logger.info("Acc X: {} Acc Y: {} Acc Z: {}", acceleration[0], acceleration[1], acceleration[2]);
+
+        payload.addMetric("Acceleration X", acceleration[0]);
+        payload.addMetric("Acceleration Y", acceleration[1]);
+        payload.addMetric("Acceleration Z", acceleration[2]);
     }
 
+    private void readTemperature(TiSensorTag myTiSensorTag, KuraPayload payload) {
+        myTiSensorTag.enableTermometer();
+        waitFor(1000);
+        double[] temperatures = myTiSensorTag.readTemperature();
+
+        logger.info("Ambient: {} Target: {}", temperatures[0], temperatures[1]);
+
+        payload.addMetric("Ambient", temperatures[0]);
+        payload.addMetric("Target", temperatures[1]);
+    }
+
+    private void waitFor(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error(INTERRUPTED_EX, e);
+        }
+    }
 }

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/BluetoothLeOptions.java
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/BluetoothLeOptions.java
@@ -9,7 +9,7 @@
  * Contributors:
  *     Eurotech
  *******************************************************************************/
-package org.eclipse.kura.example.ble.tisensortag.tinyb;
+package org.eclipse.kura.example.ble.tisensortag;
 
 import static java.util.Objects.requireNonNull;
 

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/TiSensorTagNotificationListener.java
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/TiSensorTagNotificationListener.java
@@ -1,0 +1,9 @@
+package org.eclipse.kura.example.ble.tisensortag;
+
+import java.util.Map;
+
+public interface TiSensorTagNotificationListener {
+
+    public void notify(String address, Map<String, Object> values);
+
+}

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/BluetoothGattImpl.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/BluetoothGattImpl.java
@@ -50,6 +50,10 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
     private static final String ERROR_HANDLE = "invalid handle";
     private static final String[] ERROR_UUID = { "invalid uuid",
             "read characteristics by uuid failed: attribute can't be read" };
+    private static final String ERROR_CHAR_MESSAGE = "Exception waiting for characteristics";
+    private static final String ERROR_GATT_READ_MESSAGE = "Gatttool read timeout.";
+    private static final String ERROR_GATT_TIMEOUT_MESSAGE = "Gatttool read error.";
+    private static final String ERROR = "ERROR";
 
     private List<BluetoothGattService> bluetoothServices;
     private List<BluetoothGattCharacteristic> bluetoothGattCharacteristics;
@@ -96,6 +100,7 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
                     Thread.sleep(10);
                 } catch (InterruptedException e) {
                     logger.error("Exception waiting for connection", e);
+                    Thread.currentThread().interrupt();
                 }
             }
             if (!this.ready) {
@@ -134,6 +139,7 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
                     Thread.sleep(10);
                 } catch (InterruptedException e) {
                     logger.error("Exception waiting for connection", e);
+                    Thread.currentThread().interrupt();
                 }
             }
             if (!this.ready) {
@@ -157,13 +163,14 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
     @Override
     public List<BluetoothGattService> getServices() {
         if (this.proc != null) {
-            this.bluetoothServices = new ArrayList<BluetoothGattService>();
+            this.bluetoothServices = new ArrayList<>();
             String command = "primary\n";
             sendCmd(command);
             try {
                 Thread.sleep(GATT_SERVICE_TIMEOUT);
             } catch (InterruptedException e) {
                 logger.error("Exception waiting for services", e);
+                Thread.currentThread().interrupt();
             }
         }
         return this.bluetoothServices;
@@ -173,13 +180,14 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
     public List<BluetoothGattCharacteristic> getCharacteristics(String startHandle, String endHandle) {
         logger.info("getCharacteristics {} : {}", startHandle, endHandle);
         if (this.proc != null) {
-            this.bluetoothGattCharacteristics = new ArrayList<BluetoothGattCharacteristic>();
+            this.bluetoothGattCharacteristics = new ArrayList<>();
             String command = "characteristics " + startHandle + " " + endHandle + "\n";
             sendCmd(command);
             try {
                 Thread.sleep(GATT_SERVICE_TIMEOUT);
             } catch (InterruptedException e) {
-                logger.error("Exception waiting for characteristics", e);
+                logger.error(ERROR_CHAR_MESSAGE, e);
+                Thread.currentThread().interrupt();
             }
         }
         return this.bluetoothGattCharacteristics;
@@ -194,19 +202,20 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
 
             // Wait until read is complete, error is received or timeout
             long startTime = System.currentTimeMillis();
-            while ("".equals(this.charValue) && !this.charValue.startsWith("ERROR")
+            while ("".equals(this.charValue) && !this.charValue.startsWith(ERROR)
                     && System.currentTimeMillis() - startTime < GATT_COMMAND_TIMEOUT) {
                 try {
                     Thread.sleep(10);
                 } catch (InterruptedException e) {
-                    logger.error("Exception waiting for characteristics", e);
+                    logger.error(ERROR_CHAR_MESSAGE, e);
+                    Thread.currentThread().interrupt();
                 }
             }
             if ("".equals(this.charValue)) {
-                throw new KuraTimeoutException("Gatttool read timeout.");
+                throw new KuraTimeoutException(ERROR_GATT_READ_MESSAGE);
             }
-            if (this.charValue.startsWith("ERROR")) {
-                throw KuraException.internalError("Gatttool read error.");
+            if (this.charValue.startsWith(ERROR)) {
+                throw KuraException.internalError(ERROR_GATT_TIMEOUT_MESSAGE);
             }
 
         }
@@ -218,26 +227,27 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
     public String readCharacteristicValueByUuid(UUID uuid) throws KuraException {
         if (this.proc != null) {
             this.charValueUuid = "";
-            String l_uuid = uuid.toString();
-            String command = "char-read-uuid " + l_uuid + "\n";
+            String uuidString = uuid.toString();
+            String command = "char-read-uuid " + uuidString + "\n";
             logger.info("send command : {}", command);
             sendCmd(command);
 
             // Wait until read is complete, error is received or timeout
             long startTime = System.currentTimeMillis();
-            while ("".equals(this.charValueUuid) && !this.charValueUuid.startsWith("ERROR")
+            while ("".equals(this.charValueUuid) && !this.charValueUuid.startsWith(ERROR)
                     && System.currentTimeMillis() - startTime < GATT_COMMAND_TIMEOUT) {
                 try {
                     Thread.sleep(10);
                 } catch (InterruptedException e) {
-                    logger.error("Exception waiting for characteristics", e);
+                    logger.error(ERROR_CHAR_MESSAGE, e);
+                    Thread.currentThread().interrupt();
                 }
             }
             if ("".equals(this.charValueUuid)) {
-                throw new KuraTimeoutException("Gatttool read timeout.");
+                throw new KuraTimeoutException(ERROR_GATT_READ_MESSAGE);
             }
-            if (this.charValueUuid.startsWith("ERROR")) {
-                throw KuraException.internalError("Gatttool read error.");
+            if (this.charValueUuid.startsWith(ERROR)) {
+                throw KuraException.internalError(ERROR_GATT_TIMEOUT_MESSAGE);
             }
         }
 
@@ -272,10 +282,12 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
 
     @Override
     public void processInputStream(String string) {
+        // Not implemented
     }
 
     @Override
     public void processErrorStream(String string) {
+        // Not implemented
     }
 
     @Override
@@ -291,18 +303,19 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
 
             // Wait until read is complete, error is received or timeout
             long startTime = System.currentTimeMillis();
-            while ("".equals(this.securityLevel) && !this.securityLevel.startsWith("ERROR")
+            while ("".equals(this.securityLevel) && !this.securityLevel.startsWith(ERROR)
                     && System.currentTimeMillis() - startTime < GATT_COMMAND_TIMEOUT) {
                 try {
                     Thread.sleep(10);
                 } catch (InterruptedException e) {
-                    logger.error("Exception waiting for characteristics", e);
+                    logger.error(ERROR_CHAR_MESSAGE, e);
+                    Thread.currentThread().interrupt();
                 }
             }
             if ("".equals(this.securityLevel)) {
-                throw new KuraTimeoutException("Gatttool read timeout.");
-            } else if (this.securityLevel.startsWith("ERROR")) {
-                throw KuraException.internalError("Gatttool read error.");
+                throw new KuraTimeoutException(ERROR_GATT_READ_MESSAGE);
+            } else if (this.securityLevel.startsWith(ERROR)) {
+                throw KuraException.internalError(ERROR_GATT_TIMEOUT_MESSAGE);
             }
 
             level = BluetoothGattSecurityLevel.getBluetoothGattSecurityLevel(this.securityLevel);
@@ -372,11 +385,9 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
             String endHandle = attr[6];
             String uuid = attr[8];
 
-            if (this.bluetoothServices != null) {
-                if (isNewService(uuid)) {
-                    logger.debug("Adding new GATT service: " + uuid + ":" + startHandle + ":" + endHandle);
-                    this.bluetoothServices.add(new BluetoothGattServiceImpl(uuid, startHandle, endHandle));
-                }
+            if (this.bluetoothServices != null && isNewService(uuid)) {
+                logger.debug("Adding new GATT service: {} : {} : {}", uuid, startHandle, endHandle);
+                this.bluetoothServices.add(new BluetoothGattServiceImpl(uuid, startHandle, endHandle));
             }
         }
         // characteristics are being returned
@@ -390,13 +401,11 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
             String properties = attr[4].substring(0, attr[4].length() - 1);
             String valueHandle = attr[8].substring(0, attr[8].length() - 1);
             String uuid = attr[10].substring(0, attr[10].length() - 1);
-            if (this.bluetoothGattCharacteristics != null) {
-                if (isNewGattCharacteristic(uuid)) {
-                    logger.debug("Adding new GATT characteristic: {}", uuid);
-                    logger.debug(handle + "  " + properties + "  " + valueHandle);
-                    this.bluetoothGattCharacteristics
-                            .add(new BluetoothGattCharacteristicImpl(uuid, handle, properties, valueHandle));
-                }
+            if (this.bluetoothGattCharacteristics != null && isNewGattCharacteristic(uuid)) {
+                logger.debug("Adding new GATT characteristic: {}", uuid);
+                logger.debug("{} {} {}", handle, properties, valueHandle);
+                this.bluetoothGattCharacteristics
+                        .add(new BluetoothGattCharacteristicImpl(uuid, handle, properties, valueHandle));
             }
         }
         // characteristic read by handle returned
@@ -413,8 +422,7 @@ public class BluetoothGattImpl implements BluetoothGatt, BluetoothProcessListene
             logger.debug("Receiving notification: {}", line);
             // Parse the characteristic line, line is expected to be:
             // Notification handle = 0xmmmm value: <value>
-            String x = "Notification hanlde = ";
-            String sub = line.substring(x.length()).trim();
+            String sub = line.substring(line.toLowerCase().indexOf(NOTIFICATION) + NOTIFICATION.length() + 3).trim();
             String[] attr = sub.split(":");
             String handle = attr[0].split("\\s")[0];
             String value = attr[1].trim();


### PR DESCRIPTION
This PR does the following:

1. fixes issue #1657 
2. clean-up of the org.eclipse.kura.example.ble.sensortag
3. add listeners for BLE notifications on org.eclipse.kura.example.ble.sensortag
4. adds a configuration parameter to enable the GATT services discovery on org.eclipse.kura.example.ble.sensortag and org.eclipse.kura.example.ble.sensortag.tinyb

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>