### PR TITLE
Fixed modem reset in NOT_CONNECTED state

### DIFF
--- a/kura/org.eclipse.kura.net.admin/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.net.admin/META-INF/MANIFEST.MF
@@ -49,5 +49,5 @@ Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.kura.net.admin;version="1.3.0",
- org.eclipse.kura.net.admin.modem;version="1.1.0",
+ org.eclipse.kura.net.admin.modem;version="2.0.0",
  org.eclipse.kura.net.admin.monitor;version="1.1.0"

--- a/kura/org.eclipse.kura.net.admin/OSGI-INF/modemMonitor.xml
+++ b/kura/org.eclipse.kura.net.admin/OSGI-INF/modemMonitor.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2018 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -17,9 +17,14 @@
    <service>
       <provide interface="org.eclipse.kura.net.modem.ModemMonitorService"/>
       <provide interface="org.eclipse.kura.net.modem.ModemManagerService"/>
+      <provide interface="org.osgi.service.event.EventHandler"/>
    </service>
    <reference bind="setNetworkService" cardinality="1..1" interface="org.eclipse.kura.net.NetworkService" name="NetworkService" policy="static" unbind="unsetNetworkService"/>
    <reference bind="setSystemService" cardinality="1..1" interface="org.eclipse.kura.system.SystemService" name="SystemService" policy="static" unbind="unsetSystemService"/>
    <reference bind="setNetworkConfigurationService" cardinality="1..1" interface="org.eclipse.kura.net.admin.NetworkConfigurationService" name="NetworkConfigurationService" policy="static" unbind="unsetNetworkConfigurationService"/>
    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
+   <property name="event.topics" type="String">org/eclipse/kura/net/admin/event/NETWORK_EVENT_CONFIG_CHANGE_TOPIC
+org/eclipse/kura/net/modem/ADDED
+org/eclipse/kura/net/modem/REMOVED
+   </property>
 </scr:component>

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/PppFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/PppFactory.java
@@ -11,63 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
+public final class PppFactory {
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-public class PppFactory {
-
-    private static final Logger s_logger = LoggerFactory.getLogger(PppFactory.class);
-
-    private static Map<String, IModemLinkService> s_pppServices = new HashMap<>();
-
-    public static IModemLinkService obtainPppService(int pppNo, String port) {
-
-        IModemLinkService modemLinkService = null;
-        if (pppNo >= 0) {
-            modemLinkService = obtainPppService("ppp" + pppNo, port);
-        }
-        return modemLinkService;
+    private PppFactory() {
     }
 
-    public static IModemLinkService obtainPppService(String iface, String port) {
-
-        IModemLinkService modemLinkService = null;
-
-        if (s_pppServices.containsKey(iface)) {
-            modemLinkService = s_pppServices.get(iface);
-        } else {
-            s_logger.debug("Creating new modemLinkService for {}", iface);
-            modemLinkService = new Ppp(iface, port);
-            s_pppServices.put(iface, modemLinkService);
-        }
-        return modemLinkService;
-    }
-
-    public static IModemLinkService releasePppService(String iface) {
-
-        IModemLinkService modemLinkService = null;
-
-        if (s_pppServices.containsKey(iface)) {
-            s_logger.debug("Removing modemLinkService for {}", iface);
-            modemLinkService = s_pppServices.remove(iface);
-        }
-
-        return modemLinkService;
-    }
-
-    public static void releaseAllPppServices() {
-
-        Set<String> set = s_pppServices.keySet();
-        Iterator<String> it = set.iterator();
-        while (it.hasNext()) {
-            String iface = it.next();
-            s_logger.debug("releasing modm link for {} interface", iface);
-            s_pppServices.remove(iface);
-        }
+    public static IModemLinkService getPppService(final String interfaceName, final String port) {
+        return new Ppp(interfaceName, port);
     }
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
@@ -13,19 +13,24 @@ package org.eclipse.kura.net.admin.monitor;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Dictionary;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.Hashtable;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
+import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.comm.CommURI;
 import org.eclipse.kura.core.net.AbstractNetInterface;
@@ -72,10 +77,8 @@ import org.eclipse.kura.net.modem.SerialModemDevice;
 import org.eclipse.kura.system.SystemService;
 import org.eclipse.kura.usb.UsbDeviceEvent;
 import org.eclipse.kura.usb.UsbModemDevice;
-import org.osgi.service.component.ComponentContext;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
-import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,35 +87,27 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
 
     private static final Logger logger = LoggerFactory.getLogger(ModemMonitorServiceImpl.class);
 
-    private static final String[] EVENT_TOPICS = new String[] {
-            NetworkConfigurationChangeEvent.NETWORK_EVENT_CONFIG_CHANGE_TOPIC, ModemAddedEvent.MODEM_EVENT_ADDED_TOPIC,
-            ModemRemovedEvent.MODEM_EVENT_REMOVED_TOPIC, };
-
     private static final long THREAD_INTERVAL = 30000;
     private static final long THREAD_TERMINATION_TOUT = 1; // in seconds
 
-    private static Object lock = new Object();
-
     private Future<?> task;
-    private static AtomicBoolean stopThread;
+
     private SystemService systemService;
     private NetworkService networkService;
     private NetworkConfigurationService netConfigService;
     private EventAdmin eventAdmin;
 
-    private List<ModemMonitorListener> listeners;
+    private final Set<ModemMonitorListener> listeners = Collections.synchronizedSet(new HashSet<>());
 
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private ScheduledExecutorService executor = createExecutor();
 
-    private Map<String, CellularModem> modems;
-    private Map<String, InterfaceState> interfaceStatuses;
+    private final Map<String, MonitoredModem> modems = new ConcurrentHashMap<>();
+    private Map<String, InterfaceState> interfaceStatuses = new HashMap<>();
 
     private NetworkConfiguration networkConfig;
 
-    private boolean serviceActivated;
-
-    private PppState pppState;
-    private long resetTimerStart;
+    private final AtomicBoolean monitorRequestPending = new AtomicBoolean();
+    private volatile boolean serviceActivated;
 
     public void setNetworkService(NetworkService networkService) {
         this.networkService = networkService;
@@ -146,77 +141,56 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
         this.systemService = null;
     }
 
-    protected void activate(ComponentContext componentContext) {
+    protected void activate() {
 
-        this.pppState = PppState.NOT_CONNECTED;
-        this.resetTimerStart = 0L;
-
-        Dictionary<String, String[]> d = new Hashtable<>();
-        d.put(EventConstants.EVENT_TOPIC, EVENT_TOPICS);
-        componentContext.getBundleContext().registerService(EventHandler.class.getName(), this, d);
-
-        this.modems = new HashMap<>();
-        this.interfaceStatuses = new HashMap<>();
-        this.listeners = new ArrayList<>();
-
-        stopThread = new AtomicBoolean();
-
-        // track currently installed modems
-        try {
-            this.networkConfig = this.netConfigService.getNetworkConfiguration();
-            for (NetInterface<? extends NetInterfaceAddress> netInterface : this.networkService
-                    .getNetworkInterfaces()) {
-                if (netInterface instanceof ModemInterface) {
-                    ModemDevice modemDevice = ((ModemInterface<?>) netInterface).getModemDevice();
-                    trackModem(modemDevice);
+        executor.execute(() -> {
+            // track currently installed modems
+            try {
+                this.networkConfig = this.netConfigService.getNetworkConfiguration();
+                for (NetInterface<? extends NetInterfaceAddress> netInterface : this.networkService
+                        .getNetworkInterfaces()) {
+                    if (netInterface instanceof ModemInterface) {
+                        ModemDevice modemDevice = ((ModemInterface<?>) netInterface).getModemDevice();
+                        trackModem(modemDevice);
+                    }
                 }
+            } catch (Exception e) {
+                logger.error("Error getting installed modems", e);
             }
-        } catch (Exception e) {
-            logger.error("Error getting installed modems", e);
-        }
 
-        submitMonitorTask();
+            startMonitorTask();
 
-        this.serviceActivated = true;
-        logger.debug("ModemMonitor activated and ready to receive events");
+            this.serviceActivated = true;
+            logger.debug("ModemMonitor activated and ready to receive events");
+        });
     }
 
-    private Future<?> submitMonitorTask() {
-        stopThread.set(false);
-
-        // is task already prepared?
-        if (task != null && !task.isDone()) {
+    private Future<?> startMonitorTask() {
+        if (task != null) {
             return task;
         }
-
-        task = this.executor.submit(() -> {
-            while (!stopThread.get()) {
-                Thread.currentThread().setName("ModemMonitor");
-                try {
-                    monitor();
-                    monitorWait();
-                } catch (InterruptedException interruptedException) {
-                    Thread.interrupted();
-                    logger.debug("modem monitor interrupted", interruptedException);
-                } catch (Throwable t) {
-                    logger.error("Exception while monitoring cellular connection", t);
-                }
-            }
-        });
+        task = this.executor.scheduleWithFixedDelay(this::monitor, 0, THREAD_INTERVAL, TimeUnit.MILLISECONDS);
         return task;
     }
 
-    protected void deactivate(ComponentContext componentContext) {
-        this.listeners = null;
-        PppFactory.releaseAllPppServices();
-        if (task != null && !task.isDone()) {
-            stopThread.set(true);
-            monitorNotify();
+    private void stopMonitorTask() {
+        if (this.task != null) {
             logger.debug("Cancelling ModemMonitor task ...");
-            task.cancel(true);
+            this.task.cancel(false);
             logger.info("ModemMonitor task cancelled? = {}", task.isDone());
-            task = null;
+            this.task = null;
         }
+    }
+
+    private void requestMonitor() {
+        if (!monitorRequestPending.getAndSet(true)) {
+            executor.execute(this::monitor);
+        }
+    }
+
+    protected void deactivate() {
+
+        stopMonitorTask();
 
         logger.debug("Terminating ModemMonitor Thread ...");
         this.executor.shutdownNow();
@@ -233,61 +207,63 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
     }
 
     @Override
-    public void handleEvent(Event event) {
+    public void handleEvent(final Event event) {
         logger.debug("handleEvent - topic: {}", event.getTopic());
         String topic = event.getTopic();
         if (topic.equals(NetworkConfigurationChangeEvent.NETWORK_EVENT_CONFIG_CHANGE_TOPIC)) {
 
-            NetworkConfigurationChangeEvent netConfigChangedEvent = (NetworkConfigurationChangeEvent) event;
-            String[] propNames = netConfigChangedEvent.getPropertyNames();
-            if (propNames != null && propNames.length > 0) {
-                Map<String, Object> props = new HashMap<>();
-                for (String propName : propNames) {
-                    Object prop = netConfigChangedEvent.getProperty(propName);
-                    if (prop != null) {
-                        props.put(propName, prop);
+            executor.execute(() -> {
+                NetworkConfigurationChangeEvent netConfigChangedEvent = (NetworkConfigurationChangeEvent) event;
+                String[] propNames = netConfigChangedEvent.getPropertyNames();
+                if (propNames != null && propNames.length > 0) {
+                    Map<String, Object> props = new HashMap<>();
+                    for (String propName : propNames) {
+                        Object prop = netConfigChangedEvent.getProperty(propName);
+                        if (prop != null) {
+                            props.put(propName, prop);
+                        }
+                    }
+
+                    try {
+                        final NetworkConfiguration newNetworkConfig = new NetworkConfiguration(props);
+                        processNetworkConfigurationChangeEvent(newNetworkConfig);
+                        requestMonitor();
+                    } catch (Exception e) {
+                        logger.error("Failed to handle the NetworkConfigurationChangeEvent ", e);
                     }
                 }
-                try {
-                    final NetworkConfiguration newNetworkConfig = new NetworkConfiguration(props);
-                    ExecutorService ex = Executors.newSingleThreadExecutor();
-                    ex.submit(() -> processNetworkConfigurationChangeEvent(newNetworkConfig));
-                } catch (Exception e) {
-                    logger.error("Failed to handle the NetworkConfigurationChangeEvent ", e);
-                }
-            }
+            });
         } else if (topic.equals(ModemAddedEvent.MODEM_EVENT_ADDED_TOPIC)) {
             ModemAddedEvent modemAddedEvent = (ModemAddedEvent) event;
             final ModemDevice modemDevice = modemAddedEvent.getModemDevice();
             if (this.serviceActivated) {
-                ExecutorService ex = Executors.newSingleThreadExecutor();
-                ex.submit(() -> trackModem(modemDevice));
+                trackModem(modemDevice);
             }
+            requestMonitor();
         } else if (topic.equals(ModemRemovedEvent.MODEM_EVENT_REMOVED_TOPIC)) {
             ModemRemovedEvent modemRemovedEvent = (ModemRemovedEvent) event;
             String usbPort = (String) modemRemovedEvent.getProperty(UsbDeviceEvent.USB_EVENT_USB_PORT_PROPERTY);
-            final CellularModem modem = this.modems.remove(usbPort);
+            final MonitoredModem modem = this.modems.remove(usbPort);
             if (modem != null) {
-                try {
-                    logger.debug("Releasing modem device from factory...");
-                    final CellularModemFactory factory = getCellularModemFactory(modem.getModemDevice());
-                    factory.releaseModemService(modem);
-                    logger.debug("Releasing modem device from factory...done");
-                } catch (Exception e) {
-                    logger.warn("Failed to release modem device from factory", e);
-                }
+                modem.release();
             }
         }
     }
 
     @Override
     public CellularModem getModemService(String usbPort) {
-        return this.modems.get(usbPort);
+        final MonitoredModem modem = this.modems.get(usbPort);
+
+        if (modem == null) {
+            return null;
+        }
+
+        return modem.modem;
     }
 
     @Override
     public Collection<CellularModem> getAllModemServices() {
-        return this.modems.values();
+        return this.modems.values().stream().map(MonitoredModem::getModem).collect(Collectors.toList());
     }
 
     private NetInterfaceStatus getNetInterfaceStatus(List<NetConfig> netConfigs) {
@@ -317,150 +293,112 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
 
     @Override
     public void registerListener(ModemMonitorListener newListener) {
-        boolean found = false;
-        if (this.listeners == null) {
-            this.listeners = new ArrayList<>();
-        }
-        if (!this.listeners.isEmpty()) {
-            for (ModemMonitorListener listener : this.listeners) {
-                if (listener.equals(newListener)) {
-                    found = true;
-                    break;
-                }
-            }
-        }
-        if (!found) {
-            this.listeners.add(newListener);
-        }
+        this.listeners.add(newListener);
     }
 
     @Override
     public void unregisterListener(ModemMonitorListener listenerToUnregister) {
-        if (this.listeners != null && !this.listeners.isEmpty()) {
-
-            for (int i = 0; i < this.listeners.size(); i++) {
-                if (this.listeners.get(i).equals(listenerToUnregister)) {
-                    this.listeners.remove(i);
-                }
-            }
-        }
+        this.listeners.remove(listenerToUnregister);
     }
 
     private void processNetworkConfigurationChangeEvent(NetworkConfiguration newNetworkConfig) {
-        synchronized (lock) {
-            if (this.modems == null || this.modems.isEmpty()) {
-                return;
-            }
-            for (Map.Entry<String, CellularModem> modemEntry : this.modems.entrySet()) {
-                String usbPort = modemEntry.getKey();
-                CellularModem modem = modemEntry.getValue();
-                try {
-                    String ifaceName = null;
-                    if (this.networkService != null) {
-                        ifaceName = this.networkService.getModemPppPort(modem.getModemDevice());
-                    }
-                    if (ifaceName != null) {
-                        List<NetConfig> oldNetConfigs = modem.getConfiguration();
-                        NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig = newNetworkConfig
-                                .getNetInterfaceConfig(ifaceName);
-                        if (netInterfaceConfig == null) {
-                            netInterfaceConfig = newNetworkConfig.getNetInterfaceConfig(usbPort);
-                        }
-                        List<NetConfig> newNetConfigs = null;
-                        IModemLinkService pppService = null;
-                        int ifaceNo = getInterfaceNumber(oldNetConfigs);
-                        if (ifaceNo >= 0) {
-                            pppService = PppFactory.obtainPppService(ifaceNo, modem.getDataPort());
-                        }
-
-                        if (netInterfaceConfig != null) {
-                            newNetConfigs = ((AbstractNetInterface<?>) netInterfaceConfig).getNetConfigs();
-                        } else {
-                            if (oldNetConfigs != null && pppService != null
-                                    && !ifaceName.equals(pppService.getIfaceName())) {
-                                StringBuilder key = new StringBuilder().append("net.interface.").append(ifaceName)
-                                        .append(".config.ip4.status");
-                                String statusString = KuranetConfig.getProperty(key.toString());
-                                NetInterfaceStatus netInterfaceStatus = NetInterfaceStatus.netIPv4StatusDisabled;
-                                if (statusString != null && !statusString.isEmpty()) {
-                                    netInterfaceStatus = NetInterfaceStatus.valueOf(statusString);
-                                }
-
-                                newNetConfigs = oldNetConfigs;
-                                oldNetConfigs = null;
-                                try {
-                                    setInterfaceNumber(ifaceName, newNetConfigs);
-                                    setNetInterfaceStatus(netInterfaceStatus, newNetConfigs);
-                                } catch (NumberFormatException e) {
-                                    logger.error("failed to set new interface number ", e);
-                                }
-                            }
-                        }
-
-                        if (oldNetConfigs == null || !isConfigsEqual(oldNetConfigs, newNetConfigs)) {
-                            logger.info("new configuration for cellular modem on usb port {} netinterface {}", usbPort,
-                                    ifaceName);
-                            this.networkConfig = newNetworkConfig;
-                            NetInterfaceStatus netInterfaceStatus = getNetInterfaceStatus(newNetConfigs);
-                            if (pppService != null && netInterfaceStatus != NetInterfaceStatus.netIPv4StatusUnmanaged) {
-                                PppState pppSt = pppService.getPppState();
-                                if (pppSt == PppState.CONNECTED || pppSt == PppState.IN_PROGRESS) {
-                                    logger.info("disconnecting " + pppService.getIfaceName());
-                                    pppService.disconnect();
-                                }
-                                PppFactory.releasePppService(pppService.getIfaceName());
-                            }
-
-                            if (modem.isGpsEnabled() && !disableModemGps(modem)) {
-                                logger.error("processNetworkConfigurationChangeEvent() :: Failed to disable modem GPS");
-                                modem.reset();
-                                this.resetTimerStart = System.currentTimeMillis();
-                            }
-
-                            modem.setConfiguration(newNetConfigs);
-
-                            if (modem instanceof EvdoCellularModem) {
-                                NetInterfaceStatus netIfaceStatus = getNetInterfaceStatus(newNetConfigs);
-                                if (netIfaceStatus == NetInterfaceStatus.netIPv4StatusEnabledWAN) {
-
-                                    if (!((EvdoCellularModem) modem).isProvisioned()) {
-                                        logger.info(
-                                                "NetworkConfigurationChangeEvent :: The {} is not provisioned, will try to provision it ...",
-                                                modem.getModel());
-
-                                        if (task != null && !task.isCancelled()) {
-                                            logger.info("NetworkConfigurationChangeEvent :: Cancelling monitor task");
-                                            stopThread.set(true);
-                                            monitorNotify();
-                                            task.cancel(true);
-                                            task = null;
-                                        }
-
-                                        ((EvdoCellularModem) modem).provision();
-                                        if (task == null) {
-                                            logger.info("NetworkConfigurationChangeEvent :: Restarting monitor task");
-
-                                            submitMonitorTask();
-                                        } else {
-                                            monitorNotify();
-                                        }
-                                    } else {
-                                        logger.info("NetworkConfigurationChangeEvent :: The {} is provisioned",
-                                                modem.getModel());
-                                    }
-                                }
-
-                                if (modem.isGpsSupported() && isGpsEnabledInConfig(newNetConfigs)
-                                        && !modem.isGpsEnabled()) {
-                                    modem.enableGps();
-                                    postModemGpsEvent(modem, true);
-                                }
-                            }
-                        }
-                    }
-                } catch (KuraException e) {
-                    logger.error("NetworkConfigurationChangeEvent :: Failed to process ", e);
+        if (this.modems == null || this.modems.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, MonitoredModem> modemEntry : this.modems.entrySet()) {
+            String usbPort = modemEntry.getKey();
+            final MonitoredModem monitoredModem = modemEntry.getValue();
+            CellularModem modem = monitoredModem.getModem();
+            try {
+                String ifaceName = null;
+                if (this.networkService != null) {
+                    ifaceName = this.networkService.getModemPppPort(modem.getModemDevice());
                 }
+                if (ifaceName != null) {
+                    List<NetConfig> oldNetConfigs = modem.getConfiguration();
+                    NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig = newNetworkConfig
+                            .getNetInterfaceConfig(ifaceName);
+                    if (netInterfaceConfig == null) {
+                        netInterfaceConfig = newNetworkConfig.getNetInterfaceConfig(usbPort);
+                    }
+                    List<NetConfig> newNetConfigs = null;
+                    IModemLinkService pppService = null;
+                    int ifaceNo = getInterfaceNumber(oldNetConfigs);
+                    if (ifaceNo >= 0) {
+                        pppService = getPppService("ppp" + ifaceNo, modem.getDataPort());
+                    }
+
+                    if (netInterfaceConfig != null) {
+                        newNetConfigs = ((AbstractNetInterface<?>) netInterfaceConfig).getNetConfigs();
+                    } else {
+                        if (oldNetConfigs != null && pppService != null
+                                && !ifaceName.equals(pppService.getIfaceName())) {
+                            StringBuilder key = new StringBuilder().append("net.interface.").append(ifaceName)
+                                    .append(".config.ip4.status");
+                            String statusString = KuranetConfig.getProperty(key.toString());
+                            NetInterfaceStatus netInterfaceStatus = NetInterfaceStatus.netIPv4StatusDisabled;
+                            if (statusString != null && !statusString.isEmpty()) {
+                                netInterfaceStatus = NetInterfaceStatus.valueOf(statusString);
+                            }
+
+                            newNetConfigs = oldNetConfigs;
+                            oldNetConfigs = null;
+                            try {
+                                setInterfaceNumber(ifaceName, newNetConfigs);
+                                setNetInterfaceStatus(netInterfaceStatus, newNetConfigs);
+                            } catch (NumberFormatException e) {
+                                logger.error("failed to set new interface number ", e);
+                            }
+                        }
+                    }
+
+                    if (oldNetConfigs == null || !isConfigsEqual(oldNetConfigs, newNetConfigs)) {
+                        logger.info("new configuration for cellular modem on usb port {} netinterface {}", usbPort,
+                                ifaceName);
+                        this.networkConfig = newNetworkConfig;
+                        NetInterfaceStatus netInterfaceStatus = getNetInterfaceStatus(newNetConfigs);
+                        if (pppService != null && netInterfaceStatus != NetInterfaceStatus.netIPv4StatusUnmanaged) {
+                            PppState pppSt = pppService.getPppState();
+                            if (pppSt == PppState.CONNECTED || pppSt == PppState.IN_PROGRESS) {
+                                logger.info("disconnecting " + pppService.getIfaceName());
+                                pppService.disconnect();
+                            }
+                        }
+
+                        if (modem.isGpsEnabled() && !disableModemGps(modem)) {
+                            logger.error("processNetworkConfigurationChangeEvent() :: Failed to disable modem GPS");
+                            monitoredModem.forceReset();
+                        }
+
+                        modem.setConfiguration(newNetConfigs);
+
+                        if (modem instanceof EvdoCellularModem) {
+                            NetInterfaceStatus netIfaceStatus = getNetInterfaceStatus(newNetConfigs);
+                            if (netIfaceStatus == NetInterfaceStatus.netIPv4StatusEnabledWAN) {
+
+                                if (!((EvdoCellularModem) modem).isProvisioned()) {
+                                    logger.info(
+                                            "NetworkConfigurationChangeEvent :: The {} is not provisioned, will try to provision it ...",
+                                            modem.getModel());
+
+                                    ((EvdoCellularModem) modem).provision();
+
+                                } else {
+                                    logger.info("NetworkConfigurationChangeEvent :: The {} is provisioned",
+                                            modem.getModel());
+                                }
+                            }
+
+                            if (modem.isGpsSupported() && isGpsEnabledInConfig(newNetConfigs)
+                                    && !modem.isGpsEnabled()) {
+                                modem.enableGps();
+                                postModemGpsEvent(modem, true);
+                            }
+                        }
+                    }
+                }
+            } catch (KuraException e) {
+                logger.error("NetworkConfigurationChangeEvent :: Failed to process ", e);
             }
         }
     }
@@ -530,7 +468,7 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
         }
     }
 
-    private long getModemResetTimeoutMsec(String ifaceName, List<NetConfig> netConfigs) {
+    long getModemResetTimeoutMsec(String ifaceName, List<NetConfig> netConfigs) {
         long resetToutMsec = 0L;
 
         if (ifaceName != null && netConfigs != null) {
@@ -558,151 +496,26 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
     }
 
     private void monitor() {
-        synchronized (lock) {
-            HashMap<String, InterfaceState> newInterfaceStatuses = new HashMap<>();
-            if (this.modems == null || this.modems.isEmpty()) {
-                return;
-            }
-            for (Map.Entry<String, CellularModem> modemEntry : this.modems.entrySet()) {
-                boolean modemReset = false;
-                CellularModem modem = modemEntry.getValue();
-                // get signal strength only if somebody needs it
-                if (this.listeners != null && !this.listeners.isEmpty()) {
-                    for (ModemMonitorListener listener : this.listeners) {
-                        try {
-                            int rssi = modem.getSignalStrength();
-                            listener.setCellularSignalLevel(rssi);
-                        } catch (KuraException e) {
-                            listener.setCellularSignalLevel(0);
-                            logger.error("monitor() :: Failed to obtain signal strength - {}", e);
-                        }
-                    }
-                }
+        monitorRequestPending.set(false);
 
-                IModemLinkService pppService = null;
-                PppState pppSt = null;
-                NetInterfaceStatus netInterfaceStatus = getNetInterfaceStatus(modem.getConfiguration());
-                try {
-                    String ifaceName = this.networkService.getModemPppPort(modem.getModemDevice());
-                    if (netInterfaceStatus == NetInterfaceStatus.netIPv4StatusUnmanaged) {
-                        logger.warn(
-                                "The {} interface is configured not to be managed by Kura and will not be monitored.",
-                                ifaceName);
-                        continue;
-                    }
-                    if (netInterfaceStatus == NetInterfaceStatus.netIPv4StatusEnabledWAN && ifaceName != null) {
-                        pppService = PppFactory.obtainPppService(ifaceName, modem.getDataPort());
-                        pppSt = pppService.getPppState();
-                        if (this.pppState != pppSt) {
-                            logger.info("monitor() :: previous PppState={}", this.pppState);
-                            logger.info("monitor() :: current PppState={}", pppSt);
-                        }
-
-                        if (pppSt == PppState.NOT_CONNECTED) {
-                            boolean checkIfSimCardReady = false;
-                            List<ModemTechnologyType> modemTechnologyTypes = modem.getTechnologyTypes();
-                            for (ModemTechnologyType modemTechnologyType : modemTechnologyTypes) {
-                                if (modemTechnologyType == ModemTechnologyType.GSM_GPRS
-                                        || modemTechnologyType == ModemTechnologyType.UMTS
-                                        || modemTechnologyType == ModemTechnologyType.HSDPA
-                                        || modemTechnologyType == ModemTechnologyType.HSPA) {
-                                    checkIfSimCardReady = true;
-                                    break;
-                                }
-                            }
-                            if (checkIfSimCardReady) {
-                                if (((HspaCellularModem) modem).isSimCardReady()) {
-                                    logger.info("monitor() :: !!! SIM CARD IS READY !!! connecting ...");
-                                    pppService.connect();
-                                    if (this.pppState == PppState.NOT_CONNECTED) {
-                                        this.resetTimerStart = System.currentTimeMillis();
-                                    }
-                                } else {
-                                    logger.warn("monitor() :: ! SIM CARD IS NOT READY !");
-                                }
-                            } else {
-                                logger.info("monitor() :: connecting ...");
-                                pppService.connect();
-                                if (this.pppState == PppState.NOT_CONNECTED) {
-                                    this.resetTimerStart = System.currentTimeMillis();
-                                }
-                            }
-                        } else if (pppSt == PppState.IN_PROGRESS) {
-                            long modemResetTout = getModemResetTimeoutMsec(ifaceName, modem.getConfiguration());
-                            if (modemResetTout > 0) {
-                                long timeElapsed = System.currentTimeMillis() - this.resetTimerStart;
-                                if (timeElapsed > modemResetTout) {
-                                    // reset modem
-                                    logger.info("monitor() :: Modem Reset TIMEOUT !!!");
-                                    pppService.disconnect();
-                                    if (modem.isGpsEnabled() && !disableModemGps(modem)) {
-                                        logger.error("monitor() :: Failed to disable modem GPS");
-                                    }
-                                    modem.reset();
-                                    PppFactory.releasePppService(ifaceName);
-                                    pppSt = PppState.NOT_CONNECTED;
-                                    this.resetTimerStart = System.currentTimeMillis();
-                                    modemReset = true;
-                                } else {
-                                    int timeTillReset = (int) (modemResetTout - timeElapsed) / 1000;
-                                    logger.info(
-                                            "monitor() :: PPP connection in progress. Modem will be reset in {} sec if not connected",
-                                            timeTillReset);
-                                }
-                            }
-                        } else if (pppSt == PppState.CONNECTED) {
-                            this.resetTimerStart = System.currentTimeMillis();
-                        }
-
-                        this.pppState = pppSt;
-                        ConnectionInfo connInfo = new ConnectionInfoImpl(ifaceName);
-                        InterfaceState interfaceState = new InterfaceState(ifaceName,
-                                LinuxNetworkUtil.hasAddress(ifaceName), pppSt == PppState.CONNECTED,
-                                connInfo.getIpAddress());
-                        newInterfaceStatuses.put(ifaceName, interfaceState);
-                    }
-
-                    // If the modem has been reset in this iteration of the monitor,
-                    // do not immediately enable GPS to avoid concurrency issues due to asynchronous events
-                    // (possible serial port contention between the PositionService and the trackModem() method),
-                    // GPS will be eventually enabled by trackModem() or in the next iteration of the monitor.
-                    if (!modemReset && modem.isGpsSupported() && isGpsEnabledInConfig(modem.getConfiguration())) {
-                        if (modem instanceof HspaCellularModem && !modem.isGpsEnabled()) {
-                            modem.enableGps();
-                        }
-                        postModemGpsEvent(modem, true);
-                    }
-
-                } catch (Exception e) {
-                    logger.error("monitor() :: Exception", e);
-                    if (pppService != null && pppSt != null) {
-                        try {
-                            logger.info("monitor() :: Exception :: PPPD disconnect");
-                            pppService.disconnect();
-                        } catch (KuraException e1) {
-                            logger.error("monitor() :: Exception while disconnect", e1);
-                        }
-                        this.pppState = pppSt;
-                    }
-
-                    if (modem.isGpsEnabled() && !disableModemGps(modem)) {
-                        logger.error("monitor() :: Failed to disable modem GPS");
-                    }
-
-                    try {
-                        logger.info("monitor() :: Exception :: modem reset");
-                        modem.reset();
-                        this.resetTimerStart = System.currentTimeMillis();
-                    } catch (KuraException e1) {
-                        logger.error("monitor() :: Exception modem.reset", e1);
-                    }
-                }
-            }
-
-            // post event for any status changes
-            checkStatusChange(this.interfaceStatuses, newInterfaceStatuses);
-            this.interfaceStatuses = newInterfaceStatuses;
+        if (this.modems.isEmpty()) {
+            return;
         }
+
+        final HashMap<String, InterfaceState> newInterfaceStatuses = new HashMap<>();
+
+        logger.debug("tracked modems: {}", modems.keySet());
+
+        for (final Entry<String, MonitoredModem> e : this.modems.entrySet()) {
+
+            logger.debug("processing modem {}", e.getKey());
+
+            e.getValue().monitor(newInterfaceStatuses);
+        }
+
+        // post event for any status changes
+        checkStatusChange(this.interfaceStatuses, newInterfaceStatuses);
+        this.interfaceStatuses = newInterfaceStatuses;
     }
 
     private void checkStatusChange(Map<String, InterfaceState> oldStatuses, Map<String, InterfaceState> newStatuses) {
@@ -738,92 +551,33 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
     }
 
     private void trackModem(ModemDevice modemDevice) {
-        synchronized (lock) {
-            try {
-                final CellularModemFactory modemFactoryService = getCellularModemFactory(modemDevice);
+        try {
+            final CellularModemFactory modemFactoryService = getCellularModemFactory(modemDevice);
 
-                String platform = null;
-                if (this.systemService != null) {
-                    platform = this.systemService.getPlatform();
-                }
-                CellularModem modem = modemFactoryService.obtainCellularModemService(modemDevice, platform);
-                try {
-                    HashMap<String, String> modemInfoMap = new HashMap<>();
-                    modemInfoMap.put(ModemReadyEvent.IMEI, modem.getSerialNumber());
-                    modemInfoMap.put(ModemReadyEvent.IMSI, modem.getMobileSubscriberIdentity());
-                    modemInfoMap.put(ModemReadyEvent.ICCID, modem.getIntegratedCirquitCardId());
-                    modemInfoMap.put(ModemReadyEvent.RSSI, Integer.toString(modem.getSignalStrength()));
-                    logger.info("posting ModemReadyEvent on topic {}", ModemReadyEvent.MODEM_EVENT_READY_TOPIC);
-                    this.eventAdmin.postEvent(new ModemReadyEvent(modemInfoMap));
-                } catch (Exception e) {
-                    logger.error("Failed to post the ModemReadyEvent", e);
-                }
-
-                String ifaceName = this.networkService.getModemPppPort(modemDevice);
-                List<NetConfig> netConfigs = null;
-                if (ifaceName != null) {
-                    NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig = this.networkConfig
-                            .getNetInterfaceConfig(ifaceName);
-
-                    if (netInterfaceConfig == null) {
-                        this.networkConfig = this.netConfigService.getNetworkConfiguration();
-                        netInterfaceConfig = this.networkConfig.getNetInterfaceConfig(ifaceName);
-                    }
-
-                    if (netInterfaceConfig != null) {
-                        netConfigs = ((AbstractNetInterface<?>) netInterfaceConfig).getNetConfigs();
-                        if (netConfigs != null && !netConfigs.isEmpty()) {
-                            modem.setConfiguration(netConfigs);
-                        }
-                    }
-                }
-
-                if (modemDevice instanceof UsbModemDevice) {
-                    this.modems.put(((UsbModemDevice) modemDevice).getUsbPort(), modem);
-                } else if (modemDevice instanceof SerialModemDevice) {
-                    this.modems.put(modemDevice.getProductName(), modem);
-                }
-
-                if (modem instanceof EvdoCellularModem) {
-                    NetInterfaceStatus netIfaceStatus = getNetInterfaceStatus(netConfigs);
-                    if (netIfaceStatus == NetInterfaceStatus.netIPv4StatusEnabledWAN) {
-                        if (modem.isGpsEnabled() && !disableModemGps(modem)) {
-                            logger.error("trackModem() :: Failed to disable modem GPS, resetting modem ...");
-                            modem.reset();
-                            this.resetTimerStart = System.currentTimeMillis();
-                        }
-
-                        if (!((EvdoCellularModem) modem).isProvisioned()) {
-                            logger.info("trackModem() :: The {} is not provisioned, will try to provision it ...",
-                                    modem.getModel());
-                            if (task != null && !task.isCancelled()) {
-                                logger.info("trackModem() :: Cancelling monitor task");
-                                stopThread.set(true);
-                                monitorNotify();
-                                task.cancel(true);
-                                task = null;
-                            }
-                            ((EvdoCellularModem) modem).provision();
-                            if (task == null) {
-                                logger.info("trackModem() :: Restarting monitor task");
-
-                                submitMonitorTask();
-                            } else {
-                                monitorNotify();
-                            }
-                        } else {
-                            logger.info("trackModem() :: The {} is provisioned", modem.getModel());
-                        }
-                    }
-
-                    if (modem.isGpsSupported() && isGpsEnabledInConfig(netConfigs) && !modem.isGpsEnabled()) {
-                        modem.enableGps();
-                        postModemGpsEvent(modem, true);
-                    }
-                }
-            } catch (Exception e) {
-                logger.error("trackModem() :: {}", e.getMessage(), e);
+            String platform = null;
+            if (this.systemService != null) {
+                platform = this.systemService.getPlatform();
             }
+            CellularModem modem = modemFactoryService.obtainCellularModemService(modemDevice, platform);
+            try {
+                HashMap<String, String> modemInfoMap = new HashMap<>();
+                modemInfoMap.put(ModemReadyEvent.IMEI, modem.getSerialNumber());
+                modemInfoMap.put(ModemReadyEvent.IMSI, modem.getMobileSubscriberIdentity());
+                modemInfoMap.put(ModemReadyEvent.ICCID, modem.getIntegratedCirquitCardId());
+                modemInfoMap.put(ModemReadyEvent.RSSI, Integer.toString(modem.getSignalStrength()));
+                logger.info("posting ModemReadyEvent on topic {}", ModemReadyEvent.MODEM_EVENT_READY_TOPIC);
+                this.eventAdmin.postEvent(new ModemReadyEvent(modemInfoMap));
+            } catch (Exception e) {
+                logger.error("Failed to post the ModemReadyEvent", e);
+            }
+
+            if (modemDevice instanceof UsbModemDevice) {
+                this.modems.put(((UsbModemDevice) modemDevice).getUsbPort(), new MonitoredModem(modem));
+            } else if (modemDevice instanceof SerialModemDevice) {
+                this.modems.put(modemDevice.getProductName(), new MonitoredModem(modem));
+            }
+        } catch (Exception e) {
+            logger.error("trackModem() :: {}", e.getMessage(), e);
         }
     }
 
@@ -860,6 +614,23 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
 
         return modemFactoryClass;
 
+    }
+
+    ScheduledExecutorService createExecutor() {
+        return Executors.newSingleThreadScheduledExecutor();
+    }
+
+    void addModem(final String intf, final CellularModem modem) {
+        this.modems.put(intf, new MonitoredModem(modem));
+    }
+
+    void sync() throws InterruptedException, ExecutionException {
+        this.executor.submit(() -> {
+        }).get();
+    }
+
+    IModemLinkService getPppService(final String interfaceName, final String port) {
+        return PppFactory.getPppService(interfaceName, port);
     }
 
     private boolean disableModemGps(CellularModem modem) {
@@ -922,18 +693,270 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
         }
     }
 
-    private void monitorNotify() {
-        if (stopThread != null) {
-            synchronized (stopThread) {
-                stopThread.notifyAll();
+    class ModemResetTimer {
+
+        private long startTime = -1;
+
+        void restart() {
+            startTime = -1;
+        }
+
+        boolean shouldResetModem(final long modemResetTimeout) {
+
+            if (startTime == -1) {
+                startTime = System.currentTimeMillis();
             }
+
+            final long timeTillReset = modemResetTimeout - (System.currentTimeMillis() - startTime);
+            final boolean shouldReset = timeTillReset <= 0;
+
+            if (!shouldReset) {
+                logger.info("monitor() :: Modem will be reset in {} sec if not connected", timeTillReset / 1000);
+            }
+
+            return shouldReset;
         }
     }
 
-    private void monitorWait() throws InterruptedException {
-        if (stopThread != null) {
-            synchronized (stopThread) {
-                stopThread.wait(THREAD_INTERVAL);
+    class MonitoredModem {
+
+        private final CellularModem modem;
+        private final ModemResetTimer resetTimer;
+
+        private AtomicBoolean isValid = new AtomicBoolean(true);
+        private boolean isInitialized;
+        private PppState pppState = PppState.NOT_CONNECTED;
+
+        public MonitoredModem(final CellularModem modem) {
+            this.modem = modem;
+            this.resetTimer = new ModemResetTimer();
+        }
+
+        CellularModem getModem() {
+            return modem;
+        }
+
+        boolean shouldCheckSimCard() throws KuraException {
+            return modem.getTechnologyTypes().stream()
+                    .anyMatch(t -> t == ModemTechnologyType.GSM_GPRS || t == ModemTechnologyType.UMTS
+                            || t == ModemTechnologyType.HSDPA || t == ModemTechnologyType.HSPA);
+        }
+
+        boolean isSimCardReady() throws KuraException {
+            if (!shouldCheckSimCard()) {
+                return true;
+            }
+
+            final boolean isSimCardReady = ((HspaCellularModem) modem).isSimCardReady();
+
+            if (isSimCardReady) {
+                logger.info("monitor() :: !!! SIM CARD IS READY !!!");
+            } else {
+                logger.warn("monitor() :: ! SIM CARD IS NOT READY !");
+            }
+
+            return isSimCardReady;
+        }
+
+        void release() {
+            try {
+                logger.debug("Releasing modem device from factory...");
+                this.isValid.set(false);
+                final CellularModemFactory factory = getCellularModemFactory(modem.getModemDevice());
+                factory.releaseModemService(modem);
+                logger.debug("Releasing modem device from factory...done");
+            } catch (Exception e) {
+                logger.warn("Failed to release modem device from factory", e);
+            }
+        }
+
+        void reportSignalStrength() {
+
+            if (listeners.isEmpty()) {
+                return;
+            }
+
+            int rssi = 0;
+
+            try {
+                rssi = modem.getSignalStrength();
+            } catch (KuraException e) {
+                logger.error("monitor() :: Failed to obtain signal strength - {}", e);
+            }
+
+            for (final ModemMonitorListener listener : listeners) {
+                listener.setCellularSignalLevel(rssi);
+            }
+        }
+
+        void cleanupAndReset(final IModemLinkService pppService, final PppState pppSt) {
+
+            try {
+                if (pppService != null && pppSt != null) {
+                    logger.info("monitor() :: PPPD disconnect");
+                    pppService.disconnect();
+                }
+            } catch (final Exception e) {
+                logger.error("monitor() :: Exception while disconnect", e);
+            }
+
+            try {
+                if (modem.isGpsEnabled() && !disableModemGps(modem)) {
+                    logger.error("monitor() :: Failed to disable modem GPS");
+                }
+            } catch (final Exception e) {
+                logger.error("monitor() :: Exception while disabling modem GPS", e);
+            }
+
+            forceReset();
+        }
+
+        void forceReset() {
+            this.resetTimer.restart();
+            this.pppState = PppState.NOT_CONNECTED;
+
+            try {
+                logger.info("monitor() :: modem reset");
+                modem.reset();
+            } catch (Exception e) {
+                logger.error("monitor() :: Exception during modem reset", e);
+            }
+        }
+
+        void initialize() throws KuraException {
+
+            String ifaceName = networkService.getModemPppPort(modem.getModemDevice());
+            List<NetConfig> netConfigs = null;
+            if (ifaceName != null) {
+                NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig = networkConfig
+                        .getNetInterfaceConfig(ifaceName);
+
+                if (netInterfaceConfig == null) {
+                    networkConfig = netConfigService.getNetworkConfiguration();
+                    netInterfaceConfig = networkConfig.getNetInterfaceConfig(ifaceName);
+                }
+
+                if (netInterfaceConfig != null) {
+                    netConfigs = ((AbstractNetInterface<?>) netInterfaceConfig).getNetConfigs();
+                    if (netConfigs != null && !netConfigs.isEmpty()) {
+                        modem.setConfiguration(netConfigs);
+                    }
+                }
+            }
+
+            if (modem instanceof EvdoCellularModem) {
+                NetInterfaceStatus netIfaceStatus = getNetInterfaceStatus(netConfigs);
+                if (netIfaceStatus == NetInterfaceStatus.netIPv4StatusEnabledWAN) {
+                    // TODO check if EVDO-specific gps handling is necessary
+
+                    if (modem.isGpsEnabled() && !disableModemGps(modem)) {
+                        logger.error("initialize() :: Failed to disable modem GPS, resetting modem ...");
+                        throw new KuraException(KuraErrorCode.CLOSED_DEVICE);
+                    }
+
+                    if (!((EvdoCellularModem) modem).isProvisioned()) {
+                        logger.info("trackModem() :: The {} is not provisioned, will try to provision it ...",
+                                modem.getModel());
+                        ((EvdoCellularModem) modem).provision();
+                    } else {
+                        logger.info("trackModem() :: The {} is provisioned", modem.getModel());
+                    }
+                }
+
+                if (modem.isGpsSupported() && isGpsEnabledInConfig(netConfigs) && !modem.isGpsEnabled()) {
+                    modem.enableGps();
+                    postModemGpsEvent(modem, true);
+                }
+            }
+
+            isInitialized = true;
+        }
+
+        void monitor(final HashMap<String, InterfaceState> newInterfaceStatuses) {
+
+            if (!isValid.get()) {
+                return;
+            }
+
+            IModemLinkService pppService = null;
+            PppState pppSt = null;
+
+            try {
+                if (!isInitialized) {
+                    initialize();
+                }
+
+                boolean modemReset = false;
+
+                reportSignalStrength();
+
+                NetInterfaceStatus netInterfaceStatus = getNetInterfaceStatus(modem.getConfiguration());
+
+                final String ifaceName = networkService.getModemPppPort(modem.getModemDevice());
+
+                if (netInterfaceStatus == NetInterfaceStatus.netIPv4StatusUnmanaged) {
+                    logger.warn("The {} interface is configured not to be managed by Kura and will not be monitored.",
+                            ifaceName);
+                    return;
+                }
+                if (netInterfaceStatus == NetInterfaceStatus.netIPv4StatusEnabledWAN && ifaceName != null) {
+
+                    pppService = getPppService(ifaceName, modem.getDataPort());
+                    pppSt = pppService.getPppState();
+
+                    if (this.pppState != pppSt) {
+                        logger.info("monitor() :: previous PppState={}", this.pppState);
+                        logger.info("monitor() :: current PppState={}", pppSt);
+                    }
+
+                    boolean isSimCardReady = true;
+
+                    if (pppSt == PppState.NOT_CONNECTED) {
+                        isSimCardReady = isSimCardReady();
+
+                        if (isSimCardReady) {
+                            logger.info("monitor() :: connecting ...");
+                            pppService.connect();
+                        }
+                    }
+
+                    if (pppSt == PppState.CONNECTED) {
+                        resetTimer.restart();
+                    } else if (isSimCardReady) {
+                        final long modemResetTimeout = getModemResetTimeoutMsec(ifaceName, modem.getConfiguration());
+
+                        if (resetTimer.shouldResetModem(modemResetTimeout)) {
+                            logger.info("monitor() :: Modem Reset TIMEOUT !!!");
+                            cleanupAndReset(pppService, pppSt);
+                            modemReset = true;
+                        }
+                    }
+
+                    this.pppState = pppSt;
+                    ConnectionInfo connInfo = new ConnectionInfoImpl(ifaceName);
+                    InterfaceState interfaceState = new InterfaceState(ifaceName,
+                            LinuxNetworkUtil.hasAddress(ifaceName), pppSt == PppState.CONNECTED,
+                            connInfo.getIpAddress());
+                    newInterfaceStatuses.put(ifaceName, interfaceState);
+
+                } else {
+                    resetTimer.restart();
+                }
+
+                // If the modem has been reset in this iteration of the monitor,
+                // do not immediately enable GPS to avoid concurrency issues due to asynchronous events
+                // (possible serial port contention between the PositionService and the trackModem() method),
+                // GPS will be eventually enabled in the next iteration of the monitor.
+                if (!modemReset && modem.isGpsSupported() && isGpsEnabledInConfig(modem.getConfiguration())) {
+                    if (modem instanceof HspaCellularModem && !modem.isGpsEnabled()) {
+                        modem.enableGps();
+                    }
+                    postModemGpsEvent(modem, true);
+                }
+
+            } catch (Exception e) {
+                logger.error("monitor() :: Exception, resetting modem", e);
+                cleanupAndReset(pppService, pppSt);
             }
         }
     }


### PR DESCRIPTION
* Implemented reset in `NOT_CONNECTED` state.
* `PppServiceFactory` no longer caches `Ppp` instances.
* Previous PPP state and modem reset timer are no longer global but per-modem.
* Improved executors usage.

Closes #2050
Closes #520
Closes #518

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>