### PR TITLE
Added 'turnOnDelay' for each modem to fix LE910 reset issue.

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/ModemDriver.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/ModemDriver.java
@@ -209,6 +209,7 @@ public class ModemDriver {
         }
         boolean retVal = true;
         int remainingAttempts = 5;
+        final long turnOnDelay = getTurnOnDelay();
         while (!isOn()) {
             if (remainingAttempts <= 0) {
                 retVal = false;
@@ -274,7 +275,7 @@ public class ModemDriver {
                 break;
             }
             remainingAttempts--;
-            sleep(10000);
+            sleep(turnOnDelay);
         }
 
         logger.info("turnModemOn() :: Modem is ON? - {}", retVal);
@@ -477,6 +478,14 @@ public class ModemDriver {
             return usbModemInfo.getTurnOffDelay();
         }
         return 5000;
+    }
+    
+    private long getTurnOnDelay() {
+        final SupportedUsbModemInfo usbModemInfo = getSupportedUsbModemInfo();
+        if (usbModemInfo != null) {
+            return usbModemInfo.getTurnOnDelay();
+        }
+        return 10000;
     }
 
     private boolean isOn() throws KuraException {

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
@@ -21,29 +21,29 @@ public enum SupportedUsbModemInfo {
 
     // device name, vendor, product, ttyDevs, blockDevs, AT Port, Data Port, GPS Port, Turn off delay, technology types,
     // device driver
-    Telit_HE910_DG("HE910-DG", "1bc7", "0021", 6, 0, 3, 0, 3, 5000, Arrays.asList(ModemTechnologyType.HSPA,
+    Telit_HE910_DG("HE910-DG", "1bc7", "0021", 6, 0, 3, 0, 3, 5000, 10000, Arrays.asList(ModemTechnologyType.HSPA,
             ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "1bc7", "0021")), "6 CDC-ACM"),
-    Telit_HE910_D("HE910-D", "1bc7", "0021", 7, 0, 3, 0, 3, 5000, Arrays.asList(ModemTechnologyType.HSPA,
+    Telit_HE910_D("HE910-D", "1bc7", "0021", 7, 0, 3, 0, 3, 5000, 10000, Arrays.asList(ModemTechnologyType.HSPA,
             ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "1bc7", "0021")), ""),
-    Telit_GE910("GE910", "1bc7", "0022", 2, 0, 0, 1, 0, 5000, Arrays.asList(ModemTechnologyType.GSM_GPRS), Arrays
+    Telit_GE910("GE910", "1bc7", "0022", 2, 0, 0, 1, 0, 5000, 10000, Arrays.asList(ModemTechnologyType.GSM_GPRS), Arrays
             .asList(new UsbModemDriver("cdc_acm", "1bc7", "0022")), ""),
-    Telit_DE910_DUAL("DE910-DUAL", "1bc7", "1010", 4, 0, 2, 3, 1, 5000, Arrays.asList(ModemTechnologyType.EVDO,
+    Telit_DE910_DUAL("DE910-DUAL", "1bc7", "1010", 4, 0, 2, 3, 1, 5000, 10000, Arrays.asList(ModemTechnologyType.EVDO,
             ModemTechnologyType.CDMA), Arrays.asList(new De910ModemDriver()), ""),
-    Telit_LE910("LE910", "1bc7", "1201", 5, 0, 2, 3, 1, 5000, Arrays.asList(ModemTechnologyType.LTE,
+    Telit_LE910("LE910", "1bc7", "1201", 5, 0, 2, 3, 1, 5000, 30000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.HSPA, ModemTechnologyType.UMTS), Arrays.asList(new Le910ModemDriver()), ""),
-    Telit_LE910_V2("LE910-V2", "1bc7", "0036", 6, 0, 3, 0, -1, 15000, Arrays.asList(ModemTechnologyType.LTE,
+    Telit_LE910_V2("LE910-V2", "1bc7", "0036", 6, 0, 3, 0, -1, 15000, 10000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.HSPA,
             ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "1bc7", "0036")), ""),
-    Telit_CE910_DUAL("CE910-DUAL", "1bc7", "1011", 2, 0, 1, 1, -1, 5000, Arrays.asList(ModemTechnologyType.CDMA), Arrays
-            .asList(new Ce910ModemDriver()), ""),
-    Sierra_MC8775("MC8775", "1199", "6812", 3, 0, 2, 0, -1, 5000, Arrays.asList(ModemTechnologyType.HSDPA), Arrays
-            .asList(new UsbModemDriver("sierra", "1199", "6812")), ""),
-    Sierra_MC8790("MC8790", "1199", "683c", 7, 0, 3, 4, -1, 5000, Arrays.asList(ModemTechnologyType.HSDPA), Arrays
-            .asList(new UsbModemDriver("sierra", "1199", "683c")), ""),
-    Sierra_USB598("USB598", "1199", "0025", 4, 1, 0, 0, -1, 5000, Arrays.asList(ModemTechnologyType.EVDO), Arrays
+    Telit_CE910_DUAL("CE910-DUAL", "1bc7", "1011", 2, 0, 1, 1, -1, 5000, 10000, Arrays
+            .asList(ModemTechnologyType.CDMA), Arrays.asList(new Ce910ModemDriver()), ""),
+    Sierra_MC8775("MC8775", "1199", "6812", 3, 0, 2, 0, -1, 5000, 10000, Arrays
+            .asList(ModemTechnologyType.HSDPA), Arrays.asList(new UsbModemDriver("sierra", "1199", "6812")), ""),
+    Sierra_MC8790("MC8790", "1199", "683c", 7, 0, 3, 4, -1, 5000, 10000, Arrays
+            .asList(ModemTechnologyType.HSDPA), Arrays.asList(new UsbModemDriver("sierra", "1199", "683c")), ""),
+    Sierra_USB598("USB598", "1199", "0025", 4, 1, 0, 0, -1, 5000, 10000, Arrays.asList(ModemTechnologyType.EVDO), Arrays
             .asList(new UsbModemDriver("sierra", "1199", "0025")), ""),
-    Ublox_SARA_U2("SARA-U2", "1546", "1102", 7, 0, 1, 0, -1, 5000, Arrays.asList(ModemTechnologyType.HSPA), Arrays
-            .asList(new UsbModemDriver("cdc_acm", "1546", "1102")), "");
+    Ublox_SARA_U2("SARA-U2", "1546", "1102", 7, 0, 1, 0, -1, 5000, 10000, Arrays
+            .asList(ModemTechnologyType.HSPA), Arrays.asList(new UsbModemDriver("cdc_acm", "1546", "1102")), "");
 
     private static final String TARGET_NAME = System.getProperty("target.device");
 
@@ -53,6 +53,7 @@ public enum SupportedUsbModemInfo {
     private int numTtyDevs;
     private int numBlockDevs;
     private long turnOffDelay;
+    private long turnOnDelay;
 
     private int atPort;
     private int dataPort;
@@ -64,7 +65,7 @@ public enum SupportedUsbModemInfo {
     private String productName;
 
     private SupportedUsbModemInfo(String deviceName, String vendorId, String productId, int numTtyDevs,
-            int numBlockDevs, int atPort, int dataPort, int gpsPort, long turnOffDelay,
+            int numBlockDevs, int atPort, int dataPort, int gpsPort, long turnOffDelay, long turnOnDelay,
             List<ModemTechnologyType> modemTechnology, List<? extends UsbModemDriver> drivers, String prodName) {
         this.deviceName = deviceName;
         this.vendorId = vendorId;
@@ -75,6 +76,7 @@ public enum SupportedUsbModemInfo {
         this.dataPort = dataPort;
         this.gpsPort = gpsPort;
         this.turnOffDelay = turnOffDelay;
+        this.turnOnDelay = turnOnDelay;
         this.technologyTypes = modemTechnology;
         this.deviceDrivers = drivers;
         this.productName = prodName;
@@ -154,5 +156,9 @@ public enum SupportedUsbModemInfo {
 
     public long getTurnOffDelay() {
         return turnOffDelay;
+    }
+
+    public long getTurnOnDelay() {
+        return turnOnDelay;
     }
 }


### PR DESCRIPTION
Added 'turnOnDelay' to the SupportedUsbModemInfo enum to fix LE910 reset issue.