### PR TITLE
Reporting system uptime in MacOS from kern.boottime

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/system/SystemAdminServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/system/SystemAdminServiceImpl.java
@@ -15,7 +15,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -129,33 +128,19 @@ public class SystemAdminServiceImpl extends SuperSystemService implements System
                 }
             }
         } else if (OS_MAC_OSX.equals(getOsName())) {
-            Process p = null;
-            BufferedReader br = null;
-
             try {
-                p = Runtime.getRuntime().exec("sysctl -n kern.boottime");
-                br = new BufferedReader(new InputStreamReader(p.getInputStream()));
+                String lastBootupSysCmd = runSystemCommand("sysctl -n kern.boottime", false, this.executorService);
 
-                String line = br.readLine();
-                if (line != null) {
-                    String[] uptimePairs = line.substring(1, line.indexOf("}")).replace(" ", "").split(",");
+                if (!lastBootupSysCmd.equals("")) {
+                    String[] uptimePairs = lastBootupSysCmd.substring(1, lastBootupSysCmd.indexOf("}")).replace(" ", "")
+                            .split(",");
                     String[] uptimeSeconds = uptimePairs[0].split("=");
                     uptime = System.currentTimeMillis() - (long) (Double.parseDouble(uptimeSeconds[1]));
                     uptimeStr = Long.toString(uptime);
                 }
             } catch (Exception e) {
-                logger.error("Could not parse uptime", e);
-            } finally {
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException e) {
-                        logger.error("Failed closing BufferedReader with exception {}", e);
-                    }
-                }
-                if (p != null) {
-                    p.destroy();
-                }
+                uptimeStr = "0";
+                logger.error("Could not read uptime", e);
             }
         }
         return uptimeStr;

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/system/SystemAdminServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/system/SystemAdminServiceImpl.java
@@ -131,7 +131,7 @@ public class SystemAdminServiceImpl extends SuperSystemService implements System
             try {
                 String lastBootupSysCmd = runSystemCommand("sysctl -n kern.boottime", false, this.executorService);
 
-                if (!lastBootupSysCmd.equals("")) {
+                if (!lastBootupSysCmd.isEmpty()) {
                     String[] uptimePairs = lastBootupSysCmd.substring(1, lastBootupSysCmd.indexOf("}")).replace(" ", "")
                             .split(",");
                     String[] uptimeSeconds = uptimePairs[0].split("=");


### PR DESCRIPTION
Signed-off-by: thomas.fitzgerald <thomas.fitzgerald@eurotech.com>

The current way we read system uptime on MacOS reports "UNKNOWN" when locality is not set to en.

**Related Issue:** This PR fixes/closes #1932 

**Description of the solution adopted:** This proposed change computes the time since the system has booted by reading from the kernel boottime (sysctl kern.boottime). This file returns a string containing seconds and microseconds of the time the system was booted (since the epoch). This solution parses that output and retrieves the second portion, getting the difference from the current system time. 

**Any side note on the changes made:** This solution should work regardless of locality.
