### PR TITLE
Removed compact2 check as not needed anymore.

### DIFF
--- a/kura/examples/pom.xml
+++ b/kura/examples/pom.xml
@@ -114,25 +114,6 @@
             </repositories>
         </profile>
         <profile>
-            <id>speedup</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>verify-compact2-compliance</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>bree</id>
             <build>
                 <plugins>
@@ -387,54 +368,6 @@
                             <target name="verify.jdeps">
                                 <available file="jdeps"
                                     filepath="${env.PATH}" property="jdeps.present" />
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>verify-compact2-compliance</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target name="exec.jdeps" if="jdeps.present">
-                                <echo message="Executing exec.jdeps step" />
-                                <apply executable="jdeps">
-                                    <arg value="-P" />
-                                    <arg value="-dotoutput" />
-                                    <arg
-                                        value="${project.build.directory}/logfiles" />
-                                    <fileset
-                                        dir="${project.build.directory}">
-                                        <include name="*.jar" />
-                                    </fileset>
-                                </apply>
-
-                                <fileset id="compact3.file"
-                                    dir="${project.build.directory}/logfiles"
-                                    includes="*.dot" erroronmissingdir="false">
-                                    <contains text="compact3" />
-                                </fileset>
-                                <fail message="Compact3 profile not allowed!">
-                                    <condition>
-                                        <resourcecount
-                                            when="greater" count="0"
-                                            refid="compact3.file" />
-                                    </condition>
-                                </fail>
-
-                                <fileset id="fulljre.file"
-                                    dir="${project.build.directory}/logfiles"
-                                    includes="*.dot" erroronmissingdir="false">
-                                    <contains text="Full JRE" />
-                                </fileset>
-                                <fail message="Full JRE profile not allowed!">
-                                    <condition>
-                                        <resourcecount
-                                            when="greater" count="0"
-                                            refid="fulljre.file" />
-                                    </condition>
-                                </fail>
                             </target>
                         </configuration>
                     </execution>

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -197,25 +197,6 @@
             </modules>
         </profile>
         <profile>
-            <id>speedup</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>verify-compact2-compliance</id>
-                                <configuration>
-                                    <skip>true</skip>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>bree</id>
             <build>
                 <plugins>
@@ -534,46 +515,6 @@
                             <exportAntProperties>true</exportAntProperties>
                             <target name="verify.jdeps">
                                 <available file="jdeps" filepath="${env.PATH}" property="jdeps.present" />
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>verify-compact2-compliance</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target name="exec.jdeps" if="jdeps.present">
-                                <echo message="Executing exec.jdeps step" />
-                                <apply executable="jdeps">
-                                    <arg value="-P" />
-                                    <arg value="-dotoutput" />
-                                    <arg value="${project.build.directory}/logfiles" />
-                                    <fileset dir="${project.build.directory}">
-                                        <include name="*.jar" />
-                                    </fileset>
-                                </apply>
-
-                                <fileset id="compact3.file" dir="${project.build.directory}/logfiles" includes="*.dot"
-                                    erroronmissingdir="false">
-                                    <contains text="compact3" />
-                                </fileset>
-                                <fail message="Compact3 profile not allowed!">
-                                    <condition>
-                                        <resourcecount when="greater" count="0" refid="compact3.file" />
-                                    </condition>
-                                </fail>
-
-                                <fileset id="fulljre.file" dir="${project.build.directory}/logfiles" includes="*.dot"
-                                    erroronmissingdir="false">
-                                    <contains text="Full JRE" />
-                                </fileset>
-                                <fail message="Full JRE profile not allowed!">
-                                    <condition>
-                                        <resourcecount when="greater" count="0" refid="fulljre.file" />
-                                    </condition>
-                                </fail>
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
There are currently no gateways that leverage compact 2 profile for java 8 and java 9 seems to not provide support for that.

Signed-off-by: Maiero <matteo.maiero@eurotech.com>