### PR TITLE
Fix gpio driver

### DIFF
--- a/kura/org.eclipse.kura.driver.gpio.provider/src/main/java/org/eclipse/kura/internal/driver/gpio/GPIOChannelDescriptor.java
+++ b/kura/org.eclipse.kura.driver.gpio.provider/src/main/java/org/eclipse/kura/internal/driver/gpio/GPIOChannelDescriptor.java
@@ -12,10 +12,8 @@
 package org.eclipse.kura.internal.driver.gpio;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.eclipse.kura.configuration.metatype.Option;
 import org.eclipse.kura.core.configuration.metatype.Tad;
@@ -51,12 +49,12 @@ public final class GPIOChannelDescriptor implements ChannelDescriptor {
         this.gpioServices = gpioServices;
     }
 
-    private static void addResourceNames(Tad target, Map<Integer, String> values, String defaultValue) {
+    private static void addResourceNames(Tad target, List<String> values, String defaultValue) {
         final List<Option> options = target.getOption();
-        for (Entry<Integer, String> value : values.entrySet()) {
+        for (String value : values) {
             Toption option = new Toption();
-            option.setLabel(value.getValue());
-            option.setValue(value.getValue());
+            option.setLabel(value);
+            option.setValue(value);
             options.add(option);
         }
         if (defaultValue != null && !defaultValue.isEmpty()) {
@@ -87,9 +85,9 @@ public final class GPIOChannelDescriptor implements ChannelDescriptor {
     public Object getDescriptor() {
         final List<Tad> elements = new ArrayList<>();
 
-        Map<Integer, String> availablePins = new HashMap<>();
+        List<String> availablePins = new ArrayList<>();
         for (GPIOService service : this.gpioServices) {
-            availablePins.putAll(service.getAvailablePins());
+            availablePins.addAll(service.getAvailablePins().values());
         }
 
         final Tad resourceName = new Tad();

--- a/kura/org.eclipse.kura.driver.gpio.provider/src/main/java/org/eclipse/kura/internal/driver/gpio/GPIODriver.java
+++ b/kura/org.eclipse.kura.driver.gpio.provider/src/main/java/org/eclipse/kura/internal/driver/gpio/GPIODriver.java
@@ -73,6 +73,7 @@ public final class GPIODriver implements Driver, ConfigurableComponent {
 
     private static final Logger logger = LoggerFactory.getLogger(GPIODriver.class);
     private static final GPIOMessages message = LocalizationAdapter.adapt(GPIOMessages.class);
+    private static final String WRITE_FAILED_MESSAGE = message.writeFailed();
 
     private Set<String> gpioNames;
     private Set<GPIOListener> gpioListeners;
@@ -227,10 +228,9 @@ public final class GPIODriver implements Driver, ConfigurableComponent {
     }
 
     private synchronized void runWriteRequest(GPIORequestInfo requestInfo) {
+        ChannelRecord record = requestInfo.channelRecord;
         if (!GPIOChannelDescriptor.DEFAULT_RESOURCE_NAME.equals(requestInfo.resourceName)
                 && requestInfo.resourceDirection != null) {
-            ChannelRecord record = requestInfo.channelRecord;
-
             try {
                 final TypedValue<Boolean> value = getBooleanValue(record.getValue());
                 this.gpioNames.add(requestInfo.resourceName);
@@ -242,12 +242,17 @@ public final class GPIODriver implements Driver, ConfigurableComponent {
                     record.setTimestamp(System.currentTimeMillis());
                 }
             } catch (IOException | KuraUnavailableDeviceException | KuraClosedDeviceException e) {
-                record.setChannelStatus(new ChannelStatus(ChannelFlag.FAILURE, message.readFailed(), null));
-                record.setTimestamp(System.currentTimeMillis());
-                logger.warn(message.writeFailed());
-                return;
+                setFailureRecord(record);
             }
+        } else {
+            setFailureRecord(record);
         }
+    }
+
+    private void setFailureRecord(ChannelRecord record) {
+        record.setChannelStatus(new ChannelStatus(ChannelFlag.FAILURE, message.readFailed(), null));
+        record.setTimestamp(System.currentTimeMillis());
+        logger.warn(WRITE_FAILED_MESSAGE);
     }
 
     private KuraGPIOPin getPin(String resourceName, KuraGPIODirection resourceDirection, KuraGPIOMode resourceMode,
@@ -333,9 +338,9 @@ public final class GPIODriver implements Driver, ConfigurableComponent {
     }
 
     private synchronized void runReadRequest(GPIORequestInfo requestInfo) {
+        ChannelRecord record = requestInfo.channelRecord;
         if (!GPIOChannelDescriptor.DEFAULT_RESOURCE_NAME.equals(requestInfo.resourceName)
                 && requestInfo.resourceDirection != null) {
-            ChannelRecord record = requestInfo.channelRecord;
             try {
                 KuraGPIOPin pin = getPin(requestInfo.resourceName, requestInfo.resourceDirection,
                         requestInfo.resourceMode, requestInfo.resourceTrigger);
@@ -353,11 +358,10 @@ public final class GPIODriver implements Driver, ConfigurableComponent {
                     record.setTimestamp(System.currentTimeMillis());
                 }
             } catch (IOException | KuraUnavailableDeviceException | KuraClosedDeviceException e) {
-                record.setChannelStatus(new ChannelStatus(ChannelFlag.FAILURE, message.readFailed(), null));
-                record.setTimestamp(System.currentTimeMillis());
-                logger.warn(message.readFailed());
-                return;
+                setFailureRecord(record);
             }
+        } else {
+            setFailureRecord(record);
         }
     }
 

--- a/kura/org.eclipse.kura.driver.gpio.provider/src/main/java/org/eclipse/kura/internal/driver/gpio/GPIODriver.java
+++ b/kura/org.eclipse.kura.driver.gpio.provider/src/main/java/org/eclipse/kura/internal/driver/gpio/GPIODriver.java
@@ -74,6 +74,7 @@ public final class GPIODriver implements Driver, ConfigurableComponent {
     private static final Logger logger = LoggerFactory.getLogger(GPIODriver.class);
     private static final GPIOMessages message = LocalizationAdapter.adapt(GPIOMessages.class);
     private static final String WRITE_FAILED_MESSAGE = message.writeFailed();
+    private static final String READ_FAILED_MESSAGE = message.readFailed();
 
     private Set<String> gpioNames;
     private Set<GPIOListener> gpioListeners;
@@ -242,17 +243,17 @@ public final class GPIODriver implements Driver, ConfigurableComponent {
                     record.setTimestamp(System.currentTimeMillis());
                 }
             } catch (IOException | KuraUnavailableDeviceException | KuraClosedDeviceException e) {
-                setFailureRecord(record);
+                setFailureRecord(record, WRITE_FAILED_MESSAGE);
             }
         } else {
-            setFailureRecord(record);
+            setFailureRecord(record, WRITE_FAILED_MESSAGE);
         }
     }
 
-    private void setFailureRecord(ChannelRecord record) {
-        record.setChannelStatus(new ChannelStatus(ChannelFlag.FAILURE, message.readFailed(), null));
+    private void setFailureRecord(ChannelRecord record, String errorMessage) {
+        record.setChannelStatus(new ChannelStatus(ChannelFlag.FAILURE, errorMessage, null));
         record.setTimestamp(System.currentTimeMillis());
-        logger.warn(WRITE_FAILED_MESSAGE);
+        logger.warn(errorMessage);
     }
 
     private KuraGPIOPin getPin(String resourceName, KuraGPIODirection resourceDirection, KuraGPIOMode resourceMode,
@@ -358,10 +359,10 @@ public final class GPIODriver implements Driver, ConfigurableComponent {
                     record.setTimestamp(System.currentTimeMillis());
                 }
             } catch (IOException | KuraUnavailableDeviceException | KuraClosedDeviceException e) {
-                setFailureRecord(record);
+                setFailureRecord(record, READ_FAILED_MESSAGE);
             }
         } else {
-            setFailureRecord(record);
+            setFailureRecord(record, READ_FAILED_MESSAGE);
         }
     }
 


### PR DESCRIPTION
When the "#select resource" value is selected in the "resource.name" field in a GPIO asset and the user tries to read/write data, an exception is returned.
This PR fixes this behavior.
 
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>