### PR TITLE
[#2189]: Allow customizing Jetty to evaluate reverse proxy headers

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -665,6 +665,8 @@ fi]]>
 			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/kura/plugins/org.eclipse.equinox.http.jetty_${org.eclipse.equinox.http.jetty.version}.jar@5:start" />
 			<entry key="osgi.bundles" operation="+"
+				value=", reference:file:${kura.install.dir}/kura/plugins/org.eclipse.kura.jetty.customizer_${org.eclipse.kura.jetty.customizer.version}.jar" />
+			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/kura/plugins/org.eclipse.equinox.http.servlet_${org.eclipse.equinox.http.servlet.version}.jar@5:start" />
 			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/kura/plugins/org.eclipse.jetty.continuation_${org.eclipse.jetty.continuation.version}.jar@5:start" />

--- a/kura/distrib/src/main/osgi/equinox_3.12.50/configuration/config.ini
+++ b/kura/distrib/src/main/osgi/equinox_3.12.50/configuration/config.ini
@@ -14,3 +14,4 @@ osgi.configuration.cascaded=false
 eclipse.ignoreApp=true
 iagent.controller=false
 ds.lock.timeout.milliseconds=60000
+org.eclipse.equinox.http.jetty.customizer.class=org.eclipse.kura.jetty.customizer.KuraJettyCustomizer

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -9,6 +9,8 @@ com.gwt.user.version=1.1.0-SNAPSHOT
 jdk.dio.version=1.0.300
 org.eclipse.kura.camel.sun.misc.version=1.0.300-SNAPSHOT
 org.eclipse.kura.sun.misc.version=1.0.200
+org.eclipse.kura.jetty.customizer.version=1.0.0-SNAPSHOT
+
 org.moka7.version=1.0.100
 
 org.apache.activemq.artemis.version=2.5.0-SNAPSHOT

--- a/target-platform/org.eclipse.kura.jetty.customizer/pom.xml
+++ b/target-platform/org.eclipse.kura.jetty.customizer/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  Copyright (c) 2018 Red Hat Inc
+  
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+ 
+  Contributors:
+      Red Hat Inc
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.kura</groupId>
+        <artifactId>target-platform</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>org.eclipse.kura.jetty.customizer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.equinox.http.jetty</artifactId>
+            <version>3.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>9.4.7.v20180619</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Fragment-Host>org.eclipse.equinox.http.jetty</Fragment-Host>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraJettyCustomizer.java
+++ b/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraJettyCustomizer.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.kura.jetty.customizer;
+
+import java.util.Dictionary;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.equinox.http.jetty.JettyCustomizer;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.ForwardedRequestCustomizer;
+import org.eclipse.jetty.server.HttpConfiguration.Customizer;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.ServerConnector;
+
+public class KuraJettyCustomizer extends JettyCustomizer {
+
+    @Override
+    public Object customizeHttpConnector(final Object connector, final Dictionary<String, ?> settings) {
+        customizeConnector(connector);
+        return connector;
+    }
+
+    @Override
+    public Object customizeHttpsConnector(final Object connector, final Dictionary<String, ?> settings) {
+        customizeConnector(connector);
+        return connector;
+    }
+
+    private void customizeConnector(Object connector) {
+        if (!(connector instanceof ServerConnector)) {
+            return;
+        }
+
+        final ServerConnector serverConnector = (ServerConnector) connector;
+
+        for (final ConnectionFactory factory : serverConnector.getConnectionFactories()) {
+            if (!(factory instanceof HttpConnectionFactory)) {
+                continue;
+            }
+
+            final HttpConnectionFactory httpConnectionFactory = (HttpConnectionFactory) factory;
+
+            List<Customizer> customizers = httpConnectionFactory.getHttpConfiguration().getCustomizers();
+            if (customizers == null) {
+                customizers = new LinkedList<>();
+                httpConnectionFactory.getHttpConfiguration().setCustomizers(customizers);
+            }
+
+            customizers.add(new ForwardedRequestCustomizer());
+        }
+    }
+
+}

--- a/target-platform/org.eclipse.kura.jetty.customizer/src/main/resources/about.html
+++ b/target-platform/org.eclipse.kura.jetty.customizer/src/main/resources/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>May 7, 2018</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -467,6 +467,11 @@
                                     <artifactId>org.apache.activemq.artemis</artifactId>
                                     <version>${org.apache.activemq.artemis.version}</version>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kura</groupId>
+                                    <artifactId>org.eclipse.kura.jetty.customizer</artifactId>
+                                    <version>${org.eclipse.kura.jetty.customizer.version}</version>
+                                </artifactItem>
                             </artifactItems>
                             <stripVersion>true</stripVersion>
                             <outputDirectory>${project.basedir}/target/source/plugins</outputDirectory>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -24,6 +24,7 @@
         <module>moquette-broker</module>
         <module>apache.log4j.extras</module>
         <module>org.apache.log4j2-api-config</module>
+        <module>org.eclipse.kura.jetty.customizer</module>
 		<module>p2-repo-common</module>
         <module>p2-repo-equinox_3.12.50</module>
         <module>p2-repo-test-deps</module>


### PR DESCRIPTION
This change fixes issue #2189 to allow redirects based on reverse proxy information.