### PR TITLE
Adding support of Quectel EC25 and BG96

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2018 Eurotech and/or its affiliates
+ * 				2019 Sterwen-Technology
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +9,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Sterwen-Technology for Quectel Modems
  *******************************************************************************/
 package org.eclipse.kura.linux.net.modem;
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
@@ -42,7 +42,13 @@ public enum SupportedUsbModemInfo {
     Sierra_USB598("USB598", "1199", "0025", 4, 1, 0, 0, -1, 5000, 10000, Arrays.asList(ModemTechnologyType.EVDO), Arrays
             .asList(new UsbModemDriver("sierra", "1199", "0025")), ""),
     Ublox_SARA_U2("SARA-U2", "1546", "1102", 7, 0, 1, 0, -1, 5000, 10000, Arrays
-            .asList(ModemTechnologyType.HSPA), Arrays.asList(new UsbModemDriver("cdc_acm", "1546", "1102")), "");
+            .asList(ModemTechnologyType.HSPA), Arrays.asList(new UsbModemDriver("cdc_acm", "1546", "1102")), ""),
+    Quectel_EC25("EC25", "2c7c", "0125", 4, 0, 3, 3, 1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
+            ModemTechnologyType.HSPA,
+            ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0125")), ""),
+    Quectel_BG96("BG96", "2c7c", "0296", 4, 0, 3, 3, 1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
+            ModemTechnologyType.HSPA,
+            ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0296")), "");
 
     private String deviceName;
     private String vendorId;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Sterwen-Technology for Quectel modems
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem;
 
@@ -50,7 +51,7 @@ public class SupportedUsbModemsFactoryInfo {
         Sierra_MC8790(SupportedUsbModemInfo.Sierra_MC8790, SierraMc87xxModemFactory.class, SierraMc87xxConfigGenerator.class),
         Sierra_USB598(SupportedUsbModemInfo.Sierra_USB598, SierraUsb598ModemFactory.class, SierraUsb598ConfigGenerator.class),
         Ublox_SARA_U2(SupportedUsbModemInfo.Ublox_SARA_U2, UbloxModemFactory.class, HspaModemConfigGenerator.class),
-        Quectel_EC25(SupportedUsbModemInfo.Quectel_EC25, QuectelEC25ModemFactory.class, QuectelEC25ConfigGenerator.class);
+        Quectel_EC25(SupportedUsbModemInfo.Quectel_EC25, QuectelEC25ModemFactory.class, QuectelEC25ConfigGenerator.class),
 		Quectel_BG96(SupportedUsbModemInfo.Quectel_BG96, QuectelBG96ModemFactory.class, QuectelBG96ConfigGenerator.class);
 
         private final SupportedUsbModemInfo m_usbModemInfo;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
 import org.eclipse.kura.linux.net.modem.UsbModemDriver;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModemConfigGenerator;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxConfigGenerator;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxModemFactory;
 import org.eclipse.kura.net.admin.modem.sierra.usb598.SierraUsb598ConfigGenerator;
@@ -26,8 +27,12 @@ import org.eclipse.kura.net.admin.modem.telit.he910.TelitHe910ModemFactory;
 import org.eclipse.kura.net.admin.modem.telit.le910.TelitLe910ModemFactory;
 import org.eclipse.kura.net.admin.modem.telit.le910v2.TelitLe910v2ConfigGenerator;
 import org.eclipse.kura.net.admin.modem.telit.le910v2.TelitLe910v2ModemFactory;
-import org.eclipse.kura.net.admin.modem.ublox.generic.UbloxModemConfigGenerator;
 import org.eclipse.kura.net.admin.modem.ublox.generic.UbloxModemFactory;
+import org.eclipse.kura.net.admin.modem.quectel.ec25.QuectelEC25ModemFactory;
+import org.eclipse.kura.net.admin.modem.quectel.ec25.QuectelEC25ConfigGenerator;
+import org.eclipse.kura.net.admin.modem.quectel.bg96.QuectelBG96ModemFactory;
+import org.eclipse.kura.net.admin.modem.quectel.bg96.QuectelBG96ConfigGenerator;
+
 
 public class SupportedUsbModemsFactoryInfo {
 
@@ -44,7 +49,9 @@ public class SupportedUsbModemsFactoryInfo {
         Sierra_MC8775(SupportedUsbModemInfo.Sierra_MC8775, SierraMc87xxModemFactory.class, SierraMc87xxConfigGenerator.class),
         Sierra_MC8790(SupportedUsbModemInfo.Sierra_MC8790, SierraMc87xxModemFactory.class, SierraMc87xxConfigGenerator.class),
         Sierra_USB598(SupportedUsbModemInfo.Sierra_USB598, SierraUsb598ModemFactory.class, SierraUsb598ConfigGenerator.class),
-        Ublox_SARA_U2(SupportedUsbModemInfo.Ublox_SARA_U2, UbloxModemFactory.class, UbloxModemConfigGenerator.class);
+        Ublox_SARA_U2(SupportedUsbModemInfo.Ublox_SARA_U2, UbloxModemFactory.class, HspaModemConfigGenerator.class),
+        Quectel_EC25(SupportedUsbModemInfo.Quectel_EC25, QuectelEC25ModemFactory.class, QuectelEC25ConfigGenerator.class);
+		Quectel_BG96(SupportedUsbModemInfo.Quectel_BG96, QuectelBG96ModemFactory.class, QuectelBG96ConfigGenerator.class);
 
         private final SupportedUsbModemInfo m_usbModemInfo;
         private final Class<? extends CellularModemFactory> m_factoryClass;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2019 Sterwen-Technology
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Sterwen-Technology
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem.quectel.bg96;
 
@@ -36,12 +37,12 @@ import org.slf4j.LoggerFactory;
  */
 public class QuectelBG96 extends HspaModem implements HspaCellularModem {
 
-    private static final Logger s_logger = LoggerFactory.getLogger(QuectelBG96.class);
+    private static final Logger logger = LoggerFactory.getLogger(QuectelBG96.class);
 
-    private final int m_pdpContext = 1;
+    private final int pdpContext = 1;
 
     /**
-     * TelitHe910 modem constructor
+     * Quectel BG96 modem constructor
      *
      * @param usbDevice
      *            - modem USB device as {@link UsbModemDevice}
@@ -68,14 +69,14 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
                     this.gpsSupported = isGpsSupported();
                     this.rssi = getSignalStrength();
 
-                    s_logger.trace("{} :: Serial Number={}", getClass().getName(), this.serialNumber);
-                    s_logger.trace("{} :: IMSI={}", getClass().getName(), this.imsi);
-                    s_logger.trace("{} :: ICCID={}", getClass().getName(), this.iccid);
-                    s_logger.trace("{} :: Model={}", getClass().getName(), this.model);
-                    s_logger.trace("{} :: Manufacturer={}", getClass().getName(), this.manufacturer);
-                    s_logger.trace("{} :: Revision ID={}", getClass().getName(), this.revisionId);
-                    s_logger.trace("{} :: GPS Supported={}", getClass().getName(), this.gpsSupported);
-                    s_logger.trace("{} :: RSSI={}", getClass().getName(), this.rssi);
+                    logger.trace("{} :: Serial Number={}", getClass().getName(), this.serialNumber);
+                    logger.trace("{} :: IMSI={}", getClass().getName(), this.imsi);
+                    logger.trace("{} :: ICCID={}", getClass().getName(), this.iccid);
+                    logger.trace("{} :: Model={}", getClass().getName(), this.model);
+                    logger.trace("{} :: Manufacturer={}", getClass().getName(), this.manufacturer);
+                    logger.trace("{} :: Revision ID={}", getClass().getName(), this.revisionId);
+                    logger.trace("{} :: GPS Supported={}", getClass().getName(), this.gpsSupported);
+                    logger.trace("{} :: RSSI={}", getClass().getName(), this.rssi);
                 }
             }
         } catch (KuraException e) {
@@ -96,7 +97,7 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
         }
 
         synchronized (this.atLock) {
-            s_logger.debug("sendCommand getSimStatus :: {} command to port {}",
+            logger.debug("sendCommand getSimStatus :: {} command to port {}",
                     QuectelBG96AtCommands.getSimStatus.getCommand(), port);
             byte[] reply = null;
             CommConnection commAtConnection = null;
@@ -118,28 +119,6 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
                     }
                 }
 
-                if (!simReady) {
-                    // reply = commAtConnection.sendCommand(
-                    // QuectelBG96AtCommands.simulateSimNotInserted.getCommand().getBytes(), 1000, 100);
-                    // if (reply != null) {
-                    // sleep(5000);
-                    // reply = commAtConnection.sendCommand(
-                    // QuectelBG96AtCommands.simulateSimInserted.getCommand().getBytes(), 1000, 100);
-                    // if (reply != null) {
-                    // sleep(1000);
-                    // reply = commAtConnection
-                    // .sendCommand(QuectelBG96AtCommands.getSimStatus.getCommand().getBytes(), 1000, 100);
-                    //
-                    // if (reply != null) {
-                    // String simStatus = getResponseString(reply);
-                    // String[] simStatusSplit = simStatus.split(",");
-                    // if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
-                    // simReady = true;
-                    // }
-                    // }
-                    // }
-                    // }
-                }
             } catch (IOException e) {
                 throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, e);
             } catch (KuraException e) {
@@ -156,7 +135,7 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
 
         ModemRegistrationStatus modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
         synchronized (this.atLock) {
-            s_logger.debug("sendCommand getRegistrationStatus :: {}",
+            logger.debug("sendCommand getRegistrationStatus :: {}",
                     QuectelBG96AtCommands.getRegistrationStatus.getCommand());
             byte[] reply = null;
             CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -203,7 +182,7 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
 
         long txCnt = 0;
         synchronized (this.atLock) {
-            s_logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
                     QuectelBG96AtCommands.getGprsSessionDataVolume.getCommand());
             byte[] reply = null;
             CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -231,7 +210,7 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
                             splitData = pdp.trim().split(",");
                             if (splitData.length >= 4) {
                                 int pdpNo = Integer.parseInt(splitData[0]);
-                                if (pdpNo == this.m_pdpContext) {
+                                if (pdpNo == this.pdpContext) {
                                     txCnt = Integer.parseInt(splitData[2]);
                                 }
                             }
@@ -248,7 +227,7 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
     public long getCallRxCounter() throws KuraException {
         long rxCnt = 0;
         synchronized (this.atLock) {
-            s_logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
                     QuectelBG96AtCommands.getGprsSessionDataVolume.getCommand());
             byte[] reply = null;
             CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -276,7 +255,7 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
                             splitData = pdp.trim().split(",");
                             if (splitData.length >= 4) {
                                 int pdpNo = Integer.parseInt(splitData[0]);
-                                if (pdpNo == this.m_pdpContext) {
+                                if (pdpNo == this.pdpContext) {
                                     rxCnt = Integer.parseInt(splitData[3]);
                                 }
                             }
@@ -293,7 +272,7 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
     public String getServiceType() throws KuraException {
         String serviceType = null;
         synchronized (this.atLock) {
-            s_logger.debug("sendCommand getMobileStationClass :: {}",
+            logger.debug("sendCommand getMobileStationClass :: {}",
                     QuectelBG96AtCommands.getMobileStationClass.getCommand());
             byte[] reply = null;
             CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -364,12 +343,12 @@ public class QuectelBG96 extends HspaModem implements HspaCellularModem {
 
     @Override
     public void enableGps() throws KuraException {
-        s_logger.warn("Modem GPS not supported");
+        logger.warn("Modem GPS not supported");
     }
 
     @Override
     public void disableGps() throws KuraException {
-        s_logger.warn("Modem GPS not supported");
+        logger.warn("Modem GPS not supported");
     }
 
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96.java
@@ -1,0 +1,375 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.bg96;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.comm.CommConnection;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemsInfo;
+import org.eclipse.kura.net.admin.modem.HspaCellularModem;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModem;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemPdpContext;
+import org.eclipse.kura.net.modem.ModemRegistrationStatus;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.eclipse.kura.usb.UsbModemDevice;
+import org.osgi.service.io.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Defines Quectel BG96 modem
+ */
+public class QuectelBG96 extends HspaModem implements HspaCellularModem {
+
+    private static final Logger s_logger = LoggerFactory.getLogger(QuectelBG96.class);
+
+    private final int m_pdpContext = 1;
+
+    /**
+     * TelitHe910 modem constructor
+     *
+     * @param usbDevice
+     *            - modem USB device as {@link UsbModemDevice}
+     * @param platform
+     *            - hardware platform as {@link String}
+     * @param connectionFactory
+     *            - connection factory {@link ConnectionFactory}
+     */
+    public QuectelBG96(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
+
+        super(device, platform, connectionFactory);
+
+        try {
+            String atPort = getAtPort();
+            String gpsPort = getGpsPort();
+            if (atPort != null) {
+                if (atPort.equals(getDataPort()) || atPort.equals(gpsPort)) {
+                    this.serialNumber = getSerialNumber();
+                    this.imsi = getMobileSubscriberIdentity();
+                    this.iccid = getIntegratedCirquitCardId();
+                    this.model = getModel();
+                    this.manufacturer = getManufacturer();
+                    this.revisionId = getRevisionID();
+                    this.gpsSupported = isGpsSupported();
+                    this.rssi = getSignalStrength();
+
+                    s_logger.trace("{} :: Serial Number={}", getClass().getName(), this.serialNumber);
+                    s_logger.trace("{} :: IMSI={}", getClass().getName(), this.imsi);
+                    s_logger.trace("{} :: ICCID={}", getClass().getName(), this.iccid);
+                    s_logger.trace("{} :: Model={}", getClass().getName(), this.model);
+                    s_logger.trace("{} :: Manufacturer={}", getClass().getName(), this.manufacturer);
+                    s_logger.trace("{} :: Revision ID={}", getClass().getName(), this.revisionId);
+                    s_logger.trace("{} :: GPS Supported={}", getClass().getName(), this.gpsSupported);
+                    s_logger.trace("{} :: RSSI={}", getClass().getName(), this.rssi);
+                }
+            }
+        } catch (KuraException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public boolean isSimCardReady() throws KuraException {
+
+        boolean simReady = false;
+        String port = null;
+
+        if (isGpsEnabled() && getAtPort().equals(getGpsPort()) && !getAtPort().equals(getDataPort())) {
+            port = getDataPort();
+        } else {
+            port = getAtPort();
+        }
+
+        synchronized (this.atLock) {
+            s_logger.debug("sendCommand getSimStatus :: {} command to port {}",
+                    QuectelBG96AtCommands.getSimStatus.getCommand(), port);
+            byte[] reply = null;
+            CommConnection commAtConnection = null;
+            try {
+
+                commAtConnection = openSerialPort(port);
+                if (!isAtReachable(commAtConnection)) {
+                    throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                            "Modem not available for AT commands: " + QuectelBG96.class.getName());
+                }
+
+                reply = commAtConnection.sendCommand(QuectelBG96AtCommands.getSimStatus.getCommand().getBytes(), 1000,
+                        100);
+                if (reply != null) {
+                    String simStatus = getResponseString(reply);
+                    String[] simStatusSplit = simStatus.split(",");
+                    if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
+                        simReady = true;
+                    }
+                }
+
+                if (!simReady) {
+                    // reply = commAtConnection.sendCommand(
+                    // QuectelBG96AtCommands.simulateSimNotInserted.getCommand().getBytes(), 1000, 100);
+                    // if (reply != null) {
+                    // sleep(5000);
+                    // reply = commAtConnection.sendCommand(
+                    // QuectelBG96AtCommands.simulateSimInserted.getCommand().getBytes(), 1000, 100);
+                    // if (reply != null) {
+                    // sleep(1000);
+                    // reply = commAtConnection
+                    // .sendCommand(QuectelBG96AtCommands.getSimStatus.getCommand().getBytes(), 1000, 100);
+                    //
+                    // if (reply != null) {
+                    // String simStatus = getResponseString(reply);
+                    // String[] simStatusSplit = simStatus.split(",");
+                    // if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
+                    // simReady = true;
+                    // }
+                    // }
+                    // }
+                    // }
+                }
+            } catch (IOException e) {
+                throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, e);
+            } catch (KuraException e) {
+                throw e;
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+        }
+        return simReady;
+    }
+
+    @Override
+    public ModemRegistrationStatus getRegistrationStatus() throws KuraException {
+
+        ModemRegistrationStatus modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
+        synchronized (this.atLock) {
+            s_logger.debug("sendCommand getRegistrationStatus :: {}",
+                    QuectelBG96AtCommands.getRegistrationStatus.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                        "Modem not available for AT commands: " + QuectelBG96.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelBG96AtCommands.getRegistrationStatus.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sRegStatus = getResponseString(reply);
+                String[] regStatusSplit = sRegStatus.split(",");
+                if (regStatusSplit.length >= 2) {
+                    int status = Integer.parseInt(regStatusSplit[1]);
+                    switch (status) {
+                    case 0:
+                        modemRegistrationStatus = ModemRegistrationStatus.NOT_REGISTERED;
+                        break;
+                    case 1:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_HOME;
+                        break;
+                    case 3:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTRATION_DENIED;
+                        break;
+                    case 5:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_ROAMING;
+                        break;
+                    }
+                }
+            }
+        }
+        return modemRegistrationStatus;
+    }
+
+    @Override
+    public long getCallTxCounter() throws KuraException {
+
+        long txCnt = 0;
+        synchronized (this.atLock) {
+            s_logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelBG96AtCommands.getGprsSessionDataVolume.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                        "Modem not available for AT commands: " + QuectelBG96.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelBG96AtCommands.getGprsSessionDataVolume.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] splitPdp = null;
+                String[] splitData = null;
+                String sDataVolume = this.getResponseString(reply);
+                splitPdp = sDataVolume.split("#GDATAVOL:");
+                if (splitPdp.length > 1) {
+                    for (String pdp : splitPdp) {
+                        if (pdp.trim().length() > 0) {
+                            splitData = pdp.trim().split(",");
+                            if (splitData.length >= 4) {
+                                int pdpNo = Integer.parseInt(splitData[0]);
+                                if (pdpNo == this.m_pdpContext) {
+                                    txCnt = Integer.parseInt(splitData[2]);
+                                }
+                            }
+                        }
+                    }
+                }
+                reply = null;
+            }
+        }
+        return txCnt;
+    }
+
+    @Override
+    public long getCallRxCounter() throws KuraException {
+        long rxCnt = 0;
+        synchronized (this.atLock) {
+            s_logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelBG96AtCommands.getGprsSessionDataVolume.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                        "Modem not available for AT commands: " + QuectelBG96.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelBG96AtCommands.getGprsSessionDataVolume.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] splitPdp = null;
+                String[] splitData = null;
+                String sDataVolume = this.getResponseString(reply);
+                splitPdp = sDataVolume.split("#GDATAVOL:");
+                if (splitPdp.length > 1) {
+                    for (String pdp : splitPdp) {
+                        if (pdp.trim().length() > 0) {
+                            splitData = pdp.trim().split(",");
+                            if (splitData.length >= 4) {
+                                int pdpNo = Integer.parseInt(splitData[0]);
+                                if (pdpNo == this.m_pdpContext) {
+                                    rxCnt = Integer.parseInt(splitData[3]);
+                                }
+                            }
+                        }
+                    }
+                }
+                reply = null;
+            }
+        }
+        return rxCnt;
+    }
+
+    @Override
+    public String getServiceType() throws KuraException {
+        String serviceType = null;
+        synchronized (this.atLock) {
+            s_logger.debug("sendCommand getMobileStationClass :: {}",
+                    QuectelBG96AtCommands.getMobileStationClass.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                        "Modem not available for AT commands: " + QuectelBG96.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelBG96AtCommands.getMobileStationClass.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sCgclass = this.getResponseString(reply);
+                if (sCgclass.startsWith("+CGCLASS:")) {
+                    sCgclass = sCgclass.substring("+CGCLASS:".length()).trim();
+                    if (sCgclass.equals("\"A\"")) {
+                        serviceType = "UMTS";
+                    } else if (sCgclass.equals("\"B\"")) {
+                        serviceType = "GSM/GPRS";
+                    } else if (sCgclass.equals("\"CG\"")) {
+                        serviceType = "GPRS";
+                    } else if (sCgclass.equals("\"CC\"")) {
+                        serviceType = "GSM";
+                    }
+                }
+                reply = null;
+            }
+        }
+
+        return serviceType;
+    }
+
+    @Override
+    public List<ModemTechnologyType> getTechnologyTypes() throws KuraException {
+
+        List<ModemTechnologyType> modemTechnologyTypes = null;
+        ModemDevice device = getModemDevice();
+        if (device == null) {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "No modem device");
+        }
+        if (device instanceof UsbModemDevice) {
+            SupportedUsbModemInfo usbModemInfo = SupportedUsbModemsInfo.getModem((UsbModemDevice) device);
+            if (usbModemInfo != null) {
+                modemTechnologyTypes = usbModemInfo.getTechnologyTypes();
+            } else {
+                throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "No usbModemInfo available");
+            }
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "Unsupported modem device");
+        }
+        return modemTechnologyTypes;
+    }
+
+    @Override
+    public List<ModemPdpContext> getPdpContextInfo() throws KuraException {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public boolean isGpsSupported() throws KuraException {
+        return false; // Will be activated later
+    }
+
+    @Override
+    public void enableGps() throws KuraException {
+        s_logger.warn("Modem GPS not supported");
+    }
+
+    @Override
+    public void disableGps() throws KuraException {
+        s_logger.warn("Modem GPS not supported");
+    }
+
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96AtCommands.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2019 Sterwen-Technology
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,13 +8,14 @@
  *
  * Contributors:
  *     Eurotech
+ *     Sterwen-Technology
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem.quectel.bg96;
 
 /**
- * Defines AT commands for the Telit HE910 modem.
+ * Defines AT commands for the Quectel BG96 modem.
  *
- * @author ilya.binshtok
+ * 
  *
  */
 public enum QuectelBG96AtCommands {
@@ -32,13 +33,13 @@ public enum QuectelBG96AtCommands {
     getSerialNumber("at+cgsn\r\n"),
     pdpContext("AT+CGDCONT");
 
-    private String m_command;
+    private String command;
 
     private QuectelBG96AtCommands(String atCommand) {
-        this.m_command = atCommand;
+        this.command = atCommand;
     }
 
     public String getCommand() {
-        return this.m_command;
+        return this.command;
     }
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96AtCommands.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.bg96;
+
+/**
+ * Defines AT commands for the Telit HE910 modem.
+ *
+ * @author ilya.binshtok
+ *
+ */
+public enum QuectelBG96AtCommands {
+
+    getSimStatus("AT+QSIMSTAT?\r\n"),
+    getSimPinStatus("at+cpin?\r\n"),
+    setAutoSimDetection("at+qsimdet=1,0\r\nat+qsimstat=1"),
+    getSmsc("at+csca?\r\n"),
+    getMobileStationClass("at+cgclass?\r\n"),
+    getRegistrationStatus("at+cgreg?\r\n"),
+    getGprsSessionDataVolume("at+QGDCNT?\r\n"),
+    getSignalStrength("at+csq\r\n"),
+    getModelNumber("at+gmm\r\n"),
+    getManufacturer("at+gmi\r\n"),
+    getSerialNumber("at+cgsn\r\n"),
+    pdpContext("AT+CGDCONT");
+
+    private String m_command;
+
+    private QuectelBG96AtCommands(String atCommand) {
+        this.m_command = atCommand;
+    }
+
+    public String getCommand() {
+        return this.m_command;
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ConfigGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2019 Sterwen-Technology
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Sterwen-Technology
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem.quectel.bg96;
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ConfigGenerator.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.bg96;
+
+import org.eclipse.kura.net.admin.modem.ModemPppConfigGenerator;
+import org.eclipse.kura.net.admin.modem.PppPeer;
+import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangePair;
+import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangeScript;
+import org.eclipse.kura.net.modem.ModemConfig;
+import org.eclipse.kura.net.modem.ModemConfig.PdpType;
+
+public class QuectelBG96ConfigGenerator implements ModemPppConfigGenerator {
+
+    @Override
+    public PppPeer getPppPeer(String deviceId, ModemConfig modemConfig, String logFile, String connectScript,
+            String disconnectScript) {
+
+        PppPeer pppPeer = new PppPeer();
+
+        // default values
+        pppPeer.setBaudRate(115200);
+        pppPeer.setEnableDebug(true);
+        pppPeer.setUseModemControlLines(true);
+        pppPeer.setUseRtsCtsFlowControl(false);
+        pppPeer.setLockSerialDevice(true);
+        pppPeer.setPeerMustAuthenticateItself(false);
+        pppPeer.setPeerToSupplyLocalIP(true);
+        pppPeer.setAddDefaultRoute(true);
+        pppPeer.setUsePeerDns(true);
+        pppPeer.setAllowProxyArps(false);
+        pppPeer.setAllowVanJacobsonTcpIpHdrCompression(false);
+        pppPeer.setAllowVanJacobsonConnectionIDCompression(false);
+        pppPeer.setAllowBsdCompression(false);
+        pppPeer.setAllowDeflateCompression(false);
+        pppPeer.setAllowMagic(false);
+        pppPeer.setConnectDelay(1000);
+        pppPeer.setLcpEchoInterval(0);
+
+        // other config
+        pppPeer.setLogfile(logFile);
+        pppPeer.setProvider(deviceId);
+        pppPeer.setPppUnitNumber(modemConfig.getPppNumber());
+        pppPeer.setConnectScript(connectScript);
+        pppPeer.setDisconnectScript(disconnectScript);
+        pppPeer.setApn(modemConfig.getApn());
+        pppPeer.setAuthType(modemConfig.getAuthType());
+        pppPeer.setUsername(modemConfig.getUsername());
+        pppPeer.setPassword(modemConfig.getPasswordAsPassword());
+        pppPeer.setDialString(modemConfig.getDialString());
+        pppPeer.setPersist(modemConfig.isPersist());
+        pppPeer.setMaxFail(modemConfig.getMaxFail());
+        pppPeer.setIdleTime(modemConfig.getIdle());
+        pppPeer.setActiveFilter(modemConfig.getActiveFilter());
+        pppPeer.setLcpEchoInterval(modemConfig.getLcpEchoInterval());
+        pppPeer.setLcpEchoFailure(modemConfig.getLcpEchoFailure());
+
+        return pppPeer;
+    }
+
+    @Override
+    public ModemXchangeScript getConnectScript(ModemConfig modemConfig) {
+        int pdpPid = 1;
+        String apn = "";
+        String dialString = "";
+
+        if (modemConfig != null) {
+            apn = modemConfig.getApn();
+            dialString = modemConfig.getDialString();
+        }
+
+        ModemXchangeScript modemXchange = new ModemXchangeScript();
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"ERROR\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ath\"", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"AT\"", "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formPDPcontext(pdpPid, PdpType.IP, apn), "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\d\\d\\d\"", "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formDialString(dialString), "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\c\"", "CONNECT"));
+
+        return modemXchange;
+    }
+
+    @Override
+    public ModemXchangeScript getDisconnectScript(ModemConfig modemConfig) {
+
+        ModemXchangeScript modemXchange = new ModemXchangeScript();
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("BREAK", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ATH\"", "\"\""));
+
+        return modemXchange;
+    }
+
+    /*
+     * This method forms dial string
+     */
+    private String formDialString(String dialString) {
+        StringBuffer buf = new StringBuffer();
+        buf.append('"');
+        if (dialString != null) {
+            buf.append(dialString);
+        }
+        buf.append('"');
+        return buf.toString();
+    }
+
+    /*
+     * This method forms PDP context
+     * (e.g. AT+CGDCONT=<pid>,<pdp_type>,<apn>)
+     */
+    private String formPDPcontext(int pdpPid, PdpType pdpType, String apn) {
+
+        StringBuffer pdpcontext = new StringBuffer(QuectelBG96AtCommands.pdpContext.getCommand());
+        pdpcontext.append('=');
+        pdpcontext.append(pdpPid);
+        pdpcontext.append(',');
+        pdpcontext.append('"');
+        pdpcontext.append(pdpType.toString());
+        pdpcontext.append('"');
+        pdpcontext.append(',');
+        pdpcontext.append('"');
+        if (apn != null) {
+            pdpcontext.append(apn);
+        }
+        pdpcontext.append('"');
+
+        return pdpcontext.toString();
+    }
+
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ModemFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ModemFactory.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.bg96;
+
+import java.util.Hashtable;
+
+import org.eclipse.kura.net.admin.NetworkConfigurationService;
+import org.eclipse.kura.net.admin.util.AbstractCellularModemFactory;
+import org.eclipse.kura.net.modem.CellularModem;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.io.ConnectionFactory;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * Defines Quectel BG96 Modem Factory
+ *
+ * @author ilya.binshtok
+ *
+ */
+public class QuectelBG96ModemFactory extends AbstractCellularModemFactory<QuectelBG96> {
+
+    // private static final Logger s_logger = LoggerFactory.getLogger(TelitHe910ModemFactory.class);
+
+    private static QuectelBG96ModemFactory s_factoryInstance = null;
+    private ConnectionFactory connectionFactory;
+    private static ModemTechnologyType s_type = ModemTechnologyType.HSDPA;
+
+    private BundleContext s_bundleContext = null;
+    private Hashtable<String, QuectelBG96> m_modemServices = null;
+
+    private QuectelBG96ModemFactory() {
+        this.s_bundleContext = FrameworkUtil.getBundle(NetworkConfigurationService.class).getBundleContext();
+
+        ServiceTracker<ConnectionFactory, ConnectionFactory> serviceTracker = new ServiceTracker<ConnectionFactory, ConnectionFactory>(
+                this.s_bundleContext, ConnectionFactory.class, null);
+        serviceTracker.open(true);
+        this.connectionFactory = serviceTracker.getService();
+
+        this.m_modemServices = new Hashtable<String, QuectelBG96>();
+    }
+
+    public static QuectelBG96ModemFactory getInstance() {
+        if (s_factoryInstance == null) {
+            s_factoryInstance = new QuectelBG96ModemFactory();
+        }
+        return s_factoryInstance;
+    }
+
+    @Override
+    public CellularModem obtainCellularModemService(ModemDevice modemDevice, String platform) throws Exception {
+
+        String key = modemDevice.getProductName();
+        QuectelBG96 quectelEc25 = this.m_modemServices.get(key);
+
+        if (quectelEc25 == null) {
+            quectelEc25 = new QuectelBG96(modemDevice, platform, this.connectionFactory);
+            this.m_modemServices.put(key, quectelEc25);
+        } else {
+            quectelEc25.setModemDevice(modemDevice);
+        }
+
+        return quectelEc25;
+    }
+
+    @Override
+    public Hashtable<String, ? extends CellularModem> getModemServices() {
+        return this.m_modemServices;
+    }
+
+    @Override
+    public void releaseModemService(String usbPortAddress) {
+        this.m_modemServices.remove(usbPortAddress);
+    }
+
+    @Override
+    @Deprecated
+    public ModemTechnologyType getType() {
+        return s_type;
+    }
+
+    @Override
+    protected QuectelBG96 createCellularModem(ModemDevice modemDevice, String platform) throws Exception {
+        return new QuectelBG96(modemDevice, platform, this.connectionFactory);
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ModemFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ModemFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2019 Sterwen-Technology
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Sterwen-Technology
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem.quectel.bg96;
 
@@ -26,7 +27,6 @@ import org.osgi.util.tracker.ServiceTracker;
 /**
  * Defines Quectel BG96 Modem Factory
  *
- * @author ilya.binshtok
  *
  */
 public class QuectelBG96ModemFactory extends AbstractCellularModemFactory<QuectelBG96> {
@@ -62,16 +62,16 @@ public class QuectelBG96ModemFactory extends AbstractCellularModemFactory<Quecte
     public CellularModem obtainCellularModemService(ModemDevice modemDevice, String platform) throws Exception {
 
         String key = modemDevice.getProductName();
-        QuectelBG96 quectelEc25 = this.m_modemServices.get(key);
+        QuectelBG96 quectelBg96 = this.m_modemServices.get(key);
 
-        if (quectelEc25 == null) {
-            quectelEc25 = new QuectelBG96(modemDevice, platform, this.connectionFactory);
-            this.m_modemServices.put(key, quectelEc25);
+        if (quectelBg96 == null) {
+            quectelBg96 = new QuectelBG96(modemDevice, platform, this.connectionFactory);
+            this.m_modemServices.put(key, quectelBg96);
         } else {
-            quectelEc25.setModemDevice(modemDevice);
+            quectelBg96.setModemDevice(modemDevice);
         }
 
-        return quectelEc25;
+        return quectelBg96;
     }
 
     @Override

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2019 Sterwen Technology and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *     Eurotech
+ *     Sterwen-Technology
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem.quectel.ec25;
 
@@ -37,12 +38,12 @@ import org.slf4j.LoggerFactory;
  */
 public class QuectelEC25 extends HspaModem implements HspaCellularModem {
 
-    private static final Logger s_logger = LoggerFactory.getLogger(QuectelEC25.class);
+    private static final Logger logger = LoggerFactory.getLogger(QuectelEC25.class);
 
-    private final int m_pdpContext = 1;
+    private final int pdpContext = 1;
 
     /**
-     * TelitHe910 modem constructor
+     * Quectel EC25 modem constructor
      *
      * @param usbDevice
      *            - modem USB device as {@link UsbModemDevice}
@@ -69,14 +70,14 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
                     this.m_gpsSupported = isGpsSupported();
                     this.m_rssi = getSignalStrength();
 
-                    s_logger.trace("{} :: Serial Number={}", getClass().getName(), this.m_serialNumber);
-                    s_logger.trace("{} :: IMSI={}", getClass().getName(), this.m_imsi);
-                    s_logger.trace("{} :: ICCID={}", getClass().getName(), this.m_iccid);
-                    s_logger.trace("{} :: Model={}", getClass().getName(), this.m_model);
-                    s_logger.trace("{} :: Manufacturer={}", getClass().getName(), this.m_manufacturer);
-                    s_logger.trace("{} :: Revision ID={}", getClass().getName(), this.m_revisionId);
-                    s_logger.trace("{} :: GPS Supported={}", getClass().getName(), this.m_gpsSupported);
-                    s_logger.trace("{} :: RSSI={}", getClass().getName(), this.m_rssi);
+                    logger.trace("{} :: Serial Number={}", getClass().getName(), this.m_serialNumber);
+                    logger.trace("{} :: IMSI={}", getClass().getName(), this.m_imsi);
+                    logger.trace("{} :: ICCID={}", getClass().getName(), this.m_iccid);
+                    logger.trace("{} :: Model={}", getClass().getName(), this.m_model);
+                    logger.trace("{} :: Manufacturer={}", getClass().getName(), this.m_manufacturer);
+                    logger.trace("{} :: Revision ID={}", getClass().getName(), this.m_revisionId);
+                    logger.trace("{} :: GPS Supported={}", getClass().getName(), this.m_gpsSupported);
+                    logger.trace("{} :: RSSI={}", getClass().getName(), this.m_rssi);
                 }
             }
         } catch (KuraException e) {
@@ -97,7 +98,7 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
         }
 
         synchronized (s_atLock) {
-            s_logger.debug("sendCommand getSimStatus :: {} command to port {}",
+            logger.debug("sendCommand getSimStatus :: {} command to port {}",
                     QuectelEC25AtCommands.getSimStatus.getCommand(), port);
             byte[] reply = null;
             CommConnection commAtConnection = null;
@@ -119,27 +120,7 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
                     }
                 }
 
-                if (!simReady) {
-//                    reply = commAtConnection.sendCommand(
-//                            QuectelEC25AtCommands.simulateSimNotInserted.getCommand().getBytes(), 1000, 100);
-//                    if (reply != null) {
-//                        sleep(5000);
-//                        reply = commAtConnection.sendCommand(
-//                                QuectelEC25AtCommands.simulateSimInserted.getCommand().getBytes(), 1000, 100);
-//                        if (reply != null) {
-//                            sleep(1000);
-//                            reply = commAtConnection
-//                                    .sendCommand(QuectelEC25AtCommands.getSimStatus.getCommand().getBytes(), 1000, 100);
-//
-//                            if (reply != null) {
-//                                String simStatus = getResponseString(reply);
-//                                String[] simStatusSplit = simStatus.split(",");
-//                                if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
-//                                    simReady = true;
-//                                }
-//                            }
-//                        }
-//                    }
+
                 }
             } catch (IOException e) {
                 throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
@@ -157,7 +138,7 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
 
         ModemRegistrationStatus modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
         synchronized (s_atLock) {
-            s_logger.debug("sendCommand getRegistrationStatus :: {}",
+            logger.debug("sendCommand getRegistrationStatus :: {}",
                     QuectelEC25AtCommands.getRegistrationStatus.getCommand());
             byte[] reply = null;
             CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -204,7 +185,7 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
 
         long txCnt = 0;
         synchronized (s_atLock) {
-            s_logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
                     QuectelEC25AtCommands.getGprsSessionDataVolume.getCommand());
             byte[] reply = null;
             CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -232,7 +213,7 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
                             splitData = pdp.trim().split(",");
                             if (splitData.length >= 4) {
                                 int pdpNo = Integer.parseInt(splitData[0]);
-                                if (pdpNo == this.m_pdpContext) {
+                                if (pdpNo == this.pdpContext) {
                                     txCnt = Integer.parseInt(splitData[2]);
                                 }
                             }
@@ -249,7 +230,7 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
     public long getCallRxCounter() throws KuraException {
         long rxCnt = 0;
         synchronized (s_atLock) {
-            s_logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
                     QuectelEC25AtCommands.getGprsSessionDataVolume.getCommand());
             byte[] reply = null;
             CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -277,7 +258,7 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
                             splitData = pdp.trim().split(",");
                             if (splitData.length >= 4) {
                                 int pdpNo = Integer.parseInt(splitData[0]);
-                                if (pdpNo == this.m_pdpContext) {
+                                if (pdpNo == this.pdpContext) {
                                     rxCnt = Integer.parseInt(splitData[3]);
                                 }
                             }
@@ -294,7 +275,7 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
     public String getServiceType() throws KuraException {
         String serviceType = null;
         synchronized (s_atLock) {
-            s_logger.debug("sendCommand getMobileStationClass :: {}",
+            logger.debug("sendCommand getMobileStationClass :: {}",
                     QuectelEC25AtCommands.getMobileStationClass.getCommand());
             byte[] reply = null;
             CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -370,7 +351,7 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
                 modemTechnologyType = modemTechnologyTypes.get(0);
             }
         } catch (KuraException e) {
-            s_logger.error("Failed to obtain modem technology - {}", e);
+            logger.error("Failed to obtain modem technology - {}", e);
         }
         return modemTechnologyType;
     }
@@ -382,12 +363,12 @@ public class QuectelEC25 extends HspaModem implements HspaCellularModem {
 
     @Override
     public void enableGps() throws KuraException {
-        s_logger.warn("Modem GPS not supported");
+        logger.warn("Modem GPS not supported");
     }
 
     @Override
     public void disableGps() throws KuraException {
-        s_logger.warn("Modem GPS not supported");
+        logger.warn("Modem GPS not supported");
     }
 
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25.java
@@ -1,0 +1,394 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.ec25;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.comm.CommConnection;
+import org.eclipse.kura.linux.net.modem.SupportedSerialModemInfo;
+import org.eclipse.kura.linux.net.modem.SupportedSerialModemsInfo;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemsInfo;
+import org.eclipse.kura.net.admin.modem.HspaCellularModem;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModem;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemRegistrationStatus;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.eclipse.kura.net.modem.SerialModemDevice;
+import org.eclipse.kura.usb.UsbModemDevice;
+import org.osgi.service.io.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Defines Quectel EC25 modem
+ */
+public class QuectelEC25 extends HspaModem implements HspaCellularModem {
+
+    private static final Logger s_logger = LoggerFactory.getLogger(QuectelEC25.class);
+
+    private final int m_pdpContext = 1;
+
+    /**
+     * TelitHe910 modem constructor
+     *
+     * @param usbDevice
+     *            - modem USB device as {@link UsbModemDevice}
+     * @param platform
+     *            - hardware platform as {@link String}
+     * @param connectionFactory
+     *            - connection factory {@link ConnectionFactory}
+     */
+    public QuectelEC25(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
+
+        super(device, platform, connectionFactory);
+
+        try {
+            String atPort = getAtPort();
+            String gpsPort = getGpsPort();
+            if (atPort != null) {
+                if (atPort.equals(getDataPort()) || atPort.equals(gpsPort)) {
+                    this.m_serialNumber = getSerialNumber();
+                    this.m_imsi = getMobileSubscriberIdentity();
+                    this.m_iccid = getIntegratedCirquitCardId();
+                    this.m_model = getModel();
+                    this.m_manufacturer = getManufacturer();
+                    this.m_revisionId = getRevisionID();
+                    this.m_gpsSupported = isGpsSupported();
+                    this.m_rssi = getSignalStrength();
+
+                    s_logger.trace("{} :: Serial Number={}", getClass().getName(), this.m_serialNumber);
+                    s_logger.trace("{} :: IMSI={}", getClass().getName(), this.m_imsi);
+                    s_logger.trace("{} :: ICCID={}", getClass().getName(), this.m_iccid);
+                    s_logger.trace("{} :: Model={}", getClass().getName(), this.m_model);
+                    s_logger.trace("{} :: Manufacturer={}", getClass().getName(), this.m_manufacturer);
+                    s_logger.trace("{} :: Revision ID={}", getClass().getName(), this.m_revisionId);
+                    s_logger.trace("{} :: GPS Supported={}", getClass().getName(), this.m_gpsSupported);
+                    s_logger.trace("{} :: RSSI={}", getClass().getName(), this.m_rssi);
+                }
+            }
+        } catch (KuraException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public boolean isSimCardReady() throws KuraException {
+
+        boolean simReady = false;
+        String port = null;
+
+        if (isGpsEnabled() && getAtPort().equals(getGpsPort()) && !getAtPort().equals(getDataPort())) {
+            port = getDataPort();
+        } else {
+            port = getAtPort();
+        }
+
+        synchronized (s_atLock) {
+            s_logger.debug("sendCommand getSimStatus :: {} command to port {}",
+                    QuectelEC25AtCommands.getSimStatus.getCommand(), port);
+            byte[] reply = null;
+            CommConnection commAtConnection = null;
+            try {
+
+                commAtConnection = openSerialPort(port);
+                if (!isAtReachable(commAtConnection)) {
+                    throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                            "Modem not available for AT commands: " + QuectelEC25.class.getName());
+                }
+
+                reply = commAtConnection.sendCommand(QuectelEC25AtCommands.getSimStatus.getCommand().getBytes(), 1000,
+                        100);
+                if (reply != null) {
+                    String simStatus = getResponseString(reply);
+                    String[] simStatusSplit = simStatus.split(",");
+                    if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
+                        simReady = true;
+                    }
+                }
+
+                if (!simReady) {
+//                    reply = commAtConnection.sendCommand(
+//                            QuectelEC25AtCommands.simulateSimNotInserted.getCommand().getBytes(), 1000, 100);
+//                    if (reply != null) {
+//                        sleep(5000);
+//                        reply = commAtConnection.sendCommand(
+//                                QuectelEC25AtCommands.simulateSimInserted.getCommand().getBytes(), 1000, 100);
+//                        if (reply != null) {
+//                            sleep(1000);
+//                            reply = commAtConnection
+//                                    .sendCommand(QuectelEC25AtCommands.getSimStatus.getCommand().getBytes(), 1000, 100);
+//
+//                            if (reply != null) {
+//                                String simStatus = getResponseString(reply);
+//                                String[] simStatusSplit = simStatus.split(",");
+//                                if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
+//                                    simReady = true;
+//                                }
+//                            }
+//                        }
+//                    }
+                }
+            } catch (IOException e) {
+                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+            } catch (KuraException e) {
+                throw e;
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+        }
+        return simReady;
+    }
+
+    @Override
+    public ModemRegistrationStatus getRegistrationStatus() throws KuraException {
+
+        ModemRegistrationStatus modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
+        synchronized (s_atLock) {
+            s_logger.debug("sendCommand getRegistrationStatus :: {}",
+                    QuectelEC25AtCommands.getRegistrationStatus.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                        "Modem not available for AT commands: " + QuectelEC25.class.getName());
+            }
+            try {
+                reply = commAtConnection.sendCommand(QuectelEC25AtCommands.getRegistrationStatus.getCommand().getBytes(),
+                        1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sRegStatus = getResponseString(reply);
+                String[] regStatusSplit = sRegStatus.split(",");
+                if (regStatusSplit.length >= 2) {
+                    int status = Integer.parseInt(regStatusSplit[1]);
+                    switch (status) {
+                    case 0:
+                        modemRegistrationStatus = ModemRegistrationStatus.NOT_REGISTERED;
+                        break;
+                    case 1:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_HOME;
+                        break;
+                    case 3:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTRATION_DENIED;
+                        break;
+                    case 5:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_ROAMING;
+                        break;
+                    }
+                }
+            }
+        }
+        return modemRegistrationStatus;
+    }
+
+    @Override
+    public long getCallTxCounter() throws KuraException {
+
+        long txCnt = 0;
+        synchronized (s_atLock) {
+            s_logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelEC25AtCommands.getGprsSessionDataVolume.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                        "Modem not available for AT commands: " + QuectelEC25.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelEC25AtCommands.getGprsSessionDataVolume.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] splitPdp = null;
+                String[] splitData = null;
+                String sDataVolume = this.getResponseString(reply);
+                splitPdp = sDataVolume.split("#GDATAVOL:");
+                if (splitPdp.length > 1) {
+                    for (String pdp : splitPdp) {
+                        if (pdp.trim().length() > 0) {
+                            splitData = pdp.trim().split(",");
+                            if (splitData.length >= 4) {
+                                int pdpNo = Integer.parseInt(splitData[0]);
+                                if (pdpNo == this.m_pdpContext) {
+                                    txCnt = Integer.parseInt(splitData[2]);
+                                }
+                            }
+                        }
+                    }
+                }
+                reply = null;
+            }
+        }
+        return txCnt;
+    }
+
+    @Override
+    public long getCallRxCounter() throws KuraException {
+        long rxCnt = 0;
+        synchronized (s_atLock) {
+            s_logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelEC25AtCommands.getGprsSessionDataVolume.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                        "Modem not available for AT commands: " + QuectelEC25.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelEC25AtCommands.getGprsSessionDataVolume.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] splitPdp = null;
+                String[] splitData = null;
+                String sDataVolume = this.getResponseString(reply);
+                splitPdp = sDataVolume.split("#GDATAVOL:");
+                if (splitPdp.length > 1) {
+                    for (String pdp : splitPdp) {
+                        if (pdp.trim().length() > 0) {
+                            splitData = pdp.trim().split(",");
+                            if (splitData.length >= 4) {
+                                int pdpNo = Integer.parseInt(splitData[0]);
+                                if (pdpNo == this.m_pdpContext) {
+                                    rxCnt = Integer.parseInt(splitData[3]);
+                                }
+                            }
+                        }
+                    }
+                }
+                reply = null;
+            }
+        }
+        return rxCnt;
+    }
+
+    @Override
+    public String getServiceType() throws KuraException {
+        String serviceType = null;
+        synchronized (s_atLock) {
+            s_logger.debug("sendCommand getMobileStationClass :: {}",
+                    QuectelEC25AtCommands.getMobileStationClass.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                        "Modem not available for AT commands: " + QuectelEC25.class.getName());
+            }
+            try {
+                reply = commAtConnection.sendCommand(QuectelEC25AtCommands.getMobileStationClass.getCommand().getBytes(),
+                        1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sCgclass = this.getResponseString(reply);
+                if (sCgclass.startsWith("+CGCLASS:")) {
+                    sCgclass = sCgclass.substring("+CGCLASS:".length()).trim();
+                    if (sCgclass.equals("\"A\"")) {
+                        serviceType = "UMTS";
+                    } else if (sCgclass.equals("\"B\"")) {
+                        serviceType = "GSM/GPRS";
+                    } else if (sCgclass.equals("\"CG\"")) {
+                        serviceType = "GPRS";
+                    } else if (sCgclass.equals("\"CC\"")) {
+                        serviceType = "GSM";
+                    }
+                }
+                reply = null;
+            }
+        }
+
+        return serviceType;
+    }
+
+    @Override
+    public List<ModemTechnologyType> getTechnologyTypes() throws KuraException {
+
+        List<ModemTechnologyType> modemTechnologyTypes = null;
+        ModemDevice device = getModemDevice();
+        if (device == null) {
+            throw new KuraException(KuraErrorCode.INTERNAL_ERROR, "No modem device");
+        }
+        if (device instanceof UsbModemDevice) {
+            SupportedUsbModemInfo usbModemInfo = SupportedUsbModemsInfo.getModem((UsbModemDevice) device);
+            if (usbModemInfo != null) {
+                modemTechnologyTypes = usbModemInfo.getTechnologyTypes();
+            } else {
+                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, "No usbModemInfo available");
+            }
+        } else if (device instanceof SerialModemDevice) {
+            SupportedSerialModemInfo serialModemInfo = SupportedSerialModemsInfo.getModem();
+            if (serialModemInfo != null) {
+                modemTechnologyTypes = serialModemInfo.getTechnologyTypes();
+            } else {
+                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, "No serialModemInfo available");
+            }
+        } else {
+            throw new KuraException(KuraErrorCode.INTERNAL_ERROR, "Unsupported modem device");
+        }
+        return modemTechnologyTypes;
+    }
+
+    @Override
+    @Deprecated
+    public ModemTechnologyType getTechnologyType() {
+        ModemTechnologyType modemTechnologyType = null;
+        try {
+            List<ModemTechnologyType> modemTechnologyTypes = getTechnologyTypes();
+            if (modemTechnologyTypes != null && modemTechnologyTypes.size() > 0) {
+                modemTechnologyType = modemTechnologyTypes.get(0);
+            }
+        } catch (KuraException e) {
+            s_logger.error("Failed to obtain modem technology - {}", e);
+        }
+        return modemTechnologyType;
+    }
+    
+    @Override
+    public boolean isGpsSupported() throws KuraException {
+        return false; // Will be activated later
+    }
+
+    @Override
+    public void enableGps() throws KuraException {
+        s_logger.warn("Modem GPS not supported");
+    }
+
+    @Override
+    public void disableGps() throws KuraException {
+        s_logger.warn("Modem GPS not supported");
+    }
+
+
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25AtCommands.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.ec25;
+
+/**
+ * Defines AT commands for the Telit HE910 modem.
+ *
+ * @author ilya.binshtok
+ *
+ */
+public enum QuectelEC25AtCommands {
+
+    getSimStatus("AT+QSIMSTAT?\r\n"),
+    getSimPinStatus("at+cpin?\r\n"),
+    setAutoSimDetection("at+qsimdet=1,0\r\nat+qsimstat=1"),
+    getSmsc("at+csca?\r\n"),
+    getMobileStationClass("at+cgclass?\r\n"),
+    getRegistrationStatus("at+cgreg?\r\n"),
+    getGprsSessionDataVolume("at+QGDCNT?\r\n"),
+    pdpContext("AT+CGDCONT");
+
+    private String m_command;
+
+    private QuectelEC25AtCommands(String atCommand) {
+        this.m_command = atCommand;
+    }
+
+    public String getCommand() {
+        return this.m_command;
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25AtCommands.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2019 Sterwen-Technology
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -8,13 +8,13 @@
  *
  * Contributors:
  *     Eurotech
+ *     Sterwen-Technology
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem.quectel.ec25;
 
 /**
- * Defines AT commands for the Telit HE910 modem.
+ * Defines AT commands for the Quectel EC25 modem.
  *
- * @author ilya.binshtok
  *
  */
 public enum QuectelEC25AtCommands {
@@ -28,13 +28,13 @@ public enum QuectelEC25AtCommands {
     getGprsSessionDataVolume("at+QGDCNT?\r\n"),
     pdpContext("AT+CGDCONT");
 
-    private String m_command;
+    private String command;
 
     private QuectelEC25AtCommands(String atCommand) {
-        this.m_command = atCommand;
+        this.command = atCommand;
     }
 
     public String getCommand() {
-        return this.m_command;
+        return this.command;
     }
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ConfigGenerator.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.ec25;
+
+import org.eclipse.kura.net.admin.modem.ModemPppConfigGenerator;
+import org.eclipse.kura.net.admin.modem.PppPeer;
+import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangePair;
+import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangeScript;
+import org.eclipse.kura.net.modem.ModemConfig;
+import org.eclipse.kura.net.modem.ModemConfig.PdpType;
+
+public class QuectelEC25ConfigGenerator implements ModemPppConfigGenerator {
+
+    @Override
+    public PppPeer getPppPeer(String deviceId, ModemConfig modemConfig, String logFile, String connectScript,
+            String disconnectScript) {
+
+        PppPeer pppPeer = new PppPeer();
+
+        // default values
+        pppPeer.setBaudRate(115200);
+        pppPeer.setEnableDebug(true);
+        pppPeer.setUseModemControlLines(true);
+        pppPeer.setUseRtsCtsFlowControl(false);
+        pppPeer.setLockSerialDevice(true);
+        pppPeer.setPeerMustAuthenticateItself(false);
+        pppPeer.setPeerToSupplyLocalIP(true);
+        pppPeer.setAddDefaultRoute(true);
+        pppPeer.setUsePeerDns(true);
+        pppPeer.setAllowProxyArps(false);
+        pppPeer.setAllowVanJacobsonTcpIpHdrCompression(false);
+        pppPeer.setAllowVanJacobsonConnectionIDCompression(false);
+        pppPeer.setAllowBsdCompression(false);
+        pppPeer.setAllowDeflateCompression(false);
+        pppPeer.setAllowMagic(false);
+        pppPeer.setConnectDelay(1000);
+        pppPeer.setLcpEchoInterval(0);
+
+        // other config
+        pppPeer.setLogfile(logFile);
+        pppPeer.setProvider(deviceId);
+        pppPeer.setPppUnitNumber(modemConfig.getPppNumber());
+        pppPeer.setConnectScript(connectScript);
+        pppPeer.setDisconnectScript(disconnectScript);
+        pppPeer.setApn(modemConfig.getApn());
+        pppPeer.setAuthType(modemConfig.getAuthType());
+        pppPeer.setUsername(modemConfig.getUsername());
+        pppPeer.setPassword(modemConfig.getPasswordAsPassword());
+        pppPeer.setDialString(modemConfig.getDialString());
+        pppPeer.setPersist(modemConfig.isPersist());
+        pppPeer.setMaxFail(modemConfig.getMaxFail());
+        pppPeer.setIdleTime(modemConfig.getIdle());
+        pppPeer.setActiveFilter(modemConfig.getActiveFilter());
+        pppPeer.setLcpEchoInterval(modemConfig.getLcpEchoInterval());
+        pppPeer.setLcpEchoFailure(modemConfig.getLcpEchoFailure());
+
+        return pppPeer;
+    }
+
+    @Override
+    public ModemXchangeScript getConnectScript(ModemConfig modemConfig) {
+        int pdpPid = 1;
+        String apn = "";
+        String dialString = "";
+
+        if (modemConfig != null) {
+            apn = modemConfig.getApn();
+            dialString = modemConfig.getDialString();
+        }
+
+        ModemXchangeScript modemXchange = new ModemXchangeScript();
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"ERROR\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ath\"", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"AT\"", "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formPDPcontext(pdpPid, PdpType.IP, apn), "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\d\\d\\d\"", "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formDialString(dialString), "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\c\"", "CONNECT"));
+
+        return modemXchange;
+    }
+
+    @Override
+    public ModemXchangeScript getDisconnectScript(ModemConfig modemConfig) {
+
+        ModemXchangeScript modemXchange = new ModemXchangeScript();
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("BREAK", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ATH\"", "\"\""));
+
+        return modemXchange;
+    }
+
+    /*
+     * This method forms dial string
+     */
+    private String formDialString(String dialString) {
+        StringBuffer buf = new StringBuffer();
+        buf.append('"');
+        if (dialString != null) {
+            buf.append(dialString);
+        }
+        buf.append('"');
+        return buf.toString();
+    }
+
+    /*
+     * This method forms PDP context
+     * (e.g. AT+CGDCONT=<pid>,<pdp_type>,<apn>)
+     */
+    private String formPDPcontext(int pdpPid, PdpType pdpType, String apn) {
+
+        StringBuffer pdpcontext = new StringBuffer(QuectelEC25AtCommands.pdpContext.getCommand());
+        pdpcontext.append('=');
+        pdpcontext.append(pdpPid);
+        pdpcontext.append(',');
+        pdpcontext.append('"');
+        pdpcontext.append(pdpType.toString());
+        pdpcontext.append('"');
+        pdpcontext.append(',');
+        pdpcontext.append('"');
+        if (apn != null) {
+            pdpcontext.append(apn);
+        }
+        pdpcontext.append('"');
+
+        return pdpcontext.toString();
+    }
+
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ConfigGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2019 Sterwen-Technology
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,7 +7,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Eurotech
+ *     Eurotech, Sterwen-Technology
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem.quectel.ec25;
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ModemFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ModemFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ * Copyright (c) 2019 Sterwen Technology
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -26,12 +26,11 @@ import org.osgi.util.tracker.ServiceTracker;
 /**
  * Defines Quectel EC25 Modem Factory
  *
- * @author ilya.binshtok
  *
  */
 public class QuectelEC25ModemFactory implements CellularModemFactory {
 
-    // private static final Logger s_logger = LoggerFactory.getLogger(TelitHe910ModemFactory.class);
+    private static final Logger logger = LoggerFactory.getLogger(TelitHe910ModemFactory.class);
 
     private static QuectelEC25ModemFactory s_factoryInstance = null;
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ModemFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ModemFactory.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.ec25;
+
+import java.util.Hashtable;
+
+import org.eclipse.kura.net.admin.NetworkConfigurationService;
+import org.eclipse.kura.net.admin.modem.CellularModemFactory;
+import org.eclipse.kura.net.modem.CellularModem;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.io.ConnectionFactory;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * Defines Quectel EC25 Modem Factory
+ *
+ * @author ilya.binshtok
+ *
+ */
+public class QuectelEC25ModemFactory implements CellularModemFactory {
+
+    // private static final Logger s_logger = LoggerFactory.getLogger(TelitHe910ModemFactory.class);
+
+    private static QuectelEC25ModemFactory s_factoryInstance = null;
+
+    private static ModemTechnologyType s_type = ModemTechnologyType.HSDPA;
+
+    private BundleContext s_bundleContext = null;
+    private Hashtable<String, QuectelEC25> m_modemServices = null;
+
+    private ConnectionFactory m_connectionFactory = null;
+
+    private QuectelEC25ModemFactory() {
+        this.s_bundleContext = FrameworkUtil.getBundle(NetworkConfigurationService.class).getBundleContext();
+
+        ServiceTracker<ConnectionFactory, ConnectionFactory> serviceTracker = new ServiceTracker<ConnectionFactory, ConnectionFactory>(
+                this.s_bundleContext, ConnectionFactory.class, null);
+        serviceTracker.open(true);
+        this.m_connectionFactory = serviceTracker.getService();
+
+        this.m_modemServices = new Hashtable<String, QuectelEC25>();
+    }
+
+    public static QuectelEC25ModemFactory getInstance() {
+        if (s_factoryInstance == null) {
+            s_factoryInstance = new QuectelEC25ModemFactory();
+        }
+        return s_factoryInstance;
+    }
+
+    @Override
+    public CellularModem obtainCellularModemService(ModemDevice modemDevice, String platform) throws Exception {
+
+        String key = modemDevice.getProductName();
+        QuectelEC25 quectelEc25 = this.m_modemServices.get(key);
+
+        if (quectelEc25 == null) {
+            quectelEc25 = new QuectelEC25(modemDevice, platform, this.m_connectionFactory);
+            this.m_modemServices.put(key, quectelEc25);
+        } else {
+            quectelEc25.setModemDevice(modemDevice);
+        }
+
+        return quectelEc25;
+    }
+
+    @Override
+    public Hashtable<String, ? extends CellularModem> getModemServices() {
+        return this.m_modemServices;
+    }
+
+    @Override
+    public void releaseModemService(String usbPortAddress) {
+        this.m_modemServices.remove(usbPortAddress);
+    }
+
+    @Override
+    @Deprecated
+    public ModemTechnologyType getType() {
+        return s_type;
+    }
+}


### PR DESCRIPTION
Adding the support of Quectel USB modems. Only the models EC25 (LTE class 4) and BG96 (CAT-M/NB-IOT) are introduced

**Related Issue:** This PR closes issue #2598

**Description of the solution adopted:** Support for the Quectel modems added in 
1 - org.eclipse.kura.linux.net
2 - org.eclipse.kura.net.admin


**Any side note on the changes made:**  Nothing
