### PR TITLE
Filter 0 value in timeout

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/linux/executor/ExecutorUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/linux/executor/ExecutorUtil.java
@@ -200,7 +200,7 @@ public class ExecutorUtil {
             }
         }
         // Sort pids in reverse order (useful when stop processes...)
-        return pids.entrySet().stream().sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+        return pids.entrySet().stream().sorted(Map.Entry.<String, Integer> comparingByValue().reversed())
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> new LinuxPid(e.getValue()), (e1, e2) -> e1,
                         LinkedHashMap::new));
     }
@@ -245,7 +245,7 @@ public class ExecutorUtil {
     private static DefaultExecutor configureExecutor(Command command) {
         DefaultExecutor executor = new DefaultExecutor();
         int timeout = command.getTimeout();
-        ExecuteWatchdog watchdog = timeout == -1 ? new ExecuteWatchdog(ExecuteWatchdog.INFINITE_TIMEOUT)
+        ExecuteWatchdog watchdog = timeout <= 0 ? new ExecuteWatchdog(ExecuteWatchdog.INFINITE_TIMEOUT)
                 : new ExecuteWatchdog(timeout * 1000L);
         executor.setWatchdog(watchdog);
 


### PR DESCRIPTION
This PR filters the value of the timeout configured in the CommandExecutorService.

**Related Issue:** This PR fixes/closes #2636 

**Description of the solution adopted:** The CommandExecutorService implementations use a watchdog to monitor the execution of a command. The watchdog is configured with a timeout value passed inside the Command object. The configuration fails if the value is set to 0, so this PR filters the values less than 0, disabling the watchdog.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>