### PR TITLE
WireAsset: do not log errors if they are emitted

### DIFF
--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/asset/WireAsset.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/asset/WireAsset.java
@@ -326,7 +326,6 @@ public final class WireAsset extends BaseAsset implements WireEmitter, WireRecei
         final ChannelStatus channelStatus = channelRecord.getChannelStatus();
         if (channelStatus.getChannelFlag() == ChannelFlag.FAILURE) {
             final String errorMessage = getErrorMessage(channelStatus);
-            logger.warn(errorMessage);
             wireRecordProperties.put(channelName + WireAssetConstants.PROP_SUFFIX_ERROR.value(),
                     TypedValues.newStringValue(errorMessage));
         } else {


### PR DESCRIPTION
The use case for emitting read errors to downstream components
is to implement a dedicated data logger.
In this case logging the error to the system logger is not desired.

Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>