### PR TITLE
[Emulator] Changed default file.upload.size.max to -1 in kura.properties

### DIFF
--- a/kura/emulator/org.eclipse.kura.emulator/src/main/resources/kura.properties
+++ b/kura/emulator/org.eclipse.kura.emulator/src/main/resources/kura.properties
@@ -116,7 +116,7 @@ db.service.hsqldb.nio_data_file=false
 # default 10240
 file.upload.in.memory.size.threshold=10240
 # -1: unlimited (default)
-file.upload.size.max=-
+file.upload.size.max=-1
 file.command.zip.max.size=100
 file.command.zip.max.number=1024
 


### PR DESCRIPTION
[Emulator] Changed default file.upload.size.max to -1 in kura.properties

Signed-off-by: Andreas Wojtok <Andreas.Wojtok@gmail.com>