### PR TITLE
Changed behaviour of H2DbFilter on empty query result

### DIFF
--- a/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.H2DbWireRecordFilter.xml
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.H2DbWireRecordFilter.xml
@@ -30,7 +30,7 @@
         	type="Integer"
         	cardinality="0"
         	required="true"
-        	default="60"
+        	default="0"
         	min="0"
         	description="This value specifies the cache validity in seconds. When cache expires, it will cause a new read in the database. A database read will be performed for every trigger received if the value is set to 0.">
         </AD>
@@ -42,6 +42,14 @@
             required="true"
             default="org.eclipse.kura.db.H2DbService"
             description="The Kura service pid of the H2 database instance to be used. The pid of the default instance is org.eclipse.kura.db.H2DbService."/>
+            
+        <AD id="emit.on.empty.result"
+            name="emit.on.empty.result"
+            type="Boolean"
+            cardinality="0"
+            required="true"
+            default="true"
+            description="Defines the behaviour of the component if the result of the performed query is empty. If set to true, an empty envelope will be emitted in this case, if set to false no envelopes will be emitted."/>
 
     </OCD>
     

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilter.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilter.java
@@ -266,16 +266,17 @@ public class H2DbWireRecordFilter implements WireEmitter, WireReceiver, Configur
         } else {
             result = Collections.unmodifiableList(new ArrayList<WireRecord>());
         }
-        this.wireSupport.emit(result);
+
+        if (!result.isEmpty() || options.emitOnEmptyResult()) {
+            this.wireSupport.emit(result);
+        }
     }
 
     private void refreshCachedRecords() {
         try {
             final List<WireRecord> tmpWireRecords = performSQLQuery();
-            if (!tmpWireRecords.isEmpty()) {
-                this.lastRecords = tmpWireRecords;
-                this.lastRefreshedTime = Calendar.getInstance(this.lastRefreshedTime.getTimeZone());
-            }
+            this.lastRecords = tmpWireRecords;
+            this.lastRefreshedTime = Calendar.getInstance(this.lastRefreshedTime.getTimeZone());
         } catch (SQLException e) {
             logger.error(message.errorFiltering(), e);
         }

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilterOptions.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilterOptions.java
@@ -38,6 +38,8 @@ final class H2DbWireRecordFilterOptions {
 
     private static final String CONF_SQL_VIEW = "sql.view";
 
+    private static final String EMIT_ON_EMPTY_RESULT = "emit.on.empty.result";
+
     private final Map<String, Object> properties;
 
     /**
@@ -86,5 +88,14 @@ final class H2DbWireRecordFilterOptions {
             dbServicePid = pid.toString();
         }
         return dbServicePid;
+    }
+
+    boolean emitOnEmptyResult() {
+        boolean result = true;
+        final Object emitOnEmptyResult = this.properties.get(EMIT_ON_EMPTY_RESULT);
+        if (nonNull(emitOnEmptyResult) && emitOnEmptyResult instanceof Boolean) {
+            result = (Boolean) emitOnEmptyResult;
+        }
+        return result;
     }
 }


### PR DESCRIPTION
* The default for `cache.expiration.interval` is now 0, this disables caching by default.
* Added the `emit.on.empty.result` parameter, if set to true, the component will emit an empty envelope if the query result is empty (default), if set to false no envelopes will be emitted in this case.
* Before this PR, if the component performs a query that returns an empty result the component cache is not updated. If the cache is not empty, its contents are always emitted, even if `cache.expiration.interval` is set to 0 to disable the cache. This makes impossible to completely disable the cache and might cause the db filter to emit old data in some situations (like in the scenario presented in issue #1773). With this PR the cache is always updated.

Closes #1773

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>