### PR TITLE
Use ThrowablePatternConverter for exception logging

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-centos-7-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 #
-# Copyright (c) 2018 Eurotech and/or its affiliates
+# Copyright (c) 2018, 2019 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,7 @@
     <Appenders>
         <RollingFile name="RollingFile" fileName="${filename}.log" filePattern="${filename}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
             <PatternLayout>
-                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n</Pattern>
+                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>

--- a/kura/distrib/src/main/resources/intel-up2-centos-7/log4j.xml
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 #
-# Copyright (c) 2018 Eurotech and/or its affiliates
+# Copyright (c) 2018, 2019 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,7 @@
     <Appenders>
         <RollingFile name="RollingFile" fileName="${filename}.log" filePattern="${filename}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
             <PatternLayout>
-                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n</Pattern>
+                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-16/log4j.xml
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-16/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 #
-# Copyright (c) 2018 Eurotech and/or its affiliates
+# Copyright (c) 2018, 2019 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,7 @@
     <Appenders>
         <RollingFile name="RollingFile" fileName="${filename}.log" filePattern="${filename}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
             <PatternLayout>
-                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n</Pattern>
+                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 #
-# Copyright (c) 2018 Eurotech and/or its affiliates
+# Copyright (c) 2018, 2019 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,7 @@
     <Appenders>
         <RollingFile name="RollingFile" fileName="${filename}.log" filePattern="${filename}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
             <PatternLayout>
-                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n</Pattern>
+                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>

--- a/kura/distrib/src/main/resources/raspberry-pi-2/log4j.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 #
-# Copyright (c) 2018 Eurotech and/or its affiliates
+# Copyright (c) 2018, 2019 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,7 @@
     <Appenders>
         <RollingFile name="RollingFile" fileName="${filename}.log" filePattern="${filename}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
             <PatternLayout>
-                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n</Pattern>
+                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>

--- a/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 #
-# Copyright (c) 2018 Eurotech and/or its affiliates
+# Copyright (c) 2018, 2019 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,7 @@
     <Appenders>
         <RollingFile name="RollingFile" fileName="${filename}.log" filePattern="${filename}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
             <PatternLayout>
-                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n</Pattern>
+                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
             <Policies>
                 <SizeBasedTriggeringPolicy size="20 MB"/>

--- a/kura/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml
+++ b/kura/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 #
-# Copyright (c) 2018 Eurotech and/or its affiliates
+# Copyright (c) 2018, 2019 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -19,7 +19,7 @@
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
           <PatternLayout>
-              <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n</Pattern>
+              <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
           </PatternLayout>
         </Console>
     </Appenders>


### PR DESCRIPTION
Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>

**Related Issue:** 
#2324 

**Description of the solution adopted:**
Use `ThrowablePatternConverter` instead of `ExtendedThrowablePatternConverter`
