### PR TITLE
Use form for login

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.java
@@ -14,23 +14,19 @@ import org.eclipse.kura.web.client.ui.AlertDialog.Severity;
 import org.eclipse.kura.web.shared.GwtKuraException;
 import org.eclipse.kura.web.shared.service.GwtPasswordAuthenticationService;
 import org.eclipse.kura.web.shared.service.GwtPasswordAuthenticationServiceAsync;
-import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Input;
 import org.gwtbootstrap3.client.ui.Modal;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.KeyPressEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.FormPanel;
 import com.google.gwt.user.client.ui.Widget;
 
 public class LoginUi extends Composite {
-
-    private static final int ENTER_CHAR_CODE = 13;
 
     private final GwtPasswordAuthenticationServiceAsync pwdAutenticationService = GWT
             .create(GwtPasswordAuthenticationService.class);
@@ -45,31 +41,27 @@ public class LoginUi extends Composite {
     @UiField
     Input passwordInput;
     @UiField
-    Button loginButton;
-    @UiField
     AlertDialog alertDialog;
     @UiField
     Modal loginDialog;
+    @UiField
+    FormPanel loginForm;
 
     public LoginUi() {
         initWidget(uiBinder.createAndBindUi(this));
-
-        loginButton.addClickHandler(e -> login());
-
-        RootPanel.get().addDomHandler(e -> {
-
-            if (e.getCharCode() == ENTER_CHAR_CODE) {
-                login();
-            }
-        }, KeyPressEvent.getType());
-
-        loginDialog.show();
     }
 
     @Override
     protected void onAttach() {
         super.onAttach();
         usernameInput.setFocus(true);
+
+        loginForm.addSubmitHandler(e -> {
+            e.cancel();
+            login();
+        });
+
+        loginDialog.show();
     }
 
     private void login() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.ui.xml
@@ -14,26 +14,34 @@
 
 	<b:Container fluid="true">
 
+<g:FormPanel ui:field="loginForm">
 		<b:Modal ui:field="loginDialog" title="Login" closable="false"
-			fade="true" dataBackdrop="STATIC" b:id="myModal">
+			fade="false" dataBackdrop="STATIC">
+			
 			<b:ModalBody>
-				<b:Container fluid="true">
-					<b:InputGroup addStyleNames="login-input">
-						<b:InputGroupAddon icon="USER" iconSize="LARGE" addStyleNames="login-icon"/>
-						<b:Input placeholder="Enter username" type="TEXT"
-							autoComplete="false" ui:field="usernameInput" b:id="login-user"/>
-					</b:InputGroup>
-					<b:InputGroup addStyleNames="login-input">
-						<b:InputGroupAddon icon="KEY" iconSize="LARGE" addStyleNames="login-icon"/>
-						<b:Input placeholder="Enter password" type="PASSWORD"
-							autoComplete="false" ui:field="passwordInput" b:id="login-password"/>
-					</b:InputGroup>
-				</b:Container>
+				
+						<b:InputGroup addStyleNames="login-input">
+							<b:InputGroupAddon icon="USER" iconSize="LARGE"
+								addStyleNames="login-icon" />
+							<b:Input placeholder="Enter username" type="TEXT"
+								autoComplete="false" ui:field="usernameInput" b:id="login-user" />
+						</b:InputGroup>
+						<b:InputGroup addStyleNames="login-input">
+							<b:InputGroupAddon icon="KEY" iconSize="LARGE"
+								addStyleNames="login-icon" />
+							<b:Input placeholder="Enter password" type="PASSWORD"
+								autoComplete="false" ui:field="passwordInput"
+								b:id="login-password" />
+						</b:InputGroup>
+					
 			</b:ModalBody>
 			<b:ModalFooter>
-				<b:Button text="Login" type="PRIMARY" ui:field="loginButton" b:id="login-button"/>
+				<b:SubmitButton text="Login" b:id="login-button" />
 			</b:ModalFooter>
+		
+				
 		</b:Modal>
+		</g:FormPanel>
 
 
 		<kura:AlertDialog ui:field="alertDialog" />

--- a/kura/org.eclipse.kura.web2/src/main/webapp/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/webapp/denali.css
@@ -486,7 +486,7 @@ Login START
 	width: 1cm;
 }
 
-.login-input:last-of-type {
+.login-input:not(:first-of-type) {
 	padding-top: 0.4cm;
 }
 


### PR DESCRIPTION
Signed-off-by: nicolatimeus <nicola.timeus@eurotech.com>

Implemented some suggestions by @markoer.

* Wrapped the login controls into a form
  - Login should be performed by javascript code via GWT RPC, there should not be spurious HTTP requests to `/admin/login?` when submitting the form. 
    I had to fallback to plain GWT forms for acheiving this, gwtbootstrap forms always generated spurious requests during my tests.
  - Submitting the form using the enter button should work
* Disabled login dialog animation
