### PR TITLE
Asset is removed from Drivers view when it is deleted in WireGraph

### DIFF
--- a/kura/org.eclipse.kura.web2/www
+++ b/kura/org.eclipse.kura.web2/www
@@ -1,1 +1,1 @@
-src/main/webapp/
+src/main/webapp

--- a/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireGraphServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.provider/src/main/java/org/eclipse/kura/internal/wire/WireGraphServiceImpl.java
@@ -89,7 +89,7 @@ public class WireGraphServiceImpl implements ConfigurableComponent, WireGraphSer
      * Binds the {@link WireAdmin} dependency
      *
      * @param wireAdmin
-     *                      the new {@link WireAdmin} service dependency
+     *            the new {@link WireAdmin} service dependency
      */
     public void bindWireAdmin(final WireAdmin wireAdmin) {
         if (isNull(this.wireAdmin)) {


### PR DESCRIPTION
Asset is removed from Drivers view when it is deleted in WireGraph

Describe the bug
Given an Asset, and a WireGraph which uses it in the flow, when the asset is removed from the graph, then the asset is also removed from the Drivers & Assets view. It also happens when the whole WireGraph is removed.

Expected behavior
The asset remains in Drivers & Assets view and still available as a possible asset to include in the graph

see #2544