### PR TITLE
[#1952]: Process Designate as OSGi expects it

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ComponentMetaTypeBundleTracker.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ComponentMetaTypeBundleTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and others
+ * Copyright (c) 2011, 2018 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -89,6 +89,7 @@ public class ComponentMetaTypeBundleTracker extends BundleTracker<Bundle> {
                     Designate designate = ComponentUtil.getDesignate(metadata, metatypePid);
                     if (designate.getFactoryPid() != null && !designate.getFactoryPid().isEmpty()) {
                         isFactory = true;
+                        metatypePid = designate.getFactoryPid();
                     }
 
                     // register the pid with the OCD and whether it is a factory

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and others
+ * Copyright (c) 2011, 2018 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -104,13 +104,26 @@ public class ComponentUtil {
     /**
      * Returns the Designate for the given pid
      */
-    public static Designate getDesignate(Tmetadata metadata, String pid) {
-        List<Designate> designates = metadata.getDesignate();
-        for (Designate designate : designates) {
-            if (designate.getPid().equals(pid)) {
+    public static Designate getDesignate(final Tmetadata metadata, final String pid) {
+
+        if (metadata == null || pid == null) {
+            return null;
+        }
+
+        final List<Designate> designates = metadata.getDesignate();
+        if (designates == null) {
+            return null;
+        }
+
+        for (final Designate designate : designates) {
+            if (pid.equals(designate.getPid())) {
+                return designate;
+            }
+            if (pid.equals(designate.getFactoryPid())) {
                 return designate;
             }
         }
+
         return null;
     }
 


### PR DESCRIPTION
This change uses either the PID or the factory PID. It doesn't require both anymore and also fixes the NPE.