### PR TITLE
Improved Web Ui validation for new component pid fields

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,6 +35,7 @@ import org.eclipse.kura.web.client.ui.drivers.assets.DriversAndAssetsUi;
 import org.eclipse.kura.web.client.ui.wires.WiresPanelUi;
 import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.client.util.FilterBuilder;
+import org.eclipse.kura.web.client.util.PidTextBox;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtSession;
 import org.eclipse.kura.web.shared.model.GwtXSRFToken;
@@ -154,7 +155,7 @@ public class EntryClassUi extends Composite {
     @UiField
     Button factoriesButton;
     @UiField
-    TextBox componentName;
+    PidTextBox componentName;
     @UiField
     Button sidenavButton;
     @UiField
@@ -712,12 +713,16 @@ public class EntryClassUi extends Composite {
                     @Override
                     public void onSuccess(GwtXSRFToken token) {
                         String factoryPid = EntryClassUi.this.factoriesList.getSelectedValue();
-                        String pid = EntryClassUi.this.componentName.getValue();
+                        String pid = EntryClassUi.this.componentName.getPid();
+                        if (pid == null) {
+                            return;
+                        }
                         if (SELECT_COMPONENT.equalsIgnoreCase(factoryPid) || "".equals(pid)) {
                             EntryClassUi.this.errorAlertText.setText(MSGS.servicesComponentFactoryAlertNotSelected());
                             errorModal.show();
                             return;
                         }
+                        EntryClassUi.this.newFactoryComponentModal.hide();
                         EntryClassUi.this.gwtComponentService.createFactoryComponent(token, factoryPid, pid,
                                 new AsyncCallback<Void>() {
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,7 @@
 -->
 
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
-    xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html" xmlns:g="urn:import:com.google.gwt.user.client.ui">
+    xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html" xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:kura.util="urn:import:org.eclipse.kura.web.client.util">
 
     <ui:style>
     .important {
@@ -274,14 +274,16 @@
                         <b:FormGroup>
                             <b:FormLabel for="formName" addStyleNames="col-lg-2" ui:field="componentInstanceNameLabel" />
                             <g:FlowPanel addStyleNames="col-lg-10">
-                                <b:TextBox allowBlank="false" autoComplete="false" b:id="formName" ui:field="componentName" />
+                                <kura.util:PidTextBox b:id="formName" ui:field="componentName" autoComplete="false" 
+                                 validateOnBlur="true"/>
                             </g:FlowPanel>
+                            <b:HelpBlock iconType="EXCLAMATION_TRIANGLE"/>
                         </b:FormGroup>
                     </b:FieldSet>
                 </b:Form>
             </b:ModalBody>
             <b:ModalFooter>
-                <b:Button type="PRIMARY" dataDismiss="MODAL" ui:field="buttonNewComponent" />
+                <b:Button type="PRIMARY" ui:field="buttonNewComponent" />
                 <b:Button type="PRIMARY" dataDismiss="MODAL" ui:field="buttonNewComponentCancel" />
             </b:ModalFooter>
         </b:Modal>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/DriversAndAssetsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/DriversAndAssetsUi.java
@@ -19,6 +19,7 @@ import org.eclipse.kura.web.client.configuration.HasConfiguration;
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.AlertDialog;
 import org.eclipse.kura.web.client.ui.drivers.assets.DriversAndAssetsListUi.DriverAssetInfo;
+import org.eclipse.kura.web.client.util.PidTextBox;
 import org.eclipse.kura.web.shared.AssetConstants;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtWireComponentConfiguration;
@@ -64,7 +65,7 @@ public class DriversAndAssetsUi extends Composite implements DriversAndAssetsLis
     @UiField
     ListBox driverFactoriesList;
     @UiField
-    TextBox driverName;
+    PidTextBox driverName;
     @UiField
     Button buttonNewDriverCancel;
     @UiField
@@ -73,7 +74,7 @@ public class DriversAndAssetsUi extends Composite implements DriversAndAssetsLis
     @UiField
     Modal newAssetModal;
     @UiField
-    TextBox assetName;
+    PidTextBox assetName;
     @UiField
     TextBox driverPid;
     @UiField
@@ -256,7 +257,9 @@ public class DriversAndAssetsUi extends Composite implements DriversAndAssetsLis
 
             @Override
             public void onClick(ClickEvent event) {
-                if (!driverName.validate()) {
+                final String pid = DriversAndAssetsUi.this.driverName.getPid();
+
+                if (pid == null) {
                     return;
                 }
 
@@ -264,8 +267,6 @@ public class DriversAndAssetsUi extends Composite implements DriversAndAssetsLis
                     confirmDialog.show(MSGS.driversAssetsInvalidDriverFactory(), AlertDialog.Severity.ALERT, null);
                     return;
                 }
-
-                final String pid = DriversAndAssetsUi.this.driverName.getValue();
 
                 if (configurations.isPidExisting(pid)) {
                     confirmDialog.show(MSGS.wiresComponentNameAlreadyUsed(pid), AlertDialog.Severity.ALERT, null);
@@ -295,11 +296,11 @@ public class DriversAndAssetsUi extends Composite implements DriversAndAssetsLis
 
             @Override
             public void onClick(ClickEvent event) {
-                if (!assetName.validate()) {
+                final String pid = assetName.getPid();
+
+                if (pid == null) {
                     return;
                 }
-
-                final String pid = assetName.getValue();
 
                 if (configurations.isPidExisting(pid)) {
                     confirmDialog.show(MSGS.wiresComponentNameAlreadyUsed(pid), AlertDialog.Severity.ALERT, null);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/DriversAndAssetsUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/DriversAndAssetsUi.ui.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <!--
 
-    Copyright (c) 2017 Eurotech and/or its affiliates
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,7 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
     xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html" xmlns:g="urn:import:com.google.gwt.user.client.ui"
     xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt" xmlns:da="urn:import:org.eclipse.kura.web.client.ui.drivers.assets"
-    xmlns:kura="urn:import:org.eclipse.kura.web.client.ui">
+    xmlns:kura="urn:import:org.eclipse.kura.web.client.ui" xmlns:kura.util="urn:import:org.eclipse.kura.web.client.util">
 
     <ui:with field="msgs" type="org.eclipse.kura.web.client.messages.Messages"></ui:with>
 
@@ -46,9 +46,9 @@
                         </b:FormGroup>
                         <b:FormGroup>
                             <b:FormLabel for="driverName" text="{msgs.driverName}" />
-                            <b:InlineHelpBlock iconType="EXCLAMATION_TRIANGLE" />
-                            <b:TextBox allowBlank="false" validateOnBlur="true" autoComplete="false" b:id="driverName"
-                                ui:field="driverName" />
+                            <kura.util:PidTextBox b:id="driverName" ui:field="driverName" autoComplete="false" 
+                                 validateOnBlur="true"/>
+                            <b:HelpBlock iconType="EXCLAMATION_TRIANGLE"/>
                         </b:FormGroup>
                     </b:FieldSet>
                 </b:Form>
@@ -67,9 +67,9 @@
                     <b:FieldSet>
                         <b:FormGroup>
                             <b:FormLabel for="assetName" text="{msgs.assetName}" />
-                            <b:InlineHelpBlock iconType="EXCLAMATION_TRIANGLE" />
-                            <b:TextBox allowBlank="false" validateOnBlur="true" autoComplete="false" b:id="assetName"
-                                ui:field="assetName" />
+                            <kura.util:PidTextBox b:id="assetName" ui:field="assetName" autoComplete="false" 
+                                 validateOnBlur="true"/>
+                            <b:HelpBlock iconType="EXCLAMATION_TRIANGLE" />
                         </b:FormGroup>
                         <b:FormGroup>
                             <b:FormLabel for="driverPid" text="{msgs.driverName}" />

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresDialogs.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresDialogs.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@ package org.eclipse.kura.web.client.ui.wires;
 import java.util.List;
 
 import org.eclipse.kura.web.client.messages.Messages;
+import org.eclipse.kura.web.client.util.PidTextBox;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.FormLabel;
@@ -58,7 +59,7 @@ public class WiresDialogs extends Composite {
     @UiField
     Modal newAssetModal;
     @UiField
-    TextBox newAssetName;
+    PidTextBox newAssetName;
     @UiField
     TextBox newAssetDriverInstance;
     @UiField
@@ -68,7 +69,7 @@ public class WiresDialogs extends Composite {
     @UiField
     Modal newDriverModal;
     @UiField
-    TextBox newDriverName;
+    PidTextBox newDriverName;
     @UiField
     ListBox newDriverFactory;
     @UiField
@@ -88,7 +89,7 @@ public class WiresDialogs extends Composite {
     @UiField
     Button btnComponentModalNo;
     @UiField
-    TextBox componentName;
+    PidTextBox componentName;
 
     private Listener listener;
     private Callback pickCallback;
@@ -202,7 +203,10 @@ public class WiresDialogs extends Composite {
 
             @Override
             public void onClick(ClickEvent event) {
-                String wireAssetPid = WiresDialogs.this.newAssetName.getText();
+                String wireAssetPid = WiresDialogs.this.newAssetName.getPid();
+                if (wireAssetPid == null || !listener.onNewPidInserted(wireAssetPid)) {
+                    return;
+                }
                 String driverPid = WiresDialogs.this.newAssetDriverInstance.getText();
                 WiresDialogs.this.newAssetModal.hide();
                 if (pickCallback != null) {
@@ -228,10 +232,10 @@ public class WiresDialogs extends Composite {
 
             @Override
             public void onClick(ClickEvent event) {
-                if (!WiresDialogs.this.newDriverName.validate()) {
+                final String pid = WiresDialogs.this.newDriverName.getPid();
+                if (pid == null) {
                     return;
                 }
-                final String pid = WiresDialogs.this.newDriverName.getValue();
                 if (listener == null || !listener.onNewPidInserted(pid)) {
                     return;
                 }
@@ -270,8 +274,8 @@ public class WiresDialogs extends Composite {
 
             @Override
             public void onClick(ClickEvent event) {
-                String value = WiresDialogs.this.componentName.getValue();
-                if (value != null && !value.isEmpty()) {
+                String value = WiresDialogs.this.componentName.getPid();
+                if (value != null) {
                     if (listener == null || !listener.onNewPidInserted(value)) {
                         return;
                     }
@@ -279,8 +283,8 @@ public class WiresDialogs extends Composite {
                         pickCallback.onNewComponentCreated(value);
                     }
                     genericCompModal.hide();
+                    componentName.clear();
                 }
-                componentName.clear();
             }
         });
         this.btnComponentModalNo.addClickHandler(new ClickHandler() {
@@ -309,7 +313,9 @@ public class WiresDialogs extends Composite {
         } else {
             this.newAssetModalHeader.setTitle(MSGS.wiresComponentNew());
             this.componentNameLabel.setText(MSGS.wiresComponentName());
-
+            this.componentName.clear();
+            this.newAssetName.clear();
+            this.newDriverName.clear();
             this.genericCompModal.show();
         }
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresDialogs.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresDialogs.ui.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <!--
 
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -11,14 +11,14 @@
 -->
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
     xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html" xmlns:g="urn:import:com.google.gwt.user.client.ui"
-    xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt" xmlns:kura="urn:import:org.eclipse.kura.web.client.ui">
+    xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt" xmlns:kura="urn:import:org.eclipse.kura.web.client.ui" xmlns:kura.util="urn:import:org.eclipse.kura.web.client.util">
 
     <ui:with field="msgs" type="org.eclipse.kura.web.client.messages.Messages"></ui:with>
 
     <ui:style>
-    .asset-comp-modal-body {
-    	padding-bottom: 40px;
-    }
+       .newComponentName {
+           padding-top: 8px;
+       }
     </ui:style>
 
     <b:Container fluid="true">
@@ -68,8 +68,9 @@
                     <b:FieldSet>
                         <b:FormGroup>
                             <b:FormLabel for="newAssetName" ui:field="newAssetNameLabel" text="{msgs.assetName}"/>
-                            <b:TextBox ui:field="newAssetName" b:id="newAssetName" allowBlank="false"
-                                autoComplete="false" />
+                            <kura.util:PidTextBox ui:field="newAssetName" b:id="newAssetName"
+                            autoComplete="false" validateOnBlur="true"/>
+                            <b:HelpBlock iconType="EXCLAMATION_TRIANGLE"/>
                         </b:FormGroup>
                         <b:FormGroup>
                             <b:FormLabel for="newAssetDriverInstance" ui:field="newAssetDriverInstanceLabel" text="{msgs.driverName}"/>
@@ -96,8 +97,9 @@
                         </b:FormGroup>
                         <b:FormGroup>
                             <b:FormLabel for="newDriverName" ui:field="newDriverNameLabel" text="{msgs.driverName}"/>
-                            <b:TextBox ui:field="newDriverName" b:id="newDriverName" allowBlank="false"
-                                autoComplete="false" />
+                            <kura.util:PidTextBox ui:field="newDriverName" b:id="newDriverName"
+                            autoComplete="false" validateOnBlur="true"/>
+                            <b:HelpBlock iconType="EXCLAMATION_TRIANGLE"/>
                         </b:FormGroup>
                     </b:FieldSet>
                 </b:Form>
@@ -111,15 +113,18 @@
         <b:Modal closable="false" fade="true" dataBackdrop="STATIC" dataKeyboard="true" b:id="generic-comp-modal"
             ui:field="genericCompModal">
             <b:ModalHeader ui:field="newAssetModalHeader" />
-            <b:ModalBody addStyleNames="{style.asset-comp-modal-body}">
+            <b:ModalBody>
                 <b:Form>
-                    <b:FormGroup>
-                        <b:FormLabel for="componentName" addStyleNames="col-md-4" ui:field="componentNameLabel"/>
-                        <g:FlowPanel addStyleNames="col-md-8">
-                            <b:TextBox ui:field="componentName" b:id="componentName" allowBlank="false"
-                                autoComplete="false" placeholder="{msgs.wiresComponentNamePlaceholder}"/>
-                        </g:FlowPanel>
-                    </b:FormGroup>
+                    <b:FieldSet>
+                        <b:FormGroup>
+                            <b:FormLabel for="componentName" addStyleNames="col-md-4 {style.newComponentName}" ui:field="componentNameLabel"/>
+                            <g:FlowPanel addStyleNames="col-md-8">
+                                 <kura.util:PidTextBox ui:field="componentName" b:id="componentName" autoComplete="false" 
+                                 validateOnBlur="true" placeholder="{msgs.wiresComponentNamePlaceholder}"/>
+                            </g:FlowPanel>
+                            <b:HelpBlock iconType="EXCLAMATION_TRIANGLE"/>
+                        </b:FormGroup>
+                    </b:FieldSet>
                 </b:Form>
             </b:ModalBody>
             <b:ModalFooter>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/PidTextBox.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/PidTextBox.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+package org.eclipse.kura.web.client.util;
+
+import org.eclipse.kura.web.client.messages.ValidationMessages;
+import org.gwtbootstrap3.client.ui.TextBox;
+import org.gwtbootstrap3.client.ui.form.validator.RegExValidator;
+
+import com.google.gwt.core.client.GWT;
+
+public class PidTextBox extends TextBox {
+
+    private static final ValidationMessages messages = GWT.create(ValidationMessages.class);
+    private static final String SYMBOLIC_NAME_PATTERN = "^[\\w\\-]+([\\.][\\w\\-]+)*$";
+
+    public PidTextBox() {
+        final RegExValidator validator = new RegExValidator(SYMBOLIC_NAME_PATTERN, messages.invalidPid());
+        addValidator(validator);
+    }
+
+    public String getPid() {
+        if (!validate()) {
+            return null;
+        }
+        return getValue();
+    }
+}

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -547,7 +547,7 @@ servicesComponentFactorySelectorIdle=--- Select Component Factory---
 servicesComponentFactoryNew=New Component
 servicesComponentFactoryFactory=Factory
 servicesComponentFactoryName=Name
-servicesComponentFactoryNamePlaceholder=Please enter an user friendly name
+servicesComponentFactoryNamePlaceholder=Please enter a user friendly name
 servicesComponentFactoryAlertNotSelected=Component must be selected and the name must be non-empty
 
 driversAssetsTabIntro=Create and manage your Drivers and Assets instances. Inspect and change the Assets values.

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/ValidationMessages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/ValidationMessages.properties
@@ -176,3 +176,5 @@ marketplaceInstallMinKuraVersion=Minimum required framework version:
 marketplaceInstallCurrentKuraVersion=Current framework version:
 marketplaceInstallDpVersionMismatchInstall=Install
 marketplaceInstallDpVersionMismatchCancel=Cancel
+
+invalidPid=Name must be a valid service.pid (e.g Foo, Foo.Bar1, Foo.Bar_Baz-012)


### PR DESCRIPTION
Improves Web Ui validation for input fields that allow to enter a component name (`kura.service.pid`).

The performed validation enforces that the provided names are valid OSGi `service.pid`s (only non empty sequences of alphanumeric characters, '_' or '-' separated by '.').

This `kura.service.pid` parameter in theory can allow more freedom than the `service.pid`, but its values currently need to be used at least in the following contexts:

* In LDAP filters
* As part of a topic name (e.g wires publisher allows to build an application topic from an asset name).

Validating the `kura.service.pid` in the same way as the `service.pid` should be safe at least for the scenarios above even if maybe too restrictive. This can be eventually changed in the future, performing a less strict validation should not be a breaking change.

This PR does not introduce validations on the platform side at this point of the release cycle, as this might cause compatibility issues.

Closes #1959
Closes #1955

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>