### PR TITLE
#1747: Fix the build of a release version

### DIFF
--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -260,6 +260,31 @@
                 <module>org.eclipse.kura.web2</module>
             </modules>
         </profile>
+
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.honton.chas</groupId>
+                        <artifactId>exists-maven-plugin</artifactId>
+                        <version>0.0.3</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>remote</goal>
+                                </goals>
+                                <configuration>
+                                    <skipIfSnapshot>true</skipIfSnapshot>
+                                    <failIfExists>true</failIfExists>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
     <repositories>
@@ -563,22 +588,6 @@
                                     </condition>
                                 </fail>
                             </target>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.honton.chas</groupId>
-                <artifactId>exists-maven-plugin</artifactId>
-                <version>0.0.3</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>remote</goal>
-                        </goals>
-                        <configuration>
-                            <skipIfSnapshot>true</skipIfSnapshot>
-                            <failIfExists>true</failIfExists>
                         </configuration>
                     </execution>
                 </executions>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -117,22 +117,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.honton.chas</groupId>
-                <artifactId>exists-maven-plugin</artifactId>
-                <version>0.0.3</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>remote</goal>
-                        </goals>
-                        <configuration>
-                            <skipIfSnapshot>true</skipIfSnapshot>
-                            <failIfExists>true</failIfExists>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
 
         <pluginManagement>
@@ -274,4 +258,31 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.honton.chas</groupId>
+                        <artifactId>exists-maven-plugin</artifactId>
+                        <version>0.0.3</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>remote</goal>
+                                </goals>
+                                <configuration>
+                                    <skipIfSnapshot>true</skipIfSnapshot>
+                                    <failIfExists>true</failIfExists>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
This change moves the "exists-maven-plugin" plugin into a separate
profile in order to not break the build when rebuilding a released
version of Kura.

Signed-off-by: Jens Reimann <jreimann@redhat.com>