### PR TITLE
Replaced millis with nanos in DataServiceImpl

### DIFF
--- a/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.kura.core;singleton:=true
 Bundle-Version: 1.0.600.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.kura.core.data;version="1.0.0",
+Export-Package: org.eclipse.kura.core.data;version="1.1.0",
  org.eclipse.kura.core.linux.executor;version="1.0.0",
  org.eclipse.kura.core.linux.util;version="1.2.0",
  org.eclipse.kura.core.ssl;version="1.0.0",

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -662,7 +662,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
 
             long publishPeriod = this.dataServiceOptions.getRateLimitTimeUnit() / publishRate;
 
-            logger.info("Get Throttle with burst length {} and send a message every {} millis", burstLength,
+            logger.info("Get Throttle with burst length {} and send a message every {} nanoseconds", burstLength,
                     publishPeriod);
             this.throttle = new TokenBucket(burstLength, publishPeriod);
         }
@@ -798,7 +798,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
                 }
 
                 if (!messagePublished) {
-                    suspendPublisher(sleepingTime, TimeUnit.MILLISECONDS);
+                    suspendPublisher(sleepingTime, TimeUnit.NANOSECONDS);
                 }
             }
             logger.debug("Exited publisher loop.");
@@ -823,7 +823,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
                         logger.debug("Suspending publishing thread indefinitely");
                         DataServiceImpl.this.lockCondition.await();
                     } else {
-                        logger.debug("Suspending publishing thread for {} milliseconds", timeout);
+                        logger.debug("Suspending publishing thread for {} nanoseconds", timeout);
                         DataServiceImpl.this.lockCondition.await(timeout, timeUnit);
                     }
                 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
@@ -135,7 +135,7 @@ public class DataServiceOptions {
             throw new IllegalArgumentException("Illegal time unit");
         }
 
-        return timeUnit.toMillis(1);
+        return timeUnit.toNanos(1);
     }
 
     String getDbServiceInstancePid() {

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/data/TokenBucket.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/data/TokenBucket.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,7 +22,7 @@ public class TokenBucket {
         this.capacity = capacity;
         this.remainingTokens = capacity;
         this.refillPeriod = refillPeriod;
-        this.lastRefillTime = System.currentTimeMillis();
+        this.lastRefillTime = System.nanoTime();
     }
 
     public boolean getToken() {
@@ -40,7 +40,7 @@ public class TokenBucket {
     }
 
     private void refill() {
-        long now = System.currentTimeMillis();
+        long now = System.nanoTime();
         if (now - this.lastRefillTime >= this.refillPeriod) {
             this.remainingTokens = (int) Math.min(this.capacity,
                     this.remainingTokens + (now - this.lastRefillTime) / this.refillPeriod);
@@ -50,7 +50,7 @@ public class TokenBucket {
     }
 
     public long getTokenWaitTime() {
-        long now = System.currentTimeMillis();
+        long now = System.nanoTime();
         long timeToRefill = (this.lastRefillTime + this.refillPeriod) - now;
         return Math.max(0, timeToRefill);
     }


### PR DESCRIPTION
This PR close #2581 
The currentTimeMillis() calls are replaced with nanoTime() in DataServiceImpl class.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>