### PR TITLE
Improved wire graph/asset configuration upgrade from previous versions

### DIFF
--- a/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/BaseAsset.java
+++ b/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/BaseAsset.java
@@ -43,6 +43,7 @@ import org.eclipse.kura.channel.listener.ChannelListener;
 import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.configuration.SelfConfiguringComponent;
+import org.eclipse.kura.configuration.metatype.AD;
 import org.eclipse.kura.configuration.metatype.Option;
 import org.eclipse.kura.core.configuration.ComponentConfigurationImpl;
 import org.eclipse.kura.core.configuration.metatype.Tad;
@@ -348,14 +349,14 @@ public class BaseAsset implements Asset, SelfConfiguringComponent {
         if (driver == null || this.properties == null || this.assetConfiguration == null) {
             return;
         }
-        Object driverDescriptor = null;
+        Object opaqueDriverDescriptor = null;
         try {
             final ChannelDescriptor channelDescriptor = driver.getChannelDescriptor();
             if (channelDescriptor == null) {
                 return;
             }
-            driverDescriptor = channelDescriptor.getDescriptor();
-            if (!(driverDescriptor instanceof List<?>)) {
+            opaqueDriverDescriptor = channelDescriptor.getDescriptor();
+            if (!(opaqueDriverDescriptor instanceof List<?>)) {
                 return;
             }
         } catch (Exception e) {
@@ -363,12 +364,13 @@ public class BaseAsset implements Asset, SelfConfiguringComponent {
             return;
         }
         Map<String, Object> newConfiguration = null;
-        final List<Tad> driverSpecificChannelConfiguration = (List<Tad>) driverDescriptor;
+        final List<Tad> driverDescriptor = (List<Tad>) opaqueDriverDescriptor;
         final Tocd tempOcd = new Tocd();
-        driverSpecificChannelConfiguration.forEach(tempOcd::addAD);
+        getAssetChannelDescriptor().forEach(tempOcd::addAD);
+        driverDescriptor.forEach(tempOcd::addAD);
         final Map<String, Object> defaultValues = ComponentUtil.getDefaultProperties(tempOcd, this.context);
         final Map<String, Channel> channels = getAssetConfiguration().getAssetChannels();
-        for (Tad tad : driverSpecificChannelConfiguration) {
+        for (AD tad : tempOcd.getAD()) {
             if (!tad.isRequired()) {
                 continue;
             }

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -819,6 +819,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                 factoryPid = (String) properties.get(ConfigurationAdmin.SERVICE_FACTORYPID);
             }
             if (factoryPid != null && !this.allActivatedPids.contains(config.getPid())) {
+                ConfigurationUpgrade.upgrade(config, bundleContext);
                 String pid = config.getPid();
                 logger.info("Creating configuration with pid: {} and factory pid: {}", pid, factoryPid);
                 try {
@@ -1307,7 +1308,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
     private void loadLatestSnapshotInConfigAdmin() throws KuraException {
         //
         // save away initial configuration
-        List<ComponentConfiguration> configs = loadLatestSnapshotConfigurations();
+        List<ComponentConfiguration> configs = buildCurrentConfiguration(null);
         if (configs == null) {
             return;
         }
@@ -1436,7 +1437,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             logger.warn("Error parsing xml", e);
         }
 
-        return ConfigurationUpgrade.upgrade(xmlConfigs, this.bundleContext);
+        return xmlConfigs;
     }
 
     private void updateConfigurationInternal(String pid, Map<String, Object> properties, boolean snapshotOnConfirmation)
@@ -1681,6 +1682,10 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                     break;
                 }
             }
+        }
+
+        for (final ComponentConfiguration config : result) {
+            ConfigurationUpgrade.upgrade(config, bundleContext);
         }
 
         return result;

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/upgrade/ConfigurationUpgrade.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/upgrade/ConfigurationUpgrade.java
@@ -24,8 +24,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.core.configuration.ComponentConfigurationImpl;
-import org.eclipse.kura.core.configuration.XmlComponentConfigurations;
-import org.eclipse.kura.core.configuration.metatype.Tocd;
 import org.eclipse.kura.marshalling.Marshaller;
 import org.eclipse.kura.util.service.ServiceUtil;
 import org.eclipse.kura.wire.graph.MultiportWireConfiguration;
@@ -67,44 +65,41 @@ public class ConfigurationUpgrade {
     private static final String SEPARATOR = ".";
     private static final String PATTERN = "%s.";
 
-    public static XmlComponentConfigurations upgrade(final XmlComponentConfigurations xmlConfigs,
-            final BundleContext bundleContext) {
+    public static void upgrade(final ComponentConfiguration config, final BundleContext bundleContext) {
 
-        if (xmlConfigs == null) {
-            return null;
+        if (config == null) {
+            return;
         }
 
-        List<ComponentConfiguration> result = new ArrayList<>();
+        String pid = config.getPid();
+        final Map<String, Object> props = config.getConfigurationProperties();
 
-        for (ComponentConfiguration config : xmlConfigs.getConfigurations()) {
-            String pid = config.getPid();
-            Map<String, Object> props = new HashMap<>(config.getConfigurationProperties());
-            ComponentConfigurationImpl cc = new ComponentConfigurationImpl(pid, (Tocd) config.getDefinition(), props);
-            result.add(cc);
-
-            if (CLOUD_SERVICE_PID.equals(pid)) {
-                props.put(ConfigurationAdmin.SERVICE_FACTORYPID, CLOUD_SERVICE_FACTORY_PID);
-                String name = DATA_SERVICE_REFERENCE_NAME + ComponentConstants.REFERENCE_TARGET_SUFFIX;
-                props.put(name, String.format(REFERENCE_TARGET_VALUE_FORMAT, DATA_SERVICE_PID));
-                props.put(KURA_CLOUD_SERVICE_FACTORY_PID, FACTORY_PID);
-            } else if (DATA_SERVICE_PID.equals(pid)) {
-                props.put(ConfigurationAdmin.SERVICE_FACTORYPID, DATA_SERVICE_FACTORY_PID);
-                String name = DATA_TRANSPORT_SERVICE_REFERENCE_NAME + ComponentConstants.REFERENCE_TARGET_SUFFIX;
-                props.put(name, String.format(REFERENCE_TARGET_VALUE_FORMAT, DATA_TRANSPORT_SERVICE_PID));
-                props.put(KURA_CLOUD_SERVICE_FACTORY_PID, FACTORY_PID);
-            } else if (DATA_TRANSPORT_SERVICE_PID.equals(pid)) {
-                props.put(ConfigurationAdmin.SERVICE_FACTORYPID, DATA_TRANSPORT_SERVICE_FACTORY_PID);
-                props.put(KURA_CLOUD_SERVICE_FACTORY_PID, FACTORY_PID);
-            } else if (WIRE_SERVICE_PID.equals(pid)) {
-                Map<String, Object> convertedProps = new HashMap<>(convertToNewWiresJsonFormat(props, bundleContext));
-                props.clear();
-                props.putAll(convertedProps);
-            }
+        if (props == null) {
+            return;
         }
 
-        XmlComponentConfigurations xmlConfigurations = new XmlComponentConfigurations();
-        xmlConfigurations.setConfigurations(result);
-        return xmlConfigurations;
+        final Object factoryPid = props.get(ConfigurationAdmin.SERVICE_FACTORYPID);
+
+        if (CLOUD_SERVICE_PID.equals(pid)) {
+            props.put(ConfigurationAdmin.SERVICE_FACTORYPID, CLOUD_SERVICE_FACTORY_PID);
+            String name = DATA_SERVICE_REFERENCE_NAME + ComponentConstants.REFERENCE_TARGET_SUFFIX;
+            props.put(name, String.format(REFERENCE_TARGET_VALUE_FORMAT, DATA_SERVICE_PID));
+            props.put(KURA_CLOUD_SERVICE_FACTORY_PID, FACTORY_PID);
+        } else if (DATA_SERVICE_PID.equals(pid)) {
+            props.put(ConfigurationAdmin.SERVICE_FACTORYPID, DATA_SERVICE_FACTORY_PID);
+            String name = DATA_TRANSPORT_SERVICE_REFERENCE_NAME + ComponentConstants.REFERENCE_TARGET_SUFFIX;
+            props.put(name, String.format(REFERENCE_TARGET_VALUE_FORMAT, DATA_TRANSPORT_SERVICE_PID));
+            props.put(KURA_CLOUD_SERVICE_FACTORY_PID, FACTORY_PID);
+        } else if (DATA_TRANSPORT_SERVICE_PID.equals(pid)) {
+            props.put(ConfigurationAdmin.SERVICE_FACTORYPID, DATA_TRANSPORT_SERVICE_FACTORY_PID);
+            props.put(KURA_CLOUD_SERVICE_FACTORY_PID, FACTORY_PID);
+        } else if (WIRE_SERVICE_PID.equals(pid)) {
+            Map<String, Object> convertedProps = new HashMap<>(convertToNewWiresJsonFormat(props, bundleContext));
+            props.clear();
+            props.putAll(convertedProps);
+        } else if (WireAssetConfigurationUpgrade.WIRE_ASSET_FACTORY_PID.equals(factoryPid)) {
+            WireAssetConfigurationUpgrade.upgrade(props);
+        }
     }
 
     private static Map<String, Object> convertToNewWiresJsonFormat(Map<String, Object> oldProperties,
@@ -213,7 +208,8 @@ public class ConfigurationUpgrade {
     }
 
     private static ServiceReference<Marshaller>[] getJsonMarshallers(BundleContext bundleContext) {
-        String filterString = String.format("(&(kura.service.pid=%s))", "org.eclipse.kura.json.marshaller.unmarshaller.provider");
+        String filterString = String.format("(&(kura.service.pid=%s))",
+                "org.eclipse.kura.json.marshaller.unmarshaller.provider");
         return ServiceUtil.getServiceReferences(bundleContext, Marshaller.class, filterString);
     }
 

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/upgrade/WireAssetConfigurationUpgrade.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/upgrade/WireAssetConfigurationUpgrade.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.core.configuration.upgrade;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+public final class WireAssetConfigurationUpgrade {
+
+    static final String WIRE_ASSET_FACTORY_PID = "org.eclipse.kura.wire.WireAsset";
+
+    private static final String CHANNEL_PROPERTY_SEPARATOR = "#";
+    private static final String CHANNEL_NAME_PROPERTY_SUFFIX = CHANNEL_PROPERTY_SEPARATOR + "+name";
+    private static final String EMIT_ALL_CHANNELS_PROP_NAME = "emit.all.channels";
+
+    private WireAssetConfigurationUpgrade() {
+    }
+
+    static void upgrade(final Map<String, Object> properties) {
+        if (properties.containsKey(EMIT_ALL_CHANNELS_PROP_NAME)) {
+            return;
+        }
+
+        properties.put(EMIT_ALL_CHANNELS_PROP_NAME, false);
+        final Set<String> channelNames = getChannelNames(properties);
+
+        for (final String channelName : channelNames) {
+            properties.put(channelName + CHANNEL_NAME_PROPERTY_SUFFIX, channelName);
+        }
+    }
+
+    static Set<String> getChannelNames(final Map<String, Object> properties) {
+
+        final Set<String> channelNames = new HashSet<>();
+
+        for (final Entry<String, Object> e : properties.entrySet()) {
+            final String key = e.getKey();
+            final int index = key.indexOf(CHANNEL_PROPERTY_SEPARATOR);
+            if (index == -1) {
+                continue;
+            }
+            final String channelName = key.substring(0, index);
+            channelNames.add(channelName);
+        }
+
+        return channelNames;
+    }
+}


### PR DESCRIPTION
* Fixes warning messages emitted by the Assets after upgrading from previous version
* Implements caching of the OCD in BaseAsset
* Adds support for uploading snapshots containing a wire graph created in previous Kura versions
* Fixes web ui glitch that results in incorrect channel names being shown after upgrading from previous Kura version configuration

Closes #1975 