### PR TITLE
Improved subscription management in default CloudEndpoint

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/cloudconnection/CloudEndpoint.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/cloudconnection/CloudEndpoint.java
@@ -62,18 +62,20 @@ public interface CloudEndpoint {
      *
      * @param subscriptionProperties
      *            a map representing the subscription context
-     * @param subscriber
+     * @param cloudSubscriberListener
      *            a {@link CloudSubscriberListener} object that will be notified when a message is received in a context
      *            that matches the one identified by the subscription properties.
      */
-    public void registerSubscriber(Map<String, Object> subscriptionProperties, CloudSubscriberListener subscriber);
+    public void registerSubscriber(Map<String, Object> subscriptionProperties,
+            CloudSubscriberListener cloudSubscriberListener);
 
     /**
-     * Unregisters the subscriber identified by the provided {@code subscriptionProperties}
+     * Unregisters the provided {@code cloudSubscriberListener}.
      *
-     * @param subscriptionProperties
+     * @param cloudSubscriberListener
+     *            the {@link CloudSubscriberListener} to be unregistered.
      */
-    public void unregisterSubscriber(Map<String, Object> subscriptionProperties);
+    public void unregisterSubscriber(CloudSubscriberListener cloudSubscriberListener);
 
     /**
      * Provides information related to the associated connection. The information provided depends on the specific

--- a/kura/org.eclipse.kura.broker.artemis.simple.mqtt/OSGI-INF/org.eclipse.kura.broker.artemis.simple.mqtt.BrokerInstance.xml
+++ b/kura/org.eclipse.kura.broker.artemis.simple.mqtt/OSGI-INF/org.eclipse.kura.broker.artemis.simple.mqtt.BrokerInstance.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" modified="modified" name="org.eclipse.kura.broker.artemis.simple.mqtt.BrokerInstance">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" immediate="true" modified="modified" name="org.eclipse.kura.broker.artemis.simple.mqtt.BrokerInstance">
    <implementation class="org.eclipse.kura.broker.artemis.simple.mqtt.ServiceComponent"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -735,7 +735,7 @@ public class CloudConnectionManagerImpl
     }
 
     @Override
-    public void unregisterSubscriber(Map<String, Object> subscriptionProperties) {
+    public void unregisterSubscriber(CloudSubscriberListener subscriberListener) {
         throw new UnsupportedOperationException();
     }
 

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceOptions.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceOptions.java
@@ -220,43 +220,43 @@ public class CloudServiceOptions {
         return result;
     }
 
-    public String getTopicSeparator() {
+    public static String getTopicSeparator() {
         return TOPIC_SEPARATOR;
     }
 
-    public String getTopicAccountToken() {
+    public static String getTopicAccountToken() {
         return TOPIC_ACCOUNT_TOKEN;
     }
 
-    public String getTopicClientIdToken() {
+    public static String getTopicClientIdToken() {
         return TOPIC_CLIENT_ID_TOKEN;
     }
 
-    public String getTopicBirthSuffix() {
+    public static String getTopicBirthSuffix() {
         return TOPIC_BIRTH_SUFFIX;
     }
 
-    public String getTopicDisconnectSuffix() {
+    public static String getTopicDisconnectSuffix() {
         return TOPIC_DISCONNECT_SUFFIX;
     }
 
-    public String getTopicAppsSuffix() {
+    public static String getTopicAppsSuffix() {
         return TOPIC_APPS_SUFFIX;
     }
 
-    public String getTopicWildCard() {
+    public static String getTopicWildCard() {
         return TOPIC_WILD_CARD;
     }
 
-    public int getLifeCycleMessageQos() {
+    public static int getLifeCycleMessageQos() {
         return LIFECYCLE_QOS;
     }
 
-    public int getLifeCycleMessagePriority() {
+    public static int getLifeCycleMessagePriority() {
         return LIFECYCLE_PRIORITY;
     }
 
-    public boolean getLifeCycleMessageRetain() {
+    public static boolean getLifeCycleMessageRetain() {
         return LIFECYCLE_RETAIN;
     }
 }

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/subscriber/CloudSubscriberImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/subscriber/CloudSubscriberImpl.java
@@ -72,10 +72,8 @@ public class CloudSubscriberImpl
         @Override
         public void removedService(final ServiceReference<CloudConnectionManager> reference,
                 final CloudConnectionManager service) {
-            Map<String, Object> subscriptionProps = new HashMap<>();
-            subscriptionProps.put(APP_ID.name(), CloudSubscriberImpl.this.cloudSubscriberOptions.getAppId());
 
-            CloudSubscriberImpl.this.cloudService.unregisterSubscriber(subscriptionProps);
+            CloudSubscriberImpl.this.cloudService.unregisterSubscriber(CloudSubscriberImpl.this);
             CloudSubscriberImpl.this.cloudService.unregisterCloudConnectionListener(CloudSubscriberImpl.this);
             CloudSubscriberImpl.this.cloudService = null;
         }

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/subscriber/CloudSubscriptionRecord.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/subscriber/CloudSubscriptionRecord.java
@@ -11,18 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kura.core.cloud.subscriber;
 
-import org.eclipse.kura.cloudconnection.subscriber.listener.CloudSubscriberListener;
+import org.eclipse.kura.core.cloud.CloudServiceOptions;
+import org.eclipse.kura.core.util.MqttTopicUtil;
 
 public class CloudSubscriptionRecord {
 
     private final String topic;
     private final int qos;
-    private final CloudSubscriberListener subscriber;
 
-    public CloudSubscriptionRecord(String topic, int qos, CloudSubscriberListener subscriber) {
+    private String topicFilter;
+
+    public CloudSubscriptionRecord(final String topic, final int qos) {
         this.topic = topic;
         this.qos = qos;
-        this.subscriber = subscriber;
     }
 
     public String getTopic() {
@@ -33,8 +34,24 @@ public class CloudSubscriptionRecord {
         return this.qos;
     }
 
-    public CloudSubscriberListener getSubscriber() {
-        return this.subscriber;
+    public boolean matches(final String topic) {
+        if (topicFilter == null) {
+            topicFilter = this.topic.replaceAll(CloudServiceOptions.getTopicAccountToken(), "+")
+                    .replaceAll(CloudServiceOptions.getTopicClientIdToken(), "+");
+        }
+        return MqttTopicUtil.isMatched(this.topicFilter, topic);
     }
 
+    @Override
+    public int hashCode() {
+        return topic.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (!(obj instanceof CloudSubscriptionRecord)) {
+            return false;
+        }
+        return ((CloudSubscriptionRecord) obj).topic.equals(topic);
+    }
 }

--- a/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.kura.core.data;version="1.0.0",
  org.eclipse.kura.core.linux.util;version="1.1.0",
  org.eclipse.kura.core.ssl;version="1.0.0",
- org.eclipse.kura.core.util;version="1.1.1"
+ org.eclipse.kura.core.util;version="1.2.0"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.crypto,

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/util/MqttTopicUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/util/MqttTopicUtil.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+package org.eclipse.kura.core.util;
+
+import org.eclipse.paho.client.mqttv3.MqttTopic;
+
+public final class MqttTopicUtil {
+
+    private MqttTopicUtil() {
+    }
+
+    public static void validate(final String topicString, final boolean wildcardAllowed) {
+        MqttTopic.validate(topicString, wildcardAllowed);
+    }
+
+    public static boolean isMatched(final String topicFilter, final String topicName) {
+        return MqttTopic.isMatched(topicFilter, topicName);
+    }
+}


### PR DESCRIPTION
* Changed `CloudEndpoint.unregisterCloudSubscriber()` API to unregister by listener and not by subscription properties.

* Dispatch of messages in default CloudEndpoint implementation to subscribers is now performed matching the full topic and not only the APP ID.

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>