### PR TITLE
Wires composer robustness and usability improvements

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -455,14 +455,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         }
     }
 
-    private boolean isFactoryComponent(Configuration config) {
-        final Dictionary<String, Object> configurationProperties = config.getProperties();
-        if (configurationProperties != null) {
-            return configurationProperties.get(ConfigurationAdmin.SERVICE_FACTORYPID) != null;
-        }
-        return false;
-    }
-
     @Override
     public synchronized void deleteFactoryConfiguration(String pid, boolean takeSnapshot) throws KuraException {
         if (pid == null) {

--- a/kura/org.eclipse.kura.driver.helper.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.driver.helper.provider/META-INF/MANIFEST.MF
@@ -16,6 +16,7 @@ Import-Package: org.eclipse.kura.asset;version="[1.0,2.0)",
  org.eclipse.kura.util.service;version="[1.0,2.0)",
  org.osgi.framework;version="1.8",
  org.osgi.service.cm;version="1.5.0",
- org.osgi.service.component;version="1.2.2"
+ org.osgi.service.component;version="1.2.2",
+ org.slf4j;version="1.6.4"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/kura/org.eclipse.kura.driver.helper.provider/src/main/java/org/eclipse/kura/internal/driver/DriverDescriptorServiceImpl.java
+++ b/kura/org.eclipse.kura.driver.helper.provider/src/main/java/org/eclipse/kura/internal/driver/DriverDescriptorServiceImpl.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 package org.eclipse.kura.internal.driver;
 
 import static java.util.Objects.requireNonNull;
@@ -17,9 +27,12 @@ import org.eclipse.kura.util.service.ServiceUtil;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class DriverDescriptorServiceImpl implements DriverDescriptorService{
-    
+public class DriverDescriptorServiceImpl implements DriverDescriptorService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DriverDescriptorServiceImpl.class);
     private static final AssetMessages message = LocalizationAdapter.adapt(AssetMessages.class);
 
     private BundleContext bundleContext;
@@ -69,7 +82,12 @@ public class DriverDescriptorServiceImpl implements DriverDescriptorService{
     }
 
     private DriverDescriptor newDriverDescriptor(String driverPid, String factoryPid, Driver driver) {
-        Object channelDescriptorObj = driver.getChannelDescriptor().getDescriptor();
+        Object channelDescriptorObj = null;
+        try {
+            channelDescriptorObj = driver.getChannelDescriptor().getDescriptor();
+        } catch (Exception e) {
+            logger.warn("Failed to get driver descriptor for pid: {}", driverPid, e);
+        }
         return new DriverDescriptor(driverPid, factoryPid, channelDescriptorObj);
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
@@ -202,6 +202,13 @@ public class Configurations {
         return currentConfigurations.containsKey(pid) || allActivePids.contains(pid);
     }
 
+    public void invalidateConfiguration(String pid) {
+        final HasConfiguration config = this.currentConfigurations.get(pid);
+        if (config != null) {
+            this.currentConfigurations.put(pid, new InvalidConfigurationWrapper(config));
+        }
+    }
+
     private class ConfigurationWrapper implements HasConfiguration {
 
         private boolean isDirty;
@@ -238,6 +245,45 @@ public class Configurations {
 
         @Override
         public void setListener(Listener listener) {
+        }
+    }
+
+    private class InvalidConfigurationWrapper implements HasConfiguration {
+
+        final HasConfiguration wrapped;
+
+        public InvalidConfigurationWrapper(HasConfiguration wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public GwtConfigComponent getConfiguration() {
+            return wrapped.getConfiguration();
+        }
+
+        @Override
+        public void clearDirtyState() {
+            wrapped.clearDirtyState();
+        }
+
+        @Override
+        public boolean isValid() {
+            return false;
+        }
+
+        @Override
+        public boolean isDirty() {
+            return wrapped.isDirty();
+        }
+
+        @Override
+        public void markAsDirty() {
+            wrapped.markAsDirty();
+        }
+
+        @Override
+        public void setListener(Listener listener) {
+            wrapped.setListener(listener);
         }
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -223,7 +223,7 @@ public class Configurations {
 
         @Override
         public boolean isValid() {
-            return true;
+            return configuration != null && configuration.isValid();
         }
 
         @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetDataUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetDataUi.java
@@ -169,7 +169,7 @@ public class AssetDataUi extends Composite {
                 }
                 final String value = result.getValue();
                 if (value == null) {
-                    return "asset-read-error";
+                    return "cell-not-valid cell-readonly";
                 }
                 return null;
             }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/DriversAndAssetsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/DriversAndAssetsUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -317,7 +317,7 @@ public class DriversAndAssetsUi extends Composite implements DriversAndAssetsLis
     public void onSelectionChanged(DriverAssetInfo info) {
         if (info != null) {
             this.deleteButton.setEnabled(true);
-            this.newAssetButton.setEnabled(!info.isAsset());
+            this.newAssetButton.setEnabled(!info.isAsset() && info.isValid());
         } else {
             this.deleteButton.setEnabled(false);
             this.newAssetButton.setEnabled(false);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
@@ -65,6 +65,7 @@ public class WiresPanelUi extends Composite
     static final String WIRE_ASSET = "WireAsset";
     static final String FACTORY_PID_DROP_PREFIX = "factory://";
     private static final String WIRE_ASSET_PID = "org.eclipse.kura.wire.WireAsset";
+    private static final String DRIVER_PID = "driver.pid";
 
     @UiField
     Button btnSave;
@@ -155,7 +156,7 @@ public class WiresPanelUi extends Composite
                 final List<String> invalidConfigurationPids = configurations.getInvalidConfigurationPids();
                 if (!invalidConfigurationPids.isEmpty()) {
                     confirmDialog.show(
-                            MSGS.wiresConfigurationInvalid(
+                            MSGS.cannotSaveWiresConfigurationInvalid(
                                     invalidConfigurationPids.toString().replaceAll("[\\[\\]]", "")),
                             AlertDialog.Severity.ALERT, null);
                     return;
@@ -223,6 +224,14 @@ public class WiresPanelUi extends Composite
 
             @Override
             public void onClick(ClickEvent event) {
+                final List<String> invalidConfigurationPids = configurations.getInvalidConfigurationPids();
+                if (!invalidConfigurationPids.isEmpty()) {
+                    confirmDialog.show(
+                            MSGS.cannotDownloadSnapshotWiresConfigurationInvalid(
+                                    invalidConfigurationPids.toString().replaceAll("[\\[\\]]", "")),
+                            AlertDialog.Severity.ALERT, null);
+                    return;
+                }
                 WiresRPC.downloadWiresSnapshot();
             }
         });

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
@@ -37,12 +37,14 @@ import org.eclipse.kura.web.shared.model.GwtWireComponentDescriptor;
 import org.eclipse.kura.web.shared.model.GwtWireComposerStaticInfo;
 import org.eclipse.kura.web.shared.model.GwtWireConfiguration;
 import org.eclipse.kura.web.shared.model.GwtWireGraphConfiguration;
+import org.gwtbootstrap3.client.ui.Alert;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.NavPills;
 import org.gwtbootstrap3.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.PanelBody;
 import org.gwtbootstrap3.client.ui.PanelHeader;
 import org.gwtbootstrap3.client.ui.Row;
+import org.gwtbootstrap3.client.ui.constants.AlertType;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -306,8 +308,11 @@ public class WiresPanelUi extends Composite
             final WireComponent component = WireComponent.fromGwt(config);
             final GwtWireComponentDescriptor descriptor = descriptors.getDescriptor(component.getFactoryPid());
             // TODO: place port names in GwtWireComponentConfiguration
-            component.getRenderingProperties().setInputPortNames(PortNames.fromMap(descriptor.getInputPortNames()));
-            component.getRenderingProperties().setOutputPortNames(PortNames.fromMap(descriptor.getOutputPortNames()));
+            if (descriptor != null) {
+                component.getRenderingProperties().setInputPortNames(PortNames.fromMap(descriptor.getInputPortNames()));
+                component.getRenderingProperties()
+                        .setOutputPortNames(PortNames.fromMap(descriptor.getOutputPortNames()));
+            }
             wireComposer.addWireComponent(component);
         }
 
@@ -317,6 +322,15 @@ public class WiresPanelUi extends Composite
 
         configurationList.addAll(configuration.getAdditionalConfigurations());
         configurations.setComponentConfigurations(configurationList);
+
+        for (final WireComponent component : this.wireComposer.getWireComponents()) {
+            try {
+                validateAndGetWireComponentConfiguration(component.getPid());
+                component.setValid(true);
+            } catch (Exception e) {
+                component.setValid(false);
+            }
+        }
 
         wireComposer.fitContent(false);
     }
@@ -356,17 +370,32 @@ public class WiresPanelUi extends Composite
         return result;
     }
 
-    public void showConfigurationArea(HasConfiguration configuration) {
-
+    private void clearConfigurationArea() {
         Window.scrollTo(0, 0);
         this.configurationRow.setVisible(false);
         this.configurationRow.clear();
+    }
+
+    private void showConfigurationArea(final Widget content) {
+        this.configurationRow.add(content);
+        this.configurationRow.setVisible(true);
+    }
+
+    public void showConfigurationArea(HasConfiguration configuration) {
+
+        clearConfigurationArea();
 
         final ConfigurationAreaUi configurationAreaUi = new ConfigurationAreaUi(configuration, this.configurations);
         configurationAreaUi.setListener(this);
 
-        this.configurationRow.add(configurationAreaUi);
-        this.configurationRow.setVisible(true);
+        showConfigurationArea(configurationAreaUi);
+    }
+
+    public void showConfigurationErrorMessage(String message) {
+
+        clearConfigurationArea();
+        showConfigurationArea(new Alert(message, AlertType.DANGER));
+
     }
 
     public static String getFormattedPid(final String pid) {
@@ -457,6 +486,34 @@ public class WiresPanelUi extends Composite
         return assetPids;
     }
 
+    private void validateConfiguration(GwtConfigComponent gwtConfig) {
+        final String pid = gwtConfig.getComponentId();
+        if (gwtConfig == null || !gwtConfig.isValid()) {
+            throw new IllegalArgumentException(MSGS.errorComponentConfigurationMissing(pid));
+        }
+        if (WIRE_ASSET_PID.equals(gwtConfig.getFactoryId())) {
+            final String driverPid = (String) gwtConfig.getParameterValue(DRIVER_PID);
+            if (configurations.getConfiguration(driverPid) == null) {
+                throw new IllegalArgumentException(MSGS.errorDriverConfigurationMissing(pid, driverPid));
+            }
+        }
+    }
+
+    private HasConfiguration validateAndGetWireComponentConfiguration(String pid) {
+        try {
+            final HasConfiguration configuration = configurations.getConfiguration(pid);
+            if (configuration == null) {
+                throw new IllegalArgumentException(MSGS.errorComponentConfigurationMissing(pid));
+            }
+            validateConfiguration(configuration.getConfiguration());
+            return configuration;
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException(MSGS.errorUnexpectedErrorLoadingComponentConfig(pid));
+        }
+    }
+
     @Override
     public void onWireCreated(Wire wire) {
         updateDirtyState();
@@ -474,10 +531,11 @@ public class WiresPanelUi extends Composite
 
     @Override
     public void onWireComponentSelected(WireComponent component) {
-        this.btnDelete.setEnabled(true);
-        final HasConfiguration configuration = configurations.getConfiguration(component.getPid());
-        if (configuration != null) {
-            showConfigurationArea(configuration);
+        try {
+            this.btnDelete.setEnabled(true);
+            showConfigurationArea(validateAndGetWireComponentConfiguration(component.getPid()));
+        } catch (Exception e) {
+            showConfigurationErrorMessage(e.getMessage());
         }
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
@@ -495,28 +495,28 @@ public class WiresPanelUi extends Composite
         return assetPids;
     }
 
-    private void validateConfiguration(GwtConfigComponent gwtConfig) {
-        final String pid = gwtConfig.getComponentId();
-        if (gwtConfig == null || !gwtConfig.isValid()) {
-            throw new IllegalArgumentException(MSGS.errorComponentConfigurationMissing(pid));
-        }
-        if (WIRE_ASSET_PID.equals(gwtConfig.getFactoryId())) {
-            final String driverPid = (String) gwtConfig.getParameterValue(DRIVER_PID);
-            if (configurations.getConfiguration(driverPid) == null) {
-                throw new IllegalArgumentException(MSGS.errorDriverConfigurationMissing(pid, driverPid));
-            }
-        }
-    }
-
     private HasConfiguration validateAndGetWireComponentConfiguration(String pid) {
         try {
             final HasConfiguration configuration = configurations.getConfiguration(pid);
             if (configuration == null) {
                 throw new IllegalArgumentException(MSGS.errorComponentConfigurationMissing(pid));
             }
-            validateConfiguration(configuration.getConfiguration());
+            GwtConfigComponent gwtConfig = configuration.getConfiguration();
+            if (gwtConfig == null || !gwtConfig.isValid()) {
+                throw new IllegalArgumentException(MSGS.errorComponentConfigurationMissing(pid));
+            }
+            if (WIRE_ASSET_PID.equals(gwtConfig.getFactoryId())) {
+                final String driverPid = (String) gwtConfig.getParameterValue(DRIVER_PID);
+                if (configurations.getConfiguration(driverPid) == null) {
+                    throw new IllegalArgumentException(MSGS.errorDriverConfigurationMissing(pid, driverPid));
+                }
+                if (configurations.getChannelDescriptor(driverPid) == null) {
+                    throw new IllegalArgumentException(MSGS.errorDriverDescriptorMissingForAsset(pid, driverPid));
+                }
+            }
             return configuration;
         } catch (IllegalArgumentException e) {
+            configurations.invalidateConfiguration(pid);
             throw e;
         } catch (Exception e) {
             throw new IllegalArgumentException(MSGS.errorUnexpectedErrorLoadingComponentConfig(pid));

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/BlinkEffect.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/BlinkEffect.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 package org.eclipse.kura.web.client.ui.wires.composer;
 
 import com.google.gwt.core.client.JavaScriptObject;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/DropEvent.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/DropEvent.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 package org.eclipse.kura.web.client.ui.wires.composer;
 
 import com.google.gwt.core.client.JavaScriptObject;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/Point.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/Point.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 package org.eclipse.kura.web.client.ui.wires.composer;
 
 import com.google.gwt.core.client.JavaScriptObject;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/PortNames.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/PortNames.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 package org.eclipse.kura.web.client.ui.wires.composer;
 
 import java.util.Map;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/Wire.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/Wire.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 package org.eclipse.kura.web.client.ui.wires.composer;
 
 import org.eclipse.kura.web.shared.model.GwtWireConfiguration;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/WireComponent.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/WireComponent.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 package org.eclipse.kura.web.client.ui.wires.composer;
 
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
@@ -73,6 +83,11 @@ public final class WireComponent extends JavaScriptObject {
     public native String getPortName(int portIndex, String direction)
     /*-{
         return this.getPortName(portIndex, direction)
+    }-*/;
+
+    public native void setValid(boolean isValid)
+    /*-{
+        this.setValid(isValid)
     }-*/;
 
     public static WireComponent fromGwt(GwtWireComponentConfiguration config) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/WireComponentRenderingProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/WireComponentRenderingProperties.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 package org.eclipse.kura.web.client.ui.wires.composer;
 
 import com.google.gwt.core.client.JavaScriptObject;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/WireComposer.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/composer/WireComposer.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
 package org.eclipse.kura.web.client.ui.wires.composer;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtWireServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtWireServiceImpl.java
@@ -158,15 +158,24 @@ public final class GwtWireServiceImpl extends OsgiRemoteServiceServlet implement
         final Set<String> wireComponentsInGraph = new HashSet<>();
 
         result.setWireComponentConfigurations(
-                wireGraphConfiguration.getWireComponentConfigurations().stream().map(config -> {
+                wireGraphConfiguration.getWireComponentConfigurations().stream().map(wireComponentConfig -> {
+                    final ComponentConfiguration config = wireComponentConfig.getConfiguration();
+                    if (config == null) {
+                        return null;
+                    }
+                    final String pid = config.getPid();
                     final GwtWireComponentConfiguration gwtWireComponentConfig = new GwtWireComponentConfiguration();
-                    final GwtConfigComponent gwtConfig = GwtServerUtil.toGwtConfigComponent(config.getConfiguration());
+                    GwtConfigComponent gwtConfig = GwtServerUtil.toGwtConfigComponent(config);
+                    if (gwtConfig == null) {
+                        gwtConfig = new GwtConfigComponent();
+                        gwtConfig.setComponentId(pid);
+                    }
                     gwtConfig.setIsWireComponent(true);
                     gwtWireComponentConfig.setConfiguration(gwtConfig);
-                    fillGwtRenderingProperties(gwtWireComponentConfig, config.getProperties());
-                    wireComponentsInGraph.add(gwtConfig.getComponentId());
+                    fillGwtRenderingProperties(gwtWireComponentConfig, wireComponentConfig.getProperties());
+                    wireComponentsInGraph.add(pid);
                     return gwtWireComponentConfig;
-                }).collect(Collectors.toList()));
+                }).filter(Objects::nonNull).collect(Collectors.toList()));
 
         result.setWires(wireGraphConfiguration.getWireConfigurations().stream().map(config -> {
             final GwtWireConfiguration gwtConfig = new GwtWireConfiguration();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -457,14 +457,20 @@ public final class GwtServerUtil {
         return gwtConfig;
     }
 
-    @SuppressWarnings("unchecked")
     public static GwtConfigComponent toGwtConfigComponent(String pid, Object descriptor) {
-        final List<Tad> ads = (List<Tad>) descriptor;
+        if (!(descriptor instanceof List<?>)) {
+            return null;
+        }
+
+        final List<?> ads = (List<?>) descriptor;
 
         final Tocd ocd = new Tocd();
         ocd.setId(pid);
-        for (final Tad ad : ads) {
-            ocd.addAD(ad);
+        for (final Object ad : ads) {
+            if (!(ad instanceof Tad)) {
+                return null;
+            }
+            ocd.addAD((Tad) ad);
         }
 
         return GwtServerUtil.toGwtConfigComponent(new ComponentConfigurationImpl(pid, ocd, null));
@@ -511,6 +517,10 @@ public final class GwtServerUtil {
     }
 
     public static GwtConfigComponent toGwtConfigComponent(DriverDescriptor descriptor) {
-        return toGwtConfigComponent(descriptor.getPid(), descriptor.getChannelDescriptor());
+        final Object channelDescriptor = descriptor.getChannelDescriptor();
+        if (channelDescriptor == null) {
+            return null;
+        }
+        return toGwtConfigComponent(descriptor.getPid(), channelDescriptor);
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtConfigComponent.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtConfigComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -121,6 +121,10 @@ public class GwtConfigComponent extends KuraBaseModel implements Serializable {
 
     public void setIsDriver(final boolean isDriver) {
         this.set("isDriver", isDriver);
+    }
+
+    public boolean isValid() {
+        return getComponentId() != null && this.getFactoryId() != null && this.getParameters() != null;
     }
 
     public String getParameterValue(String id) {

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -535,7 +535,7 @@ wiresAvailableDriverFactories=Driver Factory
 wiresDriverNew=New Driver
 wiresAssetNew=New Asset
 wiresAssetName=Asset Name
-wiresConfigurationInvalid=The configuration of the following components contains invalid values, please review: {0}
+wiresConfigurationInvalid=The current wire graph cannot be saved because the configuration of the following components is not valid: {0}. Please review the configuration of specified components or delete them.
 
 
 servicesComponentFactorySelectorIdle=--- Select Component Factory---
@@ -586,3 +586,7 @@ multiportDialogTitle=Port count
 multiportDialogIntro=The created component supports multiple ports, please provide the desired port count
 inputPortCount=Input port count
 outputPortCount=Output port count
+
+errorComponentConfigurationMissing=The configuration of the Component "{0}" is not available. This might be caused by the fact that the bundle providing the Component is not installed or the Component instance does not exists.
+errorDriverConfigurationMissing=The configuration of the Driver "{1}" associated with the Asset "{0}" is not available. Please check that the bundle providing the Driver is installed and that the Driver instance exists.
+errorUnexpectedErrorLoadingComponentConfig=An unexpected error occurred while loading the configuration of Component "{0}"

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -535,7 +535,8 @@ wiresAvailableDriverFactories=Driver Factory
 wiresDriverNew=New Driver
 wiresAssetNew=New Asset
 wiresAssetName=Asset Name
-wiresConfigurationInvalid=The current wire graph cannot be saved because the configuration of the following components is not valid: {0}. Please review the configuration of specified components or delete them.
+cannotSaveWiresConfigurationInvalid=The current wire graph cannot be saved because the configuration of the following components is not valid: {0}. Please fix the problem or delete the components.
+cannotDownloadSnapshotWiresConfigurationInvalid=The graph snapshot cannot be downloaded because the configuration of the following components is not valid: {0}. Please fix the problem or delete the components.
 
 
 servicesComponentFactorySelectorIdle=--- Select Component Factory---
@@ -587,6 +588,6 @@ multiportDialogIntro=The created component supports multiple ports, please provi
 inputPortCount=Input port count
 outputPortCount=Output port count
 
-errorComponentConfigurationMissing=The configuration of the Component "{0}" is not available. This might be caused by the fact that the bundle providing the Component is not installed or the Component instance does not exists.
+errorComponentConfigurationMissing=The configuration of the Component "{0}" is not available. This might be caused by the fact that the bundle providing the Component is not installed or the Component might be referenced by the wire graph but it does not actually exist on the device.
 errorDriverConfigurationMissing=The configuration of the Driver "{1}" associated with the Asset "{0}" is not available. Please check that the bundle providing the Driver is installed and that the Driver instance exists.
 errorUnexpectedErrorLoadingComponentConfig=An unexpected error occurred while loading the configuration of Component "{0}"

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -588,6 +588,8 @@ multiportDialogIntro=The created component supports multiple ports, please provi
 inputPortCount=Input port count
 outputPortCount=Output port count
 
-errorComponentConfigurationMissing=The configuration of the Component "{0}" is not available. This might be caused by the fact that the bundle providing the Component is not installed or the Component might be referenced by the wire graph but it does not actually exist on the device.
+errorComponentConfigurationMissing=The configuration of the component "{0}" is not available. This might be caused by the fact that the bundle providing the component is not installed, or the component might be referenced by other components but it does not actually exist on the device.
 errorDriverConfigurationMissing=The configuration of the Driver "{1}" associated with the Asset "{0}" is not available. Please check that the bundle providing the Driver is installed and that the Driver instance exists.
+errorDriverDescriptorMissing=The ChannelDescriptor of the Driver "{0}" is not available. Please check that the Driver instance is working properly.
+errorDriverDescriptorMissingForAsset=The ChannelDescriptor of the Driver "{1}" associated with the Asset "{0}" is not available. Please check that the Driver instance is working properly.
 errorUnexpectedErrorLoadingComponentConfig=An unexpected error occurred while loading the configuration of Component "{0}"

--- a/kura/org.eclipse.kura.web2/src/main/webapp/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/webapp/denali.css
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
@@ -737,10 +737,6 @@ img.x-tree3-node-icon {
 	background: transparent;
 }
 
-#wires-graph svg .link {
-	z-index: 2;
-}
-
 /* elements */
 .devs text {
 	font-weight: 800;
@@ -788,6 +784,38 @@ img.x-tree3-node-icon {
 
 .devs.Atomic .label {
 	fill: #F39C12;
+}
+
+.devs.Atomic.invalid .body {
+	stroke: red;
+}
+
+.devs.Atomic.invalid .label, .devs.Atomic.invalid .port-label, .devs.Atomic.invalid circle {
+	fill: red;
+}
+
+.port {
+	position: relative;
+}
+
+.port-label {
+	opacity: 0;
+	transition: opacity 0.25s;
+	transform: translateY(5px)
+}
+
+.port:hover .port-label, .port.connecting .port-label {
+	opacity: 1;
+}
+
+.port .port-body {
+	transition: transform 0.25s;
+	transition: fill 0.25s;
+}
+
+.port:hover .port-body, .port.connecting .port-body {
+	transform: scale(1.05);
+	fill: #ff7e5d;
 }
 
 /* links */

--- a/kura/org.eclipse.kura.web2/src/main/webapp/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/webapp/denali.css
@@ -246,9 +246,16 @@ Upload panel END
 Channel Table Validation START
 ***********************/
 
-.asset-read-error, .asset-read-error * {
-	pointer-events: none;
+.cell-not-valid:not(.active), .cell-not-valid:not(.active) *{
+	background-color: rgb(239, 214, 214) !important;
+}
+
+.cell-not-valid, .cell-not-valid *{
 	color: red !important;
+}
+
+.cell-readonly .cell-readonly * {
+	pointer-events: none;
 }
 
 .error-text-box {

--- a/kura/org.eclipse.kura.web2/src/main/webapp/wires_composer.js
+++ b/kura/org.eclipse.kura.web2/src/main/webapp/wires_composer.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
  * 
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which
@@ -147,31 +147,16 @@ var WireComposer = function (element) {
 		self.deselectWireComponent()
 	});
 	
-	var portHighlighter = V('circle', {
-		'r' : 14,
-		'stroke' : '#ff7e5d',
-		'stroke-width' : '6px',
-		'fill' : 'transparent',
-		'pointer-events' : 'none'
-	});
-
 	this.paper.off('cell:highlight cell:unhighlight').on({
 		'cell:highlight' : function(cellView, el, opt) {
-			var bbox = V(el).bbox(false, self.paper.viewport);
-
 			if (opt.connecting) {
-				portHighlighter.attr(bbox);
-				portHighlighter.translate(bbox.x + 10, bbox.y + 10, {
-					absolute : true
-				});
-				self.viewport.append(portHighlighter);
+				V(el.parentNode).addClass('connecting')
 			}
 		},
 
 		'cell:unhighlight' : function(cellView, el, opt) {
-
 			if (opt.connecting) {
-				portHighlighter.remove();
+				V(el.parentNode).removeClass('connecting')
 			}
 		}
 	});
@@ -238,8 +223,6 @@ WireComposer.prototype.addWireComponent = function (component) {
 		outPorts : outputPorts,
 		wireComponent: component
 	})
-
-	console.log(componentCell)
 	
 	componentCell.on('change:position', function(cellView) {
 		self.fillRenderingProperties(cellView)
@@ -251,6 +234,9 @@ WireComposer.prototype.addWireComponent = function (component) {
 	}
 	
 	this.graph.addCells([ componentCell ])
+	
+	component.v = this.paper.findViewByModel(componentCell).vel
+	
 	this.dispatchWireComponentCreated(component)
 }
 
@@ -533,6 +519,18 @@ WireComponent.prototype.getPortIndex = function (portName, direction) {
 	}
 
 	return parseInt(this.portNameRegex.exec(portName)[2])
+}
+
+WireComponent.prototype.setValid = function (isValid) {
+	if (!this.v) {
+		return
+	}
+
+	if (isValid) {
+		this.v.removeClass('invalid')
+	} else {
+		this.v.addClass('invalid')
+	}
 }
 
 WireComponent.prototype.getPortName = function (portIndex, direction) {


### PR DESCRIPTION
* Should improve the robustness of the wire composer in the following scenarios, which previously led to glitches and/or rendered the composer unusable:
  1. The WireService references a wire component for which there is no configuration available (the component does not exist).
  2. The WireService references a component for which a configuration is present but the provider bundle is not installed.
  3. An Asset in the composer is not attached to its Driver instance.

  - In all scenarios affected components will be rendered in red and a message describing the problem will be shown instead of the component configuration.
  - In scenarios 1 and 2, saving the graph will be prohibited.
  - It should be possible to recover from scenarios 1 and 2 by deleting affected components.

* Port labels are now hidden by default.
* Port labels are shown when the port is hovered with the mouse or while a wire is being attached to the port (during wire creation).
* Moved port labels a bit to avoid overlapping with horizontal wires (overlapping is still possible in other configurations).
* Changed the way ports are highlighted during wire creation.
* Fixed regression in IE11 that prevented the graph from being displayed.

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>