### PR TITLE
Cleanup Profile updates

### DIFF
--- a/kura/setups/formatting/KuraCleanupProfile.xml
+++ b/kura/setups/formatting/KuraCleanupProfile.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="2">
-<profile kind="CleanUpProfile" name="KuraCleanup_v2" version="2">
+<profile kind="CleanUpProfile" name="KuraCleanup_v3" version="2">
 <setting id="cleanup.qualify_static_method_accesses_with_declaring_class" value="false"/>
 <setting id="cleanup.always_use_this_for_non_static_method_access" value="false"/>
 <setting id="cleanup.organize_imports" value="true"/>
 <setting id="cleanup.remove_trailing_whitespaces_ignore_empty" value="false"/>
-<setting id="cleanup.use_type_arguments" value="false"/>
 <setting id="cleanup.format_source_code_changes_only" value="false"/>
 <setting id="cleanup.qualify_static_field_accesses_with_declaring_class" value="false"/>
 <setting id="cleanup.add_generated_serial_version_id" value="true"/>
+<setting id="cleanup.remove_redundant_semicolons" value="true"/>
 <setting id="cleanup.qualify_static_member_accesses_through_subtypes_with_declaring_class" value="true"/>
 <setting id="cleanup.remove_redundant_type_arguments" value="true"/>
 <setting id="cleanup.remove_unused_imports" value="true"/>
@@ -17,7 +17,7 @@
 <setting id="cleanup.use_lambda" value="true"/>
 <setting id="cleanup.always_use_blocks" value="true"/>
 <setting id="cleanup.use_this_for_non_static_field_access_only_if_necessary" value="false"/>
-<setting id="cleanup.sort_members_all" value="true"/>
+<setting id="cleanup.sort_members_all" value="false"/>
 <setting id="cleanup.remove_trailing_whitespaces_all" value="true"/>
 <setting id="cleanup.add_missing_annotations" value="true"/>
 <setting id="cleanup.always_use_this_for_non_static_field_access" value="true"/>
@@ -28,6 +28,7 @@
 <setting id="cleanup.remove_unused_local_variables" value="true"/>
 <setting id="cleanup.convert_to_enhanced_for_loop" value="true"/>
 <setting id="cleanup.remove_unused_private_fields" value="true"/>
+<setting id="cleanup.remove_redundant_modifiers" value="false"/>
 <setting id="cleanup.never_use_blocks" value="false"/>
 <setting id="cleanup.add_missing_deprecated_annotations" value="true"/>
 <setting id="cleanup.use_this_for_non_static_field_access" value="true"/>
@@ -37,7 +38,7 @@
 <setting id="cleanup.remove_unnecessary_casts" value="true"/>
 <setting id="cleanup.use_blocks_only_for_return_and_throw" value="false"/>
 <setting id="cleanup.format_source_code" value="true"/>
-<setting id="cleanup.convert_functional_interfaces" value="false"/>
+<setting id="cleanup.convert_functional_interfaces" value="true"/>
 <setting id="cleanup.add_default_serial_version_id" value="false"/>
 <setting id="cleanup.remove_unused_private_methods" value="true"/>
 <setting id="cleanup.remove_trailing_whitespaces" value="true"/>


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

Minor changes related to new Eclipse IDE options.
Enabled:
- Removing redundant semicolons
- Convert functional interfaces to Lambdas

