### PR TITLE
Updated DataService rate limit metatype message

### DIFF
--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -139,7 +139,7 @@
             required="true"
             default="1"
             min="1"
-            description="The average message publish rate in number of messages per unit of time (e.g. 10 messages per MINUTE). The maximum rate is 1000 messages per SECOND."/>
+            description="The average message publish rate in number of messages per unit of time (e.g. 10 messages per MINUTE). This parameter has some limitations described in http://eclipse.github.io/kura/config/data-service-configuration.html"/>
         
         <AD id="rate.limit.time.unit"
             name="Rate Limit Time Unit"

--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -139,7 +139,7 @@
             required="true"
             default="1"
             min="1"
-            description="The average message publish rate in number of messages per unit of time. (e.g. 10 messages per MINUTE)"/>
+            description="The average message publish rate in number of messages per unit of time (e.g. 10 messages per MINUTE). The maximum rate is 1000 messages per SECOND."/>
         
         <AD id="rate.limit.time.unit"
             name="Rate Limit Time Unit"

--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
This PR updates the DataService metatype. It adds the maximum rate limit value to the `Rate Limit Average` property.

**Related Issue:** This PR fixes/closes #2553 

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>