### PR TITLE
Allow dollar signs in SSID and WAP pre-shared key.

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigWriter.java
@@ -16,6 +16,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.regex.Matcher;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.kura.KuraErrorCode;
@@ -220,7 +221,7 @@ public class HostapdConfigWriter implements NetworkConfigurationVisitor {
                         "the WPA passphrase (passwd) must be between 8 (inclusive) and 63 (inclusive) characters in length: "
                                 + wifiConfig.getPasskey());
             } else {
-                fileAsString = fileAsString.replaceFirst("KURA_PASSPHRASE", passKey.trim());
+                fileAsString = fileAsString.replaceFirst("KURA_PASSPHRASE", Matcher.quoteReplacement(passKey.trim()));
             }
         } else {
             throw KuraException.internalError("the passwd can not be null");
@@ -276,7 +277,7 @@ public class HostapdConfigWriter implements NetworkConfigurationVisitor {
 
     private String updateSsid(WifiConfig wifiConfig, String fileAsString) throws KuraException {
         if (wifiConfig.getSSID() != null) {
-            fileAsString = fileAsString.replaceFirst("KURA_ESSID", wifiConfig.getSSID());
+            fileAsString = fileAsString.replaceFirst("KURA_ESSID", Matcher.quoteReplacement(wifiConfig.getSSID()));
         } else {
             throw KuraException.internalError("the essid can not be null");
         }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/WpaSupplicantConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/WpaSupplicantConfigWriter.java
@@ -16,6 +16,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.regex.Matcher;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.kura.KuraErrorCode;
@@ -314,7 +315,6 @@ public class WpaSupplicantConfigWriter implements NetworkConfigurationVisitor {
 
     private String updateWPA(WifiConfig wifiConfig, String fileAsString) throws KuraException {
         String result = fileAsString;
-
         String passKey = new String(wifiConfig.getPasskey().getPassword());
         if (passKey.trim().length() > 0) {
             if (passKey.length() < 8 || passKey.length() > 63) {
@@ -322,7 +322,7 @@ public class WpaSupplicantConfigWriter implements NetworkConfigurationVisitor {
                         "the WPA passphrase (passwd) must be between 8 (inclusive) and 63 (inclusive) characters in length: "
                                 + passKey);
             } else {
-                result = result.replaceFirst("KURA_PASSPHRASE", passKey.trim());
+                result = result.replaceFirst("KURA_PASSPHRASE", Matcher.quoteReplacement(passKey.trim()));
             }
         } else {
             throw KuraException.internalError("the passwd can not be null");
@@ -370,7 +370,7 @@ public class WpaSupplicantConfigWriter implements NetworkConfigurationVisitor {
         String result;
 
         if (wifiConfig.getSSID() != null) {
-            result = fileAsString.replaceFirst("KURA_ESSID", wifiConfig.getSSID());
+            result = fileAsString.replaceFirst("KURA_ESSID", Matcher.quoteReplacement(wifiConfig.getSSID()));
         } else {
             throw KuraException.internalError("the essid can not be null");
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabWirelessUi.java
@@ -458,7 +458,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             }
         }
 
-        this.ssid.setValue(this.activeConfig.getWirelessSsid());
+        this.ssid.setValue(GwtSafeHtmlUtils.htmlUnescape(this.activeConfig.getWirelessSsid()));
 
         // ------------
 


### PR DESCRIPTION
Used 'Matcher.quoteReplacement' to allow dollar signs in replacement strings for SSID and WPA psk.

Signed-off-by: ibinshtok <ilya.binshtok@eurotech.com>