### PR TITLE
[Testing] Updated JaCoCo version

### DIFF
--- a/kura/examples/test/pom.xml
+++ b/kura/examples/test/pom.xml
@@ -138,7 +138,7 @@ Copyright (c) 2018 Eurotech and/or its affiliates and others
     <properties>
         <kura.basedir>${project.basedir}/../..</kura.basedir>
 
-        <jacoco.version>0.7.4.201502262128</jacoco.version>
+        <jacoco.version>0.8.0</jacoco.version>
         <jacoco.reportDir>target/jacoco/</jacoco.reportDir>
         <sonar.jacoco.reportPath>target/jacoco.exec</sonar.jacoco.reportPath>
     </properties>

--- a/kura/examples/test/pom.xml
+++ b/kura/examples/test/pom.xml
@@ -138,7 +138,7 @@ Copyright (c) 2018 Eurotech and/or its affiliates and others
     <properties>
         <kura.basedir>${project.basedir}/../..</kura.basedir>
 
-        <jacoco.version>0.8.0</jacoco.version>
+        <jacoco.version>0.8.1</jacoco.version>
         <jacoco.reportDir>target/jacoco/</jacoco.reportDir>
         <sonar.jacoco.reportPath>target/jacoco.exec</sonar.jacoco.reportPath>
     </properties>

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -116,7 +116,7 @@
         <kura.build.version>${maven.build.timestamp}</kura.build.version>
 
         <!-- Jacoco version -->
-        <jacoco.version>0.8.0</jacoco.version>
+        <jacoco.version>0.8.1</jacoco.version>
         <jacoco.reportDir>target/jacoco/</jacoco.reportDir>
         <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -116,7 +116,7 @@
         <kura.build.version>${maven.build.timestamp}</kura.build.version>
 
         <!-- Jacoco version -->
-        <jacoco.version>0.7.4.201502262128</jacoco.version>
+        <jacoco.version>0.8.0</jacoco.version>
         <jacoco.reportDir>target/jacoco/</jacoco.reportDir>
         <sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>


### PR DESCRIPTION
Updated to latest version - 0.8.0. Jenkins built a stripped-down build just fine.

Will require a confirmed CQ before merging.