### PR TITLE
Added missing copyright header and missing import

### DIFF
--- a/kura/test/org.eclipse.kura.core.testutil/src/main/java/org/eclipse/kura/core/testutil/AssumingIsNotJenkins.java
+++ b/kura/test/org.eclipse.kura.core.testutil/src/main/java/org/eclipse/kura/core/testutil/AssumingIsNotJenkins.java
@@ -13,6 +13,7 @@ import java.io.File;
 import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 public class AssumingIsNotJenkins implements TestRule {
 

--- a/kura/test/org.eclipse.kura.core.testutil/src/main/java/org/eclipse/kura/core/testutil/AssumingIsNotMac.java
+++ b/kura/test/org.eclipse.kura.core.testutil/src/main/java/org/eclipse/kura/core/testutil/AssumingIsNotMac.java
@@ -1,3 +1,11 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
 package org.eclipse.kura.core.testutil;
 
 import org.junit.AssumptionViolatedException;


### PR DESCRIPTION
This PR simply adds a missing import in `AssumingIsNotJenkins` class that prevents the build.
Moreover, it adds a missing copyright header.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>
