### PR TITLE
kura.linux.snapctl: adding snap control provider

### DIFF
--- a/kura/distrib/config/kura.build.properties
+++ b/kura/distrib/config/kura.build.properties
@@ -45,6 +45,7 @@ org.eclipse.kura.linux.command.version=1.0.300
 org.eclipse.kura.linux.net.version=1.0.500-SNAPSHOT
 org.eclipse.kura.linux.sysv.provider.version=1.0.0
 org.eclipse.kura.linux.systemd.provider.version=1.0.0
+org.eclipse.kura.linux.snapctl.provider.version=1.0.100-SNAPSHOT
 org.eclipse.kura.linux.debian.provider.version=1.0.0
 org.eclipse.kura.linux.redhat.provider.version=1.0.0
 org.eclipse.kura.linux.gpio.version=1.0.400

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -287,6 +287,11 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.eclipse.kura</groupId>
+                                    <artifactId>org.eclipse.kura.linux.snapctl.provider</artifactId>
+                                    <version>${org.eclipse.kura.linux.snapctl.provider.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kura</groupId>
                                     <artifactId>org.eclipse.kura.linux.redhat.provider</artifactId>
                                     <version>${org.eclipse.kura.linux.redhat.provider.version}</version>
                                 </artifactItem>
@@ -614,6 +619,8 @@
                                     tofile="target/plugins/org.eclipse.kura.linux.systemd.provider_${org.eclipse.kura.linux.systemd.provider.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.linux.debian.provider.jar"
                                     tofile="target/plugins/org.eclipse.kura.linux.debian.provider_${org.eclipse.kura.linux.debian.provider.version}.jar" />
+                                <move file="target/plugins/org.eclipse.kura.linux.snapctl.provider.jar"
+                                    tofile="target/plugins/org.eclipse.kura.linux.snapctl.provider_${org.eclipse.kura.linux.snapctl.provider.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.linux.redhat.provider.jar"
                                     tofile="target/plugins/org.eclipse.kura.linux.redhat.provider_${org.eclipse.kura.linux.redhat.provider.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.linux.position.jar"

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -1383,7 +1383,14 @@ fi]]>
 		<zip destfile="${project.build.directory}/${build.output.name}.zip" update="true">
 			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.linux.snapctl.provider_${org.eclipse.kura.linux.snapctl.provider.version}.jar"
                         prefix="${build.output.name}/${plugins.folder}" />
+			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.linux.usb.*_${org.eclipse.kura.linux.usb.version}.jar"
+                        prefix="${build.output.name}/${plugins.folder}" />
 		</zip>
+		<condition property="is.tinyb.snapshot" value="">
+			<contains string="${tinyb.version}" substring="SNAPSHOT"/>
+		</condition>
+			<antcall target="tinyb-snapshot-jars-all" />
+			<antcall target="tinyb-no-snapshot-jars-all" />
 	</target>
 
 	<target name="tinyb-jars">
@@ -1415,6 +1422,28 @@ fi]]>
                 prefix="${build.output.name}/${plugins.folder}" />
 	    </zip>
 	</target>
+
+    <target name="tinyb-snapshot-jars-all" if="is.tinyb.snapshot">
+        <zip destfile="${project.build.directory}/${build.output.name}.zip" update="true">
+            <mappedresources>
+                <fileset dir="../target-definition/common/repository/plugins" includes="tinyb.*_*.jar" />
+                <globmapper from="*.SNAPSHOT.jar" to="${build.output.name}/${plugins.folder}/*-SNAPSHOT.jar" />
+            </mappedresources>
+            <mappedresources>
+                <fileset dir="../target-definition/common/repository/plugins" includes="tinyb_*.jar" />
+                <globmapper from="*.SNAPSHOT.jar" to="${build.output.name}/${plugins.folder}/*-SNAPSHOT.jar" />
+            </mappedresources>
+        </zip>
+    </target>
+
+    <target name="tinyb-no-snapshot-jars-all" unless="is.tinyb.snapshot">
+        <zip destfile="${project.build.directory}/${build.output.name}.zip" update="true">
+            <zipfileset file="../target-definition/common/repository/plugins/tinyb.*_${tinyb.version}.jar"
+                prefix="${build.output.name}/${plugins.folder}" />
+            <zipfileset file="../target-definition/common/repository/plugins/tinyb_${tinyb.version}.jar"
+                prefix="${build.output.name}/${plugins.folder}" />
+        </zip>
+    </target>
 
 	<target name="web2-jar-win" if="is.web2.jar.available">
     	<echo message="web2-jar-win ${project.build.directory}/${build.output.name}/config.ini..." />

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -1330,6 +1330,10 @@ fi]]>
 		<propertyfile file="${project.build.directory}/${build.output.name}/config.ini">
 			<entry key="osgi.bundles" operation="+"
 					value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.linux.snapctl.provider_${org.eclipse.kura.linux.snapctl.provider.version}.jar@4" />
+			<entry key="osgi.bundles" operation="+"
+					value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.emulator_${org.eclipse.kura.emulator.version}.jar@4" />
+			<entry key="osgi.bundles" operation="+"
+					value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.emulator.net_${org.eclipse.kura.emulator.net.version}.jar@4" />
 		</propertyfile>
 	</target>
 
@@ -1384,6 +1388,10 @@ fi]]>
 			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.linux.snapctl.provider_${org.eclipse.kura.linux.snapctl.provider.version}.jar"
                         prefix="${build.output.name}/${plugins.folder}" />
 			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.linux.usb.*_${org.eclipse.kura.linux.usb.version}.jar"
+                        prefix="${build.output.name}/${plugins.folder}" />
+			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.emulator_${org.eclipse.kura.emulator.version}.jar"
+                        prefix="${build.output.name}/${plugins.folder}" />
+			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.emulator.net_${org.eclipse.kura.emulator.net.version}.jar"
                         prefix="${build.output.name}/${plugins.folder}" />
 		</zip>
 		<condition property="is.tinyb.snapshot" value="">

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -191,6 +191,15 @@
 			</and>
 		</condition>
 
+		<condition property="is.snapctl">
+			<and>
+				<contains string="${service.manager}" substring="snapctl"/>
+				<not>
+					<contains string="${build.name}" substring="-nn"/>
+				</not>
+			</and>
+		</condition>
+
 		<condition property="is.debian">
 			<and>
 				<contains string="${os.base}" substring="debian"/>
@@ -212,6 +221,7 @@
 		<antcall target="linux-debian-config" />
 		<antcall target="linux-redhat-config" />
 		<antcall target="linux-systemd-config" />
+		<antcall target="linux-snapctl-config" />
 
 
 		<!-- Add mToolkit to config.ini -->
@@ -619,6 +629,7 @@ fi]]>
 		<antcall target="linux-debian-jars" />
 		<antcall target="linux-redhat-jars" />
 		<antcall target="linux-systemd-jars" />
+		<antcall target="linux-snapctl-jars" />
 		<antcall target="tinyb-jars" />
 
 		<echo message="Building Kura Distribution for ${build.name}-jars..." />
@@ -1315,6 +1326,13 @@ fi]]>
 		</propertyfile>
 	</target>
 
+	<target name="linux-snapctl-config" if="is.snapctl" depends="linux-config">
+		<propertyfile file="${project.build.directory}/${build.output.name}/config.ini">
+			<entry key="osgi.bundles" operation="+"
+					value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.linux.snapctl.provider_${org.eclipse.kura.linux.snapctl.provider.version}.jar@4" />
+		</propertyfile>
+	</target>
+
 	<target name="emulator-jars" if="is.nn">
 		<zip destfile="${project.build.directory}/${build.output.name}.zip" update="true">
 			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.emulator_${org.eclipse.kura.emulator.version}.jar"
@@ -1357,6 +1375,13 @@ fi]]>
 	<target name="linux-systemd-jars" if="is.systemd" depends="linux-jars">
 		<zip destfile="${project.build.directory}/${build.output.name}.zip" update="true">
 			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.linux.systemd.provider_${org.eclipse.kura.linux.systemd.provider.version}.jar"
+                        prefix="${build.output.name}/${plugins.folder}" />
+		</zip>
+	</target>
+
+	<target name="linux-snapctl-jars" if="is.snapctl" depends="linux-jars">
+		<zip destfile="${project.build.directory}/${build.output.name}.zip" update="true">
+			<zipfileset file="${project.build.directory}/plugins/org.eclipse.kura.linux.snapctl.provider_${org.eclipse.kura.linux.snapctl.provider.version}.jar"
                         prefix="${build.output.name}/${plugins.folder}" />
 		</zip>
 	</target>

--- a/kura/org.eclipse.kura.linux.snapctl.provider/.gitignore
+++ b/kura/org.eclipse.kura.linux.snapctl.provider/.gitignore
@@ -1,0 +1,2 @@
+/target
+/bin

--- a/kura/org.eclipse.kura.linux.snapctl.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.linux.snapctl.provider/META-INF/MANIFEST.MF
@@ -1,0 +1,17 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.linux.snapctl.provider
+Bundle-SymbolicName: org.eclipse.kura.linux.snapctl.provider;singleton:=true
+Bundle-Version: 1.0.100.qualifier
+Bundle-Vendor: Eclipse Kura
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Service-Component: OSGI-INF/*.xml
+Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy
+Import-Package: org.eclipse.kura;version="[1.1,2.0)",
+ org.eclipse.kura.core.linux.util;version="[1.1,2.0)",
+ org.eclipse.kura.internal.linux.net.dns;version="[1.0,2.0)",
+ org.eclipse.kura.net;version="[2.0,3.0)",
+ org.eclipse.kura.net.dns;version="[1.0,2.0)",
+ org.osgi.service.component;version="1.2.0",
+ org.slf4j;version="1.6.4"

--- a/kura/org.eclipse.kura.linux.snapctl.provider/OSGI-INF/dnsserver.xml
+++ b/kura/org.eclipse.kura.linux.snapctl.provider/OSGI-INF/dnsserver.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Eurotech and/or its affiliates
+
+     All rights reserved. This program and the accompanying materials
+     are made available under the terms of the Eclipse Public License v1.0
+     which accompanies this distribution, and is available at
+     http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Canonical
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" enabled="true" immediate="true" name="org.eclipse.kura.linux.snapctl.provider.DnsServerService">
+   <implementation class="org.eclipse.kura.internal.linux.snapctl.net.dns.DnsServerServiceImpl"/>
+   <service>
+      <provide interface="org.eclipse.kura.internal.linux.net.dns.DnsServerService"/>
+   </service>
+   <property name="service.pid" value="org.eclipse.kura.linux.snapctl.provider.DnsServerService"/>
+</scr:component>

--- a/kura/org.eclipse.kura.linux.snapctl.provider/about.html
+++ b/kura/org.eclipse.kura.linux.snapctl.provider/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>April 4, 2014</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/kura/org.eclipse.kura.linux.snapctl.provider/about_files/epl-v10.html
+++ b/kura/org.eclipse.kura.linux.snapctl.provider/about_files/epl-v10.html
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>Eclipse Public License - Version 1.0</title>
+<style type="text/css">
+  body {
+    size: 8.5in 11.0in;
+    margin: 0.25in 0.5in 0.25in 0.5in;
+    tab-interval: 0.5in;
+    }
+  p {  	
+    margin-left: auto;
+    margin-top:  0.5em;
+    margin-bottom: 0.5em;
+    }
+  p.list {
+  	margin-left: 0.5in;
+    margin-top:  0.05em;
+    margin-bottom: 0.05em;
+    }
+  </style>
+
+</head>
+
+<body lang="EN-US">
+
+<h2>Eclipse Public License - v 1.0</h2>
+
+<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR
+DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS
+AGREEMENT.</p>
+
+<p><b>1. DEFINITIONS</b></p>
+
+<p>&quot;Contribution&quot; means:</p>
+
+<p class="list">a) in the case of the initial Contributor, the initial
+code and documentation distributed under this Agreement, and</p>
+<p class="list">b) in the case of each subsequent Contributor:</p>
+<p class="list">i) changes to the Program, and</p>
+<p class="list">ii) additions to the Program;</p>
+<p class="list">where such changes and/or additions to the Program
+originate from and are distributed by that particular Contributor. A
+Contribution 'originates' from a Contributor if it was added to the
+Program by such Contributor itself or anyone acting on such
+Contributor's behalf. Contributions do not include additions to the
+Program which: (i) are separate modules of software distributed in
+conjunction with the Program under their own license agreement, and (ii)
+are not derivative works of the Program.</p>
+
+<p>&quot;Contributor&quot; means any person or entity that distributes
+the Program.</p>
+
+<p>&quot;Licensed Patents&quot; mean patent claims licensable by a
+Contributor which are necessarily infringed by the use or sale of its
+Contribution alone or when combined with the Program.</p>
+
+<p>&quot;Program&quot; means the Contributions distributed in accordance
+with this Agreement.</p>
+
+<p>&quot;Recipient&quot; means anyone who receives the Program under
+this Agreement, including all Contributors.</p>
+
+<p><b>2. GRANT OF RIGHTS</b></p>
+
+<p class="list">a) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free copyright license to reproduce, prepare derivative works
+of, publicly display, publicly perform, distribute and sublicense the
+Contribution of such Contributor, if any, and such derivative works, in
+source code and object code form.</p>
+
+<p class="list">b) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free patent license under Licensed Patents to make, use, sell,
+offer to sell, import and otherwise transfer the Contribution of such
+Contributor, if any, in source code and object code form. This patent
+license shall apply to the combination of the Contribution and the
+Program if, at the time the Contribution is added by the Contributor,
+such addition of the Contribution causes such combination to be covered
+by the Licensed Patents. The patent license shall not apply to any other
+combinations which include the Contribution. No hardware per se is
+licensed hereunder.</p>
+
+<p class="list">c) Recipient understands that although each Contributor
+grants the licenses to its Contributions set forth herein, no assurances
+are provided by any Contributor that the Program does not infringe the
+patent or other intellectual property rights of any other entity. Each
+Contributor disclaims any liability to Recipient for claims brought by
+any other entity based on infringement of intellectual property rights
+or otherwise. As a condition to exercising the rights and licenses
+granted hereunder, each Recipient hereby assumes sole responsibility to
+secure any other intellectual property rights needed, if any. For
+example, if a third party patent license is required to allow Recipient
+to distribute the Program, it is Recipient's responsibility to acquire
+that license before distributing the Program.</p>
+
+<p class="list">d) Each Contributor represents that to its knowledge it
+has sufficient copyright rights in its Contribution, if any, to grant
+the copyright license set forth in this Agreement.</p>
+
+<p><b>3. REQUIREMENTS</b></p>
+
+<p>A Contributor may choose to distribute the Program in object code
+form under its own license agreement, provided that:</p>
+
+<p class="list">a) it complies with the terms and conditions of this
+Agreement; and</p>
+
+<p class="list">b) its license agreement:</p>
+
+<p class="list">i) effectively disclaims on behalf of all Contributors
+all warranties and conditions, express and implied, including warranties
+or conditions of title and non-infringement, and implied warranties or
+conditions of merchantability and fitness for a particular purpose;</p>
+
+<p class="list">ii) effectively excludes on behalf of all Contributors
+all liability for damages, including direct, indirect, special,
+incidental and consequential damages, such as lost profits;</p>
+
+<p class="list">iii) states that any provisions which differ from this
+Agreement are offered by that Contributor alone and not by any other
+party; and</p>
+
+<p class="list">iv) states that source code for the Program is available
+from such Contributor, and informs licensees how to obtain it in a
+reasonable manner on or through a medium customarily used for software
+exchange.</p>
+
+<p>When the Program is made available in source code form:</p>
+
+<p class="list">a) it must be made available under this Agreement; and</p>
+
+<p class="list">b) a copy of this Agreement must be included with each
+copy of the Program.</p>
+
+<p>Contributors may not remove or alter any copyright notices contained
+within the Program.</p>
+
+<p>Each Contributor must identify itself as the originator of its
+Contribution, if any, in a manner that reasonably allows subsequent
+Recipients to identify the originator of the Contribution.</p>
+
+<p><b>4. COMMERCIAL DISTRIBUTION</b></p>
+
+<p>Commercial distributors of software may accept certain
+responsibilities with respect to end users, business partners and the
+like. While this license is intended to facilitate the commercial use of
+the Program, the Contributor who includes the Program in a commercial
+product offering should do so in a manner which does not create
+potential liability for other Contributors. Therefore, if a Contributor
+includes the Program in a commercial product offering, such Contributor
+(&quot;Commercial Contributor&quot;) hereby agrees to defend and
+indemnify every other Contributor (&quot;Indemnified Contributor&quot;)
+against any losses, damages and costs (collectively &quot;Losses&quot;)
+arising from claims, lawsuits and other legal actions brought by a third
+party against the Indemnified Contributor to the extent caused by the
+acts or omissions of such Commercial Contributor in connection with its
+distribution of the Program in a commercial product offering. The
+obligations in this section do not apply to any claims or Losses
+relating to any actual or alleged intellectual property infringement. In
+order to qualify, an Indemnified Contributor must: a) promptly notify
+the Commercial Contributor in writing of such claim, and b) allow the
+Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own
+expense.</p>
+
+<p>For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those
+performance claims and warranties, and if a court requires any other
+Contributor to pay any damages as a result, the Commercial Contributor
+must pay those damages.</p>
+
+<p><b>5. NO WARRANTY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
+PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION,
+ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY
+OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
+responsible for determining the appropriateness of using and
+distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to
+the risks and costs of program errors, compliance with applicable laws,
+damage to or loss of data, programs or equipment, and unavailability or
+interruption of operations.</p>
+
+<p><b>6. DISCLAIMER OF LIABILITY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT
+NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
+DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
+HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
+
+<p><b>7. GENERAL</b></p>
+
+<p>If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further action
+by the parties hereto, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.</p>
+
+<p>If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other
+software or hardware) infringes such Recipient's patent(s), then such
+Recipient's rights granted under Section 2(b) shall terminate as of the
+date such litigation is filed.</p>
+
+<p>All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of time
+after becoming aware of such noncompliance. If all Recipient's rights
+under this Agreement terminate, Recipient agrees to cease use and
+distribution of the Program as soon as reasonably practicable. However,
+Recipient's obligations under this Agreement and any licenses granted by
+Recipient relating to the Program shall continue and survive.</p>
+
+<p>Everyone is permitted to copy and distribute copies of this
+Agreement, but in order to avoid inconsistency the Agreement is
+copyrighted and may only be modified in the following manner. The
+Agreement Steward reserves the right to publish new versions (including
+revisions) of this Agreement from time to time. No one other than the
+Agreement Steward has the right to modify this Agreement. The Eclipse
+Foundation is the initial Agreement Steward. The Eclipse Foundation may
+assign the responsibility to serve as the Agreement Steward to a
+suitable separate entity. Each new version of the Agreement will be
+given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version
+of the Agreement is published, Contributor may elect to distribute the
+Program (including its Contributions) under the new version. Except as
+expressly stated in Sections 2(a) and 2(b) above, Recipient receives no
+rights or licenses to the intellectual property of any Contributor under
+this Agreement, whether expressly, by implication, estoppel or
+otherwise. All rights in the Program not expressly granted under this
+Agreement are reserved.</p>
+
+<p>This Agreement is governed by the laws of the State of New York and
+the intellectual property laws of the United States of America. No party
+to this Agreement will bring a legal action under this Agreement more
+than one year after the cause of action arose. Each party waives its
+rights to a jury trial in any resulting litigation.</p>
+
+</body>
+
+</html>

--- a/kura/org.eclipse.kura.linux.snapctl.provider/build.properties
+++ b/kura/org.eclipse.kura.linux.snapctl.provider/build.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2018 Eurotech and/or its affiliates
+#
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Canonical
+#
+
+bin.includes = .,\
+               META-INF/,\
+               OSGI-INF/,\
+               about.html,\
+               about_files/
+source.. = src/main/java/
+src.includes = about.html,\
+               about_files/

--- a/kura/org.eclipse.kura.linux.snapctl.provider/pom.xml
+++ b/kura/org.eclipse.kura.linux.snapctl.provider/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Eurotech and/or its affiliates
+
+     All rights reserved. This program and the accompanying materials
+     are made available under the terms of the Eclipse Public License v1.0
+     which accompanies this distribution, and is available at
+     http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Canonical
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.kura</groupId>
+		<artifactId>kura</artifactId>
+		<version>4.1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.kura.linux.snapctl.provider</artifactId>
+	<version>1.0.100-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<properties>
+		<kura.basedir>${project.basedir}/..</kura.basedir>
+	</properties>
+</project>

--- a/kura/org.eclipse.kura.linux.snapctl.provider/src/main/java/org/eclipse/kura/internal/linux/snapctl/net/dns/DnsServerServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.snapctl.provider/src/main/java/org/eclipse/kura/internal/linux/snapctl/net/dns/DnsServerServiceImpl.java
@@ -1,0 +1,333 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Canonical
+ *******************************************************************************/
+package org.eclipse.kura.internal.linux.snapctl.net.dns;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.core.linux.util.LinuxProcessUtil;
+import org.eclipse.kura.internal.linux.net.dns.DnsServerService;
+import org.eclipse.kura.net.IP4Address;
+import org.eclipse.kura.net.IPAddress;
+import org.eclipse.kura.net.NetworkPair;
+import org.eclipse.kura.net.dns.DnsServerConfig;
+import org.eclipse.kura.net.dns.DnsServerConfigIP4;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DnsServerServiceImpl implements DnsServerService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DnsServerServiceImpl.class);
+
+    private static final String PERSISTENT_CONFIG_FILE_NAME = System.getProperty("kura.data.snap.common") + "/etc/bind/named.conf";
+    private static final String RFC_1912_ZONES_FILENAME = System.getProperty("kura.data.snap.common") + "/etc/bind/named.rfc1912.zones";
+    private static final String PROC_STRING = "named -u named -t";
+	private static final String SNAP_NAME = System.getProperty("kura.os.snap.name");
+
+    private DnsServerConfigIP4 dnsServerConfigIP4;
+
+    protected void activate() {
+        logger.info("Activating LinuxNamed...");
+        try {
+            init();
+        } catch (KuraException e) {
+            logger.info("Error activating LinuxNamed...");
+            if (this.dnsServerConfigIP4 == null) {
+                Set<IP4Address> forwarders = new HashSet<>();
+                HashSet<NetworkPair<IP4Address>> allowedNetworks = new HashSet<>();
+                this.dnsServerConfigIP4 = new DnsServerConfigIP4(forwarders, allowedNetworks);
+            }
+        }
+    }
+
+    protected void deactivate(ComponentContext componentContext) {
+        logger.info("Deactivating LinuxNamed...");
+    }
+
+    private void init() throws KuraException {
+        File configFile = new File(DnsServerServiceImpl.PERSISTENT_CONFIG_FILE_NAME);
+        if (!configFile.exists() || !isForwardOnlyConfiguration(configFile)) {
+            logger.debug("There is no current DNS server configuration that allows forwarding");
+            return;
+        }
+
+        logger.debug("initing DNS Server configuration");
+
+        Set<IP4Address> forwarders = new HashSet<>();
+        Set<NetworkPair<IP4Address>> allowedNetworks = new HashSet<>();
+
+        try (FileReader fr = new FileReader(configFile); BufferedReader br = new BufferedReader(fr)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                StringTokenizer st = new StringTokenizer(line);
+                while (st.hasMoreTokens()) {
+                    String token = st.nextToken();
+                    if ("forwarders".equals(token)) {
+                        // get the forwarders 'forwarders {192.168.1.1;192.168.2.1;};'
+                        StringTokenizer st2 = new StringTokenizer(st.nextToken(), "{} ;");
+                        while (st2.hasMoreTokens()) {
+                            String forwarder = st2.nextToken();
+                            if (forwarder != null && !"".equals(forwarder.trim())) {
+                                logger.debug("found forwarder: {}", forwarder);
+                                forwarders.add((IP4Address) IPAddress.parseHostAddress(forwarder));
+                            }
+                        }
+                    } else if ("allow-query".equals(token)) {
+                        // get the networks 'allow-query {192.168.2.0/24;192.168.3.0/24};'
+                        StringTokenizer st2 = new StringTokenizer(st.nextToken(), "{} ;");
+                        while (st2.hasMoreTokens()) {
+                            String allowedNetwork = st2.nextToken();
+                            if (allowedNetwork != null && !"".equals(allowedNetwork.trim())) {
+                                String[] splitNetwork = allowedNetwork.split("/");
+                                allowedNetworks
+                                        .add(new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(splitNetwork[0]),
+                                                Short.parseShort(splitNetwork[1])));
+                            }
+                        }
+                    }
+                }
+            }
+
+            // set the configuration and return
+            this.dnsServerConfigIP4 = new DnsServerConfigIP4(forwarders, allowedNetworks);
+        } catch (Exception e) {
+            logger.error("init() :: failed to read the {} configuration file ", configFile.getName(), e);
+            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR, e);
+        }
+    }
+
+    private boolean isForwardOnlyConfiguration(File configFile) throws KuraException {
+        boolean forwardingConfig = false;
+        try (FileReader fr = new FileReader(configFile); BufferedReader br = new BufferedReader(fr)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if ("forward only;".equals(line.trim())) {
+                    forwardingConfig = true;
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            logger.error("isForwardOnlyConfiguration() :: failed to read the {} configuration file ",
+                    configFile.getName(), e);
+            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR, e);
+        }
+        return forwardingConfig;
+    }
+
+    @Override
+    public boolean isRunning() {
+        try {
+            // Check if named is running
+            int pid = LinuxProcessUtil.getPid(DnsServerServiceImpl.PROC_STRING);
+            return pid > -1;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void start() throws KuraException {
+        // write config happened during 'set config' step
+        try {
+            // Check if named is running
+            int pid = LinuxProcessUtil.getPid(DnsServerServiceImpl.PROC_STRING);
+            if (pid > -1) {
+                // If so, disable it
+                logger.error("DNS server is already running, bringing it down...");
+                stop();
+            }
+            // Start named
+            int result = LinuxProcessUtil.start("snapctl start --enable " + SNAP_NAME + ".named");
+
+            if (result == 0) {
+                logger.debug("DNS server started.");
+                logger.trace("{}", this.dnsServerConfigIP4);
+            } else {
+                throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR);
+            }
+
+        } catch (Exception e) {
+            throw new KuraException(KuraErrorCode.PROCESS_EXECUTION_ERROR, e);
+        }
+    }
+
+    @Override
+    public void stop() throws KuraException {
+        try {
+            int result = LinuxProcessUtil.start("snapctl stop --disable " + SNAP_NAME + ".named");
+
+            if (result == 0) {
+                logger.debug("DNS server stopped.");
+                logger.trace("{}", this.dnsServerConfigIP4);
+            } else {
+                logger.debug("tried to kill DNS server for interface but it is not running");
+                throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR);
+            }
+        } catch (Exception e) {
+            throw new KuraException(KuraErrorCode.PROCESS_EXECUTION_ERROR, e);
+        }
+    }
+
+    @Override
+    public void restart() throws KuraException {
+        try {
+            if (LinuxProcessUtil.start("snapctl restart " + SNAP_NAME + ".named") == 0 ) {
+                logger.debug("DNS server restarted.");
+            } else {
+                throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, "error restarting");
+            }
+        } catch (Exception e) {
+            throw new KuraException(KuraErrorCode.PROCESS_EXECUTION_ERROR, e);
+        }
+    }
+
+    @Override
+    public boolean isConfigured() {
+        if (this.dnsServerConfigIP4 == null || this.dnsServerConfigIP4.getForwarders() == null
+                || this.dnsServerConfigIP4.getAllowedNetworks() == null) {
+            return false;
+        }
+        return this.dnsServerConfigIP4.getForwarders().isEmpty()
+                || this.dnsServerConfigIP4.getAllowedNetworks().isEmpty() ? false : true;
+    }
+
+    @Override
+    public void setConfig(DnsServerConfig dnsServerConfig) {
+        if (this.dnsServerConfigIP4 == null) {
+            logger.warn("Set DNS server configuration to null");
+        }
+        if (dnsServerConfig instanceof DnsServerConfigIP4) {
+            this.dnsServerConfigIP4 = (DnsServerConfigIP4) dnsServerConfig;
+        }
+        try {
+            writeConfig();
+        } catch (IOException e) {
+            logger.error("Error setting DNS server config", e);
+        }
+    }
+
+    @Override
+    public DnsServerConfig getConfig() {
+        return this.dnsServerConfigIP4;
+    }
+
+    private void writeConfig() throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(DnsServerServiceImpl.PERSISTENT_CONFIG_FILE_NAME);
+                PrintWriter pw = new PrintWriter(fos);) {
+            // build up the file
+            if (isConfigured()) {
+                logger.debug("writing custom named.conf to {} with: {}",
+                        DnsServerServiceImpl.PERSISTENT_CONFIG_FILE_NAME, this.dnsServerConfigIP4);
+                pw.print(getForwardingNamedFile());
+            } else {
+                logger.debug("writing default named.conf to {} with: {}",
+                        DnsServerServiceImpl.PERSISTENT_CONFIG_FILE_NAME, this.dnsServerConfigIP4);
+                pw.print(getDefaultNamedFile());
+            }
+            pw.flush();
+            fos.getFD().sync();
+        }
+    }
+
+    private String getForwardingNamedFile() {
+        StringBuilder sb = new StringBuilder().append("// Forwarding and Caching Name Server Configuration\n")
+                .append("options {\n") //
+                .append("\tdirectory \"" + System.getProperty("kura.data.snap.common") + "/var/named\";\n") //
+                .append("\tversion \"not currently available\";\n") //
+                .append("\tforwarders {");
+
+        Set<IP4Address> forwarders = this.dnsServerConfigIP4.getForwarders();
+        for (IPAddress forwarder : forwarders) {
+            sb.append(forwarder.getHostAddress()).append(";");
+        }
+        sb.append("};\n");
+
+        sb.append("\tforward only;\n") //
+                .append("\tallow-transfer{\"none\";};\n") //
+                .append("\tallow-query {");
+
+        Set<NetworkPair<IP4Address>> allowedNetworks = this.dnsServerConfigIP4.getAllowedNetworks();
+        for (NetworkPair<IP4Address> pair : allowedNetworks) {
+            sb.append(pair.getIpAddress().getHostAddress()) //
+                    .append("/") //
+                    .append(pair.getPrefix()) //
+                    .append(";");
+        }
+        sb.append("};\n");
+        sb.append("\tmax-cache-ttl 30;\n");
+        sb.append("\tmax-ncache-ttl 30;\n");
+        sb.append("};\n") //
+                .append("zone \".\" IN {\n") //
+                .append("\ttype hint;\n") //
+                .append("\tfile \"named.ca\";\n") //
+                .append("};\n") //
+                .append("include \"") //
+                .append(DnsServerServiceImpl.RFC_1912_ZONES_FILENAME) //
+                .append("\";\n");
+
+        return sb.toString();
+    }
+
+    private String getDefaultNamedFile() {
+        StringBuilder sb = new StringBuilder().append("//\n") //
+                .append("// named.conf\n") //
+                .append("//\n") //
+                .append("// Provided by Red Hat bind package to configure the ISC BIND named(8) DNS\n") //
+                .append("// server as a caching only nameserver (as a localhost DNS resolver only).\n") //
+                .append("//\n") //
+                .append("// See /usr/share/doc/bind*/sample/ for example named configuration files.\n") //
+                .append("//\n") //
+                .append("\n") //
+                .append("options {\n") //
+                .append("\tlisten-on port 53 { 127.0.0.1; };\n") //
+                .append("\tlisten-on-v6 port 53 { ::1; };\n") //
+                .append("\tdirectory	\"" + System.getProperty("kura.data.snap.common") + "/var/named\";\n") //
+                .append("\tdump-file	\"" + System.getProperty("kura.data.snap.common") + "/var/named/data/cache_dump.db\";\n") //
+                .append("\tstatistics-file \"" + System.getProperty("kura.data.snap.common") + "/var/named/data/named_stats.txt\";\n") //
+                .append("\tmemstatistics-file \"" + System.getProperty("kura.data.snap.common") + "/var/named/data/named_mem_stats.txt\";\n") //
+                .append("\tpid-file \"" + System.getProperty("kura.data.snap.data") + "/run/named.pid\";\n") //
+                .append("\tstatistics-file \"" + System.getProperty("kura.data.snap.data") + "/run/named.stats\";\n") //
+                .append("\tsession-keyfile \"" + System.getProperty("kura.data.snap.data") + "/run/session.key\";\n") //
+                .append("\tallow-query     { localhost; };\n") //
+                .append("\trecursion yes;\n") //
+                .append("\n") //
+                .append("\tmax-cache-ttl 30;\n") //
+                .append("\tmax-ncache-ttl 30;\n") //
+                .append("\tdnssec-enable yes;\n") //
+                .append("\tdnssec-validation yes;\n") //
+                .append("\tdnssec-lookaside auto;\n") //
+                .append("\n") //
+                .append("\t/* Path to ISC DLV key */\n") //
+                .append("\nbindkeys-file \"" + System.getProperty("kura.data.snap.common") + "/etc/named.iscdlv.key\";\n") //
+                .append("};\n") //
+                .append("\n") //
+                .append("zone \".\" IN {\n") //
+                .append("\ttype hint;\n") //
+                .append("\tfile \"named.ca\";\n") //
+                .append("};\n") //
+                .append("\n") //
+                .append("include \"") //
+                .append(DnsServerServiceImpl.RFC_1912_ZONES_FILENAME) //
+                .append("\";\n"); //
+        return sb.toString();
+    }
+}

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -97,6 +97,7 @@
 
         <module>org.eclipse.kura.linux.sysv.provider</module>
         <module>org.eclipse.kura.linux.systemd.provider</module>
+        <module>org.eclipse.kura.linux.snapctl.provider</module>
 
         <module>org.eclipse.kura.linux.debian.provider</module>
         <module>org.eclipse.kura.linux.redhat.provider</module>


### PR DESCRIPTION
kura.linux.snapctl: adding snap control provider
    
Adding dns server service provider for snap confinement
It reflests constrains when Kura runs in snap confinement.
In snap confinement Kura runs in own sandbox, so usual writable paths
might not be accessible.
systemd is also not accessible directly, instead kura can control
own services (named) through snapctl interface

Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

