### PR TITLE
Added note in data service doc

### DIFF
--- a/_posts/config/2017-05-10-data-service-configuration.md
+++ b/_posts/config/2017-05-10-data-service-configuration.md
@@ -43,6 +43,13 @@ The DataService offers methods and configuration options to manage the connectio
 - **enable.rate.limit** - Enables the token bucket message rate limiting.
 
 - **rate.limit.average** - The average message publishing rate. It is intended as the number of messages per unit of time.
+  
+{% include alerts.html message="The maximum allowed message rate is **1 message per millisecond**, so the following limitations are applied:
+
+- 86400000 per DAY
+- 3600000 per HOUR
+- 60000 messages per MINUTE
+- 1000 messages per SECOND" %}
 
 - **rate.limit.time.unit** - The time unit for the rate.limit.average.
 


### PR DESCRIPTION
This PR adds a note in the rate limit documentation, presenting the parameter limitations.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>