### PR TITLE
Implemented downloading a partial snapshot containing the wire graph

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/Console.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/Console.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -38,6 +38,7 @@ import org.eclipse.kura.web.server.servlet.DeviceSnapshotsServlet;
 import org.eclipse.kura.web.server.servlet.EventHandlerServlet;
 import org.eclipse.kura.web.server.servlet.FileServlet;
 import org.eclipse.kura.web.server.servlet.SkinServlet;
+import org.eclipse.kura.web.server.servlet.WiresSnapshotServlet;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.event.Event;
@@ -287,6 +288,7 @@ public class Console implements ConfigurableComponent {
         this.m_httpService.registerServlet(servletRoot + "/ssl", new GwtSslServiceImpl(), null, httpCtx);
         this.m_httpService.registerServlet(servletRoot + "/cloudservices", new GwtCloudServiceImpl(), null, httpCtx);
         this.m_httpService.registerServlet(servletRoot + "/wires", new GwtWireServiceImpl(), null, httpCtx);
+        this.m_httpService.registerServlet(servletRoot + "/wiresSnapshot", new WiresSnapshotServlet(), null, httpCtx);
         this.m_httpService.registerServlet(servletRoot + "/assetservices", new GwtAssetServiceImpl(), null, httpCtx);
         this.m_httpService.registerServlet("/sse", new EventHandlerServlet(), null, httpCtx);
         this.m_httpService.registerServlet(servletRoot + "/event", this.eventService, null, httpCtx);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,10 +16,8 @@ package org.eclipse.kura.web.client.ui.wires;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.kura.web.client.configuration.Configurations;
@@ -64,14 +62,14 @@ public class WiresPanelUi extends Composite
 
     static final String WIRE_ASSET = "WireAsset";
     static final String FACTORY_PID_DROP_PREFIX = "factory://";
-    private static final String ASSET_DESCRIPTION_PROP = "asset.desc";
     private static final String WIRE_ASSET_PID = "org.eclipse.kura.wire.WireAsset";
-    private static final String DRIVER_PID = "driver.pid";
 
     @UiField
     Button btnSave;
     @UiField
     Button btnReset;
+    @UiField
+    Button btnDownload;
     @UiField
     Button btnZoomIn;
     @UiField
@@ -108,17 +106,6 @@ public class WiresPanelUi extends Composite
     interface WiresPanelUiUiBinder extends UiBinder<Widget, WiresPanelUi> {
     }
 
-    private List<String> components;
-    private final Map<String, GwtConfigComponent> configs = new HashMap<>();
-    private final List<String> drivers;
-    private final List<String> emitters;
-
-    private String graph;
-    private final List<String> receivers;
-    private String wireComponentsConfigJson;
-    private String wireConfigsJson;
-    private String wires;
-
     private WireComposer wireComposer;
     private BlinkEffect blinkEffect;
 
@@ -127,10 +114,6 @@ public class WiresPanelUi extends Composite
 
     public WiresPanelUi() {
         initWidget(uiBinder.createAndBindUi(this));
-        this.emitters = new ArrayList<>();
-        this.receivers = new ArrayList<>();
-        this.components = new ArrayList<>();
-        this.drivers = new ArrayList<>();
 
         this.wireComposer = WireComposer.create(composer.getElement());
         this.wireComposer.setListener(this);
@@ -232,6 +215,13 @@ public class WiresPanelUi extends Composite
                         wireComposer.clear();
                     }
                 });
+            }
+        });
+        this.btnDownload.addClickHandler(new ClickHandler() {
+
+            @Override
+            public void onClick(ClickEvent event) {
+                WiresRPC.downloadWiresSnapshot();
             }
         });
     }
@@ -448,6 +438,7 @@ public class WiresPanelUi extends Composite
         final boolean isDirty = isDirty();
         this.btnSave.setEnabled(isDirty);
         this.btnReset.setEnabled(isDirty);
+        this.btnDownload.setEnabled(!isDirty);
     }
 
     public void unload() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.ui.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <!--
 
-    Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -44,6 +44,7 @@
                             <b:ButtonGroup size="SMALL">
                                 <b:Button icon="SAVE" b:id="btn-config-save" ui:field="btnSave" text="{msgs.apply}" enabled="false"/>
                                 <b:Button icon="TIMES" b:id="btn-reset" ui:field="btnReset" text="{msgs.reset}" enabled="false"/>
+                                <b:Button icon="DOWNLOAD" b:id="btn-download-snapshot" ui:field="btnDownload" text="{msgs.download}" enabled="false"/>
                             </b:ButtonGroup>
                             <b:ButtonGroup size="SMALL" addStyleNames="pull-right">
                                 <b:Button icon="TRASH" b:id="btn-config-delete" ui:field="btnDelete" text="{msgs.wiresDeleteComponent}" enabled="false"/>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresRPC.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresRPC.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@ package org.eclipse.kura.web.client.ui.wires;
 import java.util.List;
 
 import org.eclipse.kura.web.client.ui.EntryClassUi;
+import org.eclipse.kura.web.client.util.DownloadHelper;
 import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtWireComposerStaticInfo;
@@ -179,6 +180,24 @@ public final class WiresRPC {
                         });
                     }
                 });
+            }
+        });
+    }
+
+    public static void downloadWiresSnapshot() {
+        EntryClassUi.showWaitModal();
+        gwtXSRFService.generateSecurityToken(new AsyncCallback<GwtXSRFToken>() {
+
+            @Override
+            public void onFailure(Throwable ex) {
+                EntryClassUi.hideWaitModal();
+                FailureHandler.handle(ex);
+            }
+
+            @Override
+            public void onSuccess(GwtXSRFToken token) {
+                EntryClassUi.hideWaitModal();
+                DownloadHelper.instance().startDownload(token, "/wiresSnapshot");
             }
         });
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/DownloadHelper.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/DownloadHelper.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+package org.eclipse.kura.web.client.util;
+
+import org.eclipse.kura.web.shared.model.GwtXSRFToken;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.http.client.URL;
+
+public final class DownloadHelper {
+
+    private static DownloadHelper instance;
+    private Element downloadIframe;
+
+    private DownloadHelper() {
+        initDownloadIframe();
+    }
+
+    private native void initDownloadIframe()
+    /*-{
+        var iframe = document.createElement('iframe');
+        iframe.style.display = 'none'
+        document.getElementsByTagName('body')[0].appendChild(iframe);
+        this.@org.eclipse.kura.web.client.util.DownloadHelper::downloadIframe = iframe;
+    }-*/;
+
+    public native void startDownload(String url)
+    /*-{
+        var downloadIframe = this.@org.eclipse.kura.web.client.util.DownloadHelper::downloadIframe;
+        downloadIframe.setAttribute('src', url);
+    }-*/;
+
+    public void startDownload(GwtXSRFToken token, String resource) {
+        final StringBuilder sbUrl = new StringBuilder();
+
+        sbUrl.append("/").append(GWT.getModuleName()).append(resource).append(resource.indexOf('?') != -1 ? '&' : '?')
+                .append("xsrfToken=").append(URL.encodeQueryString(token.getToken()));
+
+        startDownload(sbUrl.toString());
+    }
+
+    public static DownloadHelper instance() {
+        if (instance == null) {
+            instance = new DownloadHelper();
+        }
+        return instance;
+    }
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtWireServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtWireServiceImpl.java
@@ -324,6 +324,8 @@ public final class GwtWireServiceImpl extends OsgiRemoteServiceServlet implement
 
     @Override
     public GwtWireComposerStaticInfo getWireComposerStaticInfo(GwtXSRFToken xsrfToken) throws GwtKuraException {
+        this.checkXSRFToken(xsrfToken);
+
         final GwtWireComposerStaticInfo result = new GwtWireComposerStaticInfo();
 
         final List<GwtWireComponentDescriptor> componentDescriptors = new ArrayList<>();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/WiresSnapshotServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/WiresSnapshotServlet.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *******************************************************************************/
+package org.eclipse.kura.web.server.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.kura.asset.provider.AssetConstants;
+import org.eclipse.kura.configuration.ComponentConfiguration;
+import org.eclipse.kura.configuration.ConfigurationService;
+import org.eclipse.kura.core.configuration.XmlComponentConfigurations;
+import org.eclipse.kura.marshalling.Marshaller;
+import org.eclipse.kura.web.server.GwtWireServiceImpl;
+import org.eclipse.kura.web.server.KuraRemoteServiceServlet;
+import org.eclipse.kura.web.server.util.ServiceLocator;
+import org.eclipse.kura.web.shared.GwtKuraException;
+import org.eclipse.kura.web.shared.model.GwtXSRFToken;
+import org.eclipse.kura.wire.graph.WireComponentConfiguration;
+import org.eclipse.kura.wire.graph.WireGraphService;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WiresSnapshotServlet extends HttpServlet {
+
+    private static final String WIRE_SERVICE_PID = "org.eclipse.kura.wire.WireService";
+    private static final String WIRE_ASSET_FACTORY_PID = "org.eclipse.kura.wire.WireAsset";
+
+    private static final long serialVersionUID = -7483037360719617846L;
+    private static final Logger logger = LoggerFactory.getLogger(WiresSnapshotServlet.class);
+
+    private String toSnapshot(XmlComponentConfigurations configs) throws GwtKuraException {
+        final BundleContext context = FrameworkUtil.getBundle(GwtWireServiceImpl.class).getBundleContext();
+        ServiceReference<Marshaller> marshallerRef = null;
+        Marshaller marshaller = null;
+        try {
+            marshallerRef = context
+                    .getServiceReferences(Marshaller.class,
+                            "(kura.service.pid=org.eclipse.kura.xml.marshaller.unmarshaller.provider)")
+                    .iterator().next();
+
+            marshaller = context.getService(marshallerRef);
+            return marshaller.marshal(configs);
+        } catch (Exception e) {
+            throw new GwtKuraException(e.getMessage());
+        } finally {
+            if (marshaller != null) {
+                context.ungetService(marshallerRef);
+            }
+        }
+    }
+
+    private Set<String> findReferencedDrivers(List<ComponentConfiguration> configs) {
+        return configs.stream().map(config -> {
+            final Map<String, Object> configurationProperties = config.getConfigurationProperties();
+            if (configurationProperties == null) {
+                return null;
+            }
+            if (!WIRE_ASSET_FACTORY_PID.equals(configurationProperties.get(ConfigurationAdmin.SERVICE_FACTORYPID))) {
+                return null;
+            }
+            final Object driverPid = configurationProperties.get(AssetConstants.ASSET_DRIVER_PROP.value());
+            if (!(driverPid instanceof String)) {
+                return null;
+            }
+            return (String) driverPid;
+        }).filter(Objects::nonNull).collect(Collectors.toSet());
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+
+        try {
+            GwtXSRFToken token = new GwtXSRFToken(request.getParameter("xsrfToken"));
+            KuraRemoteServiceServlet.checkXSRFToken(request, token);
+        } catch (Exception e) {
+            throw new ServletException("Security error: please retry this operation correctly.", e);
+        }
+
+        try {
+            final List<ComponentConfiguration> result = new ArrayList<>();
+
+            ServiceLocator.applyToServiceOptionally(WireGraphService.class, wireGraphService -> {
+                wireGraphService.get().getWireComponentConfigurations().stream()
+                        .map(WireComponentConfiguration::getConfiguration).forEach(result::add);
+                return null;
+            });
+
+            final Set<String> driverPids = findReferencedDrivers(result);
+
+            ServiceLocator.applyToServiceOptionally(ConfigurationService.class, configurationService -> {
+                configurationService.getComponentConfigurations().stream()
+                        .filter(config -> driverPids.contains(config.getPid())).forEach(result::add);
+                result.add(configurationService.getComponentConfiguration(WIRE_SERVICE_PID));
+                return null;
+            });
+
+            final XmlComponentConfigurations xmlConfigs = new XmlComponentConfigurations();
+            xmlConfigs.setConfigurations(result);
+
+            final String marshalled = toSnapshot(xmlConfigs);
+
+            response.setCharacterEncoding("UTF-8");
+            response.setContentType("application/xml");
+            response.setHeader("Content-Disposition",
+                    "attachment; filename=graph_snapshot_" + System.currentTimeMillis() + ".xml");
+            response.setHeader("Cache-Control", "no-transform, max-age=0");
+
+            try (PrintWriter writer = response.getWriter()) {
+                writer.write(marshalled);
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to download snapshot", e);
+            throw new ServletException("Failed to download snapshot");
+        }
+    }
+
+}


### PR DESCRIPTION
Adds a button in the wire composer that allows downloading a partial snapshot containing the configuration of:

* All wire components in the graph
* The configuration of the drivers referenced by the assets in the graph
* The configuration of the WireService

Closes #1906

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>