### PR TITLE
Dhcp cable unplugged

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
@@ -159,7 +159,7 @@ public class DhcpClientManager {
             sb.append(interfaceName);
             sb.append(' ');
             if (usePidFile) {
-            	sb.append("-p ");
+                sb.append("-p ");
                 sb.append(getPidFilename(interfaceName));
                 sb.append(' ');
             }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
@@ -159,6 +159,7 @@ public class DhcpClientManager {
             sb.append(interfaceName);
             sb.append(' ');
             if (usePidFile) {
+            	sb.append("-p ");
                 sb.append(getPidFilename(interfaceName));
                 sb.append(' ');
             }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -1076,6 +1076,30 @@ public class LinuxNetworkUtil {
         return config != null ? config.isUp() : false;
     }
 
+    /*
+     * returns the number of times the linux has gone up or down
+     * If an error occurs, it return 0
+     */
+    public static int getCarrierChanges(String interfaceName) {
+        // ignore logical interfaces like "1-1.2"
+        if (Character.isDigit(interfaceName.charAt(0))) {
+            return 0;
+        }
+
+        StringBuilder sb = new StringBuilder("/sys/class/net/").append(interfaceName);
+        sb.append("/carrier_changes");
+
+        String fileName = sb.toString();
+        try (FileReader fr = new FileReader(fileName); BufferedReader br = new BufferedReader(fr);) {
+            int changes = Integer.parseInt(br.readLine());
+            logger.debug("interface {} carrier changes {}", interfaceName, changes);
+            return changes;
+        } catch (IOException | NumberFormatException e) {
+            logger.error("error reading {}, error message {}", fileName, e.getMessage());
+        }
+        return 0;
+    }
+
     static String formIfconfigIfaceCommand(String ifaceName) {
         StringBuilder sb = new StringBuilder("ifconfig ");
         sb.append(ifaceName);

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/EthernetMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/EthernetMonitorServiceImpl.java
@@ -294,6 +294,12 @@ public class EthernetMonitorServiceImpl implements EthernetMonitorService, Event
                             logger.debug("link is down - disabling {}", interfaceName);
                             disableInterface(interfaceName);
                             interfaceStateChanged = true;
+                        } else if (isDhcpClient && prevInterfaceState == null || currentInterfaceState
+                                .getCarrierChanges() != prevInterfaceState.getCarrierChanges()) {
+                            // Carrier counter changed - cable has been plugged or unplugged
+                            logger.debug("link is up, carrier changes counter updated - enabling {}", interfaceName);
+                            this.netAdminService.enableInterface(interfaceName, isDhcpClient);
+                            interfaceStateChanged = true;
                         }
                     } else {
                         // State is currently down

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/InterfaceState.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/InterfaceState.java
@@ -27,12 +27,14 @@ public class InterfaceState {
     private final boolean up;
     protected boolean link;
     private final IPAddress ipAddress;
+    private final int carrierChanges;
 
-    public InterfaceState(String interfaceName, boolean up, boolean link, IPAddress ipAddress) {
+    public InterfaceState(String interfaceName, boolean up, boolean link, IPAddress ipAddress, int carrierChanges) {
         this.name = interfaceName;
         this.up = up;
         this.link = link;
         this.ipAddress = ipAddress;
+        this.carrierChanges = carrierChanges;
     }
 
     public InterfaceState(NetInterfaceType type, String interfaceName) throws KuraException {
@@ -43,6 +45,7 @@ public class InterfaceState {
         logger.debug("InterfaceState() :: {} - up?={}", interfaceName, this.up);
         ConnectionInfo connInfo = new ConnectionInfoImpl(interfaceName);
         this.ipAddress = connInfo.getIpAddress();
+        this.carrierChanges = LinuxNetworkUtil.getCarrierChanges(interfaceName);
     }
 
     public InterfaceState(NetInterfaceType type, String interfaceName, boolean isL2OnlyInterface) throws KuraException {
@@ -53,6 +56,7 @@ public class InterfaceState {
         logger.debug("InterfaceState() :: {} - up?={}", interfaceName, this.up);
         ConnectionInfo connInfo = new ConnectionInfoImpl(interfaceName);
         this.ipAddress = connInfo.getIpAddress();
+        this.carrierChanges = LinuxNetworkUtil.getCarrierChanges(interfaceName);
     }
 
     @Override
@@ -63,6 +67,7 @@ public class InterfaceState {
         result = prime * result + (this.link ? 1231 : 1237);
         result = prime * result + (this.up ? 1231 : 1237);
         result = prime * result + (this.ipAddress != null ? this.ipAddress.hashCode() : 0);
+        result = prime * result + (this.carrierChanges);
         return result;
     }
 
@@ -98,7 +103,9 @@ public class InterfaceState {
         } else if (other.ipAddress != null) {
             return false;
         }
-
+        if (this.carrierChanges != other.carrierChanges) {
+            return false;
+        }
         return true;
     }
 
@@ -118,6 +125,10 @@ public class InterfaceState {
         return this.ipAddress;
     }
 
+    public int getCarrierChanges() {
+        return carrierChanges;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -128,6 +139,8 @@ public class InterfaceState {
         sb.append(this.up);
         sb.append(", IP Address: ");
         sb.append(this.ipAddress);
+        sb.append(", Carrier changes: ");
+        sb.append(this.carrierChanges);
         return sb.toString();
     }
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
@@ -59,6 +59,8 @@ import org.eclipse.kura.net.admin.modem.PppFactory;
 import org.eclipse.kura.net.admin.modem.PppState;
 import org.eclipse.kura.net.admin.modem.SupportedUsbModemsFactoryInfo;
 import org.eclipse.kura.net.admin.modem.SupportedUsbModemsFactoryInfo.UsbModemFactoryInfo;
+import org.eclipse.kura.net.admin.monitor.ModemMonitorServiceImpl.ModemResetTimer;
+import org.eclipse.kura.net.admin.monitor.ModemMonitorServiceImpl.MonitoredModem;
 import org.eclipse.kura.net.admin.visitor.linux.util.KuranetConfig;
 import org.eclipse.kura.net.modem.CellularModem;
 import org.eclipse.kura.net.modem.ModemAddedEvent;
@@ -977,7 +979,7 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
                     ConnectionInfo connInfo = new ConnectionInfoImpl(ifaceName);
                     InterfaceState interfaceState = new InterfaceState(ifaceName,
                             LinuxNetworkUtil.hasAddress(ifaceName), pppSt == PppState.CONNECTED,
-                            connInfo.getIpAddress());
+                            connInfo.getIpAddress(), 0);
                     newInterfaceStatuses.put(ifaceName, interfaceState);
 
                 } else {


### PR DESCRIPTION
Ethernet monitor service renews DHCP lease when cable has been plugged/unplugged.

**Related Issue:** This PR fixes/closes #2578 

**Description of the solution adopted:** 
Monitor **/sys/class/net/{interfaceName}/carrier_changes** counter for changes, if the interface is a DHCP client trigger a lease renew

