### PR TITLE
Adding snap layout support

### DIFF
--- a/kura/org.eclipse.kura.linux.debian.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.debian.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
@@ -45,7 +45,10 @@ public class NetInterfaceConfigSerializationServiceImpl implements NetInterfaceC
     private static final Logger logger = LoggerFactory.getLogger(NetInterfaceConfigSerializationServiceImpl.class);
 
     private static final String DEBIAN_NET_CONFIGURATION_FILE = "/etc/network/interfaces";
-    private static final String DEBIAN_TMP_NET_CONFIGURATION_FILE = "/etc/network/interfaces.tmp";
+    private static final String DEBIAN_TMP_NET_CONFIGURATION_FILE =
+                         System.getProperty("kura.data.snap.common") == null ?
+                               "/etc/network/interfaces.tmp"
+                             : "/tmp/network_interfaces.tmp";
 
     private static final String ONBOOT_PROP_NAME = "ONBOOT";
     private static final String BOOTPROTO_PROP_NAME = "BOOTPROTO";

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxDns.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxDns.java
@@ -41,7 +41,9 @@ public class LinuxDns {
 
     private static final String DNS_FILE_NAME = "/etc/resolv.conf";
     private static final String[] PPP_DNS_FILES = { "/var/run/ppp/resolv.conf", "/etc/ppp/resolv.conf" };
-    private static final String BACKUP_DNS_FILE_NAME = "/etc/resolv.conf.save";
+    private static final String BACKUP_DNS_FILE_NAME = (System.getProperty("kura.data.snap.common") == null ?
+                      "/etc/resolv.conf.save"
+                    : System.getProperty("kura.data.snap.common") + "/etc/resolv.conf.save");
 
     private static final String NAMESERVER = "nameserver";
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/HostapdManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/HostapdManager.java
@@ -102,7 +102,12 @@ public class HostapdManager {
     public static String getHostapdConfigFileName(String ifaceName) {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("/etc/hostapd-").append(ifaceName).append(".conf");
+        String snapCommon = System.getProperty("kura.data.snap.common");
+        if (snapCommon == null) {
+            sb.append("/etc/hostapd-").append(ifaceName).append(".conf");
+        } else {
+            sb.append(snapCommon + "/etc/hostapd/hostapd-").append(ifaceName).append(".conf");
+        }
 
         return sb.toString();
     }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/WpaSupplicantManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/WpaSupplicantManager.java
@@ -149,8 +149,12 @@ public class WpaSupplicantManager {
 
     public static String getWpaSupplicantConfigFilename(String ifaceName) {
         StringBuilder sb = new StringBuilder();
-
-        sb.append("/etc/wpa_supplicant-").append(ifaceName).append(".conf");
+        String snapCommon = System.getProperty("kura.data.snap.common");
+        if (snapCommon == null) {
+            sb.append("/etc/wpa_supplicant-").append(ifaceName).append(".conf");
+        } else {
+            sb.append(snapCommon + "/etc/wpa_supplicant/wpa_supplicant-").append(ifaceName).append(".conf");
+        }
 
         return sb.toString();
     }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigWriter.java
@@ -49,7 +49,9 @@ public class HostapdConfigWriter implements NetworkConfigurationVisitor {
 
     private static final String HEXES = "0123456789ABCDEF";
 
-    private static final String HOSTAPD_TMP_CONFIG_FILE = "/etc/hostapd.conf.tmp";
+    private static final String HOSTAPD_TMP_CONFIG_FILE = (System.getProperty("kura.data.snap.common") == null ?
+                  "/etc/hostapd.conf.tmp"
+                : System.getProperty("kura.data.snap.common") + "/etc/hostapd.conf.tmp" );
 
     private static HostapdConfigWriter instance;
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/WpaSupplicantConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/WpaSupplicantConfigWriter.java
@@ -50,7 +50,9 @@ public class WpaSupplicantConfigWriter implements NetworkConfigurationVisitor {
 
     private static final Logger logger = LoggerFactory.getLogger(WpaSupplicantConfigWriter.class);
 
-    private static final String WPA_TMP_CONFIG_FILE = "/etc/wpa_supplicant.conf.tmp";
+    private static final String WPA_TMP_CONFIG_FILE = (System.getProperty("kura.data.snap.common") == null ?
+                  "/etc/wpa_supplicant.conf.tmp"
+                : System.getProperty("kura.data.snap.common") + "/etc/wpa_supplicant.conf.tmp");
     private static final String TMP_WPA_CONFIG_FILE = "/tmp/wpa_supplicant.conf";
     private static final String WPA_SUPPLICANT_CONF_RESOURCE = "/src/main/resources/wifi/wpasupplicant.conf";
 


### PR DESCRIPTION
When kura is deployed as snap, it runs in own sandbox and some parts of the system and read only or not accessible at all. Therefore some configuration files and tmp files needs to be relocated when snap environment is detected

/etc/ and  /etc/network/ directories are read only so following files needs to be relocated:
 - /etc/resolv.conf.save 
 - /etc/hostapd-
 - /etc/wpa_supplicant-
 - /etc/hostapd.conf.tmp
 - /etc/wpa_supplicant.conf.tmp
 - /etc/network/interfaces.tmp

Signed-off-by: Ondrej Kubik ondrej.kubik@canonical.com