### PR TITLE
Fixed regression when saving empty wire graph

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/cloudconnection/CloudConnectionConfigurationsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/cloudconnection/CloudConnectionConfigurationsUi.java
@@ -140,21 +140,27 @@ public class CloudConnectionConfigurationsUi extends Composite {
 
     private void getCloudStackConfigurations(final String factoryPid, final String cloudServicePid) {
 
+        connectionNavtabs.clear();
         RequestQueue.submit(context -> gwtCloudService.findStackPidsByFactory(factoryPid, cloudServicePid,
-                context.callback(pidsResult -> gwtXSRFService.generateSecurityToken(
-                        context.callback(token -> gwtComponentService.findComponentConfigurations(token,
-                                FilterUtil.getPidFilter(pidsResult.iterator()), context.callback(result -> {
-                                    final ArrayList<GwtConfigComponent> sorted = new ArrayList<>(result);
-                                    sorted.sort(Comparator.comparing(this::getSimplifiedComponentName));
-                                    boolean isFirstEntry = true;
-                                    connectionNavtabs.clear();
-                                    for (GwtConfigComponent pair : sorted) {
-                                        if (pidsResult.contains(pair.getComponentId())) {
-                                            renderTabs(pair, isFirstEntry);
-                                            isFirstEntry = false;
+                context.callback(pidsResult -> {
+                    if (pidsResult.isEmpty()) {
+                        return;
+                    }
+
+                    gwtXSRFService.generateSecurityToken(
+                            context.callback(token -> gwtComponentService.findComponentConfigurations(token,
+                                    FilterUtil.getPidFilter(pidsResult.iterator()), context.callback(result -> {
+                                        final ArrayList<GwtConfigComponent> sorted = new ArrayList<>(result);
+                                        sorted.sort(Comparator.comparing(this::getSimplifiedComponentName));
+                                        boolean isFirstEntry = true;
+                                        for (GwtConfigComponent pair : sorted) {
+                                            if (pidsResult.contains(pair.getComponentId())) {
+                                                renderTabs(pair, isFirstEntry);
+                                                isFirstEntry = false;
+                                            }
                                         }
-                                    }
-                                })))))));
+                                    }))));
+                })));
 
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtWireGraphServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtWireGraphServiceImpl.java
@@ -15,6 +15,7 @@
 package org.eclipse.kura.web.server;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -256,13 +257,19 @@ public final class GwtWireGraphServiceImpl extends OsgiRemoteServiceServlet impl
                         .map(GwtConfigComponent::getComponentId))
                 .iterator();
 
-        final Filter receivedConfigurationPidsFilter = getFilter(FilterUtil.getPidFilter(receivedConfigurationPids));
+        final Map<String, ComponentConfiguration> originalConfigs;
 
-        final Map<String, ComponentConfiguration> originalConfigs = ServiceLocator
-                .applyToServiceOptionally(ConfigurationService.class, cs -> cs //
-                        .getComponentConfigurations(receivedConfigurationPidsFilter) //
-                        .stream() //
-                        .collect(Collectors.toMap(ComponentConfiguration::getPid, c -> c)));
+        if (receivedConfigurationPids.hasNext()) {
+            final Filter receivedConfigurationPidsFilter = getFilter(
+                    FilterUtil.getPidFilter(receivedConfigurationPids));
+
+            originalConfigs = ServiceLocator.applyToServiceOptionally(ConfigurationService.class, cs -> cs //
+                    .getComponentConfigurations(receivedConfigurationPidsFilter) //
+                    .stream() //
+                    .collect(Collectors.toMap(ComponentConfiguration::getPid, c -> c)));
+        } else {
+            originalConfigs = Collections.emptyMap();
+        }
 
         final List<WireComponentConfiguration> wireComponentConfigurations = gwtConfigurations
                 .getWireComponentConfigurations() //

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/FilterUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/FilterUtil.java
@@ -18,7 +18,7 @@ public final class FilterUtil {
 
     public static String getPidFilter(final Iterator<String> pids) {
         if (!pids.hasNext()) {
-            return "()";
+            throw new IllegalArgumentException("pids list must be non empty");
         }
         final StringBuilder builder = new StringBuilder();
         builder.append("(|");


### PR DESCRIPTION
Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>

**Related Issue:**

Currently if an empty wire graph is saved, an OSGi filter with invalid syntax is generated by `GwtWireServiceImpl`.

**Description of the solution adopted:**

If `GwtWireServiceImpl` will not perform the call to the `ConfigurationService` which led to the invalid filter if the configuration set provided by the web ui is empty.
