### PR TITLE
Try to fix tests for executor service

### DIFF
--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/linux/executor/ExecutorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/linux/executor/ExecutorServiceImplTest.java
@@ -53,9 +53,15 @@ public class ExecutorServiceImplTest {
     private static final String TMP = "/tmp";
     private static CommandExecutorService service;
 
+    public ExecutorServiceImplTest(CommandExecutorService service) {
+        ExecutorServiceImplTest.service = service;
+    }
+
+    // Don't run tests on MAC OS X
     @ClassRule
     public static final AssumingIsNotMac assumingIsNotMac = new AssumingIsNotMac();
 
+    // Don't run tests on Jenkins
     @ClassRule
     public static final AssumingIsNotJenkins assumingIsNotJenkins = new AssumingIsNotJenkins();
 

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/linux/executor/ExecutorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/linux/executor/ExecutorServiceImplTest.java
@@ -33,6 +33,7 @@ import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.io.Charsets;
 import org.eclipse.kura.core.linux.executor.privileged.PrivilegedExecutorServiceImpl;
 import org.eclipse.kura.core.linux.executor.unprivileged.UnprivilegedExecutorServiceImpl;
+import org.eclipse.kura.core.testutil.AssumingIsNotJenkins;
 import org.eclipse.kura.core.testutil.AssumingIsNotMac;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
@@ -52,17 +53,15 @@ public class ExecutorServiceImplTest {
     private static final String TMP = "/tmp";
     private static CommandExecutorService service;
 
-    public ExecutorServiceImplTest(CommandExecutorService service) {
-        ExecutorServiceImplTest.service = service;
-    }
+    @ClassRule
+    public static final AssumingIsNotMac assumingIsNotMac = new AssumingIsNotMac();
 
     @ClassRule
-    public static AssumingIsNotMac assumingIsNotMac = new AssumingIsNotMac();
+    public static final AssumingIsNotJenkins assumingIsNotJenkins = new AssumingIsNotJenkins();
 
     @Parameterized.Parameters
     public static Collection<CommandExecutorService> getServices() {
-        return Arrays.asList(new CommandExecutorService[] { new UnprivilegedExecutorServiceImpl(),
-                new PrivilegedExecutorServiceImpl() });
+        return Arrays.asList(new UnprivilegedExecutorServiceImpl(), new PrivilegedExecutorServiceImpl());
     }
 
     @BeforeClass

--- a/kura/test/org.eclipse.kura.core.testutil/src/main/java/org/eclipse/kura/core/testutil/AssumingIsNotJenkins.java
+++ b/kura/test/org.eclipse.kura.core.testutil/src/main/java/org/eclipse/kura/core/testutil/AssumingIsNotJenkins.java
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
 package org.eclipse.kura.core.testutil;
 
 import java.io.File;
@@ -5,7 +13,6 @@ import java.io.File;
 import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 
 public class AssumingIsNotJenkins implements TestRule {
 

--- a/kura/test/org.eclipse.kura.core.testutil/src/main/java/org/eclipse/kura/core/testutil/AssumingIsNotJenkins.java
+++ b/kura/test/org.eclipse.kura.core.testutil/src/main/java/org/eclipse/kura/core/testutil/AssumingIsNotJenkins.java
@@ -1,0 +1,27 @@
+package org.eclipse.kura.core.testutil;
+
+import java.io.File;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class AssumingIsNotJenkins implements TestRule {
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                File tempFile = new File("/tmp/isJenkins.txt");
+                if (tempFile.exists()) {
+                    throw new AssumptionViolatedException("Jenkins detected. Skipping tests!");
+                } else {
+                    base.evaluate();
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
The tests about the command executor service fail. This PR tries to fix them adding the absolute paths on command run in the tests.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>