### PR TITLE
Pid and ExitStatus refactor

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/executor/ExitStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/executor/ExitStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,7 +14,7 @@ package org.eclipse.kura.executor;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * This interface provides a method to retrieve the exit status of a system commands.
+ * This interface provides a method to retrieve the exit status of a system command.
  *
  * @noimplement This interface is not intended to be implemented by clients.
  */
@@ -22,10 +22,17 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface ExitStatus {
 
     /**
-     * Return a value representing the exit status of a command or process
+     * Returns a value representing the exit status of a command or process
      * 
-     * @return an object that represents the exit status
+     * @return an integer that represents the exit code
      */
-    public Object getExitValue();
+    public int getExitCode();
+
+    /**
+     * Returns if a command or process is successful
+     * 
+     * @return a boolean that is true if the command is successful, false otherwise
+     */
+    public boolean isSuccessful();
 
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/executor/Pid.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/executor/Pid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,6 @@ package org.eclipse.kura.executor;
 
 public interface Pid {
 
-    public Object getPid();
+    public int getPid();
 
 }

--- a/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/util/BluetoothProcess.java
+++ b/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/util/BluetoothProcess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -66,7 +66,7 @@ public class BluetoothProcess {
             logger.debug("Executing: {}", Arrays.toString(cmdArray));
         }
         Consumer<CommandStatus> callback = status -> logger.debug("Command ended with exit value {}",
-                status.getExitStatus().getExitValue());
+                status.getExitStatus().getExitCode());
         Command command = new Command(cmdArray);
         command.setOutputStream(this.outputStream);
         command.setErrorStream(this.errorStream);
@@ -103,7 +103,7 @@ public class BluetoothProcess {
             logger.debug("Executing: {}", Arrays.toString(cmdArray));
         }
         Consumer<CommandStatus> callback = status -> logger.debug("Command ended with exit value {}",
-                status.getExitStatus().getExitValue());
+                status.getExitStatus().getExitCode());
         Command command = new Command(cmdArray);
         command.setOutputStream(this.outputStream);
         command.setErrorStream(this.errorStream);

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/cloud/app/command/CommandCloudApp.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/cloud/app/command/CommandCloudApp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -254,7 +254,7 @@ public class CommandCloudApp implements ConfigurableComponent, PasswordCommandSe
                 ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
                 CommandStatus stats = executeProcessSync(defaultDir, cmdArray, environment, timeout, outputStream,
                         errorStream);
-                if (stats.getExitStatus() != null && (Integer) stats.getExitStatus().getExitValue() == 0) {
+                if (stats.getExitStatus() != null && stats.getExitStatus().isSuccessful()) {
                     return new String(((ByteArrayOutputStream) stats.getOutputStream()).toByteArray(), Charsets.UTF_8);
                 } else {
                     return new String(((ByteArrayOutputStream) stats.getErrorStream()).toByteArray(), Charsets.UTF_8);
@@ -398,9 +398,9 @@ public class CommandCloudApp implements ConfigurableComponent, PasswordCommandSe
         if (status.isTimedout()) {
             resp.setTimedout(true);
         } else {
-            resp.setExitCode((Integer) status.getExitStatus().getExitValue());
+            resp.setExitCode(status.getExitStatus().getExitCode());
             resp.setTimedout(false);
-            if ((Integer) status.getExitStatus().getExitValue() != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 resp.setResponseCode(KuraResponsePayload.RESPONSE_CODE_ERROR);
                 resp.setExceptionMessage(new String(err.toByteArray(), Charsets.UTF_8));
             }

--- a/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/install/InstallImpl.java
+++ b/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/install/InstallImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -162,12 +162,12 @@ public class InstallImpl {
         Command command = new Command(new String[] { "chmod", "700", shFilePath });
         command.setTimeout(60);
         status = this.executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             throw new KuraProcessExecutionErrorException("Failed to change file mode");
         }
 
         status = this.executorService.execute(new Command(new String[] { shFilePath }));
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             throw new KuraProcessExecutionErrorException("Failed to execute script");
         }
 
@@ -239,14 +239,14 @@ public class InstallImpl {
         Command command = new Command(new String[] { "chmod", "700", fileEntryPath });
         command.setTimeout(60);
         status = this.executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             logger.error("Failed to change file mode");
         }
 
         String[] commandLine = { fileEntryPath };
         try {
             status = this.executorService.execute(new Command(commandLine));
-            if ((Integer) status.getExitStatus().getExitValue() == 0) {
+            if (status.getExitStatus().isSuccessful()) {
                 sendSysUpdateSuccess(fileEntry.getName(), notificationPublisher);
             } else {
                 sendSysUpdateFailure(fileEntry.getName(), notificationPublisher);

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/linux/executor/ExecutorUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/linux/executor/ExecutorUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,7 +33,7 @@ import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.exec.environment.EnvironmentUtils;
 import org.apache.commons.io.output.NullOutputStream;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.linux.executor.LinuxPid;
 import org.eclipse.kura.core.linux.executor.LinuxResultHandler;
 import org.eclipse.kura.core.linux.executor.LinuxSignal;
@@ -92,7 +92,7 @@ public class ExecutorUtil {
             killCommand.setTimeout(60);
             killCommand.setSignal(signal);
             CommandStatus commandStatus = executeUnprivileged(killCommand);
-            isStopped = (Integer) commandStatus.getExitStatus().getExitValue() == 0;
+            isStopped = commandStatus.getExitStatus().isSuccessful();
         }
         return isStopped;
     }
@@ -113,7 +113,7 @@ public class ExecutorUtil {
             killCommand.setTimeout(60);
             killCommand.setSignal(signal);
             CommandStatus commandStatus = executePrivileged(killCommand);
-            isStopped = (Integer) commandStatus.getExitStatus().getExitValue() == 0;
+            isStopped = commandStatus.getExitStatus().isSuccessful();
         }
         return isStopped;
     }
@@ -210,7 +210,7 @@ public class ExecutorUtil {
     }
 
     private static CommandStatus executeSync(Command command, CommandLine commandLine) {
-        CommandStatus commandStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus commandStatus = new CommandStatus(new LinuxExitStatus(0));
         commandStatus.setOutputStream(command.getOutputStream());
         commandStatus.setErrorStream(command.getErrorStream());
         commandStatus.setInputStream(command.getInputStream());
@@ -235,7 +235,7 @@ public class ExecutorUtil {
             exitStatus = 1;
             logger.error(COMMAND_MESSAGE + " {} failed", commandLine, e);
         } finally {
-            commandStatus.setExitStatus(new LinuxExitValue(exitStatus));
+            commandStatus.setExitStatus(new LinuxExitStatus(exitStatus));
             commandStatus.setTimedout(executor.getWatchdog().killedProcess());
         }
 
@@ -271,7 +271,7 @@ public class ExecutorUtil {
     }
 
     private static void executeAsync(Command command, CommandLine commandLine, Consumer<CommandStatus> callback) {
-        CommandStatus commandStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus commandStatus = new CommandStatus(new LinuxExitStatus(0));
         commandStatus.setOutputStream(command.getOutputStream());
         commandStatus.setErrorStream(command.getErrorStream());
         commandStatus.setInputStream(command.getInputStream());
@@ -292,7 +292,7 @@ public class ExecutorUtil {
                 executor.execute(commandLine, resultHandler);
             }
         } catch (IOException e) {
-            commandStatus.setExitStatus(new LinuxExitValue(1));
+            commandStatus.setExitStatus(new LinuxExitStatus(1));
             logger.error(COMMAND_MESSAGE + commandLine + " failed", e);
         }
     }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/LinuxExitStatus.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/LinuxExitStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,17 +13,22 @@ package org.eclipse.kura.core.linux.executor;
 
 import org.eclipse.kura.executor.ExitStatus;
 
-public class LinuxExitValue implements ExitStatus {
+public class LinuxExitStatus implements ExitStatus {
 
-    private Integer exitValue;
+    private int exitValue;
 
-    public LinuxExitValue(int exitStatus) {
+    public LinuxExitStatus(int exitStatus) {
         this.exitValue = exitStatus;
     }
 
     @Override
-    public Object getExitValue() {
+    public int getExitCode() {
         return this.exitValue;
+    }
+
+    @Override
+    public boolean isSuccessful() {
+        return this.exitValue == 0;
     }
 
     @Override
@@ -35,7 +40,7 @@ public class LinuxExitValue implements ExitStatus {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((exitValue == null) ? 0 : exitValue.hashCode());
+        result = prime * result + exitValue;
         return result;
     }
 
@@ -47,13 +52,8 @@ public class LinuxExitValue implements ExitStatus {
             return false;
         if (getClass() != obj.getClass())
             return false;
-        LinuxExitValue other = (LinuxExitValue) obj;
-        if (exitValue == null) {
-            if (other.exitValue != null)
-                return false;
-        } else if (!exitValue.equals(other.exitValue))
-            return false;
-        return true;
+        LinuxExitStatus other = (LinuxExitStatus) obj;
+        return this.exitValue == other.exitValue;
     }
 
 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/LinuxPid.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/LinuxPid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,14 +15,14 @@ import org.eclipse.kura.executor.Pid;
 
 public class LinuxPid implements Pid {
 
-    private Integer pid;
+    private int pid;
 
     public LinuxPid(int pid) {
         this.pid = pid;
     }
 
     @Override
-    public Object getPid() {
+    public int getPid() {
         return this.pid;
     }
 
@@ -35,7 +35,7 @@ public class LinuxPid implements Pid {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((pid == null) ? 0 : pid.hashCode());
+        result = prime * result + pid;
         return result;
     }
 
@@ -48,12 +48,7 @@ public class LinuxPid implements Pid {
         if (getClass() != obj.getClass())
             return false;
         LinuxPid other = (LinuxPid) obj;
-        if (pid == null) {
-            if (other.pid != null)
-                return false;
-        } else if (!pid.equals(other.pid))
-            return false;
-        return true;
+        return this.pid != other.pid;
     }
 
 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/LinuxResultHandler.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/LinuxResultHandler.java
@@ -38,13 +38,13 @@ public class LinuxResultHandler implements ExecuteResultHandler {
 
     @Override
     public void onProcessComplete(int exitValue) {
-        this.commandStatus.setExitStatus(new LinuxExitValue(exitValue));
+        this.commandStatus.setExitStatus(new LinuxExitStatus(exitValue));
         this.callback.accept(this.commandStatus);
     }
 
     @Override
     public void onProcessFailed(ExecuteException e) {
-        this.commandStatus.setExitStatus(new LinuxExitValue(e.getExitValue()));
+        this.commandStatus.setExitStatus(new LinuxExitStatus(e.getExitValue()));
         // The PrivilegedExecutorService kills a command with SIGTERM and exits with 143 when timedout; the
         // UnprivilegedExecutorService uses timeout command that exits with 124.
         if (e.getExitValue() == TIMEOUT_EXIT_VALUE || e.getExitValue() == SIGTERM_EXIT_VALUE) {

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/privileged/PrivilegedExecutorServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/privileged/PrivilegedExecutorServiceImpl.java
@@ -18,7 +18,7 @@ import java.util.function.Consumer;
 
 import org.apache.commons.io.Charsets;
 import org.eclipse.kura.core.internal.linux.executor.ExecutorUtil;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.linux.executor.LinuxSignal;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandStatus;
@@ -107,7 +107,7 @@ public class PrivilegedExecutorServiceImpl implements PrivilegedExecutorService 
     }
 
     private CommandStatus buildErrorStatus() {
-        CommandStatus status = new CommandStatus(new LinuxExitValue(1));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
         ByteArrayOutputStream err = new ByteArrayOutputStream();
         try {
             err.write("The commandLine cannot be empty or not defined".getBytes(Charsets.UTF_8));

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/unprivileged/UnprivilegedExecutorServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/unprivileged/UnprivilegedExecutorServiceImpl.java
@@ -19,7 +19,7 @@ import java.util.function.Consumer;
 import org.apache.commons.io.Charsets;
 import org.eclipse.kura.configuration.ConfigurableComponent;
 import org.eclipse.kura.core.internal.linux.executor.ExecutorUtil;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.linux.executor.LinuxSignal;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandStatus;
@@ -119,7 +119,7 @@ public class UnprivilegedExecutorServiceImpl implements UnprivilegedExecutorServ
     }
 
     private CommandStatus buildErrorStatus() {
-        CommandStatus status = new CommandStatus(new LinuxExitValue(1));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
         ByteArrayOutputStream err = new ByteArrayOutputStream();
         try {
             err.write("The commandLine cannot be empty or not defined".getBytes(Charsets.UTF_8));

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/system/SuperSystemService.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/system/SuperSystemService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
@@ -32,7 +32,7 @@ public class SuperSystemService {
         command.setOutputStream(new ByteArrayOutputStream());
         command.setExecuteInAShell(runInShell);
         CommandStatus status = executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             response = new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8);
         } else {
             if (logger.isErrorEnabled()) {

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/system/SystemAdminServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/system/SystemAdminServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -193,7 +193,7 @@ public class SystemAdminServiceImpl extends SuperSystemService implements System
         Command command = new Command(cmd);
         command.setTimeout(60);
         CommandStatus status = this.executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (status.getExitStatus().isSuccessful()) {
             logger.error("failed to issue {} command", cmd[0]);
         }
     }

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -77,7 +77,7 @@ public class BluetoothProcess {
             logger.debug("Executing: {}", Arrays.toString(cmdArray));
         }
         Consumer<CommandStatus> callback = status -> logger.debug("Command ended with exit value {}",
-                status.getExitStatus().getExitValue());
+                status.getExitStatus().getExitCode());
         Command command = new Command(cmdArray);
         command.setOutputStream(this.outputStream);
         command.setErrorStream(this.errorStream);
@@ -115,7 +115,7 @@ public class BluetoothProcess {
             logger.debug("Executing: {}", Arrays.toString(cmdArray));
         }
         Consumer<CommandStatus> callback = status -> logger.debug("Command ended with exit value {}",
-                status.getExitStatus().getExitValue());
+                status.getExitStatus().getExitCode());
         Command command = new Command(cmdArray);
         command.setOutputStream(this.outputStream);
         command.setErrorStream(this.errorStream);

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -90,7 +90,7 @@ public class BluetoothUtil {
         command.setOutputStream(outputStream);
         command.setErrorStream(errorStream);
         CommandStatus status = executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             // Check Input stream
             String[] outputLines = new String(outputStream.toByteArray(), Charsets.UTF_8).split("\n");
             // TODO: Pull more parameters from hciconfig?
@@ -152,7 +152,7 @@ public class BluetoothUtil {
         command.setOutputStream(outputStream);
         command.setErrorStream(errorStream);
         CommandStatus status = executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             String[] outputLines = new String(outputStream.toByteArray(), Charsets.UTF_8).split("\n");
             for (String line : outputLines) {
                 if (line.contains("UP")) {
@@ -183,7 +183,7 @@ public class BluetoothUtil {
         command.setOutputStream(outputStream);
         command.setErrorStream(errorStream);
         CommandStatus status = executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             outputString = new String(outputStream.toByteArray(), Charsets.UTF_8);
         } else {
             if (logger.isErrorEnabled()) {

--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ClockServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ClockServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and others
+ * Copyright (c) 2011, 2020 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -190,14 +190,13 @@ public class ClockServiceImpl implements ConfigurableComponent, ClockService, Cl
             Command command = new Command(new String[] { "date", "-s", "@" + Long.toString(time / 1000) });
             command.setTimeout(60);
             CommandStatus status = this.executorService.execute(command);
-            final int rc = (Integer) status.getExitStatus().getExitValue();
-            if (rc == 0) {
+            if (status.getExitStatus().isSuccessful()) {
                 bClockUpToDate = true;
                 logger.info("System Clock Updated to {}", new Date());
             } else {
                 logger.error(
                         "Unexpected error while updating System Clock - rc = {}, CommandLine:{}, it should've been {}",
-                        rc, command.getCommandLine(), new Date());
+                        status.getExitStatus().getExitCode(), command.getCommandLine(), new Date());
             }
         } else {
             bClockUpToDate = true;
@@ -212,11 +211,11 @@ public class ClockServiceImpl implements ConfigurableComponent, ClockService, Cl
             Command command = new Command(new String[] { "hwclock", "--utc", "--systohc" });
             command.setTimeout(60);
             CommandStatus status = this.executorService.execute(command);
-            final int rc = (Integer) status.getExitStatus().getExitValue();
-            if (rc == 0) {
+            if (status.getExitStatus().isSuccessful()) {
                 logger.info("Hardware Clock Updated");
             } else {
-                logger.error("Unexpected error while updating Hardware Clock - rc = {}", rc);
+                logger.error("Unexpected error while updating Hardware Clock - rc = {}",
+                        status.getExitStatus().getExitCode());
             }
         }
 

--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/NtpdClockSyncProvider.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/NtpdClockSyncProvider.java
@@ -46,7 +46,7 @@ public class NtpdClockSyncProvider extends AbstractNtpClockSyncProvider {
             Command command = new Command(new String[] { "ntpdate", "-t", Integer.toString(ntpTimeout), this.ntpHost });
             command.setTimeout(60);
             CommandStatus status = this.executorService.execute(command);
-            if ((Integer) status.getExitStatus().getExitValue() == 0) {
+            if (status.getExitStatus().isSuccessful()) {
                 logger.info("System Clock Synchronized with {}", this.ntpHost);
                 this.lastSync = new Date();
 

--- a/kura/org.eclipse.kura.linux.command/src/main/java/org/eclipse/kura/linux/command/CommandServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.command/src/main/java/org/eclipse/kura/linux/command/CommandServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -82,7 +82,7 @@ public class CommandServiceImpl implements CommandService {
         command.setOutputStream(new ByteArrayOutputStream());
         command.setErrorStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             return new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8);
         } else {
             return new String(((ByteArrayOutputStream) status.getErrorStream()).toByteArray(), Charsets.UTF_8);

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpClientManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -59,7 +59,7 @@ public class DhcpClientManager {
         }
         logger.info("enable() :: Starting DHCP client for {}", interfaceName);
         CommandStatus status = this.executorService.execute(new Command(formCommand(interfaceName, true, true, true)));
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             throw new KuraProcessExecutionErrorException("Failed to start dhcp client on interface " + interfaceName);
         }
     }
@@ -83,7 +83,7 @@ public class DhcpClientManager {
         Command command = new Command(formReleaseCurrentLeaseCommand(interfaceName));
         command.setTimeout(60);
         CommandStatus status = this.executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             throw new KuraProcessExecutionErrorException("Failed to release current lease");
         }
     }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerImpl.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -181,7 +181,7 @@ public class DhcpServerImpl implements DhcpServer {
         }
         // Start dhcpd
         CommandStatus status = this.executorService.execute(new Command(formDhcpdCommand()));
-        if ((Integer) status.getExitStatus().getExitValue() == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             logger.debug("DHCP server started.");
             logger.trace(this.dhcpServerConfig4.toString());
             return true;

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -72,7 +72,7 @@ public class DhcpServerManager {
         if (configFile.exists()) {
             CommandStatus status = this.executorService
                     .execute(new Command(DhcpServerManager.formDhcpdCommand(interfaceName)));
-            if ((Integer) status.getExitStatus().getExitValue() == 0) {
+            if (status.getExitStatus().isSuccessful()) {
                 logger.debug("DHCP server started.");
                 return true;
             } else {

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxDns.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxDns.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -211,7 +211,7 @@ public class LinuxDns {
             Command command = new Command(new String[] { "mv", DNS_FILE_NAME, BACKUP_DNS_FILE_NAME });
             command.setTimeout(COMMAND_TIMEOUT);
             CommandStatus status = executorService.execute(command);
-            if ((Integer) status.getExitStatus().getExitValue() != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 logger.error("Failed to move the {} file to {}. The 'mv' command has failed ...", DNS_FILE_NAME,
                         BACKUP_DNS_FILE_NAME);
                 throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, "Failed to backup DNS file " + DNS_FILE_NAME);
@@ -225,7 +225,7 @@ public class LinuxDns {
         Command command = new Command(new String[] { "ln", "-sf", sPppDnsFileName, DNS_FILE_NAME });
         command.setTimeout(COMMAND_TIMEOUT);
         CommandStatus status = executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             logger.error("failed to create symbolic link: {} -> {}", DNS_FILE_NAME, sPppDnsFileName);
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR,
                     "failed to create symbolic link to " + sPppDnsFileName);
@@ -240,7 +240,7 @@ public class LinuxDns {
             Command command = new Command(new String[] { "rm", DNS_FILE_NAME });
             command.setTimeout(COMMAND_TIMEOUT);
             CommandStatus status = executorService.execute(command);
-            if ((Integer) status.getExitStatus().getExitValue() != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 logger.error("failed to delete {} symlink that points to {}", DNS_FILE_NAME, pppDnsFilename);
                 throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR,
                         "failed to delete " + DNS_FILE_NAME + " symlink that points to " + pppDnsFilename);
@@ -263,7 +263,7 @@ public class LinuxDns {
         Command command = new Command(new String[] { "mv", BACKUP_DNS_FILE_NAME, DNS_FILE_NAME });
         command.setTimeout(COMMAND_TIMEOUT);
         CommandStatus status = executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             logger.error("failed to restore {} to {}", BACKUP_DNS_FILE_NAME, DNS_FILE_NAME);
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR,
                     "failed to restore " + BACKUP_DNS_FILE_NAME + " to " + DNS_FILE_NAME);
@@ -276,7 +276,7 @@ public class LinuxDns {
         Command command = new Command(new String[] { "touch", DNS_FILE_NAME });
         command.setTimeout(COMMAND_TIMEOUT);
         CommandStatus status = executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             logger.error("failed to create empty {}", DNS_FILE_NAME);
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, "failed to create empty " + DNS_FILE_NAME);
         } else {

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxDnsServer.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxDnsServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and others
+ * Copyright (c) 2019, 2020 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -165,7 +165,7 @@ public abstract class LinuxDnsServer {
         }
         // Start named
         CommandStatus status = this.executorService.execute(new Command(getDnsStartCommand()));
-        if ((Integer) status.getExitStatus().getExitValue() == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             logger.debug("DNS server started.");
             logger.trace("{}", this.dnsServerConfigIP4);
         } else {
@@ -176,7 +176,7 @@ public abstract class LinuxDnsServer {
     public void stop() throws KuraException {
         // Stop named
         CommandStatus status = this.executorService.execute(new Command(getDnsStopCommand()));
-        if ((Integer) status.getExitStatus().getExitValue() == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             logger.debug("DNS server stopped.");
             logger.trace("{}", this.dnsServerConfigIP4);
         } else {
@@ -188,7 +188,7 @@ public abstract class LinuxDnsServer {
     public void restart() throws KuraException {
         // Restart named
         CommandStatus status = this.executorService.execute(new Command(getDnsRestartCommand()));
-        if ((Integer) status.getExitStatus().getExitValue() == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             logger.debug("DNS server restarted.");
         } else {
             logger.debug("tried to kill DNS server for interface but it is not running");

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfig.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -134,7 +134,7 @@ public class IptablesConfig {
         if (this.executorService != null) {
             CommandStatus status = execute(new String[] { "iptables-save" });
             iptablesSave((ByteArrayOutputStream) status.getOutputStream());
-            exitValue = (Integer) status.getExitStatus().getExitValue();
+            exitValue = status.getExitStatus().getExitCode();
         } else {
             logger.error(COMMAND_EXECUTOR_SERVICE_MESSAGE);
             throw new IllegalArgumentException(COMMAND_EXECUTOR_SERVICE_MESSAGE);
@@ -158,7 +158,7 @@ public class IptablesConfig {
         command.setErrorStream(err);
         command.setOutputStream(out);
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
+        int exitValue = status.getExitStatus().getExitCode();
         if (exitValue != 0) {
             if (logger.isErrorEnabled()) {
                 logger.error("command {} :: failed - {}", command, new String(err.toByteArray(), Charsets.UTF_8));
@@ -177,7 +177,7 @@ public class IptablesConfig {
         try {
             if (this.executorService != null) {
                 CommandStatus status = execute(new String[] { "iptables-restore", filename });
-                exitValue = (Integer) status.getExitStatus().getExitValue();
+                exitValue = status.getExitStatus().getExitCode();
             } else {
                 logger.error(COMMAND_EXECUTOR_SERVICE_MESSAGE);
                 throw new IllegalArgumentException(COMMAND_EXECUTOR_SERVICE_MESSAGE);

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/LinuxFirewall.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/LinuxFirewall.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -482,7 +482,7 @@ public class LinuxFirewall {
             logger.info("Running custom firewall script - {}", CUSTOM_FIREWALL_SCRIPT_NAME);
             Command command = new Command(new String[] { "sh", CUSTOM_FIREWALL_SCRIPT_NAME });
             CommandStatus status = this.executorService.execute(command);
-            if ((Integer) status.getExitStatus().getExitValue() != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 throw new KuraProcessExecutionErrorException("Failed to apply custom firewall script");
             }
         }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModems.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModems.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and others
+ * Copyright (c) 2011, 2020 Eurotech and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -172,7 +172,7 @@ public class SupportedUsbModems {
         command.setOutputStream(new ByteArrayOutputStream());
 
         CommandStatus status = executorService.execute(command);
-        logger.debug("Called {} - rc = {}", commandLine, (Integer) status.getExitStatus().getExitValue());
+        logger.debug("Called {} - rc = {}", commandLine, (Integer) status.getExitStatus().getExitCode());
 
         return IOUtils
                 .readLines(new ByteArrayInputStream(((ByteArrayOutputStream) command.getOutputStream()).toByteArray()));

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/UsbModemDriver.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/UsbModemDriver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -102,6 +102,6 @@ public class UsbModemDriver {
 
     private Integer manageDriver(CommandExecutorService executorService, String command) {
         return (Integer) executorService.execute(new Command(new String[] { command, this.name })).getExitStatus()
-                .getExitValue();
+                .getExitCode();
     }
 }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/ppp/PppLinux.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/ppp/PppLinux.java
@@ -50,7 +50,7 @@ public class PppLinux {
         Command command = new Command(cmd);
         command.setTimeout(60);
         CommandStatus status = this.executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             throw new KuraException(KuraErrorCode.PROCESS_EXECUTION_ERROR, String.join(" ", cmd) + " command failed");
         }
     }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/route/RouteServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/route/RouteServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -55,12 +55,12 @@ public class RouteServiceImpl implements RouteService {
         Command command = new Command(commandLine);
         command.setTimeout(60);
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             if (logger.isErrorEnabled()) {
                 logger.error("Error adding static Route: {}", String.join(" ", commandLine));
             }
-            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", commandLine), exitValue);
+            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", commandLine),
+                    status.getExitStatus().getExitCode());
         }
 
         if (destination instanceof IP4Address) {
@@ -147,7 +147,7 @@ public class RouteServiceImpl implements RouteService {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             if (logger.isErrorEnabled()) {
                 logger.warn(FAILED_TO_EXECUTE_MSG, String.join(" ", commandLine));
             }
@@ -182,12 +182,12 @@ public class RouteServiceImpl implements RouteService {
         Command command = new Command(commandLine);
         command.setTimeout(60);
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             if (logger.isErrorEnabled()) {
                 logger.error("Error removing static route: {}", String.join(" ", commandLine));
             }
-            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", commandLine), exitValue);
+            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", commandLine),
+                    status.getExitStatus().getExitCode());
         }
 
         if (destination instanceof IP4Address) {

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/EthTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/EthTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -66,10 +66,9 @@ public class EthTool implements LinkTool {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        boolean result = (Integer) status.getExitStatus().getExitValue() == 0;
         parse(new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8));
 
-        return result;
+        return status.getExitStatus().isSuccessful();
     }
 
     private void parse(String commandOutput) {

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IpAddrShow.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IpAddrShow.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -66,9 +66,9 @@ public class IpAddrShow {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
-            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, sb.toString(), exitValue);
+        if (!status.getExitStatus().isSuccessful()) {
+            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, sb.toString(),
+                    status.getExitStatus().getExitCode());
         }
         parseExecLink(new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8));
     }
@@ -142,9 +142,9 @@ public class IpAddrShow {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
-            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, sb.toString(), exitValue);
+        if (!status.getExitStatus().isSuccessful()) {
+            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, sb.toString(),
+                    status.getExitStatus().getExitCode());
         }
         parseExecInet(new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8));
     }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwCapabilityTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwCapabilityTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -131,9 +131,9 @@ public class IwCapabilityTool {
         Command command = new Command(commandLine);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = executorService.execute(command);
-        final int exitValue = (Integer) status.getExitStatus().getExitValue();
+        final int exitValue = status.getExitStatus().getExitCode();
 
-        if (exitValue != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             logger.warn("error executing command --- {} --- exit value = {}", commandLine, exitValue);
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, commandLine, exitValue);
         }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwLinkTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwLinkTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -47,9 +47,8 @@ public class IwLinkTool extends LinkToolImpl implements LinkTool {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
-            logger.warn("The iwconfig returned with exit value {}", exitValue);
+        if (!status.getExitStatus().isSuccessful()) {
+            logger.warn("The iwconfig returned with exit value {}", status.getExitStatus().getExitCode());
             return false;
         }
         parse(new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8));

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwScanTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwScanTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -79,7 +79,7 @@ public class IwScanTool extends ScanTool implements IScanTool {
             iwScanCommand.setOutputStream(new ByteArrayOutputStream());
             iwScanCommand.setErrorStream(new ByteArrayOutputStream());
             CommandStatus iwCommandStatus = executorService.execute(iwScanCommand);
-            int exitValue = (Integer) iwCommandStatus.getExitStatus().getExitValue();
+            int exitValue = (Integer) iwCommandStatus.getExitStatus().getExitCode();
             if (logger.isInfoEnabled()) {
                 logger.info("scan() :: {} command returns status = {}", String.join(" ", cmd), exitValue);
             }
@@ -116,7 +116,7 @@ public class IwScanTool extends ScanTool implements IScanTool {
             // activate the interface
             String[] cmdIpLink = { "ip", "link", "set", this.ifaceName, "up" };
             CommandStatus commandStatus = this.executorService.execute(new Command(cmdIpLink));
-            if ((Integer) commandStatus.getExitStatus().getExitValue() != 0) {
+            if (!commandStatus.getExitStatus().isSuccessful()) {
                 throw new KuraException(KuraErrorCode.PROCESS_EXECUTION_ERROR,
                         "Failed to activate interface " + this.ifaceName);
             }
@@ -124,7 +124,7 @@ public class IwScanTool extends ScanTool implements IScanTool {
             // remove the previous ip address (needed on mgw)
             String[] cmdIpAddr = { "ip", "addr", "flush", "dev", this.ifaceName };
             commandStatus = this.executorService.execute(new Command(cmdIpAddr));
-            if ((Integer) commandStatus.getExitStatus().getExitValue() != 0) {
+            if (!commandStatus.getExitStatus().isSuccessful()) {
                 throw new KuraException(KuraErrorCode.PROCESS_EXECUTION_ERROR,
                         "Failed to remove address for interface " + this.ifaceName);
             }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwconfigLinkTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwconfigLinkTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -52,9 +52,8 @@ public class IwconfigLinkTool extends LinkToolImpl implements LinkTool {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
-            logger.warn("The iwconfig returned with exit value {}", exitValue);
+        if (!status.getExitStatus().isSuccessful()) {
+            logger.warn("The iwconfig returned with exit value {}", status.getExitStatus().getExitCode());
             return false;
         }
         parse(new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8));

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwlistCapabilityTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwlistCapabilityTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -47,8 +47,8 @@ public final class IwlistCapabilityTool {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
+        int exitValue = (Integer) status.getExitStatus().getExitCode();
+        if (!status.getExitStatus().isSuccessful()) {
             logger.warn("error executing command --- iwlist --- exit value = {}", exitValue);
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd), exitValue);
         }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwlistScanTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwlistScanTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -74,7 +74,7 @@ public class IwlistScanTool implements IScanTool {
         Command ifconfigCommand = new Command(cmdIfconfig);
         ifconfigCommand.setErrorStream(new ByteArrayOutputStream());
         CommandStatus ifconfigCommandStatus = executorService.execute(ifconfigCommand);
-        if ((Integer) ifconfigCommandStatus.getExitStatus().getExitValue() != 0 && logger.isErrorEnabled()) {
+        if (!ifconfigCommandStatus.getExitStatus().isSuccessful() && logger.isErrorEnabled()) {
             logger.error("failed to execute the {} command {}", String.join(" ", cmdIfconfig), new String(
                     ((ByteArrayOutputStream) ifconfigCommandStatus.getErrorStream()).toByteArray(), Charsets.UTF_8));
         }
@@ -91,11 +91,11 @@ public class IwlistScanTool implements IScanTool {
             iwListCommand.setTimeout(IwlistScanTool.this.timeout);
             iwListCommand.setOutputStream(new ByteArrayOutputStream());
             CommandStatus iwListCommandStatus = executorService.execute(iwListCommand);
-            int exitValue = (Integer) iwListCommandStatus.getExitStatus().getExitValue();
+            int exitValue = iwListCommandStatus.getExitStatus().getExitCode();
             if (logger.isInfoEnabled()) {
                 logger.info("scan() :: {} command returns status = {}", String.join(" ", cmdIwList), exitValue);
             }
-            if (exitValue == 0) {
+            if (iwListCommandStatus.getExitStatus().isSuccessful()) {
                 IwlistScanTool.this.status = true;
                 IwlistScanTool.this.scanOutput = new ByteArrayInputStream(
                         ((ByteArrayOutputStream) iwListCommandStatus.getOutputStream()).toByteArray());

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -97,10 +97,9 @@ public class LinuxNetworkUtil {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             if (logger.isErrorEnabled()) {
-                logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), exitValue);
+                logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), status.getExitStatus().getExitCode());
             }
             throw new KuraException(KuraErrorCode.PROCESS_EXECUTION_ERROR,
                     formFailedCommandMessage(String.join(" ", cmd)));
@@ -399,8 +398,7 @@ public class LinuxNetworkUtil {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue == 0) {
+        if (status.getExitStatus().isSuccessful()) {
             getInterfaceConfigurationInternalParse(ifaceName, linuxIfconfig,
                     new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8));
         } else {
@@ -480,7 +478,7 @@ public class LinuxNetworkUtil {
     public boolean canPing(String ipAddress, int count) {
         String[] cmd = { "ping", "-c", String.valueOf(count), ipAddress };
         CommandStatus status = this.executorService.execute(new Command(cmd));
-        return ((Integer) status.getExitStatus().getExitValue() == 0);
+        return status.getExitStatus().isSuccessful();
     }
 
     /*
@@ -592,10 +590,10 @@ public class LinuxNetworkUtil {
             command.setTimeout(60);
             command.setOutputStream(new ByteArrayOutputStream());
             CommandStatus status = this.executorService.execute(command);
-            int exitValue = (Integer) status.getExitStatus().getExitValue();
-            if (exitValue != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 if (logger.isErrorEnabled()) {
-                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", ethtoolCmd), exitValue);
+                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", ethtoolCmd),
+                            status.getExitStatus().getExitCode());
                 }
                 return driver;
             }
@@ -642,18 +640,16 @@ public class LinuxNetworkUtil {
         CommandStatus status;
         Command command;
         String[] cmd;
-        int exitValue = 0;
         if (toolExists(IW)) {
             cmd = formIwDevIfaceInfoCommand(ifaceName);
             command = new Command(cmd);
             command.setTimeout(60);
             command.setOutputStream(new ByteArrayOutputStream());
             status = this.executorService.execute(command);
-            exitValue = (Integer) status.getExitStatus().getExitValue();
-            if (exitValue != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 // fallback to iwconfig
                 if (logger.isErrorEnabled()) {
-                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), exitValue);
+                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), status.getExitStatus().getExitCode());
                 }
             } else {
                 mode = getWifiModeParseIw(
@@ -667,12 +663,12 @@ public class LinuxNetworkUtil {
             command.setTimeout(60);
             command.setOutputStream(new ByteArrayOutputStream());
             status = this.executorService.execute(command);
-            exitValue = (Integer) status.getExitStatus().getExitValue();
-            if (exitValue != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 if (logger.isErrorEnabled()) {
-                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), exitValue);
+                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), status.getExitStatus().getExitCode());
                 }
-                throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd), exitValue);
+                throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd),
+                        status.getExitStatus().getExitCode());
             }
             // get the output
             mode = getWifiModeParseIwconfig(
@@ -735,7 +731,6 @@ public class LinuxNetworkUtil {
         }
         CommandStatus status;
         Command command;
-        int exitValue = 0;
         String[] cmd;
         if (toolExists(IW)) {
             // start the process
@@ -744,11 +739,10 @@ public class LinuxNetworkUtil {
             command.setTimeout(60);
             command.setOutputStream(new ByteArrayOutputStream());
             status = this.executorService.execute(command);
-            exitValue = (Integer) status.getExitStatus().getExitValue();
-            if (exitValue != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 // fallback to iwconfig
                 if (logger.isErrorEnabled()) {
-                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), exitValue);
+                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), status.getExitStatus().getExitCode());
                 }
             } else {
                 // get the output
@@ -762,12 +756,12 @@ public class LinuxNetworkUtil {
             command.setTimeout(60);
             command.setOutputStream(new ByteArrayOutputStream());
             status = this.executorService.execute(command);
-            exitValue = (Integer) status.getExitStatus().getExitValue();
-            if (exitValue != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 if (logger.isErrorEnabled()) {
-                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), exitValue);
+                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), status.getExitStatus().getExitCode());
                 }
-                throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd), exitValue);
+                throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd),
+                        status.getExitStatus().getExitCode());
             }
 
             // get the output
@@ -833,7 +827,6 @@ public class LinuxNetworkUtil {
 
         CommandStatus status;
         Command command;
-        int exitValue = 0;
         String ssid = null;
         String[] cmd;
         if (toolExists(IW)) {
@@ -843,11 +836,10 @@ public class LinuxNetworkUtil {
             command.setTimeout(60);
             command.setOutputStream(new ByteArrayOutputStream());
             status = this.executorService.execute(command);
-            exitValue = (Integer) status.getExitStatus().getExitValue();
-            if (exitValue != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 // fallback to iwconfig
                 if (logger.isErrorEnabled()) {
-                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), exitValue);
+                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), status.getExitStatus().getExitCode());
                 }
             } else {
                 // get the output
@@ -861,12 +853,12 @@ public class LinuxNetworkUtil {
             command.setTimeout(60);
             command.setOutputStream(new ByteArrayOutputStream());
             status = this.executorService.execute(command);
-            exitValue = (Integer) status.getExitStatus().getExitValue();
-            if (exitValue != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 if (logger.isErrorEnabled()) {
-                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), exitValue);
+                    logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), status.getExitStatus().getExitCode());
                 }
-                throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd), exitValue);
+                throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd),
+                        status.getExitStatus().getExitCode());
             }
 
             // get the output
@@ -954,7 +946,7 @@ public class LinuxNetworkUtil {
             Command command = new Command(new String[] { IFCONFIG, interfaceName, "up" });
             command.setTimeout(60);
             CommandStatus status = this.executorService.execute(command);
-            if ((Integer) status.getExitStatus().getExitValue() != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR,
                         "Failed to bring up interface " + interfaceName);
             }
@@ -964,13 +956,13 @@ public class LinuxNetworkUtil {
             command.setOutputStream(new ByteArrayOutputStream());
             command.setErrorStream(new ByteArrayOutputStream());
             status = this.executorService.execute(command);
-            if ((Integer) status.getExitStatus().getExitValue() != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 command = new Command(new String[] { "ifup", interfaceName });
                 command.setTimeout(60);
                 command.setOutputStream(new ByteArrayOutputStream());
                 command.setErrorStream(new ByteArrayOutputStream());
                 status = this.executorService.execute(command);
-                if ((Integer) status.getExitStatus().getExitValue() != 0) {
+                if (!status.getExitStatus().isSuccessful()) {
                     throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR,
                             "Failed to bring up interface " + interfaceName);
                 }
@@ -1020,12 +1012,12 @@ public class LinuxNetworkUtil {
         Command command = new Command(cmd);
         command.setTimeout(60);
         CommandStatus status = this.executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             if (logger.isErrorEnabled()) {
-                logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), exitValue);
+                logger.error(ERR_EXECUTING_CMD_MSG, String.join(" ", cmd), status.getExitStatus().getExitCode());
             }
-            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd), exitValue);
+            throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd),
+                    status.getExitStatus().getExitCode());
         }
     }
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/MiiTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/MiiTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -61,10 +61,9 @@ public class MiiTool implements LinkTool {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        boolean result = (Integer) status.getExitStatus().getExitValue() == 0;
         parse(new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8));
 
-        return result;
+        return status.getExitStatus().isSuccessful();
     }
 
     private void parse(String commandOutput) {

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/HostapdManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/HostapdManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -58,10 +58,9 @@ public class HostapdManager {
             String[] launchHostapdCommand = formHostapdStartCommand(ifaceName);
             logger.info("starting hostapd for the {} interface --> {}", ifaceName, launchHostapdCommand);
             CommandStatus status = this.executorService.execute(new Command(launchHostapdCommand));
-            int exitValue = (Integer) status.getExitStatus().getExitValue();
-            if (exitValue != 0) {
+            if (!status.getExitStatus().isSuccessful()) {
                 logger.error("failed to start hostapd for the {} interface for unknown reason - errorCode={}",
-                        ifaceName, exitValue);
+                        ifaceName, status.getExitStatus().getExitCode());
                 throw KuraException.internalError("failed to start hostapd for unknown reason");
             }
             Thread.sleep(1000);

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/WifiOptions.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/WifiOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -72,7 +72,7 @@ public class WifiOptions {
         Command command = new Command(formIwDevInfoCommand(ifaceName));
         command.setTimeout(60);
         CommandStatus status = this.executorService.execute(command);
-        return (Integer) status.getExitStatus().getExitValue() == 0;
+        return status.getExitStatus().isSuccessful();
     }
 
     private boolean isWextDriverSupported(String ifaceName) {
@@ -85,7 +85,7 @@ public class WifiOptions {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = this.executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             if (logger.isWarnEnabled()) {
                 logger.warn(FAILED_TO_EXECUTE_MSG, String.join(" ", cmd));
             }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/WpaSupplicantManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/WpaSupplicantManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -76,7 +76,7 @@ public class WpaSupplicantManager {
             Command command = new Command(wpaSupplicantCommand);
             command.setTimeout(60);
             CommandStatus status = this.executorService.execute(command);
-            int exitValue = (Integer) status.getExitStatus().getExitValue();
+            int exitValue = (Integer) status.getExitStatus().getExitCode();
             if (exitValue != 0 && exitValue != 255) {
                 logger.error("failed to start wpa_supplicant for the {} interface for unknown reason - errorCode={}",
                         interfaceName, exitValue);

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/WpaSupplicantStatus.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/wifi/WpaSupplicantStatus.java
@@ -49,10 +49,10 @@ public class WpaSupplicantStatus {
         command.setTimeout(60);
         command.setOutputStream(new ByteArrayOutputStream());
         CommandStatus status = executorService.execute(command);
-        int exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             if (logger.isErrorEnabled()) {
-                logger.error("error executing command --- {} --- exit value = {}", String.join(" ", cmd), exitValue);
+                logger.error("error executing command --- {} --- exit value = {}", String.join(" ", cmd),
+                        status.getExitStatus().getExitCode());
             }
             throw new KuraException(KuraErrorCode.PROCESS_EXECUTION_ERROR, "Failed to get wpa supplicant status");
         }

--- a/kura/test/org.eclipse.kura.cloud.test/src/test/java/org/eclipse/kura/cloud/app/command/CommandCloudAppTest.java
+++ b/kura/test/org.eclipse.kura.cloud.test/src/test/java/org/eclipse/kura/cloud/app/command/CommandCloudAppTest.java
@@ -38,7 +38,7 @@ import org.eclipse.kura.cloud.CloudClient;
 import org.eclipse.kura.cloud.CloudService;
 import org.eclipse.kura.cloudconnection.message.KuraMessage;
 import org.eclipse.kura.configuration.Password;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.crypto.CryptoService;
 import org.eclipse.kura.executor.CommandStatus;
@@ -369,7 +369,7 @@ public class CommandCloudAppTest {
         int exitVal = 0;
 
         KuraCommandResponsePayload resp = new KuraCommandResponsePayload(KuraResponsePayload.RESPONSE_CODE_OK);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -396,7 +396,7 @@ public class CommandCloudAppTest {
         baes.write(err.getBytes(UTF_8));
 
         KuraCommandResponsePayload resp = new KuraCommandResponsePayload(KuraResponsePayload.RESPONSE_CODE_OK);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(1));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -423,7 +423,7 @@ public class CommandCloudAppTest {
         baes.write(err.getBytes(UTF_8));
 
         KuraCommandResponsePayload resp = new KuraCommandResponsePayload(KuraResponsePayload.RESPONSE_CODE_OK);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(true);
@@ -565,7 +565,7 @@ public class CommandCloudAppTest {
         baos.write("OK".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("err".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -618,7 +618,7 @@ public class CommandCloudAppTest {
         baos.write("NOK".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("err".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -663,7 +663,7 @@ public class CommandCloudAppTest {
         baos.write("OK".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("err".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -732,7 +732,7 @@ public class CommandCloudAppTest {
         baos.write("OK".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("err".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);

--- a/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
+++ b/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
@@ -33,7 +33,7 @@ import org.eclipse.kura.core.deployment.CloudDeploymentHandlerV2;
 import org.eclipse.kura.core.deployment.DeploymentPackageOptions;
 import org.eclipse.kura.core.deployment.InstallStatus;
 import org.eclipse.kura.core.deployment.download.DeploymentPackageDownloadOptions;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.executor.CommandExecutorService;
@@ -307,7 +307,7 @@ public class InstallImplTest {
     @Test
     public void testSendInstallConfirmations() throws IOException, KuraException {
         CloudDeploymentHandlerV2 callbackMock = mock(CloudDeploymentHandlerV2.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         String kuraDataDir = "/tmp";
@@ -387,7 +387,7 @@ public class InstallImplTest {
     @Test
     public void testSendInstallConfirmationsError() throws IOException, KuraException {
         CloudDeploymentHandlerV2 callbackMock = mock(CloudDeploymentHandlerV2.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(1));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         String kuraDataDir = "/tmp";

--- a/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -308,7 +308,7 @@ public class SystemServiceTest {
         if (!osName.contains("indows")) {
             if (LINUX.equals(osName)) {
                 CommandStatus status = executorService.execute(new Command(new String[] { "dmidecode" }));
-                if ((Integer) status.getExitStatus().getExitValue() != 0) {
+                if (!status.getExitStatus().isSuccessful()) {
                     assertEquals(UNKNOWN, modelName);
                 }
 
@@ -343,7 +343,7 @@ public class SystemServiceTest {
         if (!osName.contains("indows")) {
             if (LINUX.equals(osName)) {
                 CommandStatus status = executorService.execute(new Command(new String[] { "dmidecode" }));
-                if ((Integer) status.getExitStatus().getExitValue() != 0) {
+                if (!status.getExitStatus().isSuccessful()) {
                     assertEquals(UNKNOWN, serialNumber);
                 }
                 // note: this assert works locally and on travis, but not on hudson

--- a/kura/test/org.eclipse.kura.internal.ble.test/src/test/java/org/eclipse/kura/internal/ble/util/BluetoothProcessTest.java
+++ b/kura/test/org.eclipse.kura.internal.ble.test/src/test/java/org/eclipse/kura/internal/ble/util/BluetoothProcessTest.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.junit.Test;
@@ -66,7 +66,7 @@ public class BluetoothProcessTest {
         baos.write("test\\r?\\n".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("testerror\\r?\\n".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);

--- a/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/ClockServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/ClockServiceImplTest.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.clock.ClockEvent;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.executor.CommandStatus;
@@ -182,7 +182,7 @@ public class ClockServiceImplTest {
         assumeTrue("Only run this test on Linux", System.getProperty("os.name").matches("[Ll]inux"));
         assumeTrue("Only run this test as root", "root".equals(System.getProperty("user.name")));
 
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         ClockServiceImpl svc = new ClockServiceImpl();
@@ -205,7 +205,7 @@ public class ClockServiceImplTest {
     public void testClockUpdateErrors() throws Throwable {
         // test the service's onClockUpdate() with clock update failures; test of proper logging, mostly
 
-        CommandStatus status = new CommandStatus(new LinuxExitValue(1));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         ClockServiceImpl svc = new ClockServiceImpl();
@@ -228,7 +228,7 @@ public class ClockServiceImplTest {
     public void testClockUpdate() throws Throwable {
         // test the service's onClockUpdate()
 
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         ClockServiceImpl svc = new ClockServiceImpl();

--- a/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/NtpdClockSyncProviderTest.java
+++ b/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/NtpdClockSyncProviderTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.executor.CommandExecutorService;
@@ -29,7 +29,7 @@ public class NtpdClockSyncProviderTest {
     @Test
     public void testSynch() throws KuraException, NoSuchFieldException {
 
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         NtpdClockSyncProvider provider = new NtpdClockSyncProvider(serviceMock);
@@ -55,7 +55,7 @@ public class NtpdClockSyncProviderTest {
     @Test
     public void testSynchError() throws KuraException, NoSuchFieldException {
 
-        CommandStatus status = new CommandStatus(new LinuxExitValue(1));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         NtpdClockSyncProvider provider = new NtpdClockSyncProvider(serviceMock);

--- a/kura/test/org.eclipse.kura.linux.net.test/src/main/java/org/eclipse/kura/linux/test/net/IPTablesTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/main/java/org/eclipse/kura/linux/test/net/IPTablesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -208,7 +208,7 @@ public class IPTablesTest extends TestCase {
         Command command = new Command(new String[] { "iptables-restore", "<", oldConfig });
         command.setExecuteInAShell(true);
         CommandStatus status = this.executorService.execute(command);
-        if ((Integer) status.getExitStatus().getExitValue() != 0) {
+        if (!status.getExitStatus().isSuccessful()) {
             fail("Error restoring iptables config");
         }
     }
@@ -218,9 +218,9 @@ public class IPTablesTest extends TestCase {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         command.setOutputStream(out);
         CommandStatus status = this.executorService.execute(command);
-        Integer exitValue = (Integer) status.getExitStatus().getExitValue();
-        if (exitValue != 0) {
-            logger.error("error executing command --- iptables-save --- exit value = {}", exitValue);
+        if (!status.getExitStatus().isSuccessful()) {
+            logger.error("error executing command --- iptables-save --- exit value = {}",
+                    status.getExitStatus().getExitCode());
             throw new KuraProcessExecutionErrorException("Error saving iptables config");
         }
         return new String(out.toByteArray(), Charsets.UTF_8);

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImplTest.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.comm.CommURI;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.net.NetworkConfiguration;
 import org.eclipse.kura.core.net.modem.ModemInterfaceAddressConfigImpl;
 import org.eclipse.kura.core.net.modem.ModemInterfaceConfigImpl;
@@ -202,7 +202,7 @@ public class ModemMonitorServiceImplTest {
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
 
-        CommandStatus linkStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus linkStatus = new CommandStatus(new LinuxExitStatus(0));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(outputStream);
         out.write(
@@ -216,7 +216,7 @@ public class ModemMonitorServiceImplTest {
         linkStatusCommand.setTimeout(60);
         when(esMock.execute(linkStatusCommand)).thenReturn(linkStatus);
         
-        CommandStatus addrStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus addrStatus = new CommandStatus(new LinuxExitStatus(0));
         outputStream = new ByteArrayOutputStream();
         out = new DataOutputStream(outputStream);
         out.write(
@@ -230,13 +230,13 @@ public class ModemMonitorServiceImplTest {
         addrStatusCommand.setTimeout(60);
         when(esMock.execute(addrStatusCommand)).thenReturn(addrStatus);
 
-        CommandStatus infoStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus infoStatus = new CommandStatus(new LinuxExitStatus(0));
         cmd = new String[] {"iw", "dev", "ppp1", "info"};
         Command infoCommand = new Command(cmd);
         infoCommand.setTimeout(60);
         when(esMock.execute(infoCommand)).thenReturn(infoStatus);
         
-        CommandStatus iwconfigStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus iwconfigStatus = new CommandStatus(new LinuxExitStatus(0));
         cmd = new String[] {"iwconfig", "ppp1"};
         Command iwconfigCommand = new Command(cmd);
         iwconfigCommand.setTimeout(60);
@@ -248,7 +248,7 @@ public class ModemMonitorServiceImplTest {
         iwconfigStatus.setOutputStream(outputStream);
         when(esMock.execute(iwconfigCommand)).thenReturn(iwconfigStatus);
         
-        CommandStatus ethtoolStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus ethtoolStatus = new CommandStatus(new LinuxExitStatus(0));
         cmd = new String[] {"ethtool", "-i", "ppp1"};
         Command ethtoolCommand = new Command(cmd);
         ethtoolCommand.setTimeout(60);
@@ -964,7 +964,7 @@ public class ModemMonitorServiceImplTest {
         org.eclipse.kura.executor.CommandExecutorService esMock = mock(
                 org.eclipse.kura.executor.CommandExecutorService.class);
 
-        CommandStatus linkStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus linkStatus = new CommandStatus(new LinuxExitStatus(0));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(outputStream);
         out.write(
@@ -978,7 +978,7 @@ public class ModemMonitorServiceImplTest {
         linkStatusCommand.setTimeout(60);
         when(esMock.execute(linkStatusCommand)).thenReturn(linkStatus);
 
-        CommandStatus addrStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus addrStatus = new CommandStatus(new LinuxExitStatus(0));
         outputStream = new ByteArrayOutputStream();
         out = new DataOutputStream(outputStream);
         out.write(
@@ -992,13 +992,13 @@ public class ModemMonitorServiceImplTest {
         addrStatusCommand.setTimeout(60);
         when(esMock.execute(addrStatusCommand)).thenReturn(addrStatus);
 
-        CommandStatus infoStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus infoStatus = new CommandStatus(new LinuxExitStatus(0));
         cmd = new String[] {"iw", "dev", "ppp0", "info"};
         Command infoCommand = new Command(cmd);
         infoCommand.setTimeout(60);
         when(esMock.execute(infoCommand)).thenReturn(infoStatus);
 
-        CommandStatus iwconfigStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus iwconfigStatus = new CommandStatus(new LinuxExitStatus(0));
         cmd = new String[] {"iwconfig", "ppp0"};
         Command iwconfigCommand = new Command(cmd);
         iwconfigCommand.setTimeout(60);
@@ -1012,7 +1012,7 @@ public class ModemMonitorServiceImplTest {
         iwconfigStatus.setOutputStream(outputStream);
         when(esMock.execute(iwconfigCommand)).thenReturn(iwconfigStatus);
 
-        CommandStatus ethtoolStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus ethtoolStatus = new CommandStatus(new LinuxExitStatus(0));
         cmd = new String[] {"ethtool", "-i", "ppp0"};
         Command ethtoolCommand = new Command(cmd);
         ethtoolCommand.setTimeout(60);

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImplTest.java
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.net.NetworkConfiguration;
 import org.eclipse.kura.core.net.WifiAccessPointImpl;
 import org.eclipse.kura.core.net.WifiInterfaceAddressConfigImpl;
@@ -805,7 +805,7 @@ public class WifiMonitorServiceImplTest {
         String ssid = "mySSID";
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(outputStream);
         out.write(
@@ -962,7 +962,7 @@ public class WifiMonitorServiceImplTest {
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
 
-        CommandStatus linkStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus linkStatus = new CommandStatus(new LinuxExitStatus(0));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(outputStream);
         out.write(
@@ -976,7 +976,7 @@ public class WifiMonitorServiceImplTest {
         linkStatusCommand.setTimeout(60);
         when(esMock.execute(linkStatusCommand)).thenReturn(linkStatus);
 
-        CommandStatus addrStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus addrStatus = new CommandStatus(new LinuxExitStatus(0));
         outputStream = new ByteArrayOutputStream();
         out = new DataOutputStream(outputStream);
         out.write(
@@ -990,13 +990,13 @@ public class WifiMonitorServiceImplTest {
         addrStatusCommand.setTimeout(60);
         when(esMock.execute(addrStatusCommand)).thenReturn(addrStatus);
 
-        CommandStatus infoStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus infoStatus = new CommandStatus(new LinuxExitStatus(0));
         cmd = new String[] { "iw", "dev", "wlan3", "info" };
         Command infoCommand = new Command(cmd);
         infoCommand.setTimeout(60);
         when(esMock.execute(infoCommand)).thenReturn(infoStatus);
 
-        CommandStatus iwconfigStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus iwconfigStatus = new CommandStatus(new LinuxExitStatus(0));
         cmd = new String[] { "iwconfig", "wlan3" };
         Command iwconfigCommand = new Command(cmd);
         iwconfigCommand.setTimeout(60);
@@ -1010,7 +1010,7 @@ public class WifiMonitorServiceImplTest {
         iwconfigStatus.setOutputStream(outputStream);
         when(esMock.execute(iwconfigCommand)).thenReturn(iwconfigStatus);
 
-        CommandStatus ethtoolStatus = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus ethtoolStatus = new CommandStatus(new LinuxExitStatus(0));
         cmd = new String[] { "ethtool", "-i", "wlan3" };
         Command ethtoolCommand = new Command(cmd);
         ethtoolCommand.setTimeout(60);

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/FirewallAutoNatConfigTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/FirewallAutoNatConfigTest.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.net.EthernetInterfaceConfigImpl;
 import org.eclipse.kura.core.net.NetInterfaceAddressConfigImpl;
 import org.eclipse.kura.core.net.NetworkConfiguration;
@@ -82,7 +82,7 @@ public class FirewallAutoNatConfigTest {
         NetworkConfiguration config = prepareNetworkConfiguration(intfName, destinationInterface, false, false);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);
@@ -252,7 +252,7 @@ public class FirewallAutoNatConfigTest {
         NetworkConfiguration config = prepareNetworkConfiguration(intfName, destinationInterface, false, true);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         reader.setExecutorService(esMock);
@@ -296,7 +296,7 @@ public class FirewallAutoNatConfigTest {
         NetworkConfiguration config = prepareNetworkConfiguration(intfName, destinationInterface, false, true);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         // ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         // DataOutputStream out = new DataOutputStream(outputStream);
         // out.write(
@@ -417,7 +417,7 @@ public class FirewallAutoNatConfigTest {
         NetworkConfiguration config = prepareNetworkConfiguration(intfName, destinationInterface, false, true);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         reader.setExecutorService(esMock);

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.core.linux.executor.LinuxExitValue;
+import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.net.NetworkConfiguration;
 import org.eclipse.kura.core.net.WifiInterfaceAddressConfigImpl;
 import org.eclipse.kura.core.net.WifiInterfaceConfigImpl;
@@ -93,7 +93,7 @@ public class HostapdConfigTest {
         netInterfaceConfig.setNetInterfaceAddresses(interfaceAddressConfigs);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);
@@ -144,7 +144,7 @@ public class HostapdConfigTest {
 
         try {
             CommandExecutorService esMock = mock(CommandExecutorService.class);
-            CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+            CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
             when(esMock.execute(anyObject())).thenReturn(status);
 
             writer.setExecutorService(esMock);
@@ -224,7 +224,7 @@ public class HostapdConfigTest {
         netInterfaceConfig.setNetInterfaceAddresses(interfaceAddressConfigs);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);
@@ -341,7 +341,7 @@ public class HostapdConfigTest {
         netInterfaceConfig.setNetInterfaceAddresses(interfaceAddressConfigs);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);
@@ -569,7 +569,7 @@ public class HostapdConfigTest {
         netInterfaceConfig.setNetInterfaceAddresses(interfaceAddressConfigs);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitValue(0));
+        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);


### PR DESCRIPTION
This PR improves the CommandExecutor service refactoring the ExitStatus and Pid classes.

**Related Issue:** This PR fixes/closes #2617 

**Description of the solution adopted:** In order to simplify the CommandExecutorService, the ExitStatus class is improved adding a the `isSuccessful`  method. Also the Pid class is simplified, since the type returned by the getPid method is now a integer.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>
