### PR TITLE
Added the interfaceName as argument in monitor listeners; fixed NPE

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/modem/ModemMonitorListener.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/modem/ModemMonitorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,5 +16,5 @@ import org.osgi.annotation.versioning.ConsumerType;
 @ConsumerType
 public interface ModemMonitorListener {
 
-    public void setCellularSignalLevel(int signalLevel);
+    public void setCellularSignalLevel(String interfaceName, int signalLevel);
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/modem/ModemMonitorListener.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/modem/ModemMonitorListener.java
@@ -16,5 +16,8 @@ import org.osgi.annotation.versioning.ConsumerType;
 @ConsumerType
 public interface ModemMonitorListener {
 
+    /**
+     * @since 2.0
+     */
     public void setCellularSignalLevel(String interfaceName, int signalLevel);
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiClientMonitorListener.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiClientMonitorListener.java
@@ -16,5 +16,8 @@ import org.osgi.annotation.versioning.ConsumerType;
 @ConsumerType
 public interface WifiClientMonitorListener {
 
+    /**
+     * @since 2.0
+     */
     public void setWifiSignalLevel(String interfaceName, int signalLevel);
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiClientMonitorListener.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiClientMonitorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2018 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,5 +16,5 @@ import org.osgi.annotation.versioning.ConsumerType;
 @ConsumerType
 public interface WifiClientMonitorListener {
 
-    public void setWifiSignalLevel(int signalLevel);
+    public void setWifiSignalLevel(String interfaceName, int signalLevel);
 }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
@@ -570,7 +570,10 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
             ModemDevice modemDevice = null;
             if (interfaceName.startsWith("ppp")) {
                 // already connected - find the corresponding usb device
-                modemDevice = this.usbModems.get(getModemUsbPort(interfaceName));
+                String modemUsbPort = getModemUsbPort(interfaceName);
+                if (modemUsbPort != null && !modemUsbPort.isEmpty()) {
+                    modemDevice = this.usbModems.get(getModemUsbPort(interfaceName));
+                }
                 if (modemDevice == null && this.serialModem != null) {
                     modemDevice = this.serialModem;
                 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
@@ -770,7 +770,7 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
             }
         }
 
-        void reportSignalStrength() {
+        void reportSignalStrength(String interfaceName) {
 
             if (listeners.isEmpty()) {
                 return;
@@ -785,7 +785,7 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
             }
 
             for (final ModemMonitorListener listener : listeners) {
-                listener.setCellularSignalLevel(rssi);
+                listener.setCellularSignalLevel(interfaceName, rssi);
             }
         }
 
@@ -888,11 +888,11 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
 
                 boolean modemReset = false;
 
-                reportSignalStrength();
-
                 NetInterfaceStatus netInterfaceStatus = getNetInterfaceStatus(modem.getConfiguration());
 
                 final String ifaceName = networkService.getModemPppPort(modem.getModemDevice());
+
+                reportSignalStrength(ifaceName);
 
                 if (netInterfaceStatus == NetInterfaceStatus.netIPv4StatusUnmanaged) {
                     logger.warn("The {} interface is configured not to be managed by Kura and will not be monitored.",

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImpl.java
@@ -392,7 +392,7 @@ public class WifiMonitorServiceImpl implements WifiClientMonitorService, EventHa
                                     rssi = 0;
                                 }
                                 for (WifiClientMonitorListener listener : this.listeners) {
-                                    listener.setWifiSignalLevel(rssi);
+                                    listener.setWifiSignalLevel(interfaceName, rssi);
                                 }
                             }
 


### PR DESCRIPTION
This PR adds the interface name as argument to monitor listener.
Moreover a potential NPE is fixed in to the NetworkServiceImpl.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>