### PR TITLE
Cleanup Kura folders

### DIFF
--- a/kura/distrib/src/main/deb/control/prerm
+++ b/kura/distrib/src/main/deb/control/prerm
@@ -56,16 +56,18 @@ function preRemove {
     rm /etc/init.d/kura
     update-rc.d firewall remove
     update-rc.d kura remove
-    
-    #Delete Eclipse directory if present
-    if [ -d "${INSTALL_DIR}/kura/data" ] ; then
-      rm -rf ${INSTALL_DIR}/kura/data
-    fi
-    
+
+    rm -f  /etc/logrotate.d/kura
+    rm -f  /var/log/kura*.log
+    rm -rf /tmp/.kura
+    rm -rf /tmp/kura
+
     if [ -d "${INSTALL_DIR}/kura" ] ; then
+      PARENT=`readlink -f ${INSTALL_DIR}/kura`
       rm -rf ${INSTALL_DIR}/kura
+      rm -rf $PARENT
     fi
-    
+
     echo ""
     echo "Uninstalling KURA... Done!"
 }

--- a/kura/distrib/src/main/deb/control_nn/prerm
+++ b/kura/distrib/src/main/deb/control_nn/prerm
@@ -54,16 +54,19 @@ function preRemove {
     #Remove INIT scripts
     rm /etc/init.d/kura
     update-rc.d kura remove
-    
+
+    rm -f  /etc/logrotate.d/kura
+    rm -f  /var/log/kura*.log
+    rm -rf /tmp/.kura
+    rm -rf /tmp/kura
+
     #Delete Eclipse directory if present
-    if [ -d "${INSTALL_DIR}/kura/data" ] ; then
-      rm -rf ${INSTALL_DIR}/kura/data
-    fi
-    
     if [ -d "${INSTALL_DIR}/kura" ] ; then
+      PARENT=`readlink -f ${INSTALL_DIR}/kura`
       rm -rf ${INSTALL_DIR}/kura
+      rm -rf $PARENT
     fi
-    
+
     echo ""
     echo "Uninstalling KURA... Done!"
 }


### PR DESCRIPTION
Deletes most files that Kura brought to the system.

**Related Issue:** This PR fixes #362.

**Description of the solution adopted:** Removes most of the files. It does leave some behind - those that can still be used after (e.g. dhcpcd, wpa-supplicant, named, hostapd, ppp, etc. configuration).