### PR TITLE
Set the command service as disabled per default.

### DIFF
--- a/kura/org.eclipse.kura.core.cloud/OSGI-INF/metatype/org.eclipse.kura.cloud.app.command.CommandCloudApp.xml
+++ b/kura/org.eclipse.kura.core.cloud/OSGI-INF/metatype/org.eclipse.kura.cloud.app.command.CommandCloudApp.xml
@@ -24,7 +24,7 @@
             type="Boolean"
             cardinality="0"
             required="true"
-            default="true"
+            default="false"
             description="Enables or disables the Command Service">
         </AD>
         


### PR DESCRIPTION
The user will need to opt-in to use this feature.

Signed-off-by: Maiero <matteo.maiero@eurotech.com>