### PR TITLE
Properly declare required/provided services

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core.configuration/META-INF/MANIFEST.MF
@@ -41,3 +41,5 @@ Import-Package: com.eclipsesource.json;version="0.9.4",
 Export-Package: org.eclipse.kura.core.configuration;version="2.0.0",
  org.eclipse.kura.core.configuration.metatype;version="1.0.0",
  org.eclipse.kura.core.configuration.util;version="2.0.0"
+Require-Capability: osgi.service;filter:="(objectClass=org.eclipse.kura.marshalling.Marshaller)";
+ osgi.service;filter:="(objectClass=org.eclipse.kura.marshalling.Unmarshaller)"

--- a/kura/org.eclipse.kura.driver.ble.sensortag.provider/pom.xml
+++ b/kura/org.eclipse.kura.driver.ble.sensortag.provider/pom.xml
@@ -26,7 +26,6 @@
 	
 	<properties>
 		<kura.basedir>${project.basedir}/..</kura.basedir>
-		<tycho-version>0.26.0</tycho-version>
 	</properties>
 	
 </project>

--- a/kura/org.eclipse.kura.driver.gpio.provider/pom.xml
+++ b/kura/org.eclipse.kura.driver.gpio.provider/pom.xml
@@ -26,7 +26,6 @@
 	
 	<properties>
 		<kura.basedir>${project.basedir}/..</kura.basedir>
-		<tycho-version>0.26.0</tycho-version>
 	</properties>
 	
 </project>

--- a/kura/org.eclipse.kura.driver.opcua.provider/pom.xml
+++ b/kura/org.eclipse.kura.driver.opcua.provider/pom.xml
@@ -24,10 +24,9 @@
 	<artifactId>org.eclipse.kura.driver.opcua.provider</artifactId>
 	<version>1.0.300-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
-	
+
 	<properties>
 		<kura.basedir>${project.basedir}/..</kura.basedir>
-		<tycho-version>0.26.0</tycho-version>
 	</properties>
 	
 </project>

--- a/kura/org.eclipse.kura.xml.marshaller.unmarshaller.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.xml.marshaller.unmarshaller.provider/META-INF/MANIFEST.MF
@@ -24,3 +24,5 @@ Import-Package: javax.xml.parsers,
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.kura.internal.xml.marshaller.unmarshaller;version="1.0.0"
+Provide-Capability: osgi.service;objectClass:List<String>="org.eclipse.kura.marshalling.Marshaller,
+ org.eclipse.kura.marshalling.Unmarshaller"

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -99,7 +99,7 @@
     </modules>
 
     <properties>
-        <tycho-version>0.26.0</tycho-version>
+        <tycho-version>1.2.0</tycho-version>
 
         <!-- SCM: Note that we are in the "kura" sub-dir here already -->
         <tycho.scmUrl>scm:git:ssh://github.com/eclipse/kura/kura</tycho.scmUrl>

--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -543,7 +543,6 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-p2-extras-plugin</artifactId>
-				<version>0.26.0</version>
 				<executions>
 					<execution>
 						<phase>prepare-package</phase>

--- a/target-platform/p2-repo-equinox_3.11.1/pom.xml
+++ b/target-platform/p2-repo-equinox_3.11.1/pom.xml
@@ -126,7 +126,6 @@
             <plugin>
                 <groupId>org.eclipse.tycho.extras</groupId>
                 <artifactId>tycho-p2-extras-plugin</artifactId>
-                <version>0.26.0</version>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>

--- a/target-platform/p2-repo-test-deps/pom.xml
+++ b/target-platform/p2-repo-test-deps/pom.xml
@@ -95,7 +95,6 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-p2-extras-plugin</artifactId>
-				<version>0.26.0</version>
 				<executions>
 					<execution>
 						<phase>prepare-package</phase>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -70,6 +70,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <check.plugins.exist.remote>false</check.plugins.exist.remote>
+        <tycho.version>1.2.0</tycho.version>
     </properties>
     
     <profiles>
@@ -152,6 +153,11 @@
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.tycho.extras</groupId>
+                    <artifactId>tycho-p2-extras-plugin</artifactId>
+                    <version>${tycho.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
As the ConfigurationServiceImpl doesn't properly work when the XML marshaller/unmarshaller is missing, it should declare a dependency on this service.