### PR TITLE
Prevent getters from creating new object instances

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireEnvelope.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireEnvelope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
  * Contributors:
  *  Eurotech
  *  Amit Kumar Mondal
+ *  Red Hat Inc
  *
  *******************************************************************************/
 package org.eclipse.kura.wire;
@@ -39,8 +40,8 @@ import org.osgi.service.wireadmin.Envelope;
 public class WireEnvelope extends BasicEnvelope {
 
     /**
-     * The scope as agreed by the composite producer and consumer. This remains
-     * same for all the Kura Wires communications.
+     * The scope as agreed by the composite producer and consumer. This remains same
+     * for all the Kura Wires communications.
      */
     private static final String SCOPE = "WIRES";
 
@@ -52,8 +53,8 @@ public class WireEnvelope extends BasicEnvelope {
      * @param wireRecords
      *            the {@link WireRecord}s
      */
-    public WireEnvelope(String emitterPid, List<WireRecord> wireRecords) {
-        super(wireRecords, emitterPid, SCOPE);
+    public WireEnvelope(final String emitterPid, final List<WireRecord> wireRecords) {
+        super(Collections.unmodifiableList(wireRecords), emitterPid, SCOPE);
     }
 
     /**
@@ -72,6 +73,6 @@ public class WireEnvelope extends BasicEnvelope {
      */
     @SuppressWarnings("unchecked")
     public List<WireRecord> getRecords() {
-        return Collections.unmodifiableList((List<WireRecord>) getValue());
+        return (List<WireRecord>) getValue();
     }
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireRecord.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/wire/WireRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,6 +9,7 @@
  * Contributors:
  *  Eurotech
  *  Amit Kumar Mondal
+ *  Red Hat Inc
  *
  *******************************************************************************/
 package org.eclipse.kura.wire;
@@ -46,10 +47,10 @@ public class WireRecord {
      * @throws NullPointerException
      *             if any of the argument is null
      */
-    public WireRecord(Map<String, TypedValue<?>> properties) {
+    public WireRecord(final Map<String, TypedValue<?>> properties) {
         requireNonNull(properties, "Properties cannot be null");
 
-        this.properties = new HashMap<>(properties);
+        this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
     }
 
     /**
@@ -58,6 +59,6 @@ public class WireRecord {
      * @return the fields
      */
     public Map<String, TypedValue<?>> getProperties() {
-        return Collections.unmodifiableMap(this.properties);
+        return this.properties;
     }
 }


### PR DESCRIPTION
This change does create the unmodifiable wrapper in the constructor
and not in the getter. So that the getter can return the same object
instance without create a new instance every time the getter is called.

Signed-off-by: Jens Reimann <jreimann@redhat.com>