### PR TITLE
Fixed NPE on DhcpClientLeaseBlock

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientLeaseBlock.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientLeaseBlock.java
@@ -46,10 +46,10 @@ public class DhcpClientLeaseBlock {
     private String iface;
     private IPAddress fixedAddress;
     private IPAddress subnetMask;
-    private List<IPAddress> routers;
+    private List<IPAddress> routers = new ArrayList<>();
     private long dhcpLeaseTime;
     private int dhcpMessageType;
-    private List<IPAddress> dnsServers;
+    private List<IPAddress> dnsServers = new ArrayList<>();
     private IPAddress dhcpServer;
     private long dhcpRenewalTime;
     private long dhcpRebindingTime;


### PR DESCRIPTION
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>

The webUI fails to load the "Status" and "Network" pages when eth0 is configured as dhcp client and the DNS servers names are not passed by the dhcp server. This PR fixes the issue.

**Description of the solution adopted:** 
The issue is caused by the `DhcpClientLeaseBlock` class that doesn't initialize the List of dns servers. It is created only when the leases file is parsed, but if the values aren't passed, the list is null.
So, this PR simply adds the list initialization for the dns servers and routers.
