### PR TITLE
Added dp for gpio driver

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -412,6 +412,11 @@
                                     <artifactId>org.eclipse.kura.wire.script.filter.provider</artifactId>
                                     <version>${org.eclipse.kura.wire.script.filter.provider.version}</version>
                                 </artifactItem>
+                               <artifactItem>
+                                    <groupId>org.eclipse.kura</groupId>
+                                    <artifactId>org.eclipse.kura.driver.gpio.provider</artifactId>
+                                    <version>${org.eclipse.kura.driver.gpio.provider.version}</version>
+                                </artifactItem>
                                 <artifactItem>
                                     <groupId>org.eclipse.kura</groupId>
                                     <artifactId>org.eclipse.kura.linux.gpio</artifactId>
@@ -638,6 +643,8 @@
                                     tofile="target/plugins/org.eclipse.kura.driver.ble.sensortag.provider_${org.eclipse.kura.driver.ble.sensortag.provider.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.wire.script.filter.provider.jar"
                                     tofile="target/plugins/org.eclipse.kura.wire.script.filter.provider_${org.eclipse.kura.wire.script.filter.provider.version}.jar" />
+                                <move file="target/plugins/org.eclipse.kura.driver.gpio.provider.jar"
+                                    tofile="target/plugins/org.eclipse.kura.driver.gpio.provider_${org.eclipse.kura.driver.gpio.provider.version}.jar" />
                                 <move file="target/plugins/org.moka7.jar"
                                     tofile="target/plugins/org.moka7_${org.moka7.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.rest.provider.jar"
@@ -2784,6 +2791,12 @@
                             <groupId>org.eclipse.kura.feature</groupId>
                             <artifactId>org.eclipse.kura.wire.script.filter</artifactId>
                             <version>${org.eclipse.kura.wire.script.filter.version}</version>
+                            <type>dp</type>
+                          </artifactItem>
+                          <artifactItem>
+                            <groupId>org.eclipse.kura.feature</groupId>
+                            <artifactId>org.eclipse.kura.driver.gpio</artifactId>
+                            <version>${org.eclipse.kura.driver.gpio.version}</version>
                             <type>dp</type>
                           </artifactItem>
                         </artifactItems>


### PR DESCRIPTION
This PR adds the ability to create the .dp file for the gpio driver during the distrib build.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>