### PR TITLE
fix apply changes dialog opening when it shouldn't

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -237,7 +237,9 @@ public abstract class AbstractServicesUi extends Composite {
         });
         textBox.addKeyUpHandler(event -> {
             textBox.validate(true);
-            setDirty(true);
+        });
+        textBox.addValueChangeHandler(event -> {
+        	setDirty(true);
         });
 
         if (param.getId().endsWith(TARGET_SUFFIX)) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabModemUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabModemUi.java
@@ -461,7 +461,7 @@ public class TabModemUi extends Composite implements NetworkTab {
 
         // INTERFACE NUMBER
         this.labelNumber.setText(MSGS.netModemInterfaceNum() + "*");
-        this.number.addBlurHandler(event -> {
+        this.number.addValueChangeHandler(event -> {
             setDirty(true);
             if (TabModemUi.this.number.getText().trim() != null
                     && (!TabModemUi.this.number.getText().trim().matches(REGEX_NUM)
@@ -512,7 +512,7 @@ public class TabModemUi extends Composite implements NetworkTab {
                 }
             }
         });
-        this.dial.addBlurHandler(event -> {
+        this.dial.addValueChangeHandler(event -> {
             setDirty(true);
             if (TabModemUi.this.dial.getText() == null || "".equals(TabModemUi.this.dial.getText().trim())) {
                 TabModemUi.this.groupDial.setValidationState(ValidationState.ERROR);
@@ -543,7 +543,7 @@ public class TabModemUi extends Composite implements NetworkTab {
             }
         });
         this.apn.addMouseOutHandler(event -> resetHelp());
-        this.apn.addBlurHandler(event -> {
+        this.apn.addValueChangeHandler(event -> {
             setDirty(true);
             if (TabModemUi.this.apn.getText() == null || "".equals(TabModemUi.this.apn.getText().trim())) {
                 if (TabModemUi.this.apn.isEnabled()) {
@@ -604,7 +604,7 @@ public class TabModemUi extends Composite implements NetworkTab {
             }
         });
         this.reset.addMouseOutHandler(event -> resetHelp());
-        this.reset.addBlurHandler(event -> {
+        this.reset.addValueChangeHandler(event -> {
             setDirty(true);
             if (TabModemUi.this.reset.getText().trim() != null
                     && (!TabModemUi.this.reset.getText().trim().matches(REGEX_NUM)
@@ -647,7 +647,7 @@ public class TabModemUi extends Composite implements NetworkTab {
             }
         });
         this.maxfail.addMouseOutHandler(event -> resetHelp());
-        this.maxfail.addBlurHandler(event -> {
+        this.maxfail.addValueChangeHandler(event -> {
             setDirty(true);
             if (TabModemUi.this.maxfail.getText().trim() != null
                     && (!TabModemUi.this.maxfail.getText().trim().matches(REGEX_NUM)
@@ -670,7 +670,7 @@ public class TabModemUi extends Composite implements NetworkTab {
             }
         });
         this.idle.addMouseOutHandler(event -> resetHelp());
-        this.idle.addBlurHandler(event -> {
+        this.idle.addValueChangeHandler(event -> {
             setDirty(true);
             if (TabModemUi.this.idle.getText().trim() != null
                     && (!TabModemUi.this.idle.getText().trim().matches(REGEX_NUM)
@@ -703,7 +703,7 @@ public class TabModemUi extends Composite implements NetworkTab {
             }
         });
         this.interval.addMouseOutHandler(event -> resetHelp());
-        this.interval.addBlurHandler(event -> {
+        this.interval.addValueChangeHandler(event -> {
             setDirty(true);
             if (TabModemUi.this.interval.getText().trim() != null
                     && (!TabModemUi.this.interval.getText().trim().matches(REGEX_NUM)
@@ -724,7 +724,7 @@ public class TabModemUi extends Composite implements NetworkTab {
             }
         });
         this.failure.addMouseOutHandler(event -> resetHelp());
-        this.failure.addBlurHandler(event -> {
+        this.failure.addValueChangeHandler(event -> {
             setDirty(true);
             if (TabModemUi.this.failure.getText().trim() != null
                     && (!TabModemUi.this.failure.getText().trim().matches(REGEX_NUM)

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
@@ -431,7 +431,7 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
             }
         });
         this.dns.addMouseOutHandler(event -> resetHelp());
-        this.dns.addChangeHandler(event -> {
+        this.dns.addValueChangeHandler(event -> {
             setDirty(true);
 
             if (TabTcpIpUi.this.dns.getText().trim().length() == 0) {
@@ -466,7 +466,7 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
             }
         });
         this.gateway.addMouseOutHandler(event -> resetHelp());
-        this.gateway.addChangeHandler(event -> {
+        this.gateway.addValueChangeHandler(event -> {
             setDirty(true);
             if (!TabTcpIpUi.this.gateway.getText().trim().matches(FieldType.IPv4_ADDRESS.getRegex())
                     && TabTcpIpUi.this.gateway.getText().trim().length() > 0) {
@@ -487,7 +487,7 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
             }
         });
         this.subnet.addMouseOutHandler(event -> resetHelp());
-        this.subnet.addChangeHandler(event -> {
+        this.subnet.addValueChangeHandler(event -> {
             setDirty(true);
             if (!TabTcpIpUi.this.subnet.getText().trim().matches(FieldType.IPv4_ADDRESS.getRegex())
                     && TabTcpIpUi.this.subnet.getText().trim().length() > 0) {
@@ -508,7 +508,7 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
             }
         });
         this.ip.addMouseOutHandler(event -> resetHelp());
-        this.ip.addBlurHandler(event -> {
+        this.ip.addValueChangeHandler(event -> {
             setDirty(true);
             if (!TabTcpIpUi.this.ip.getText().trim().matches(FieldType.IPv4_ADDRESS.getRegex())
                     || TabTcpIpUi.this.ip.getText().trim().length() <= 0) {


### PR DESCRIPTION
Signed-off-by: thomas.fitzgerald thomas.fitzgerald@eurotech.com

Currently, component text fields are being set as "dirty" on loss of focus and key events. This incorrectly causes a dialog to display asking "There are unsaved changes. Do you want to discard and continue?" when no change has been made to the field.

Related Issue: This PR fixes/closes issue #2013

Description of the solution adopted: This solution now only displays the dialogue when a change has been made to the field's value after loss of focus. No arbitrary key event or loss of field focus without change will trigger the dialog.

NOTE:

This does not apply to password fields.
The value change handler only registers on modified value, even when the field has been edited but reverted back to original value.
Screenshots: Below is a screenshot of dialog in reference:

![2020-01-21-111136_1824x984_scrot](https://user-images.githubusercontent.com/53527784/73291746-cc026980-41ce-11ea-86ae-d8a19e4fb1b2.png)
