### PR TITLE
Moved the distributions listed from sysv to systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ The Eclipse Installer based setup works for the main used platforms like Linux, 
 
 ### Prerequisites
 Before installing Kura, you need to have the following programs installed in your OS
-* JDK 1.8 
+* JDK 1.8
 * Maven 3.5.x
 
 #### Installing Prerequisites in Mac OS 
-Using Brew you can easily install both Java and Maven from the command line.
+Using [Brew](https://brew.sh/) you can easily install both Java and Maven from the command line.
 
 Use the following commands in a terminal
 
@@ -67,6 +67,20 @@ brew install maven@3.5
 Run `mvn -version`to ensure that Maven has been added to the PATH.
 If Maven cannot be found, try running `brew link maven@3.5 --force`.  
 
+#### Installing Prerequisites in Linux
+For Java
+```
+sudo apt install openjdk-8-jdk
+```
+For Maven
+Download the Maven X version from the [Apache Archives](https://archive.apache.org/dist/maven/maven-3/)
+
+Move the tarball to the X folder and run this command 
+
+```
+tar xzvf apache-maven-3.X.X-bin.tar.gz
+```
+Then add the bin folder to the PATH in .....
 
 ### Eclipse IDE
 The simplest way to start developing on Eclipse Kura is to use an Eclipse Installer based setup.

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ For more information, see the [Eclipse project proposal](http://www.eclipse.org/
 System Requirements
 -------------------
 
-Eclipse Kura is compatible with Java 8 (`Bundle-RequiredExecutionEnåvironment: JavaSE-1.8`) and OSGi R6.
+Eclipse Kura requires at least Java 8 and OSGi R6. All bundles can make use of a Java 8 as execution environment. All bundles must be limited to the "compact2" profile of Java.
 
 
 Development Model
 -----------------
-Development on Kura follows a [variant of the gitflow model](https://github.com/eclipse/kura/wiki/New-Kura-Git-Workflow).  Development is made on the [develop branch](/eclipse/kura/tree/develop). The master branch is not used anymore.
+Development on Kura follows the [gitflow model](http://nvie.com/posts/a-successful-git-branching-model/).  Thus, the working copy is in the develop branch, and the master branch is used for releases.
 
 
 Getting Started
@@ -39,50 +39,6 @@ Getting Started
 Development for Kura can be done in Eclipse IDE using the Kura Development Environment, in a gateway or in a Docker container.
 
 ## Development Environment
-
-### Supported Development Platforms
-The Eclipse Installer based setup works for the main used platforms like Linux, Mac Os and Windows.
-
-### Prerequisites
-Before installing Kura, you need to have the following programs installed in your OS
-* JDK 1.8
-* Maven 3.5.x
-
-#### Installing Prerequisites in Mac OS 
-Using [Brew](https://brew.sh/) you can easily install both Java and Maven from the command line.
-
-Use the following commands in a terminal
-
-For Java  
-```
-brew tap adoptopenjdk/openjdk 
-brew cask install adoptopenjdk8   
-```
-Run `java -version` to make sure it is installed correctly.  
-
-For Maven
-```
-brew install maven@3.5
-```
-Run `mvn -version`to ensure that Maven has been added to the PATH.
-If Maven cannot be found, try running `brew link maven@3.5 --force`.  
-
-#### Installing Prerequisites in Linux
-For Java
-```
-sudo apt install openjdk-8-jdk
-```
-For Maven
-Download the Maven X version from the [Apache Archives](https://archive.apache.org/dist/maven/maven-3/)
-
-Move the tarball to the X folder and run this command 
-
-```
-tar xzvf apache-maven-3.X.X-bin.tar.gz
-```
-Then add the bin folder to the PATH in .....
-
-### Eclipse IDE
 The simplest way to start developing on Eclipse Kura is to use an Eclipse Installer based setup.
 To correctly setup the environment, proceed as follows:
 - Start the Eclipse Installer
@@ -98,8 +54,12 @@ To correctly setup the environment, proceed as follows:
 
 At first startup Eclipse IDE will checkout the code, perform a full build and configure a few Working Sets. Now you are ready to develop on Eclipse Kura.
 
+For further information, building and deployment instructions, please visit the [getting started page](https://wiki.eclipse.org/Kura/Getting_Started).
+
 To raise an issue, please report a bug on [GitHub issues](https://github.com/eclipse/kura/issues/new).
 
+### Supported Development Platforms
+The Eclipse Installer based setup works for the main used platforms like Linux, Mac Os and Windows.
 
 
 ### Known Issues

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ For more information, see the [Eclipse project proposal](http://www.eclipse.org/
 System Requirements
 -------------------
 
-Eclipse Kura requires at least Java 8 and OSGi R6. All bundles can make use of a Java 8 as execution environment. All bundles must be limited to the "compact2" profile of Java.
+Eclipse Kura is compatible with Java 8 (`Bundle-RequiredExecutionEnåvironment: JavaSE-1.8`) and OSGi R6.
 
 
 Development Model
 -----------------
-Development on Kura follows the [gitflow model](http://nvie.com/posts/a-successful-git-branching-model/).  Thus, the working copy is in the develop branch, and the master branch is used for releases.
+Development on Kura follows a [variant of the gitflow model](https://github.com/eclipse/kura/wiki/New-Kura-Git-Workflow).  Development is made on the [develop branch](/eclipse/kura/tree/develop). The master branch is not used anymore.
 
 
 Getting Started
@@ -39,6 +39,36 @@ Getting Started
 Development for Kura can be done in Eclipse IDE using the Kura Development Environment, in a gateway or in a Docker container.
 
 ## Development Environment
+
+### Supported Development Platforms
+The Eclipse Installer based setup works for the main used platforms like Linux, Mac Os and Windows.
+
+### Prerequisites
+Before installing Kura, you need to have the following programs installed in your OS
+* JDK 1.8 
+* Maven 3.5.x
+
+#### Installing Prerequisites in Mac OS 
+Using Brew you can easily install both Java and Maven from the command line.
+
+Use the following commands in a terminal
+
+For Java  
+```
+brew tap adoptopenjdk/openjdk 
+brew cask install adoptopenjdk8   
+```
+Run `java -version` to make sure it is installed correctly.  
+
+For Maven
+```
+brew install maven@3.5
+```
+Run `mvn -version`to ensure that Maven has been added to the PATH.
+If Maven cannot be found, try running `brew link maven@3.5 --force`.  
+
+
+### Eclipse IDE
 The simplest way to start developing on Eclipse Kura is to use an Eclipse Installer based setup.
 To correctly setup the environment, proceed as follows:
 - Start the Eclipse Installer
@@ -54,12 +84,8 @@ To correctly setup the environment, proceed as follows:
 
 At first startup Eclipse IDE will checkout the code, perform a full build and configure a few Working Sets. Now you are ready to develop on Eclipse Kura.
 
-For further information, building and deployment instructions, please visit the [getting started page](https://wiki.eclipse.org/Kura/Getting_Started).
-
 To raise an issue, please report a bug on [GitHub issues](https://github.com/eclipse/kura/issues/new).
 
-### Supported Development Platforms
-The Eclipse Installer based setup works for the main used platforms like Linux, Mac Os and Windows.
 
 
 ### Known Issues

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -17,8 +17,9 @@ INSTALL_DIR=/opt/eclipse
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 
 #set up Kura init
-cp ${INSTALL_DIR}/kura/install/kura.init.raspbian /etc/init.d/kura
-chmod +x /etc/init.d/kura
+sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
+systemctl daemon-reload
+systemctl enable kura
 chmod +x ${INSTALL_DIR}/kura/bin/*.sh
 
 # setup snapshot_0 recovery folder
@@ -54,10 +55,11 @@ cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/b
 chmod +x ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 
 #set up default firewall configuration
-cp ${INSTALL_DIR}/kura/install/firewall.init /etc/init.d/firewall
-chmod +x /etc/init.d/firewall
-cp ${INSTALL_DIR}/kura/install/iptables.init /etc/sysconfig/iptables
-cp /etc/sysconfig/iptables ${INSTALL_DIR}/kura/.data/iptables
+cp /etc/sysconfig/iptables /etc/sysconfig/iptables.esfsave
+cp ${BASE_DIR}/${KURA_SYMLINK}/.data/iptables /etc/sysconfig/iptables
+sed -i "s|/bin/sh KURA_DIR|/bin/bash ${BASE_DIR}/${KURA_SYMLINK}|" /lib/systemd/system/firewall.service
+systemctl daemon-reload
+systemctl enable firewall
 
 #set up networking configuration
 mac_addr=$(head -1 /sys/class/net/enp2s0/address | tr '[:lower:]' '[:upper:]')
@@ -83,16 +85,6 @@ cp ${INSTALL_DIR}/kura/install/named.rfc1912.zones /etc/
 if [ ! -f "/etc/bind/rndc.key" ] ; then
 	rndc-confgen -r /dev/urandom -a
 fi
-
-#set up monit
-cp ${INSTALL_DIR}/kura/install/monit.init.raspbian /etc/init.d/monit
-chmod +x /etc/init.d/monit
-cp ${INSTALL_DIR}/kura/install/monitrc.raspbian /etc/monitrc
-chmod 700 /etc/monitrc
-
-#set up runlevels to start/stop Kura by default
-update-rc.d firewall defaults
-update-rc.d kura defaults
 
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -17,14 +17,12 @@ INSTALL_DIR=/opt/eclipse
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 
 #set up Kura init
-cp ${INSTALL_DIR}/kura/install/kura.init.raspbian /etc/init.d/kura
-chmod +x /etc/init.d/kura
+sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
+systemctl daemon-reload
+systemctl enable kura
 chmod +x ${INSTALL_DIR}/kura/bin/*.sh
 
 mkdir -p ${INSTALL_DIR}/kura/data
-
-#set up runlevels to start/stop Kura by default
-update-rc.d kura defaults
 
 # setup snapshot_0 recovery folder
 if [ ! -d ${INSTALL_DIR}/kura/.data ]; then

--- a/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -18,14 +18,12 @@ INSTALL_DIR=/opt/eclipse
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 
 #set up Kura init
-cp ${INSTALL_DIR}/kura/install/kura.init.raspbian /etc/init.d/kura
-chmod +x /etc/init.d/kura
+sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
+systemctl daemon-reload
+systemctl enable kura
 chmod +x ${INSTALL_DIR}/kura/bin/*.sh
 
 mkdir -p ${INSTALL_DIR}/kura/data
-
-#set up runlevels to start/stop Kura by default
-update-rc.d kura defaults
 
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf


### PR DESCRIPTION
Changed the `kura_install.sh` scripts for 

- `raspberry-pi-2`
- `raspberry-pi-2-nn`
- `intel-up2-ubuntu-18`
- `rock960-ubuntu-16-nn`

**Related Issue:** This PR fixes/closes #2602 

**Description of the solution adopted:** Changed the scripts to use `systemd` instead of `sysv`