### PR TITLE
Changed parsing of ip route command

### DIFF
--- a/kura/distrib/src/main/resources/common/ifup-local
+++ b/kura/distrib/src/main/resources/common/ifup-local
@@ -23,8 +23,8 @@ if [[ -n "$ipaddr" ]] ; then
 	find=`expr index "$ipaddr" ' '`
 	lind=`expr index "$ipaddr" '/'`
 	echo "IPADDR="${ipaddr:$find:`expr $lind-$find-1`} >> $FILENAME
-	ipgw=`ip route show dev $DEVICE | grep default`
-	echo "GATEWAY="${ipgw:12} >> $FILENAME
+	ipgw=(`ip route show dev $DEVICE | grep default`)
+	echo "GATEWAY="${ipgw[2]} >> $FILENAME
 	#ip route del $ipgw
 
 	# Only add DNS if this is a gateway - this also implies /etc/resolv.conf was overwritten

--- a/kura/distrib/src/main/resources/common/ifup-local.debian
+++ b/kura/distrib/src/main/resources/common/ifup-local.debian
@@ -58,8 +58,8 @@ if [[ -n "$ipaddr" ]] ; then
 	find=`expr index "$ipaddr" ' '`                                
 	lind=`expr index "$ipaddr" '/'`                                
 	echo "IPADDR="${ipaddr:$find:`expr $lind-$find-1`} >> $FILENAME
-	ipgw=`ip route show dev $DEVICE | grep default`
-	echo "GATEWAY="${ipgw:12} >> $FILENAME
+	ipgw=(`ip route show dev $DEVICE | grep default`)
+	echo "GATEWAY="${ipgw[2]} >> $FILENAME
 	#ip route del $ipgw        
 	if [[ $HASDNS == 1 ]]; then
 	        for j in "${Dns[@]}"; do

--- a/kura/distrib/src/main/resources/common/ifup-local.raspbian
+++ b/kura/distrib/src/main/resources/common/ifup-local.raspbian
@@ -58,8 +58,8 @@ if [[ -n "$ipaddr" ]] ; then
 	find=`expr index "$ipaddr" ' '`                                
 	lind=`expr index "$ipaddr" '/'`                                
 	echo "IPADDR="${ipaddr:$find:`expr $lind-$find-1`} >> $FILENAME
-	ipgw=`ip route show dev $DEVICE | grep default`
-	echo "GATEWAY="${ipgw:12} >> $FILENAME
+	ipgw=(`ip route show dev $DEVICE | grep default`)
+	echo "GATEWAY="${ipgw[2]} >> $FILENAME
 	#ip route del $ipgw        
 	if [[ $HASDNS == 1 ]]; then
 	        for j in "${Dns[@]}"; do


### PR DESCRIPTION
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>

This PR changes the way the `ip route` command is parsed by `ifup-local` script.

**Related Issue:** This PR fixes/closes #2540 

**Description of the solution adopted:** The parsing splits the output command by space and takes the third element (the IP address).
