### PR TITLE
Fix #2561 for Wire Publisher and Subscriber

### DIFF
--- a/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudPublisherComponent.xml
+++ b/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudPublisherComponent.xml
@@ -16,7 +16,6 @@
                immediate="true"
                configuration-policy="require">
    <implementation class="org.eclipse.kura.internal.wire.publisher.CloudPublisher"/>
-   <property name="service.pid" value="org.eclipse.kura.wire.CloudPublisher"/>
    <property name="kura.ui.service.hide" type="Boolean" value="true"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
@@ -24,13 +23,8 @@
       <provide interface="org.eclipse.kura.wire.WireReceiver"/>
       <provide interface="org.osgi.service.wireadmin.Consumer"/>
    </service>
-   <reference bind="bindWireHelperService"
-   	          cardinality="1..1"
-   	          interface="org.eclipse.kura.wire.WireHelperService"
-   	          name="WireHelperService"
-   	          policy="static"
-   	          unbind="unbindWireHelperService"/>
-   <reference bind="setPositionService" cardinality="1..1" interface="org.eclipse.kura.position.PositionService" name="PositionService" policy="static" unbind="unsetPositionService"/>
+   <reference bind="bindWireHelperService" cardinality="1..1" interface="org.eclipse.kura.wire.WireHelperService" name="WireHelperService" policy="static"/>
+   <reference bind="setPositionService" cardinality="1..1" interface="org.eclipse.kura.position.PositionService" name="PositionService" policy="static"/>
    <reference name="CloudPublisher"
            policy="dynamic"
            bind="setCloudPublisher"

--- a/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudSubscriberComponent.xml
+++ b/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/CloudSubscriberComponent.xml
@@ -16,7 +16,6 @@
                immediate="true"
                configuration-policy="require">
    <implementation class="org.eclipse.kura.internal.wire.subscriber.CloudSubscriber"/>
-   <property name="service.pid" value="org.eclipse.kura.wire.CloudSubscriber"/>
    <property name="kura.ui.service.hide" type="Boolean" value="true"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>

--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
@@ -89,24 +89,8 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
         }
     }
 
-    /**
-     * Unbinds the Wire Helper Service.
-     *
-     * @param wireHelperService
-     *            the new Wire Helper Service
-     */
-    public void unbindWireHelperService(final WireHelperService wireHelperService) {
-        if (this.wireHelperService == wireHelperService) {
-            this.wireHelperService = null;
-        }
-    }
-
     public void setPositionService(PositionService positionService) {
         this.positionService = positionService;
-    }
-
-    public void unsetPositionService(PositionService positionService) {
-        this.positionService = null;
     }
 
     public void setCloudPublisher(org.eclipse.kura.cloudconnection.publisher.CloudPublisher cloudPublisher) {
@@ -114,7 +98,9 @@ public final class CloudPublisher implements WireReceiver, ConfigurableComponent
     }
 
     public void unsetCloudPublisher(org.eclipse.kura.cloudconnection.publisher.CloudPublisher cloudPublisher) {
-        this.cloudConnectionPublisher = null;
+        if (cloudPublisher == this.cloudConnectionPublisher) {
+            this.cloudConnectionPublisher = null;
+        }
     }
 
     // ----------------------------------------------------------------

--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/subscriber/CloudSubscriber.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/subscriber/CloudSubscriber.java
@@ -85,26 +85,16 @@ public final class CloudSubscriber implements WireEmitter, ConfigurableComponent
         }
     }
 
-    /**
-     * Unbinds the Wire Helper Service.
-     *
-     * @param wireHelperService
-     *            the new Wire Helper Service
-     */
-    public void unbindWireHelperService(final WireHelperService wireHelperService) {
-        if (this.wireHelperService == wireHelperService) {
-            this.wireHelperService = null;
-        }
-    }
-
     public void setCloudSubscriber(org.eclipse.kura.cloudconnection.subscriber.CloudSubscriber cloudSubscriber) {
         this.cloudSubscriber = cloudSubscriber;
         this.cloudSubscriber.registerCloudSubscriberListener(CloudSubscriber.this);
     }
 
     public void unsetCloudSubscriber(org.eclipse.kura.cloudconnection.subscriber.CloudSubscriber cloudSubscriber) {
-        this.cloudSubscriber.unregisterCloudSubscriberListener(CloudSubscriber.this);
-        this.cloudSubscriber = null;
+        cloudSubscriber.unregisterCloudSubscriberListener(CloudSubscriber.this);
+        if (this.cloudSubscriber == cloudSubscriber) {
+            this.cloudSubscriber = null;
+        }
     }
 
     // ----------------------------------------------------------------
@@ -126,7 +116,7 @@ public final class CloudSubscriber implements WireEmitter, ConfigurableComponent
         this.wireSupport = this.wireHelperService.newWireSupport(this,
                 (ServiceReference<WireComponent>) componentContext.getServiceReference());
 
-        options = new CloudSubscriberOptions(properties);
+        this.options = new CloudSubscriberOptions(properties);
         logger.debug("Activating Cloud Subscriber Wire Component... Done");
     }
 
@@ -139,7 +129,7 @@ public final class CloudSubscriber implements WireEmitter, ConfigurableComponent
     public void updated(final Map<String, Object> properties) {
         logger.debug("Updating Cloud Subscriber Wire Component...");
 
-        options = new CloudSubscriberOptions(properties);
+        this.options = new CloudSubscriberOptions(properties);
 
         logger.debug("Updating Cloud Subscriber Wire Component... Done");
     }
@@ -200,7 +190,7 @@ public final class CloudSubscriber implements WireEmitter, ConfigurableComponent
         final Optional<String> bodyProperty = this.options.getBodyProperty();
 
         if (bodyProperty.isPresent()) {
-            emitBody(wireProperties, payload, bodyProperty.get(), options.getBodyPropertyType());
+            emitBody(wireProperties, payload, bodyProperty.get(), this.options.getBodyPropertyType());
         }
 
         final WireRecord wireRecord = new WireRecord(wireProperties);


### PR DESCRIPTION
Also removed unbind methods for static 1..1 references

Signed-off-by: alebianchin <alessandrobianchin311@gmail.com>

**Related Issue:** This PR fixes #2561 for WirePublisher and WireSubscriber.

**Description of the solution adopted:** Added checks to the unbind methods to avoid setting null references when changing to another target. 

**Any side note on the changes made:** Removed unused unbind methods for static 1..1 references.
