### PR TITLE
Use greedy policy-option for publisher/subscriber references

### DIFF
--- a/kura/examples/org.eclipse.kura.demo.heater/OSGI-INF/heater.xml
+++ b/kura/examples/org.eclipse.kura.demo.heater/OSGI-INF/heater.xml
@@ -13,11 +13,11 @@
       Red Hat Inc
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0"
     name="org.eclipse.kura.demo.heater.Heater"
-    activate="activate" 
-    deactivate="deactivate" 
-    modified="updated" 
+    activate="activate"
+    deactivate="deactivate"
+    modified="updated"
     enabled="true"
     immediate="true"
     configuration-policy="require">
@@ -28,11 +28,12 @@
    <service>
        <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
-   
+
    <reference name="CloudPublisher"
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
 </scr:component>

--- a/kura/examples/org.eclipse.kura.demo.modbus/OSGI-INF/modbusexample.xml
+++ b/kura/examples/org.eclipse.kura.demo.modbus/OSGI-INF/modbusexample.xml
@@ -13,23 +13,24 @@
       Red Hat Inc
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.demo.modbus.ModbusExample">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.demo.modbus.ModbusExample">
    <implementation class="org.eclipse.kura.demo.modbus.ModbusExample"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.demo.modbus.ModbusExample"/>
 
-   <reference bind="setModbusProtocolDeviceService" 
-    		  cardinality="1..1" 
-    		  interface="org.eclipse.kura.protocol.modbus.ModbusProtocolDeviceService" 
-    		  name="ModbusProtocolDeviceService" 
-    		  policy="static" 
+   <reference bind="setModbusProtocolDeviceService"
+    		  cardinality="1..1"
+    		  interface="org.eclipse.kura.protocol.modbus.ModbusProtocolDeviceService"
+    		  name="ModbusProtocolDeviceService"
+    		  policy="static"
     		  unbind="unsetModbusProtocolDeviceService"/>
    <reference name="CloudPublisher"
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
 </scr:component>

--- a/kura/examples/org.eclipse.kura.example.beacon.scanner/OSGI-INF/beaconExample.xml
+++ b/kura/examples/org.eclipse.kura.example.beacon.scanner/OSGI-INF/beaconExample.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.beacon.scanner.BeaconScannerExample">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.beacon.scanner.BeaconScannerExample">
    <implementation class="org.eclipse.kura.example.beacon.scanner.BeaconScannerExample"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
-    <reference bind="setBluetoothService" 
-              cardinality="1..1" 
-              interface="org.eclipse.kura.bluetooth.BluetoothService" 
-              name="BluetoothService" 
-              policy="static" 
+    <reference bind="setBluetoothService"
+              cardinality="1..1"
+              interface="org.eclipse.kura.bluetooth.BluetoothService"
+              name="BluetoothService"
+              policy="static"
               unbind="unsetBluetoothService"/>
     <reference name="CloudPublisher"
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
     <property name="service.pid" type="String" value="org.eclipse.kura.example.beacon.scanner.BeaconScannerExample"/>

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag.tinyb/OSGI-INF/bleExample.xml
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag.tinyb/OSGI-INF/bleExample.xml
@@ -10,7 +10,7 @@
 
 -->
 
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.ble.tisensortag.tinyb.BluetoothLe">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.ble.tisensortag.tinyb.BluetoothLe">
    <implementation class="org.eclipse.kura.example.ble.tisensortag.tinyb.BluetoothLe"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
@@ -20,12 +20,13 @@
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
-    <reference bind="setBluetoothLeService" 
-              cardinality="1..1" 
-              interface="org.eclipse.kura.bluetooth.le.BluetoothLeService" 
-              name="BluetoothLeService" 
-              policy="static" 
+    <reference bind="setBluetoothLeService"
+              cardinality="1..1"
+              interface="org.eclipse.kura.bluetooth.le.BluetoothLeService"
+              name="BluetoothLeService"
+              policy="static"
               unbind="unsetBluetoothLeService"/>
 </scr:component>

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag/OSGI-INF/bleExample.xml
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag/OSGI-INF/bleExample.xml
@@ -14,7 +14,7 @@
 
 -->
 
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.ble.tisensortag.BluetoothLe">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.ble.tisensortag.BluetoothLe">
    <implementation class="org.eclipse.kura.example.ble.tisensortag.BluetoothLe"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
@@ -24,12 +24,13 @@
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
-    <reference bind="setBluetoothService" 
-              cardinality="1..1" 
-              interface="org.eclipse.kura.bluetooth.BluetoothService" 
-              name="BluetoothService" 
-              policy="static" 
+    <reference bind="setBluetoothService"
+              cardinality="1..1"
+              interface="org.eclipse.kura.bluetooth.BluetoothService"
+              name="BluetoothService"
+              policy="static"
               unbind="unsetBluetoothService"/>
 </scr:component>

--- a/kura/examples/org.eclipse.kura.example.eddystone.scanner/OSGI-INF/EddystoneScanner.xml
+++ b/kura/examples/org.eclipse.kura.example.eddystone.scanner/OSGI-INF/EddystoneScanner.xml
@@ -9,21 +9,22 @@
      http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.eddystone.scanner.EddystoneScanner">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.eddystone.scanner.EddystoneScanner">
    <implementation class="org.eclipse.kura.example.eddystone.scanner.EddystoneScanner"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
-    <reference bind="setBluetoothLeService" 
-              cardinality="1..1" 
-              interface="org.eclipse.kura.bluetooth.le.BluetoothLeService" 
-              name="BluetoothLeService" 
-              policy="static" 
+    <reference bind="setBluetoothLeService"
+              cardinality="1..1"
+              interface="org.eclipse.kura.bluetooth.le.BluetoothLeService"
+              name="BluetoothLeService"
+              policy="static"
               unbind="unsetBluetoothLeService"/>
     <reference name="CloudPublisher"
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
     <property name="service.pid" type="String" value="org.eclipse.kura.example.eddystone.scanner.EddystoneScanner"/>

--- a/kura/examples/org.eclipse.kura.example.ibeacon.scanner/OSGI-INF/IBeaconScanner.xml
+++ b/kura/examples/org.eclipse.kura.example.ibeacon.scanner/OSGI-INF/IBeaconScanner.xml
@@ -9,21 +9,22 @@
      http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.ibeacon.scanner.IBeaconScanner">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.ibeacon.scanner.IBeaconScanner">
    <implementation class="org.eclipse.kura.example.ibeacon.scanner.IBeaconScanner"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
-    <reference bind="setBluetoothLeService" 
-              cardinality="1..1" 
-              interface="org.eclipse.kura.bluetooth.le.BluetoothLeService" 
-              name="BluetoothLeService" 
-              policy="static" 
+    <reference bind="setBluetoothLeService"
+              cardinality="1..1"
+              interface="org.eclipse.kura.bluetooth.le.BluetoothLeService"
+              name="BluetoothLeService"
+              policy="static"
               unbind="unsetBluetoothLeService"/>
     <reference name="CloudPublisher"
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
     <property name="service.pid" type="String" value="org.eclipse.kura.example.ibeacon.scanner.IBeaconScannerExample"/>

--- a/kura/examples/org.eclipse.kura.example.publisher/OSGI-INF/example.xml
+++ b/kura/examples/org.eclipse.kura.example.publisher/OSGI-INF/example.xml
@@ -13,11 +13,11 @@
       Red Hat Inc - Export ConfigurableComponent
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0"
     name="org.eclipse.kura.example.publisher.ExamplePublisher"
-    activate="activate" 
-    deactivate="deactivate" 
-    modified="updated" 
+    activate="activate"
+    deactivate="deactivate"
+    modified="updated"
     enabled="true"
     immediate="true"
     configuration-policy="require">
@@ -28,17 +28,19 @@
    <service>
        <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
-   
+
    <reference name="CloudPublisher"
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
    <reference name="CloudSubscriber"
            policy="static"
            bind="setCloudSubscriber"
            unbind="unsetCloudSubscriber"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.subscriber.CloudSubscriber"/>
 </scr:component>

--- a/kura/examples/org.eclipse.kura.example.serial.publisher/OSGI-INF/example.xml
+++ b/kura/examples/org.eclipse.kura.example.serial.publisher/OSGI-INF/example.xml
@@ -13,11 +13,11 @@
       Red Hat Inc
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0"
     name="org.eclipse.kura.example.serial.publisher.ExampleSerialPublisher"
-    activate="activate" 
-    deactivate="deactivate" 
-    modified="updated" 
+    activate="activate"
+    deactivate="deactivate"
+    modified="updated"
     enabled="true"
     immediate="true"
     configuration-policy="require">
@@ -28,18 +28,20 @@
    <service>
        <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
    </service>
-   
+
    <reference name="CloudPublisher"
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
            cardinality="0..1"
+           policy-option="greedy"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
    <reference name="CloudSubscriber"
            policy="static"
            bind="setCloudSubscriber"
            unbind="unsetCloudSubscriber"
            cardinality="0..1"
+           policy-option="greedy"
            interface="org.eclipse.kura.cloudconnection.subscriber.CloudSubscriber"/>
    <reference bind="setConnectionFactory" cardinality="1..1" interface="org.osgi.service.io.ConnectionFactory" name="ConnectionFactory" policy="static" unbind="unsetConnectionFactory"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudPublisherComponent.xml
+++ b/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudPublisherComponent.xml
@@ -7,7 +7,7 @@
      which accompanies this distribution, and is available at
      http://www.eclipse.org/legal/epl-v10.html
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0"
                name="org.eclipse.kura.wire.CloudPublisher"
                activate="activate"
                deactivate="deactivate"
@@ -35,6 +35,7 @@
            policy="static"
            bind="setCloudPublisher"
            unbind="unsetCloudPublisher"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.publisher.CloudPublisher"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudSubscriberComponent.xml
+++ b/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudSubscriberComponent.xml
@@ -7,7 +7,7 @@
      which accompanies this distribution, and is available at
      http://www.eclipse.org/legal/epl-v10.html
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.2.0"
                name="org.eclipse.kura.wire.CloudSubscriber"
                activate="activate"
                deactivate="deactivate"
@@ -34,6 +34,7 @@
            policy="static"
            bind="setCloudSubscriber"
            unbind="unsetCloudSubscriber"
+           policy-option="greedy"
            cardinality="0..1"
            interface="org.eclipse.kura.cloudconnection.subscriber.CloudSubscriber"/>
 </scr:component>


### PR DESCRIPTION
#2224 is caused by the fact that `static` publisher/subscriber references currently do not specify the `policy-option` property, and so DS will use the `reluctant` policy by default.

Since the cardinality is `0..1`, if the wires publisher starts before its cloud publisher, it will be activated with the publisher reference not bound (this is fine for the ` 0..1`  cardinality), and will not be re-activated when the cloud publisher component comes up due to the `reluctant` policy.

This PR should solve this by using  `policy-option=greedy`, which should force DS to reactivate components when a new component that satisfies reference filter is available.

Closes #2224

Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>