### PR TITLE
Fixed race condition in WireAssetTest

### DIFF
--- a/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/asset/WireAssetTest.java
+++ b/kura/test/org.eclipse.kura.wire.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/asset/WireAssetTest.java
@@ -217,7 +217,6 @@ public class WireAssetTest {
         wireAsset.activate(mockComponentContext, wireAssetProperties);
 
         Driver mockDriver = mock(Driver.class);
-        wireAsset.setDriver(mockDriver);
 
         doAnswer(invocation -> {
             Object[] arguments = invocation.getArguments();
@@ -239,6 +238,8 @@ public class WireAssetTest {
 
             return null;
         }).when(mockDriver).read(any());
+
+        wireAsset.setDriver(mockDriver);
 
         {
             wireAssetProperties.put(WireAssetOptions.TIMESTAMP_MODE_PROP_NAME, TimestampMode.NO_TIMESTAMPS.name());


### PR DESCRIPTION
`WireAsset.setDriver()` spawns a background task that interacts the driver.
This might interfere with the ongoing stubbing performed by the test thread, causing the test to fail. Performing the stubbing before calling `setDriver()` should prevent this.
This should improve repeatability of `org.eclupse.kura.wire.component.provider.test`

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>