### PR TITLE
Fixed osgi component for LinuxDnsServer implementations

### DIFF
--- a/kura/org.eclipse.kura.linux.systemd.provider/OSGI-INF/dnsserver.xml
+++ b/kura/org.eclipse.kura.linux.systemd.provider/OSGI-INF/dnsserver.xml
@@ -13,7 +13,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" enabled="true" immediate="true" name="org.eclipse.kura.linux.systemd.provider.DnsServerService">
-   <implementation class="org.eclipse.kura.internal.linux.systemd.net.dns.DnsServerServiceImpl"/>
+   <implementation class="org.eclipse.kura.internal.linux.systemd.net.dns.LinuxDnsServerSystemD"/>
    <service>
       <provide interface="org.eclipse.kura.internal.linux.net.dns.DnsServerService"/>
    </service>

--- a/kura/org.eclipse.kura.linux.sysv.provider/OSGI-INF/dnsserver.xml
+++ b/kura/org.eclipse.kura.linux.sysv.provider/OSGI-INF/dnsserver.xml
@@ -13,7 +13,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" enabled="true" immediate="true" name="org.eclipse.kura.net.sysv.provider.DnsServerService">
-   <implementation class="org.eclipse.kura.internal.linux.sysv.net.dns.DnsServerServiceImpl"/>
+   <implementation class="org.eclipse.kura.internal.linux.sysv.net.dns.LinuxDnsServerSysV"/>
    <service>
       <provide interface="org.eclipse.kura.internal.linux.net.dns.DnsServerService"/>
    </service>


### PR DESCRIPTION
This PR closes #2575 
It simply updates the class that implements the DnsServerService in osgi components files for SystemD and SysV provider.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>