### PR TITLE
Fixed GPS config if modem has never been enabled

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/PppConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/PppConfigWriter.java
@@ -204,6 +204,20 @@ public class PppConfigWriter implements NetworkConfigurationVisitor {
                 ModemPppConfigGenerator scriptGenerator = configClass.newInstance();
 
                 if (modemConfig != null) {
+
+                    String modemIdentifier = modemInterfaceConfig.getModemIdentifier();
+                    if (modemIdentifier != null) {
+                        StringBuilder key = new StringBuilder("net.interface.").append(modemInterfaceConfig.getName())
+                                .append(".modem.identifier");
+                        s_logger.debug("Storing modem identifier " + modemIdentifier + " using key: " + key);
+                        KuranetConfig.setProperty(key.toString(), modemIdentifier);
+                    }
+
+                    final StringBuilder gpsEnabledKey = new StringBuilder().append("net.interface.")
+                            .append(newInterfaceName).append(".config.gpsEnabled");
+                    s_logger.debug("Setting gpsEnabled for {}", newInterfaceName);
+                    KuranetConfig.setProperty(gpsEnabledKey.toString(), Boolean.toString(modemConfig.isGpsEnabled()));
+
                     s_logger.debug("Writing connect scripts for " + modemInterfaceConfig.getName() + " using "
                             + configClass.toString());
 
@@ -212,14 +226,6 @@ public class PppConfigWriter implements NetworkConfigurationVisitor {
                             chatFilename, disconnectFilename);
                     pppPeer.setBaudRate(baudRate);
                     pppPeer.write(pppPeerFilename);
-
-                    s_logger.debug("Writing {}", chatFilename);
-                    ModemXchangeScript connectScript = scriptGenerator.getConnectScript(modemConfig);
-                    connectScript.writeScript(chatFilename);
-
-                    s_logger.debug("Writing {}", disconnectFilename);
-                    ModemXchangeScript disconnectScript = scriptGenerator.getDisconnectScript(modemConfig);
-                    disconnectScript.writeScript(disconnectFilename);
 
                     if (pppNum >= 0) {
                         s_logger.debug("Linking peer file using ppp number: {}", pppNum);
@@ -230,13 +236,13 @@ public class PppConfigWriter implements NetworkConfigurationVisitor {
                                 "Can't create symbolic link to " + pppPeerFilename + ", invalid ppp number: " + pppNum);
                     }
 
-                    String modemIdentifier = modemInterfaceConfig.getModemIdentifier();
-                    if (modemIdentifier != null) {
-                        StringBuilder key = new StringBuilder("net.interface.").append(modemInterfaceConfig.getName())
-                                .append(".modem.identifier");
-                        s_logger.debug("Storing modem identifier " + modemIdentifier + " using key: " + key);
-                        KuranetConfig.setProperty(key.toString(), modemIdentifier);
-                    }
+                    s_logger.debug("Writing {}", chatFilename);
+                    ModemXchangeScript connectScript = scriptGenerator.getConnectScript(modemConfig);
+                    connectScript.writeScript(chatFilename);
+
+                    s_logger.debug("Writing {}", disconnectFilename);
+                    ModemXchangeScript disconnectScript = scriptGenerator.getDisconnectScript(modemConfig);
+                    disconnectScript.writeScript(disconnectFilename);
 
                     // Custom dns servers
                     if (netConfigIP4 != null) {
@@ -260,15 +266,11 @@ public class PppConfigWriter implements NetworkConfigurationVisitor {
                         }
                     }
 
-                    StringBuilder key = new StringBuilder().append("net.interface.").append(newInterfaceName)
-                            .append(".config.gpsEnabled");
-                    s_logger.debug("Setting gpsEnabled for {}", newInterfaceName);
-                    KuranetConfig.setProperty(key.toString(), Boolean.toString(modemConfig.isGpsEnabled()));
-
-                    key = new StringBuilder().append("net.interface.").append(newInterfaceName)
-                            .append(".config.resetTimeout");
+                    final StringBuilder resetTimeoutKey = new StringBuilder().append("net.interface.")
+                            .append(newInterfaceName).append(".config.resetTimeout");
                     s_logger.debug("Setting modem resetTimeout for {}", newInterfaceName);
-                    KuranetConfig.setProperty(key.toString(), Integer.toString(modemConfig.getResetTimeout()));
+                    KuranetConfig.setProperty(resetTimeoutKey.toString(),
+                            Integer.toString(modemConfig.getResetTimeout()));
                 } else {
                     s_logger.error("Error writing connect scripts - modemConfig is null");
                 }


### PR DESCRIPTION
Due to #2096 the `PppConfigWriter` can crash while writing the chat scripts, preventing the rest of modem config from being persisted.

This rearranges operations in `PppConfigWriter` in order to persist the following items before trying to write the chat scripts.

* the `gpsEnabled` flag in `kuranet.conf`
* the peer file
* the `pppx` symlink

The last two items are necessary for identifying the modem interface as` pppX`, and not with the usb path. This is needed because the `gpsEnabled` is associated to `pppX` in kuranet.conf.

The exception will still appear on the log, but GPS should be usable. In order to get rid of the exception it is enough to enable modem at least once with a proper dial string.

Closes #2096 

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>