### PR TITLE
Fix GPS enable when PPP is not configured

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/he910/TelitHe910ConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/he910/TelitHe910ConfigGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -111,7 +111,11 @@ public class TelitHe910ConfigGenerator implements ModemPppConfigGenerator {
     }
 
     private int getPdpContextNumber(String dialString) {
-        return Integer.parseInt(dialString.substring("atd*99***".length(), dialString.length() - 1));
+        int pdpPid = 1;
+        if (!dialString.isEmpty() && dialString.contains("atd*99***")) {
+            pdpPid = Integer.parseInt(dialString.substring("atd*99***".length(), dialString.length() - 1));
+        }
+        return pdpPid;
     }
 
     /*


### PR DESCRIPTION
When the PPP is not configured, the dial string is empty. So, if the GPS is enabled, the PPPConfigWriter tries to parse the empty dial string to get the pdp number, throwing an exception.

This PR adds a check for empty dial string.

