### PR TITLE
Disabled the kura.primary.network.interface property.

### DIFF
--- a/kura/emulator/org.eclipse.kura.emulator/src/main/resources/kura.properties
+++ b/kura/emulator/org.eclipse.kura.emulator/src/main/resources/kura.properties
@@ -27,8 +27,8 @@ kura.serialNumber=DevSerialNumber
 kura.bios.version=DevBiosVersion
 kura.firmware.version=DevFirmwareVersion
 
-# Used by Linux Emulator
-kura.primary.network.interface=eth0
+# Use this in Linux Emulator if your system support Predictable Network Interface Names
+# kura.primary.network.interface=eth0
 
 # kura.mac.address= Fetch from Java
 kura.home=/tmp/kura


### PR DESCRIPTION
This property needs to be enabled only on systems that support
Predictable Network Interface Names.

Signed-off-by: Maiero <matteo.maiero@eurotech.com>