### PR TITLE
Synchronized BLE iBeacon scanner configuration with code

### DIFF
--- a/kura/examples/org.eclipse.kura.example.ibeacon.scanner/OSGI-INF/metatype/org.eclipse.kura.example.ibeacon.scanner.IBeaconScanner.xml
+++ b/kura/examples/org.eclipse.kura.example.ibeacon.scanner/OSGI-INF/metatype/org.eclipse.kura.example.ibeacon.scanner.IBeaconScanner.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017 Eurotech and/or its affiliates
+    Copyright (c) 2017, 2018 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -11,11 +11,11 @@
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kura.example.ibeacon.scanner.IBeaconScanner"
-         name="iBeacon Scanner" 
+         name="iBeacon Scanner"
          description="The iBeacon Scanner detects iBeacon frames and publishes on the cloud the detected beacons.">
-         
+
          <Icon resource="http://s3.amazonaws.com/kura-resources/application/icon/beacon.png" size="32"/>
-         
+
          <AD id="enable.scanning"
             name="Enable iBeacon scanning"
             type="Boolean"
@@ -23,15 +23,15 @@
             required="true"
             default="false"
             description="Enable scan for iBeacons."/>
-            
-        <AD id="scan.interval"
-            name="Scan interval"
+
+        <AD id="scan.duration"
+            name="Scan duration"
             type="Integer"
             cardinality="0"
             required="true"
             default="60"
             description="iBeacon scan duration in seconds."/>
-            
+
          <AD id="topic.prefix"
             name="Topic"
             type="String"
@@ -39,7 +39,7 @@
             required="true"
             default="beacons"
             description="Prefix for discovered items' topic"/>
-            
+
         <AD id="iname"
             name="Bluetooth interface name"
             type="String"
@@ -47,7 +47,7 @@
             required="true"
             default="hci0"
             description="Name of bluetooth adapter."/>
-            
+
         <AD id="publish.period"
             name="Publish period"
             type="Integer"
@@ -55,7 +55,7 @@
             required="true"
             default="10"
             description="Shortest time between publishes per beacon in seconds"/>
-                                
+
     </OCD>
 
     <Designate pid="org.eclipse.kura.example.ibeacon.scanner.IBeaconScanner">


### PR DESCRIPTION
Code expected scan.duration while configuration was scan.interval. Duration makes more sense, so it's done that way.