### PR TITLE
Renew DHCP lease when cable has been unplugged/plugged

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/EthernetMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/EthernetMonitorServiceImpl.java
@@ -309,8 +309,8 @@ public class EthernetMonitorServiceImpl implements EthernetMonitorService, Event
                             logger.debug("link is down - disabling {}", interfaceName);
                             disableInterface(interfaceName);
                             interfaceStateChanged = true;
-                        } else if (isDhcpClient && prevInterfaceState == null || currentInterfaceState
-                                .getCarrierChanges() != prevInterfaceState.getCarrierChanges()) {
+                        } else if (isDhcpClient && (prevInterfaceState == null || currentInterfaceState
+                                .getCarrierChanges() != prevInterfaceState.getCarrierChanges())) {
                             // Carrier counter changed - cable has been plugged or unplugged
                             logger.debug("link is up, carrier changes counter updated - enabling {}", interfaceName);
                             this.netAdminService.enableInterface(interfaceName, isDhcpClient);

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/EthernetMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/EthernetMonitorServiceImpl.java
@@ -309,6 +309,12 @@ public class EthernetMonitorServiceImpl implements EthernetMonitorService, Event
                             logger.debug("link is down - disabling {}", interfaceName);
                             disableInterface(interfaceName);
                             interfaceStateChanged = true;
+                        } else if (isDhcpClient && prevInterfaceState == null || currentInterfaceState
+                                .getCarrierChanges() != prevInterfaceState.getCarrierChanges()) {
+                            // Carrier counter changed - cable has been plugged or unplugged
+                            logger.debug("link is up, carrier changes counter updated - enabling {}", interfaceName);
+                            this.netAdminService.enableInterface(interfaceName, isDhcpClient);
+                            interfaceStateChanged = true;
                         }
                     } else {
                         // State is currently down

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/InterfaceState.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/InterfaceState.java
@@ -19,23 +19,25 @@ public class InterfaceState {
     private final boolean up;
     protected boolean link;
     private final IPAddress ipAddress;
+    private final int carrierChanges;
 
     /**
      *
      * @param interfaceName
-     *            interface name as {@link String}
+     *                          interface name as {@link String}
      * @param up
-     *            if true the interface is up
+     *                          if true the interface is up
      * @param link
-     *            if true the interface has link
+     *                          if true the interface has link
      * @param ipAddress
-     *            the {@link IPAddress} assigned to the interface
+     *                          the {@link IPAddress} assigned to the interface
      */
-    public InterfaceState(String interfaceName, boolean up, boolean link, IPAddress ipAddress) {
+    public InterfaceState(String interfaceName, boolean up, boolean link, IPAddress ipAddress, int carrierChanges) {
         this.name = interfaceName;
         this.up = up;
         this.link = link;
         this.ipAddress = ipAddress;
+        this.carrierChanges = carrierChanges;
     }
 
     public String getName() {
@@ -54,6 +56,10 @@ public class InterfaceState {
         return this.ipAddress;
     }
 
+    public int getCarrierChanges() {
+        return this.carrierChanges;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -64,6 +70,8 @@ public class InterfaceState {
         sb.append(this.up);
         sb.append(", IP Address: ");
         sb.append(this.ipAddress);
+        sb.append(", Carrier changes: ");
+        sb.append(this.carrierChanges);
         return sb.toString();
     }
 
@@ -75,6 +83,7 @@ public class InterfaceState {
         result = prime * result + (this.link ? 1231 : 1237);
         result = prime * result + (this.name == null ? 0 : this.name.hashCode());
         result = prime * result + (this.up ? 1231 : 1237);
+        result = prime * result + (this.carrierChanges);
         return result;
     }
 
@@ -108,6 +117,9 @@ public class InterfaceState {
             return false;
         }
         if (this.up != other.up) {
+            return false;
+        }
+        if (this.carrierChanges != other.carrierChanges) {
             return false;
         }
         return true;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/InterfaceStateBuilder.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/InterfaceStateBuilder.java
@@ -33,6 +33,7 @@ public class InterfaceStateBuilder {
     private boolean up;
     protected boolean link;
     private IPAddress ipAddress;
+    private int carrierChanges;
     private boolean isL2OnlyInterface;
     private NetInterfaceType type;
     private WifiMode wifiMode;
@@ -93,6 +94,14 @@ public class InterfaceStateBuilder {
         this.wifiMode = wifiMode;
     }
 
+    public int getCarrierChanges() {
+        return this.carrierChanges;
+    }
+
+    public void setCarrierChanges(int carrierChanges) {
+        this.carrierChanges = carrierChanges;
+    }
+
     public static Logger getLogger() {
         return logger;
     }
@@ -117,8 +126,9 @@ public class InterfaceStateBuilder {
             logger.debug("InterfaceState() :: {} - up?={}", this.interfaceName, this.up);
             ConnectionInfo connInfo = new ConnectionInfoImpl(this.interfaceName);
             this.ipAddress = connInfo.getIpAddress();
+            this.carrierChanges = this.linuxNetworkUtil.getCarrierChanges(this.interfaceName);
         }
-        return new InterfaceState(this.interfaceName, this.up, this.link, this.ipAddress);
+        return new InterfaceState(this.interfaceName, this.up, this.link, this.ipAddress, this.carrierChanges);
     }
 
     public WifiInterfaceState buildWifiInterfaceState() throws KuraException {
@@ -133,7 +143,8 @@ public class InterfaceStateBuilder {
         ConnectionInfo connInfo = new ConnectionInfoImpl(this.interfaceName);
         this.ipAddress = connInfo.getIpAddress();
         setWifiLinkState(this.interfaceName, this.wifiMode);
-        return new WifiInterfaceState(this.interfaceName, this.up, this.link, this.ipAddress);
+        this.carrierChanges = this.linuxNetworkUtil.getCarrierChanges(this.interfaceName);
+        return new WifiInterfaceState(this.interfaceName, this.up, this.link, this.ipAddress, this.carrierChanges);
     }
 
     private void setWifiLinkState(String interfaceName, WifiMode wifiMode) throws KuraException {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
@@ -992,7 +992,7 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
                     ConnectionInfo connInfo = new ConnectionInfoImpl(ifaceName);
                     InterfaceState interfaceState = new InterfaceState(ifaceName,
                             this.linuxNetworkUtil.hasAddress(ifaceName), pppSt == PppState.CONNECTED,
-                            connInfo.getIpAddress());
+                            connInfo.getIpAddress(), this.linuxNetworkUtil.getCarrierChanges(ifaceName));
                     newInterfaceStatuses.put(ifaceName, interfaceState);
 
                 } else {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/WifiInterfaceState.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/WifiInterfaceState.java
@@ -25,9 +25,11 @@ public class WifiInterfaceState extends InterfaceState {
      *            if true the interface has link
      * @param ipAddress
      *            the {@link IPAddress} assigned to the interface
+     * @param carrierChanges
+     *            the number of times the network has been connected or disconnected
      */
-    public WifiInterfaceState(String interfaceName, boolean up, boolean link, IPAddress ipAddress) {
-        super(interfaceName, up, link, ipAddress);
+    public WifiInterfaceState(String interfaceName, boolean up, boolean link, IPAddress ipAddress, int carrierChanges) {
+        super(interfaceName, up, link, ipAddress, carrierChanges);
     }
 
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImpl.java
@@ -281,7 +281,10 @@ public class WifiMonitorServiceImpl implements WifiClientMonitorService, EventHa
                 // Check all interfaces configured to be enabled.
                 // This includes the interfaces that might have been enabled by the above configuration change.
                 // Get fresh interface statuses and post status change events.
-                Map<String, InterfaceState> oldStatues = new HashMap<>(this.interfaceStatuses);
+                Map<String, InterfaceState> oldStatuses = new HashMap<>();
+                if (this.interfaceStatuses != null) {
+                    oldStatuses.putAll(this.interfaceStatuses);
+                }
                 Map<String, InterfaceState> newStatuses = getInterfaceStatuses(this.enabledInterfaces);
                 checkStatusChange(this.interfaceStatuses, newStatuses);
                 this.interfaceStatuses = newStatuses;
@@ -440,7 +443,7 @@ public class WifiMonitorServiceImpl implements WifiClientMonitorService, EventHa
                             }
 
                             // Check if wifi network reconnected between monitor executions
-                            InterfaceState oldState = oldStatues.get(interfaceName);
+                            InterfaceState oldState = oldStatuses.get(interfaceName);
                             if (!dhcpLeaseRenewed && isDhcpClient && (oldState == null
                                     || oldState.getCarrierChanges() != wifiState.getCarrierChanges())) {
                                 logger.debug("monitor() :: carrier changes - renewing DHCP lease {}", interfaceName);

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImpl.java
@@ -281,6 +281,7 @@ public class WifiMonitorServiceImpl implements WifiClientMonitorService, EventHa
                 // Check all interfaces configured to be enabled.
                 // This includes the interfaces that might have been enabled by the above configuration change.
                 // Get fresh interface statuses and post status change events.
+                Map<String, InterfaceState> oldStatues = new HashMap<>(this.interfaceStatuses);
                 Map<String, InterfaceState> newStatuses = getInterfaceStatuses(this.enabledInterfaces);
                 checkStatusChange(this.interfaceStatuses, newStatuses);
                 this.interfaceStatuses = newStatuses;
@@ -419,28 +420,35 @@ public class WifiMonitorServiceImpl implements WifiClientMonitorService, EventHa
                                 up = false;
                             }
 
+                            NetConfigIP4 netConfigIP4 = ((AbstractNetInterface<?>) wifiInterfaceConfig).getIP4config();
+                            boolean isDhcpClient = netConfigIP4 != null && netConfigIP4.isDhcp();
+                            boolean dhcpLeaseRenewed = false;
                             logger.debug("monitor() :: pingAccessPoint()? {}", wifiConfig.pingAccessPoint());
-                            if (wifiConfig.pingAccessPoint()) {
-                                NetConfigIP4 netConfigIP4 = ((AbstractNetInterface<?>) wifiInterfaceConfig)
-                                        .getIP4config();
-                                if (netConfigIP4 != null && netConfigIP4.isDhcp()) {
-                                    boolean isApReachable = false;
-                                    for (int i = 0; i < 3; i++) {
-                                        isApReachable = isAccessPointReachable(interfaceName, 1000);
-                                        if (isApReachable) {
-                                            break;
-                                        }
-                                        sleep(1000);
+                            if (isDhcpClient && wifiConfig.pingAccessPoint()) {
+                                boolean isApReachable = false;
+                                for (int i = 0; i < 3; i++) {
+                                    isApReachable = isAccessPointReachable(interfaceName, 1000);
+                                    if (isApReachable) {
+                                        break;
                                     }
-                                    if (!isApReachable) {
-                                        this.netAdminService.renewDhcpLease(interfaceName);
-                                    }
+                                    sleep(1000);
+                                }
+                                if (!isApReachable) {
+                                    this.netAdminService.renewDhcpLease(interfaceName);
+                                    dhcpLeaseRenewed = true;
                                 }
                             }
 
-                            NetConfigIP4 netConfigIP4 = ((AbstractNetInterface<?>) wifiInterfaceConfig).getIP4config();
-                            if (netConfigIP4.getStatus().equals(NetInterfaceStatus.netIPv4StatusEnabledLAN)
-                                    && netConfigIP4.isDhcp()) {
+                            // Check if wifi network reconnected between monitor executions
+                            InterfaceState oldState = oldStatues.get(interfaceName);
+                            if (!dhcpLeaseRenewed && isDhcpClient && (oldState == null
+                                    || oldState.getCarrierChanges() != wifiState.getCarrierChanges())) {
+                                logger.debug("monitor() :: carrier changes - renewing DHCP lease {}", interfaceName);
+                                this.netAdminService.renewDhcpLease(interfaceName);
+                            }
+
+                            if (isDhcpClient
+                                    && netConfigIP4.getStatus().equals(NetInterfaceStatus.netIPv4StatusEnabledLAN)) {
                                 RouteConfig rconf = this.routeService.getDefaultRoute(interfaceName);
                                 if (rconf != null) {
                                     logger.debug(
@@ -481,6 +489,7 @@ public class WifiMonitorServiceImpl implements WifiClientMonitorService, EventHa
                 logger.warn("Error during WiFi Monitor handle event", e);
             }
         }
+
     }
 
     private void checkStatusChange(Map<String, InterfaceState> oldStatuses, Map<String, InterfaceState> newStatuses) {

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImplTest.java
@@ -727,8 +727,8 @@ public class ModemMonitorServiceImplTest {
         String ppp2 = "wlan2";
         String ppp3 = "wlan3";
 
-        InterfaceState ppp3OldState = new InterfaceState(ppp3, true, true, IPAddress.parseHostAddress("10.10.0.3"));
-        InterfaceState ppp3NewState = new InterfaceState(ppp3, true, true, IPAddress.parseHostAddress("10.10.0.4"));
+        InterfaceState ppp3OldState = new InterfaceState(ppp3, true, true, IPAddress.parseHostAddress("10.10.0.3"), 2);
+        InterfaceState ppp3NewState = new InterfaceState(ppp3, true, true, IPAddress.parseHostAddress("10.10.0.4"), 2);
 
         EventAdmin eaMock = mock(EventAdmin.class);
         svc.setEventAdmin(eaMock);
@@ -752,13 +752,13 @@ public class ModemMonitorServiceImplTest {
         }).when(eaMock).postEvent(anyObject());
 
         Map<String, InterfaceState> oldStatuses = new HashMap<>();
-        oldStatuses.put(ppp1, new InterfaceState(ppp1, true, true, IPAddress.parseHostAddress("10.10.0.1")));
-        oldStatuses.put(ppp2, new InterfaceState(ppp2, true, true, IPAddress.parseHostAddress("10.10.0.2"))); // disabled
+        oldStatuses.put(ppp1, new InterfaceState(ppp1, true, true, IPAddress.parseHostAddress("10.10.0.1"), 2));
+        oldStatuses.put(ppp2, new InterfaceState(ppp2, true, true, IPAddress.parseHostAddress("10.10.0.2"), 2)); // disabled
         oldStatuses.put(ppp3, ppp3OldState);
 
         Map<String, InterfaceState> newStatuses = new HashMap<>();
-        newStatuses.put(ppp0, new InterfaceState(ppp0, true, true, IPAddress.parseHostAddress("10.10.0.0"))); // enabled
-        newStatuses.put(ppp1, new InterfaceState(ppp1, true, true, IPAddress.parseHostAddress("10.10.0.1")));
+        newStatuses.put(ppp0, new InterfaceState(ppp0, true, true, IPAddress.parseHostAddress("10.10.0.0"), 2)); // enabled
+        newStatuses.put(ppp1, new InterfaceState(ppp1, true, true, IPAddress.parseHostAddress("10.10.0.1"), 2));
         newStatuses.put(ppp3, ppp3NewState); // modified
 
         TestUtil.invokePrivate(svc, "checkStatusChange", oldStatuses, newStatuses);

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImplTest.java
@@ -651,8 +651,8 @@ public class WifiMonitorServiceImplTest {
         String wlan2 = "wlan2";
         String wlan3 = "wlan3";
 
-        InterfaceState wlan3OldState = new InterfaceState(wlan3, true, true, IPAddress.parseHostAddress("10.10.0.3"));
-        InterfaceState wlan3NewState = new InterfaceState(wlan3, true, true, IPAddress.parseHostAddress("10.10.0.4"));
+        InterfaceState wlan3OldState = new InterfaceState(wlan3, true, true, IPAddress.parseHostAddress("10.10.0.3"), 2);
+        InterfaceState wlan3NewState = new InterfaceState(wlan3, true, true, IPAddress.parseHostAddress("10.10.0.4"), 2);
 
         EventAdmin eaMock = mock(EventAdmin.class);
         svc.setEventAdmin(eaMock);
@@ -676,13 +676,13 @@ public class WifiMonitorServiceImplTest {
         }).when(eaMock).postEvent(anyObject());
 
         Map<String, InterfaceState> oldStatuses = new HashMap<>();
-        oldStatuses.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1")));
-        oldStatuses.put(wlan2, new InterfaceState(wlan2, true, true, IPAddress.parseHostAddress("10.10.0.2"))); // disabled
+        oldStatuses.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1"), 2));
+        oldStatuses.put(wlan2, new InterfaceState(wlan2, true, true, IPAddress.parseHostAddress("10.10.0.2"), 2)); // disabled
         oldStatuses.put(wlan3, wlan3OldState);
 
         Map<String, InterfaceState> newStatuses = new HashMap<>();
-        newStatuses.put(wlan0, new InterfaceState(wlan0, true, true, IPAddress.parseHostAddress("10.10.0.0"))); // enabled
-        newStatuses.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1")));
+        newStatuses.put(wlan0, new InterfaceState(wlan0, true, true, IPAddress.parseHostAddress("10.10.0.0"), 2)); // enabled
+        newStatuses.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1"), 2));
         newStatuses.put(wlan3, wlan3NewState); // modified
 
         TestUtil.invokePrivate(svc, "checkStatusChange", oldStatuses, newStatuses);
@@ -842,7 +842,7 @@ public class WifiMonitorServiceImplTest {
         WifiMonitorServiceImpl svc = getServiceWithScanTool(ssid, 0, ltMock);
 
         Map<String, InterfaceState> stats = new HashMap<>();
-        stats.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1")));
+        stats.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1"), 2));
 
         TestUtil.setFieldValue(svc, "interfaceStatuses", stats);
 
@@ -869,7 +869,7 @@ public class WifiMonitorServiceImplTest {
         WifiMonitorServiceImpl svc = getServiceWithScanTool(ssid, -5, ltMock);
 
         Map<String, InterfaceState> stats = new HashMap<>();
-        stats.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1")));
+        stats.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1"), 2));
 
         TestUtil.setFieldValue(svc, "interfaceStatuses", stats);
 
@@ -897,7 +897,7 @@ public class WifiMonitorServiceImplTest {
         WifiMonitorServiceImpl svc = getServiceWithScanTool(ssid, 5, ltMock);
 
         Map<String, InterfaceState> stats = new HashMap<>();
-        stats.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1")));
+        stats.put(wlan1, new InterfaceState(wlan1, true, true, IPAddress.parseHostAddress("10.10.0.1"), 2));
 
         TestUtil.setFieldValue(svc, "interfaceStatuses", stats);
 


### PR DESCRIPTION
Ethernet monitor service renews DHCP lease when cable has been plugged/unplugged

**Related Issue:** This PR fixes/closes #2578 

**Description of the solution adopted:** 
Check /sys/class/net/{interface}/carrier_changes counter for changes
