### PR TITLE
Fixed oomph kura.setup file setting https for maven reference

### DIFF
--- a/kura/setups/kura.setup
+++ b/kura/setups/kura.setup
@@ -87,7 +87,7 @@
         name="org.sonarlint.eclipse.feature.feature.group"
         optional="true"/>
     <repository
-        url="http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST/"/>
+        url="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST/"/>
     <repository
         url="http://mtoolkit-neon.s3-website-us-east-1.amazonaws.com"/>
     <repository


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes #2632 

**Description of the solution adopted:** Changed the tycho maven url to use https instead of plain http

**Screenshots:** N/A

**Any side note on the changes made:** N/A
