### PR TITLE
Ignore the created JAR file from Git

### DIFF
--- a/kura/org.eclipse.kura.driver.s7plc.provider/lib/.gitignore
+++ b/kura/org.eclipse.kura.driver.s7plc.provider/lib/.gitignore
@@ -1,1 +1,1 @@
-/org.eclipse.kura.driver.block.optimizer.jar
+/*.jar


### PR DESCRIPTION
Currently a JAR file named `org.eclipse.kura.driver.block.jar` lingers in my git status and wants to be committed. I think this file should be ignored.