### PR TITLE
Added support for null notification publisher in deploy-v2.

### DIFF
--- a/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/CloudDeploymentHandlerV2.java
+++ b/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/CloudDeploymentHandlerV2.java
@@ -300,7 +300,9 @@ public class CloudDeploymentHandlerV2 implements ConfigurableComponent, RequestH
             KuraMessage message = new KuraMessage(messagePayload, properties);
 
             CloudNotificationPublisher notificationPublisher = options.getNotificationPublisher();
-            notificationPublisher.publish(message);
+            if (notificationPublisher != null) {
+                notificationPublisher.publish(message);
+            }
         } catch (KuraException e) {
             logger.error("Error publishing response for command {}", messageType, e);
         }


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

This can be useful if the remote cloud platform does not support an asynchronous notification publisher.