### PR TITLE
Use TLSv1.2 by default

### DIFF
--- a/kura/distrib/src/main/resources/aarch64-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/aarch64-nn/snapshot_0.xml
@@ -191,7 +191,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/beaglebone-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/beaglebone-nn/snapshot_0.xml
@@ -191,7 +191,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/beaglebone/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/beaglebone/snapshot_0.xml
@@ -528,7 +528,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/fedora-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/fedora-nn/snapshot_0.xml
@@ -192,7 +192,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/fedora/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/fedora/snapshot_0.xml
@@ -532,7 +532,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/intel-edison-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/intel-edison-nn/snapshot_0.xml
@@ -188,7 +188,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/pcengines-apu-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/pcengines-apu-nn/snapshot_0.xml
@@ -191,7 +191,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/pcengines-apu/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/pcengines-apu/snapshot_0.xml
@@ -532,7 +532,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/snapshot_0.xml
@@ -191,7 +191,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/raspberry-pi-2/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/snapshot_0.xml
@@ -531,7 +531,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/raspberry-pi-bplus-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-bplus-nn/snapshot_0.xml
@@ -191,7 +191,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/raspberry-pi-bplus/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-bplus/snapshot_0.xml
@@ -531,7 +531,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/raspberry-pi-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-nn/snapshot_0.xml
@@ -191,7 +191,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/distrib/src/main/resources/raspberry-pi/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi/snapshot_0.xml
@@ -531,7 +531,7 @@
     <esf:configuration pid="org.eclipse.kura.ssl.SslManagerService">
         <esf:properties>
             <esf:property name="ssl.default.protocol" array="false" encrypted="false" type="String">
-                <esf:value>TLSv1</esf:value>
+                <esf:value>TLSv1.2</esf:value>
             </esf:property>
             <esf:property name="ssl.hostname.verification" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>

--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.ssl.SslManagerService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.ssl.SslManagerService.xml
@@ -14,19 +14,19 @@
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kura.ssl.SslManagerService"
-         name="SslManagerService" 
+         name="SslManagerService"
          description="The SslManagerService is responsible to manage the configuration of the SSL connections.">
 
         <Icon resource="SslManagerService" size="32"/>
-        
+
         <AD id="ssl.default.protocol"
             name="ssl.default.protocol"
             type="String"
             cardinality="0"
             required="false"
-            default="TLSv1"
+            default="TLSv1.2"
             description="The protocol to use to initialize the SSLContext. If not specified, TLSv1 will be used."/>
-                        
+
         <AD id="ssl.hostname.verification"
         	name="ssl.hostname.verification"
         	type="Boolean"
@@ -34,23 +34,23 @@
         	required="false"
         	default="true"
         	description="Enable or disable hostname verification." />
-        	        	
+
         <AD id="ssl.default.trustStore"
             name="ssl.default.trustStore"
             type="String"
-            cardinality="0" 
+            cardinality="0"
             required="false"
             default="/opt/eclipse/security/cacerts"
             description="Location of the Java keystore file containing the collection of CA certificates trusted by this application process (trust store). Key store type is expected to be JKS. If not specified or the specified file does not exist, the default Java VM trust store will be used."/>
-            
-        <AD id="ssl.keystore.password"  
+
+        <AD id="ssl.keystore.password"
             name="ssl.keystore.password"
             type="Password"
-            cardinality="0" 
+            cardinality="0"
             required="true"
-            default="changeit" 
+            default="changeit"
             description="Keystore access password."/>
-        
+
         <AD id="ssl.default.cipherSuites"
             name="ssl.default.cipherSuites"
             type="String"
@@ -58,9 +58,9 @@
             required="false"
             default=""
             description="Comma-separated list of allosed ciphers. If not specifed, all Java VM ciphers will be allowed."/>
-            
+
     </OCD>
-    
+
     <Designate pid="org.eclipse.kura.ssl.SslManagerService">
         <Object ocdref="org.eclipse.kura.ssl.SslManagerService"/>
     </Designate>


### PR DESCRIPTION
Since TLSv1.2 is supported by most cloud platforms, and it is required by some of them, this PR makes it the default.

Closes #1835 

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>