### PR TITLE
udhcpc pid file parameter fix

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
@@ -159,7 +159,7 @@ public class DhcpClientManager {
             sb.append(interfaceName);
             sb.append(' ');
             if (usePidFile) {
-            	sb.append("-p ");
+                sb.append("-p ");
                 sb.append(getPidFilename(interfaceName));
                 sb.append(' ');
             }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
@@ -159,6 +159,7 @@ public class DhcpClientManager {
             sb.append(interfaceName);
             sb.append(' ');
             if (usePidFile) {
+            	sb.append("-p ");
                 sb.append(getPidFilename(interfaceName));
                 sb.append(' ');
             }


### PR DESCRIPTION
The command that starts the **udhcpc** dhcp client is missing the -p parameter before the pid file. The pid file is not created