### PR TITLE
Fix PDP auth with CID 1 in 4G.

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/de910/TelitDe910.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/de910/TelitDe910.java
@@ -396,7 +396,7 @@ public class TelitDe910 extends TelitModem implements EvdoCellularModem {
     }
 
     @Override
-    public boolean isSimCardReady() throws KuraException {
+    public boolean isTelitSimCardReady() throws KuraException {
         return true;
     }
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
@@ -20,7 +20,6 @@ import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.comm.CommConnection;
 import org.eclipse.kura.comm.CommURI;
-import org.eclipse.kura.internal.board.BoardPowerState;
 import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
 import org.eclipse.kura.linux.net.modem.SupportedUsbModemsInfo;
 import org.eclipse.kura.linux.net.modem.UsbModemDriver;
@@ -453,7 +452,7 @@ public abstract class TelitModem {
     public String getMobileSubscriberIdentity() throws KuraException {
         synchronized (this.atLock) {
             if (this.imsi == null) {
-                if (isSimCardReady()) {
+                if (isTelitSimCardReady()) {
                     logger.debug("sendCommand getIMSI :: {}", TelitModemAtCommands.getIMSI.getCommand());
                     byte[] reply;
                     CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -488,7 +487,7 @@ public abstract class TelitModem {
     public String getIntegratedCirquitCardId() throws KuraException {
         synchronized (this.atLock) {
             if (this.iccid == null) {
-                if (isSimCardReady()) {
+                if (isTelitSimCardReady()) {
                     logger.debug("sendCommand getICCID :: {}", TelitModemAtCommands.getICCID.getCommand());
                     byte[] reply;
                     CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -627,7 +626,7 @@ public abstract class TelitModem {
         return this.gpsEnabled;
     }
 
-    public abstract boolean isSimCardReady() throws KuraException;
+    public abstract boolean isTelitSimCardReady() throws KuraException;
 
     protected CommConnection openSerialPort(String port) throws KuraException {
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/he910/TelitHe910.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/he910/TelitHe910.java
@@ -12,6 +12,7 @@
 package org.eclipse.kura.net.admin.modem.telit.he910;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -21,8 +22,11 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.comm.CommConnection;
 import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
 import org.eclipse.kura.linux.net.modem.SupportedUsbModemsInfo;
+import org.eclipse.kura.net.NetConfig;
 import org.eclipse.kura.net.admin.modem.HspaCellularModem;
 import org.eclipse.kura.net.admin.modem.telit.generic.TelitModem;
+import org.eclipse.kura.net.modem.ModemConfig;
+import org.eclipse.kura.net.modem.ModemConfig.PdpType;
 import org.eclipse.kura.net.modem.ModemDevice;
 import org.eclipse.kura.net.modem.ModemPdpContext;
 import org.eclipse.kura.net.modem.ModemPdpContextType;
@@ -39,9 +43,6 @@ import org.slf4j.LoggerFactory;
 public class TelitHe910 extends TelitModem implements HspaCellularModem {
 
     private static final Logger logger = LoggerFactory.getLogger(TelitHe910.class);
-
-    // FIXME PDP context should not be hard coded
-    private static final int PDP_CONTEXT = 1;
 
     /**
      * TelitHe910 modem constructor
@@ -85,70 +86,36 @@ public class TelitHe910 extends TelitModem implements HspaCellularModem {
     }
 
     @Override
-    public boolean isSimCardReady() throws KuraException {
-
+    public boolean isTelitSimCardReady() throws KuraException {
         boolean simReady = false;
-        String port = null;
-
-        if (isGpsEnabled() && getAtPort().equals(getGpsPort()) && !getAtPort().equals(getDataPort())) {
-            port = getDataPort();
-        } else {
-            port = getAtPort();
-        }
-
         synchronized (this.atLock) {
-            logger.debug("sendCommand getSimStatus :: {} command to port {}",
-                    TelitHe910AtCommands.getSimStatus.getCommand(), port);
-            byte[] reply = null;
             CommConnection commAtConnection = null;
             try {
+                String port = getUnusedAtPort();
+                logger.debug("sendCommand getSimStatus :: {} command to port {}",
+                        TelitHe910AtCommands.getSimStatus.getCommand(), port);
 
                 commAtConnection = openSerialPort(port);
                 if (!isAtReachable(commAtConnection)) {
                     throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
                 }
 
-                reply = commAtConnection.sendCommand(TelitHe910AtCommands.getSimStatus.getCommand().getBytes(), 1000,
-                        100);
-                if (reply != null) {
-                    String simStatus = getResponseString(reply);
-                    String[] simStatusSplit = simStatus.split(",");
-                    if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
-                        simReady = true;
-                    }
-                }
-
+                simReady = isSimCardReady(commAtConnection);
                 if (!simReady) {
-                    reply = commAtConnection.sendCommand(
-                            TelitHe910AtCommands.simulateSimNotInserted.getCommand().getBytes(), 1000, 100);
-                    if (reply != null) {
-                        sleep(5000);
-                        reply = commAtConnection.sendCommand(
-                                TelitHe910AtCommands.simulateSimInserted.getCommand().getBytes(), 1000, 100);
-                        if (reply != null) {
-                            sleep(1000);
-                            reply = commAtConnection
-                                    .sendCommand(TelitHe910AtCommands.getSimStatus.getCommand().getBytes(), 1000, 100);
-
-                            if (reply != null) {
-                                String simStatus = getResponseString(reply);
-                                String[] simStatusSplit = simStatus.split(",");
-                                if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
-                                    simReady = true;
-                                }
-                            }
-                        }
-                    }
+                    simReady = simultateInsertSimCard(commAtConnection);
                 }
             } catch (IOException e) {
                 throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
-            } catch (KuraException e) {
-                throw e;
             } finally {
                 closeSerialPort(commAtConnection);
             }
         }
         return simReady;
+    }
+
+    @Override
+    public boolean isSimCardReady() throws KuraException {
+        return isTelitSimCardReady();
     }
 
     @Override
@@ -165,7 +132,8 @@ public class TelitHe910 extends TelitModem implements HspaCellularModem {
                 throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
             }
             try {
-                reply = commAtConnection.sendCommand(TelitHe910AtCommands.getRegistrationStatus.getCommand().getBytes(),
+                reply = commAtConnection.sendCommand(
+                        TelitHe910AtCommands.getRegistrationStatus.getCommand().getBytes(StandardCharsets.US_ASCII),
                         1000, 100);
             } catch (IOException e) {
                 closeSerialPort(commAtConnection);
@@ -212,8 +180,9 @@ public class TelitHe910 extends TelitModem implements HspaCellularModem {
                 throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
             }
             try {
-                reply = commAtConnection
-                        .sendCommand(TelitHe910AtCommands.getGprsSessionDataVolume.getCommand().getBytes(), 1000, 100);
+                reply = commAtConnection.sendCommand(
+                        TelitHe910AtCommands.getGprsSessionDataVolume.getCommand().getBytes(StandardCharsets.US_ASCII),
+                        1000, 100);
             } catch (IOException e) {
                 closeSerialPort(commAtConnection);
                 throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
@@ -230,7 +199,7 @@ public class TelitHe910 extends TelitModem implements HspaCellularModem {
                             splitData = pdp.trim().split(",");
                             if (splitData.length >= 4) {
                                 int pdpNo = Integer.parseInt(splitData[0]);
-                                if (pdpNo == this.PDP_CONTEXT) {
+                                if (pdpNo == Integer.valueOf(getContextId())) {
                                     txCnt = Integer.parseInt(splitData[2]);
                                 }
                             }
@@ -255,8 +224,9 @@ public class TelitHe910 extends TelitModem implements HspaCellularModem {
                 throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
             }
             try {
-                reply = commAtConnection
-                        .sendCommand(TelitHe910AtCommands.getGprsSessionDataVolume.getCommand().getBytes(), 1000, 100);
+                reply = commAtConnection.sendCommand(
+                        TelitHe910AtCommands.getGprsSessionDataVolume.getCommand().getBytes(StandardCharsets.US_ASCII),
+                        1000, 100);
             } catch (IOException e) {
                 closeSerialPort(commAtConnection);
                 throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
@@ -273,7 +243,7 @@ public class TelitHe910 extends TelitModem implements HspaCellularModem {
                             splitData = pdp.trim().split(",");
                             if (splitData.length >= 4) {
                                 int pdpNo = Integer.parseInt(splitData[0]);
-                                if (pdpNo == this.PDP_CONTEXT) {
+                                if (pdpNo == Integer.valueOf(getContextId())) {
                                     rxCnt = Integer.parseInt(splitData[3]);
                                 }
                             }
@@ -287,40 +257,14 @@ public class TelitHe910 extends TelitModem implements HspaCellularModem {
 
     @Override
     public List<ModemPdpContext> getPdpContextInfo() throws KuraException {
-        List<ModemPdpContext> pdpContextInfo = new ArrayList<>();
         synchronized (this.atLock) {
-            byte[] reply;
             CommConnection commAtConnection = openSerialPort(getAtPort());
-            if (!isAtReachable(commAtConnection)) {
-                closeSerialPort(commAtConnection);
-                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
-            }
             try {
-                reply = commAtConnection.sendCommand(formGetPdpContextAtCommand().getBytes(), 1000, 100);
-            } catch (IOException e) {
+                return getPdpContextInfo(commAtConnection);
+            } finally {
                 closeSerialPort(commAtConnection);
-                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
-            }
-            closeSerialPort(commAtConnection);
-            if (reply != null) {
-                String sreply = this.getResponseString(reply);
-                Scanner scanner = new Scanner(sreply);
-                while (scanner.hasNextLine()) {
-                    String[] tokens = scanner.nextLine().split(",");
-                    if (!tokens[0].startsWith("+CGDCONT:")) {
-                        continue;
-                    }
-                    int contextNo = Integer.parseInt(tokens[0].substring("+CGDCONT:".length()).trim());
-                    ModemPdpContextType pdpType = ModemPdpContextType
-                            .getContextType(tokens[1].substring(1, tokens[1].length() - 1));
-                    String apn = tokens[2].substring(1, tokens[2].length() - 1);
-                    ModemPdpContext modemPdpContext = new ModemPdpContext(contextNo, pdpType, apn);
-                    pdpContextInfo.add(modemPdpContext);
-                }
-                scanner.close();
             }
         }
-        return pdpContextInfo;
     }
 
     @Override
@@ -336,7 +280,8 @@ public class TelitHe910 extends TelitModem implements HspaCellularModem {
                 throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
             }
             try {
-                reply = commAtConnection.sendCommand(TelitHe910AtCommands.getMobileStationClass.getCommand().getBytes(),
+                reply = commAtConnection.sendCommand(
+                        TelitHe910AtCommands.getMobileStationClass.getCommand().getBytes(StandardCharsets.US_ASCII),
                         1000, 100);
             } catch (IOException e) {
                 closeSerialPort(commAtConnection);
@@ -384,7 +329,163 @@ public class TelitHe910 extends TelitModem implements HspaCellularModem {
         return modemTechnologyTypes;
     }
 
-    private String formGetPdpContextAtCommand() {
+    protected String getUnusedAtPort() throws KuraException {
+        String port;
+        if (isGpsEnabled() && getAtPort().equals(getGpsPort()) && !getAtPort().equals(getDataPort())) {
+            port = getDataPort();
+        } else {
+            port = getAtPort();
+        }
+        return port;
+    }
+
+    protected List<ModemPdpContext> getPdpContextInfo(CommConnection comm) throws KuraException {
+        List<ModemPdpContext> pdpContextInfo = new ArrayList<>();
+        byte[] reply;
+        if (!isAtReachable(comm)) {
+            closeSerialPort(comm);
+            throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
+        }
+        try {
+            reply = comm.sendCommand(formGetPdpContextAtCommand().getBytes(StandardCharsets.US_ASCII), 1000, 100);
+        } catch (IOException e) {
+            throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+        }
+        if (reply != null) {
+            String sreply = this.getResponseString(reply);
+            Scanner scanner = new Scanner(sreply);
+            while (scanner.hasNextLine()) {
+                String[] tokens = scanner.nextLine().split(",");
+                if (!tokens[0].startsWith("+CGDCONT:")) {
+                    continue;
+                }
+                int contextNo = Integer.parseInt(tokens[0].substring("+CGDCONT:".length()).trim());
+                ModemPdpContextType pdpType = ModemPdpContextType
+                        .getContextType(tokens[1].substring(1, tokens[1].length() - 1));
+                String apn = tokens[2].substring(1, tokens[2].length() - 1);
+                ModemPdpContext modemPdpContext = new ModemPdpContext(contextNo, pdpType, apn);
+                pdpContextInfo.add(modemPdpContext);
+            }
+            scanner.close();
+        }
+        return pdpContextInfo;
+    }
+
+    protected boolean isSimCardReady(CommConnection comm) throws KuraException, IOException {
+        boolean simReady = false;
+        byte[] reply = comm.sendCommand(
+                TelitHe910AtCommands.getSimStatus.getCommand().getBytes(StandardCharsets.US_ASCII), 1000, 100);
+        if (reply != null) {
+            String simStatus = getResponseString(reply);
+            String[] simStatusSplit = simStatus.split(",");
+            if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
+                simReady = true;
+            }
+        }
+        return simReady;
+    }
+
+    protected boolean simultateInsertSimCard(CommConnection comm) throws KuraException, IOException {
+        boolean simReady = false;
+        byte[] reply = comm.sendCommand(
+                TelitHe910AtCommands.simulateSimNotInserted.getCommand().getBytes(StandardCharsets.US_ASCII), 1000,
+                100);
+        if (reply != null) {
+            sleep(5000);
+            reply = comm.sendCommand(
+                    TelitHe910AtCommands.simulateSimInserted.getCommand().getBytes(StandardCharsets.US_ASCII), 1000,
+                    100);
+            if (reply != null) {
+                sleep(1000);
+                simReady = isSimCardReady(comm);
+            }
+        }
+        return simReady;
+    }
+
+    protected boolean execCommand(CommConnection comm, byte[] command, int timeout) throws KuraException, IOException {
+        boolean ok;
+        byte[] reply = comm.sendCommand(command, timeout, 100);
+        if (reply != null) {
+            ok = new String(reply, StandardCharsets.US_ASCII).contains("OK");
+        } else {
+            throw new KuraException(KuraErrorCode.TIMED_OUT);
+        }
+        return ok;
+    }
+
+    protected String formSetPdpContextAtCommand() {
+        String result = null;
+        List<NetConfig> configs = getConfiguration();
+        for (NetConfig config : configs) {
+            if (config instanceof ModemConfig) {
+                ModemConfig modemConfig = (ModemConfig) config;
+                // a little bit silly
+                String cid = parseContextIdFromDialString(modemConfig.getDialString());
+                String apn = modemConfig.getApn();
+                String pdpType = modemConfig.getPdpType().name();
+                StringBuilder sb = new StringBuilder(TelitHe910AtCommands.pdpContext.getCommand()).append("=")
+                        .append(cid).append(",").append('"').append(pdpType).append('"').append(",").append('"')
+                        .append(apn).append('"').append("\r\n");
+                result = sb.toString();
+                break;
+            }
+        }
+        return result;
+    }
+
+    protected String parseContextIdFromDialString(String dialString) {
+        int start = dialString.lastIndexOf('*');
+        return dialString.substring(start + 1, dialString.length() - 1);
+    }
+
+    protected ModemPdpContext getConfigPdpContext() {
+        ModemPdpContext result = null;
+        List<NetConfig> configs = getConfiguration();
+        for (NetConfig config : configs) {
+            if (config instanceof ModemConfig) {
+                ModemConfig modemConfig = (ModemConfig) config;
+                // a little bit silly
+                int cid = Integer.parseInt(parseContextIdFromDialString(modemConfig.getDialString()));
+                String apn = modemConfig.getApn();
+                PdpType pdpType = modemConfig.getPdpType();
+
+                ModemPdpContextType modemPdpType;
+                switch (pdpType) {
+                case IP:
+                    modemPdpType = ModemPdpContextType.IP;
+                    break;
+                case IPv6:
+                    modemPdpType = ModemPdpContextType.IPV6;
+                    break;
+                case PPP:
+                    modemPdpType = ModemPdpContextType.PPP;
+                    break;
+                default:
+                    modemPdpType = ModemPdpContextType.IPV4IPV6;
+                }
+
+                result = new ModemPdpContext(cid, modemPdpType, apn);
+            }
+        }
+        return result;
+    }
+
+    protected String getContextId() {
+        String cid = null;
+        List<NetConfig> configs = getConfiguration();
+        for (NetConfig config : configs) {
+            if (config instanceof ModemConfig) {
+                ModemConfig modemConfig = (ModemConfig) config;
+                // a little bit silly
+                cid = parseContextIdFromDialString(modemConfig.getDialString());
+                break;
+            }
+        }
+        return cid;
+    }
+
+    protected String formGetPdpContextAtCommand() {
         StringBuilder sb = new StringBuilder(TelitHe910AtCommands.pdpContext.getCommand());
         sb.append("?\r\n");
         return sb.toString();

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/he910/TelitHe910AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/he910/TelitHe910AtCommands.java
@@ -13,9 +13,6 @@ package org.eclipse.kura.net.admin.modem.telit.he910;
 
 /**
  * Defines AT commands for the Telit HE910 modem.
- *
- * @author ilya.binshtok
- *
  */
 public enum TelitHe910AtCommands {
 
@@ -28,7 +25,7 @@ public enum TelitHe910AtCommands {
     getMobileStationClass("at+cgclass?\r\n"),
     getRegistrationStatus("at+cgreg?\r\n"),
     getGprsSessionDataVolume("at#gdatavol=1\r\n"),
-    pdpContext("AT+CGDCONT");
+    pdpContext("at+cgdcont");
 
     private String command;
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/le910v2/TelitLe910v2.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/le910v2/TelitLe910v2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -10,14 +10,29 @@
 
 package org.eclipse.kura.net.admin.modem.telit.le910v2;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
+import org.eclipse.kura.comm.CommConnection;
+import org.eclipse.kura.net.NetConfig;
 import org.eclipse.kura.net.admin.modem.HspaCellularModem;
 import org.eclipse.kura.net.admin.modem.telit.he910.TelitHe910;
+import org.eclipse.kura.net.admin.modem.telit.he910.TelitHe910AtCommands;
+import org.eclipse.kura.net.modem.ModemConfig;
+import org.eclipse.kura.net.modem.ModemConfig.AuthType;
 import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemPdpContext;
 import org.osgi.service.io.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TelitLe910v2 extends TelitHe910 implements HspaCellularModem {
+
+    private static final Logger logger = LoggerFactory.getLogger(TelitLe910v2.class);
+    private boolean initialized;
 
     public TelitLe910v2(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
         super(device, platform, connectionFactory);
@@ -42,5 +57,154 @@ public class TelitLe910v2 extends TelitHe910 implements HspaCellularModem {
     public boolean isGpsSupported() throws KuraException {
         // GPS devices attached to the modem are not yet supported
         return false;
+    }
+
+    @Override
+    public void setConfiguration(List<NetConfig> netConfigs) {
+        super.setConfiguration(netConfigs);
+        this.initialized = false;
+    }
+
+    @Override
+    public boolean isSimCardReady() throws KuraException {
+        synchronized (this.atLock) {
+            CommConnection commAtConnection = null;
+            try {
+                String port = getUnusedAtPort();
+                logger.debug("sendCommand getSimStatus :: {} command to port {}",
+                        TelitHe910AtCommands.getSimStatus.getCommand(), port);
+
+                commAtConnection = openSerialPort(port);
+                if (!isAtReachable(commAtConnection)) {
+                    throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
+                }
+
+                // FIXME we need an explicit initialization method.
+                if (!this.initialized) {
+                    initialize(commAtConnection);
+                }
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+        }
+        return this.initialized;
+    }
+
+    protected void initialize(CommConnection comm) throws KuraException {
+        try {
+            boolean simReady = isSimCardReady(comm);
+            if (!simReady) {
+                simReady = simultateInsertSimCard(comm);
+            }
+            if (simReady) {
+                // SIM must be ready before configuring PDP context
+                configurePdpContext(comm);
+                this.initialized = true;
+            }
+        } catch (IOException e) {
+            throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+        }
+    }
+
+    // This is tricky.
+    // In an LTE network, context #1 is special as it is automatically activated on network registration
+    // and it is assigned the "default EPS bearer".
+    // Usually it's not recommended to update this context unless explicitly required by the mobile network
+    // operator.
+    //
+    // Setting the context is usually done by the PPP application, for example by the 'pppd' dialer program
+    // 'chat'.
+    // With LE910-EU1 fw v.20.00.412 this is not recommended by Telit as the modem will attempt to update
+    // the context
+    // on the network when
+    // PPP starts. It has been observed that this may often lead to an unresponsive modem.
+    // According to Telit, this behavior will change in LE910-EU1 fw v.20.00.413 where setting the context
+    // will take effect only on the next network registration.
+    //
+    // The current fix tries to set the context only when the ModemConfig does not match the modem NVM
+    // where the context is saved and used automatically by modem on network registration, for example
+    // after a modem reset or a system reboot.
+    // There's a defect however: the authentication password cannot be read back from the NVM, so
+    // only the APN is used for the check.
+    // In practice, with context #1, to make sure the NVM is in sync with the ModemConfig, the APN must be
+    // changed twice.
+    // This may still lead to an unresponsive modem but it will be recovered by the ESF modem monitor.
+    protected void configurePdpContext(CommConnection comm) throws KuraException {
+        try {
+            String setPdpContextAtCommand = formSetPdpContextAtCommand();
+            String setPdpAuthAtCommand = formSetPdpAuthAtCommand();
+            String testPdpAuthAtCommand = formTestPdpAuthAtCommand();
+
+            if (setPdpContextAtCommand == null || setPdpAuthAtCommand == null) {
+                throw new IllegalStateException("Null PDP context or authentication");
+            }
+
+            List<ModemPdpContext> contexts = getPdpContextInfo(comm);
+            ModemPdpContext configContext = getConfigPdpContext();
+            boolean changed = contexts.stream().noneMatch(t -> t.getNumber() == configContext.getNumber()
+                    && t.getType().equals(configContext.getType()) && t.getApn().equals(configContext.getApn()));
+
+            if (configContext.getNumber() != 1 || changed) {
+                // Authentication command is not always supported (e.g. LE910-V2 NA with AT&T firmware)
+                if (execCommand(comm, testPdpAuthAtCommand.getBytes(StandardCharsets.US_ASCII), 1000)
+                        && !execCommand(comm, setPdpAuthAtCommand.getBytes(StandardCharsets.US_ASCII), 1000)) {
+                    throw new KuraException(KuraErrorCode.CONNECTION_FAILED, "Set PDP authentication command failed");
+                }
+                if (!execCommand(comm, setPdpContextAtCommand.getBytes(StandardCharsets.US_ASCII), 1000)) {
+                    throw new KuraException(KuraErrorCode.CONNECTION_FAILED, "Set PDP context command failed");
+                }
+                if (configContext.getNumber() == 1) {
+                    String message = "FIXME: context #1 has been modified and will be updated on the network when PPP starts (e.g. LE910-EU1 fw v.20.00.412). This may lead to an unreasponsive modem";
+                    logger.warn(message);
+                }
+            }
+        } catch (IOException | IllegalStateException e) {
+            throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+        }
+    }
+
+    protected String formTestPdpAuthAtCommand() {
+        StringBuilder sb = new StringBuilder(TelitLe910v2AtCommands.pdpAuth.getCommand()).append("=?\r\n");
+        return sb.toString();
+    }
+
+    protected String formSetPdpAuthAtCommand() {
+        String result = null;
+        List<NetConfig> configs = getConfiguration();
+        for (NetConfig config : configs) {
+            if (config instanceof ModemConfig) {
+                ModemConfig modemConfig = (ModemConfig) config;
+                AuthType authType = modemConfig.getAuthType();
+
+                int auth;
+                switch (authType) {
+                case NONE:
+                    auth = 0;
+                    break;
+                case PAP:
+                    auth = 1;
+                    break;
+                case CHAP:
+                    auth = 2;
+                    break;
+                default:
+                    logger.warn("{} Authentication not supported. Falling back to PAP", authType);
+                    auth = 1;
+                    break;
+                }
+
+                String username = modemConfig.getUsername();
+                char[] password = modemConfig.getPasswordAsPassword().getPassword();
+                // a little bit silly
+                String cid = parseContextIdFromDialString(modemConfig.getDialString());
+
+                StringBuilder sb = new StringBuilder(TelitLe910v2AtCommands.pdpAuth.getCommand()).append("=")
+                        .append(cid).append(",").append(auth).append(",").append('"').append(username).append('"')
+                        .append(",").append('"').append(password).append('"').append("\r\n");
+                result = sb.toString();
+                break;
+            }
+        }
+        return result;
     }
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/le910v2/TelitLe910v2AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/le910v2/TelitLe910v2AtCommands.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.telit.le910v2;
+
+/**
+ * Defines AT commands for the Telit LE910 v2 modem.
+ */
+public enum TelitLe910v2AtCommands {
+
+    pdpAuth("at#pdpauth");
+
+    private String command;
+
+    private TelitLe910v2AtCommands(String atCommand) {
+        this.command = atCommand;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/PppConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/PppConfigWriter.java
@@ -175,6 +175,16 @@ public class PppConfigWriter implements NetworkConfigurationVisitor {
                 logger.debug("Removing gpsEnabled for {}", oldInterfaceName);
                 KuranetConfig.deleteProperty(key.toString());
 
+                // Remove apn
+                key = new StringBuilder().append("net.interface.").append(oldInterfaceName).append(".config.apn");
+                logger.debug("Removing apn for {}", oldInterfaceName);
+                KuranetConfig.deleteProperty(key.toString());
+
+                // Remove pdpType
+                key = new StringBuilder().append("net.interface.").append(oldInterfaceName).append(".config.pdpType");
+                logger.debug("Removing pdpType for {}", oldInterfaceName);
+                KuranetConfig.deleteProperty(key.toString());
+
                 // Remove status
                 IfcfgConfigWriter.removeKuraExtendedConfig(oldInterfaceName);
             } catch (IOException e) {
@@ -200,6 +210,16 @@ public class PppConfigWriter implements NetworkConfigurationVisitor {
                             .append(newInterfaceName).append(".config.gpsEnabled");
                     logger.debug("Setting gpsEnabled for {}", newInterfaceName);
                     KuranetConfig.setProperty(gpsEnabledKey.toString(), Boolean.toString(modemConfig.isGpsEnabled()));
+
+                    final StringBuilder apnKey = new StringBuilder().append("net.interface.").append(newInterfaceName)
+                            .append(".config.apn");
+                    logger.debug("Setting apn for {}", newInterfaceName);
+                    KuranetConfig.setProperty(apnKey.toString(), modemConfig.getApn());
+
+                    final StringBuilder pdpTypeKey = new StringBuilder().append("net.interface.")
+                            .append(newInterfaceName).append(".config.pdpType");
+                    logger.debug("Setting pdpType for {}", newInterfaceName);
+                    KuranetConfig.setProperty(pdpTypeKey.toString(), modemConfig.getPdpType().name());
 
                     logger.debug("Writing connect scripts for {} using {}", modemInterfaceConfig.getName(),
                             configClass);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabModemUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Network/TabModemUi.java
@@ -23,6 +23,7 @@ import org.eclipse.kura.web.client.util.MessageUtils;
 import org.eclipse.kura.web.shared.model.GwtModemAuthType;
 import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtModemPdpEntry;
+import org.eclipse.kura.web.shared.model.GwtModemPdpType;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtSession;
 import org.eclipse.kura.web.shared.model.GwtXSRFToken;
@@ -276,6 +277,7 @@ public class TabModemUi extends Composite implements NetworkTab {
         this.tcpTab = tcp;
 
         this.defaultDialString.put("HE910", "atd*99***1#");
+        this.defaultDialString.put("LE910", "atd*99***2#");
         this.defaultDialString.put("DE910", "atd#777");
         initForm();
 
@@ -363,6 +365,7 @@ public class TabModemUi extends Composite implements NetworkTab {
     @Override
     public void getUpdatedNetInterface(GwtNetInterfaceConfig updatedNetIf) {
         GwtModemInterfaceConfig updatedModemNetIf = (GwtModemInterfaceConfig) updatedNetIf;
+        updatedModemNetIf.setPdpType(GwtModemPdpType.netModemPdpIP);
 
         if (this.model.getText() != null && this.service.getText() != null) {
             // note - status is set in tcp/ip tab
@@ -560,6 +563,8 @@ public class TabModemUi extends Composite implements NetworkTab {
             if (modemModel != null && !modemModel.isEmpty()) {
                 if (modemModel.contains("HE910")) {
                     this.dialString = this.defaultDialString.get("HE910");
+                } else if (modemModel.contains("LE910")) {
+                    this.dialString = this.defaultDialString.get("LE910");
                 } else if (modemModel.contains("DE910")) {
                     this.dialString = this.defaultDialString.get("DE910");
                 } else {

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -452,7 +452,7 @@ netModemToolTipNetworkTopology=Select the appropriate network topology.
 netModemToolTipModemIndentifier=Enter a unique name for the modem.
 netModemToolTipModemInterfaceNumber=Enter a unique number for the modem interface. For example: <br><br>An Interface # of 0 would name the modem interface ppp0<br><br>An Interface # of 1 would name the modem interface ppp1
 netModemToolTipDialString=Instructions for how the modem should attempt to connect.<br><br>A typical dial string for the detected modem is: <b>{0}</b>
-netModemToolTipDialStringDefault=Instructions for how the modem should attempt to connect.<br><br>Typical dial strings are:<br>* EVDO Modems => <b>atd#777</b><br>* HSPA/LTE Modems => <b>atd*99***1#</b><br>where number '1' defines PDP context to be used for this connection<br><br>Click the button to display/select existing PDP profiles. 
+netModemToolTipDialStringDefault=Instructions for how the modem should attempt to connect.<br><br>Typical dial strings are:<br>* EVDO Modems => <b>atd#777</b><br>* HSPA Modems => <b>atd*99***1#</b><br>* LTE Modems => <b>atd*99***2#</b><br>where the number before '#' defines the PDP context to be used for this connection.<br>LTE modems should not use PDP context 1 unless it is required by the mobile network operator.<br><br>Click the button to display/select existing PDP profiles. 
 netModemToolTipApn=Modem access point name.
 netModemToolTipAuthentication=Select modem authentication type.
 netModemToolTipUsername=Enter user name.

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/PppConfigTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/PppConfigTest.java
@@ -130,12 +130,11 @@ public class PppConfigTest {
             fw.write("user='a user'\n");
             fw.write("connect=connect -f " + dir + "chat\n");
         }
-
-        try (FileWriter fw = new FileWriter(dir + "chat")) {
+        
+        try (FileWriter fw = new FileWriter(dir + "chat")) {    
             fw.write("expectedresult send\n");
             fw.write("dial a number\n");
             fw.write("CONNECT connect\n");
-            fw.write("OK 1,PPP,apn\n");
         }
 
         PppConfigReader reader = new PppConfigReader() {
@@ -150,6 +149,10 @@ public class PppConfigTest {
                     return "true";
                 } else if (key.equals("net.interface." + intfName + ".config.resetTimeout")) {
                     return "123";
+                } else if (key.equals("net.interface." + intfName + ".config.apn")) {
+                    return "apn";
+                } else if (key.equals("net.interface." + intfName + ".config.pdpType")) {
+                    return "PPP";
                 }
 
                 return null;


### PR DESCRIPTION
This is an attempt to fix #2264.

It is not perfect and relies on the modem monitor to recover the modem
if something goes wrong.
It applies to Telit products LE910-EU1 and LE910-V2 EU/NA.
PDP context 1 is rarely used and there should not be any
performance impact for the other contexts.
See also comment in TelitLe910v2.java.
* AT+CGDCONT removed from chat script
* PDP context and auth set only if config changes
* Improved tip in UI for LTE modems
Configuring context 1 it's likely to require a modem reset before
the changes take effect.
NOTE: changes to PDP auth type and credentials only take effect
if the APN is changed too.

Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>