### PR TITLE
Prevented altering state if another download is in progress

### DIFF
--- a/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/CloudDeploymentHandlerV2.java
+++ b/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/CloudDeploymentHandlerV2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and others
+ * Copyright (c) 2011, 2019 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -483,7 +483,6 @@ public class CloudDeploymentHandlerV2 implements ConfigurableComponent, RequestH
             options = new DeploymentPackageDownloadOptions(request, this.deploymentHookManager,
                     this.componentOptions.getDownloadsDirectory());
             options.setClientId(this.dataTransportService.getClientId());
-            downloadImplementation = createDownloadImpl(options);
         } catch (Exception ex) {
             logger.info("Malformed download request!");
             throw new KuraException(KuraErrorCode.BAD_REQUEST);
@@ -509,6 +508,8 @@ public class CloudDeploymentHandlerV2 implements ConfigurableComponent, RequestH
             }
             return response;
         }
+
+        downloadImplementation = createDownloadImpl(options);
 
         boolean alreadyDownloaded = false;
 


### PR DESCRIPTION
Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:**
Closes #2256 

**Description of the solution adopted:**
Currently if a download is in progress and another request is received, the DEPLOY-V2 cloudlet correctly returns an error code but alters its internal state, causing glitches in successive requests like the one reported in #2256.

This PR provides a quick fix that prevents existing download state to be altered in this case
