### PR TITLE
Fixed change in asset configuration property types

### DIFF
--- a/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/internal/asset/provider/BaseAssetConfiguration.java
+++ b/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/internal/asset/provider/BaseAssetConfiguration.java
@@ -235,7 +235,9 @@ public final class BaseAssetConfiguration {
                 continue;
             }
 
-            parser.process(property, e.getValue());
+            final Object value = e.getValue();
+
+            parser.process(property, value != null ? value.toString() : null);
         }
 
         return parser.getChannelList();

--- a/kura/test/org.eclipse.kura.asset.provider.test/src/main/java/org/eclipse/kura/asset/provider/test/AssetTest.java
+++ b/kura/test/org.eclipse.kura.asset.provider.test/src/main/java/org/eclipse/kura/asset/provider/test/AssetTest.java
@@ -657,7 +657,8 @@ public final class AssetTest {
         ((BaseAsset) asset).updated(channels);
         sync(asset);
 
-        assertEquals(5, asset.getAssetConfiguration().getAssetChannels().get("3.CH").getConfiguration().get("unit.id"));
+        assertEquals("5",
+                asset.getAssetConfiguration().getAssetChannels().get("3.CH").getConfiguration().get("unit.id"));
 
         initt();
     }


### PR DESCRIPTION
Since Kura 3.0.0 Assets uses `String` as type for all channel values that are supplied to Drivers in channel configuration, regardless of the actual types declared in channel descriptor.
PR #2161 switched to using the type defined in channel descriptor `AD`s.
This PR reverts the change to keep compatibility with existing drivers.

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>