### PR TITLE
Fix Milo tests

### DIFF
--- a/kura/test/org.eclipse.kura.internal.driver.opcua.test/src/main/java/org/eclipse/kura/internal/driver/opcua/test/OpcUaDriverTest.java
+++ b/kura/test/org.eclipse.kura.internal.driver.opcua.test/src/main/java/org/eclipse/kura/internal/driver/opcua/test/OpcUaDriverTest.java
@@ -80,9 +80,13 @@ public class OpcUaDriverTest {
         CertificateManager certificateManager = new DefaultCertificateManager();
         CertificateValidator certificateValidator = new DefaultCertificateValidator(new File("/tmp"));
         List<String> bindAddresses = new ArrayList<>();
-        bindAddresses.add("0.0.0.0");
+        bindAddresses.add("localhost");
+        List<String> endpointAddresses = new ArrayList<>();
+        endpointAddresses.add("localhost");
         OpcUaServerConfig config = new OpcUaServerConfigBuilder().setBindPort(12685).setApplicationUri("opcsvr")
-                .setBindAddresses(bindAddresses).setServerName("opcsvr")
+                .setBindAddresses(bindAddresses)
+                .setEndpointAddresses(endpointAddresses)
+                .setServerName("opcsvr")
                 .setApplicationName(LocalizedText.english("opcsvr")).setCertificateManager(certificateManager)
                 .setCertificateValidator(certificateValidator)
                 .setUserTokenPolicies(Arrays.asList(OpcUaServerConfig.USER_TOKEN_POLICY_ANONYMOUS)).build();


### PR DESCRIPTION
Tests seem to be failing due to new Eclipse Hipp deployment.
This PR sets a specific endpoint and bind address to work
around this.

Signed-off-by: David Woodard <david.woodard@eurotech.com>