### PR TITLE
Added support for Quectel EG25

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
@@ -48,7 +48,10 @@ public enum SupportedUsbModemInfo {
             ModemTechnologyType.GSM_GPRS,
             ModemTechnologyType.UMTS), Arrays.asList(new OptionModemDriver("19d2", "1476")), ""),
     SimTech_SIM7000("SIM7000", "1e0e", "9001", 5, 0, 3, 2, 3, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
-            ModemTechnologyType.GSM_GPRS), Arrays.asList(new OptionModemDriver("1e0e", "9001")), "");
+            ModemTechnologyType.GSM_GPRS), Arrays.asList(new OptionModemDriver("1e0e", "9001")), ""),
+    Quectel_EG25("EG25", "2c7c", "0125", 4, 0, 2, 3, -1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
+            ModemTechnologyType.HSPA,
+            ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0125")), "");
 
     private String deviceName;
     private String vendorId;

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
@@ -49,7 +49,7 @@ public enum SupportedUsbModemInfo {
             ModemTechnologyType.UMTS), Arrays.asList(new OptionModemDriver("19d2", "1476")), ""),
     SimTech_SIM7000("SIM7000", "1e0e", "9001", 5, 0, 3, 2, 3, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.GSM_GPRS), Arrays.asList(new OptionModemDriver("1e0e", "9001")), ""),
-    Quectel_EG25("EG25", "2c7c", "0125", 4, 0, 2, 3, -1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
+    QUECTEL_EG25("EG25", "2c7c", "0125", 4, 0, 2, 3, -1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.HSPA,
             ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0125")), "");
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
@@ -54,7 +54,7 @@ public class SupportedUsbModemsFactoryInfo {
         Ublox_SARA_U2(SupportedUsbModemInfo.Ublox_SARA_U2, UbloxModemFactory.class, UbloxModemConfigGenerator.class),
         Zte_ME3630(SupportedUsbModemInfo.Zte_ME3630, ZteMe3630ModemFactory.class, ZteMe3630ConfigGenerator.class),
         SimTech_SIM7000(SupportedUsbModemInfo.SimTech_SIM7000, SimTechSim7000ModemFactory.class, SimTechSim7000ConfigGenerator.class),
-        Quectel_EG25(SupportedUsbModemInfo.Quectel_EG25, QuectelEG25ModemFactory.class, QuectelEG25ConfigGenerator.class);
+        QUECTEL_EG25(SupportedUsbModemInfo.QUECTEL_EG25, QuectelEG25ModemFactory.class, QuectelEG25ConfigGenerator.class);
 
         private final SupportedUsbModemInfo m_usbModemInfo;
         private final Class<? extends CellularModemFactory> m_factoryClass;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
@@ -16,6 +16,8 @@ import java.util.List;
 
 import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
 import org.eclipse.kura.linux.net.modem.UsbModemDriver;
+import org.eclipse.kura.net.admin.modem.quectel.eg25.QuectelEG25ConfigGenerator;
+import org.eclipse.kura.net.admin.modem.quectel.eg25.QuectelEG25ModemFactory;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxConfigGenerator;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxModemFactory;
 import org.eclipse.kura.net.admin.modem.sierra.usb598.SierraUsb598ConfigGenerator;
@@ -51,7 +53,8 @@ public class SupportedUsbModemsFactoryInfo {
         Sierra_USB598(SupportedUsbModemInfo.Sierra_USB598, SierraUsb598ModemFactory.class, SierraUsb598ConfigGenerator.class),
         Ublox_SARA_U2(SupportedUsbModemInfo.Ublox_SARA_U2, UbloxModemFactory.class, UbloxModemConfigGenerator.class),
         Zte_ME3630(SupportedUsbModemInfo.Zte_ME3630, ZteMe3630ModemFactory.class, ZteMe3630ConfigGenerator.class),
-        SimTech_SIM7000(SupportedUsbModemInfo.SimTech_SIM7000, SimTechSim7000ModemFactory.class, SimTechSim7000ConfigGenerator.class);
+        SimTech_SIM7000(SupportedUsbModemInfo.SimTech_SIM7000, SimTechSim7000ModemFactory.class, SimTechSim7000ConfigGenerator.class),
+        Quectel_EG25(SupportedUsbModemInfo.Quectel_EG25, QuectelEG25ModemFactory.class, QuectelEG25ConfigGenerator.class);
 
         private final SupportedUsbModemInfo m_usbModemInfo;
         private final Class<? extends CellularModemFactory> m_factoryClass;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25.java
@@ -1,0 +1,336 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.eg25;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.comm.CommConnection;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemsInfo;
+import org.eclipse.kura.linux.net.modem.UsbModemDriver;
+import org.eclipse.kura.net.admin.modem.HspaCellularModem;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModem;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemRegistrationStatus;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.eclipse.kura.usb.UsbModemDevice;
+import org.osgi.service.io.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class QuectelEG25 extends HspaModem implements HspaCellularModem {
+
+    private static final Logger logger = LoggerFactory.getLogger(QuectelEG25.class);
+    private static final String MODEM_NOT_AVAILABLE = "Modem not available for AT commands: ";
+
+    public QuectelEG25(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
+
+        super(device, platform, connectionFactory);
+
+        try {
+            String atPort = getAtPort();
+            String gpsPort = getGpsPort();
+            if (atPort != null && (atPort.equals(getDataPort()) || atPort.equals(gpsPort))) {
+                this.serialNumber = getSerialNumber();
+                this.imsi = getMobileSubscriberIdentity();
+                this.iccid = getIntegratedCirquitCardId();
+                this.model = getModel();
+                this.manufacturer = getManufacturer();
+                this.revisionId = getRevisionID();
+                this.gpsSupported = isGpsSupported();
+                this.rssi = getSignalStrength();
+
+                logger.trace("{} :: Serial Number={}", getClass().getName(), this.serialNumber);
+                logger.trace("{} :: IMSI={}", getClass().getName(), this.imsi);
+                logger.trace("{} :: ICCID={}", getClass().getName(), this.iccid);
+                logger.trace("{} :: Model={}", getClass().getName(), this.model);
+                logger.trace("{} :: Manufacturer={}", getClass().getName(), this.manufacturer);
+                logger.trace("{} :: Revision ID={}", getClass().getName(), this.revisionId);
+                logger.trace("{} :: GPS Supported={}", getClass().getName(), this.gpsSupported);
+                logger.trace("{} :: RSSI={}", getClass().getName(), this.rssi);
+            }
+        } catch (KuraException e) {
+            logger.error("Failed to initialize " + QuectelEG25.class.getName(), e);
+        }
+    }
+
+    @Override
+    public boolean isSimCardReady() throws KuraException {
+
+        boolean simReady = false;
+        String port = null;
+
+        if (isGpsEnabled() && getAtPort().equals(getGpsPort()) && !getAtPort().equals(getDataPort())) {
+            port = getDataPort();
+        } else {
+            port = getAtPort();
+        }
+
+        synchronized (atLock) {
+            logger.debug("sendCommand getSimStatus :: {} command to port {}",
+                    QuectelEG25AtCommands.GET_SIM_STATUS.getCommand(), port);
+            byte[] reply = null;
+            CommConnection commAtConnection = null;
+            try {
+
+                commAtConnection = openSerialPort(port);
+                if (!isAtReachable(commAtConnection)) {
+                    throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                            MODEM_NOT_AVAILABLE + QuectelEG25.class.getName());
+                }
+
+                reply = commAtConnection.sendCommand(QuectelEG25AtCommands.GET_SIM_STATUS.getCommand().getBytes(), 1000,
+                        100);
+                if (reply != null) {
+                    String simStatus = getResponseString(reply);
+                    String[] simStatusSplit = simStatus.split(",");
+                    if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
+                        simReady = true;
+                    }
+                }
+            } catch (IOException e) {
+                throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, e);
+            } catch (KuraException e) {
+                throw e;
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+        }
+        return simReady;
+
+    }
+
+    @Override
+    public ModemRegistrationStatus getRegistrationStatus() throws KuraException {
+
+        ModemRegistrationStatus modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
+        synchronized (atLock) {
+            logger.debug("sendCommand getRegistrationStatus :: {}",
+                    QuectelEG25AtCommands.GET_REGISTRATION_STATUS.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelEG25.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelEG25AtCommands.GET_REGISTRATION_STATUS.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sRegStatus = getResponseString(reply);
+                String[] regStatusSplit = sRegStatus.split(",");
+                if (regStatusSplit.length >= 2) {
+                    int status = Integer.parseInt(regStatusSplit[1]);
+                    switch (status) {
+                    case 0:
+                        modemRegistrationStatus = ModemRegistrationStatus.NOT_REGISTERED;
+                        break;
+                    case 1:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_HOME;
+                        break;
+                    case 3:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTRATION_DENIED;
+                        break;
+                    case 4:
+                        modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
+                        break;
+                    case 5:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_ROAMING;
+                        break;
+                    default:
+                    }
+                }
+            }
+        }
+        return modemRegistrationStatus;
+    }
+
+    @Override
+    public long getCallTxCounter() throws KuraException {
+
+        long txCnt = 0;
+        synchronized (atLock) {
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelEG25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelEG25.class.getName());
+            }
+            try {
+                reply = commAtConnection.sendCommand(
+                        QuectelEG25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] sDataVolume = this.getResponseString(reply).split(" ");
+                if (sDataVolume.length >= 2) {
+                    txCnt = Integer.parseInt(sDataVolume[1].split(",")[0]);
+                }
+            }
+        }
+        return txCnt;
+    }
+
+    @Override
+    public long getCallRxCounter() throws KuraException {
+        long rxCnt = 0;
+        synchronized (atLock) {
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelEG25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelEG25.class.getName());
+            }
+            try {
+                reply = commAtConnection.sendCommand(
+                        QuectelEG25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] sDataVolume = this.getResponseString(reply).split(" ");
+                if (sDataVolume.length >= 2) {
+                    rxCnt = Integer.parseInt(sDataVolume[1].split(",")[1]);
+                }
+            }
+        }
+        return rxCnt;
+    }
+
+    @Override
+    public String getServiceType() throws KuraException {
+        String serviceType = null;
+        synchronized (atLock) {
+            logger.debug("sendCommand getMobileStationClass :: {}",
+                    QuectelEG25AtCommands.GET_MOBILESTATION_CLASS.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelEG25.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelEG25AtCommands.GET_MOBILESTATION_CLASS.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sCgclass = this.getResponseString(reply);
+                if (sCgclass.startsWith("+CGCLASS:")) {
+                    sCgclass = sCgclass.substring("+CGCLASS:".length()).trim();
+                    if (sCgclass.equals("\"A\"")) {
+                        serviceType = "UMTS";
+                    } else if (sCgclass.equals("\"B\"")) {
+                        serviceType = "GSM/GPRS";
+                    } else if (sCgclass.equals("\"CG\"")) {
+                        serviceType = "GPRS";
+                    } else if (sCgclass.equals("\"CC\"")) {
+                        serviceType = "GSM";
+                    }
+                }
+            }
+        }
+
+        return serviceType;
+    }
+
+    @Override
+    public List<ModemTechnologyType> getTechnologyTypes() throws KuraException {
+
+        List<ModemTechnologyType> modemTechnologyTypes = null;
+        ModemDevice device = getModemDevice();
+        if (device == null) {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "No modem device");
+        }
+        if (device instanceof UsbModemDevice) {
+            SupportedUsbModemInfo usbModemInfo = SupportedUsbModemsInfo.getModem((UsbModemDevice) device);
+            if (usbModemInfo != null) {
+                modemTechnologyTypes = usbModemInfo.getTechnologyTypes();
+            } else {
+                throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "No usbModemInfo available");
+            }
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "Unsupported modem device");
+        }
+        return modemTechnologyTypes;
+    }
+
+    @Override
+    public boolean isGpsSupported() throws KuraException {
+        return false; // Will be activated later
+    }
+
+    @Override
+    public void enableGps() throws KuraException {
+        logger.warn("Modem GPS not supported");
+    }
+
+    @Override
+    public void disableGps() throws KuraException {
+        logger.warn("Modem GPS not supported");
+    }
+
+    @Override
+    public void reset() throws KuraException {
+        sleep(5000);
+        while (true) {
+            try {
+                turnOff();
+                sleep(1000);
+                turnOn();
+                logger.info("reset() :: modem reset successful");
+                break;
+            } catch (Exception e) {
+                logger.error("Failed to reset the modem", e);
+            }
+        }
+    }
+
+    private void turnOff() throws KuraException {
+        UsbModemDriver modemDriver = getModemDriver();
+        if (modemDriver != null) {
+            modemDriver.disable();
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE);
+        }
+    }
+
+    private void turnOn() throws KuraException {
+        UsbModemDriver modemDriver = getModemDriver();
+        if (modemDriver != null) {
+            modemDriver.enable();
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE);
+        }
+    }
+
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25.java
@@ -291,12 +291,12 @@ public class QuectelEG25 extends HspaModem implements HspaCellularModem {
 
     @Override
     public void enableGps() throws KuraException {
-        logger.warn("Modem GPS not supported");
+        throw new UnsupportedOperationException("Modem GPS not supported");
     }
 
     @Override
     public void disableGps() throws KuraException {
-        logger.warn("Modem GPS not supported");
+        throw new UnsupportedOperationException("Modem GPS not supported");
     }
 
     @Override

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25AtCommands.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.eg25;
+
+public enum QuectelEG25AtCommands {
+
+    GET_SIM_STATUS("at+qsimstat?\r\n"),
+    GET_SIM_PIN_STATUS("at+cpin?\r\n"),
+    GET_MOBILESTATION_CLASS("at+cgclass?\r\n"),
+    GET_REGISTRATION_STATUS("at+cgreg?\r\n"),
+    GET_GPRS_SESSION_DATA_VOLUME("at+qgdcnt?\r\n"),
+    PDP_CONTEXT("at+cgdcont\r\n");
+
+    private String command;
+
+    private QuectelEG25AtCommands(String atCommand) {
+        this.command = atCommand;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25ConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25ConfigGenerator.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.eg25;
+
+import org.eclipse.kura.net.admin.modem.ModemPppConfigGenerator;
+import org.eclipse.kura.net.admin.modem.PppPeer;
+import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangePair;
+import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangeScript;
+import org.eclipse.kura.net.modem.ModemConfig;
+import org.eclipse.kura.net.modem.ModemConfig.PdpType;
+
+public class QuectelEG25ConfigGenerator implements ModemPppConfigGenerator {
+
+    private static final String ABORT = "ABORT";
+
+    @Override
+    public PppPeer getPppPeer(String deviceId, ModemConfig modemConfig, String logFile, String connectScript,
+            String disconnectScript) {
+
+        PppPeer pppPeer = new PppPeer();
+
+        // default values
+        pppPeer.setBaudRate(115200);
+        pppPeer.setEnableDebug(true);
+        pppPeer.setUseModemControlLines(true);
+        pppPeer.setUseRtsCtsFlowControl(false);
+        pppPeer.setLockSerialDevice(true);
+        pppPeer.setPeerMustAuthenticateItself(false);
+        pppPeer.setPeerToSupplyLocalIP(true);
+        pppPeer.setAddDefaultRoute(true);
+        pppPeer.setUsePeerDns(true);
+        pppPeer.setAllowProxyArps(false);
+        pppPeer.setAllowVanJacobsonTcpIpHdrCompression(false);
+        pppPeer.setAllowVanJacobsonConnectionIDCompression(false);
+        pppPeer.setAllowBsdCompression(false);
+        pppPeer.setAllowDeflateCompression(false);
+        pppPeer.setAllowMagic(false);
+        pppPeer.setConnectDelay(1000);
+        pppPeer.setLcpEchoInterval(0);
+
+        // other config
+        pppPeer.setLogfile(logFile);
+        pppPeer.setProvider(deviceId);
+        pppPeer.setPppUnitNumber(modemConfig.getPppNumber());
+        pppPeer.setConnectScript(connectScript);
+        pppPeer.setDisconnectScript(disconnectScript);
+        pppPeer.setApn(modemConfig.getApn());
+        pppPeer.setAuthType(modemConfig.getAuthType());
+        pppPeer.setUsername(modemConfig.getUsername());
+        pppPeer.setPassword(modemConfig.getPasswordAsPassword());
+        pppPeer.setDialString(modemConfig.getDialString());
+        pppPeer.setPersist(modemConfig.isPersist());
+        pppPeer.setMaxFail(modemConfig.getMaxFail());
+        pppPeer.setIdleTime(modemConfig.getIdle());
+        pppPeer.setActiveFilter(modemConfig.getActiveFilter());
+        pppPeer.setLcpEchoInterval(modemConfig.getLcpEchoInterval());
+        pppPeer.setLcpEchoFailure(modemConfig.getLcpEchoFailure());
+
+        return pppPeer;
+    }
+
+    @Override
+    public ModemXchangeScript getConnectScript(ModemConfig modemConfig) {
+        // PDP context is fixed to 1 for this modem
+        int pdpPid = 1;
+        String apn = "";
+        String dialString = "";
+
+        if (modemConfig != null) {
+            apn = modemConfig.getApn();
+            dialString = modemConfig.getDialString();
+        }
+
+        ModemXchangeScript modemXchange = new ModemXchangeScript();
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"ERROR\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ath\"", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"AT\"", "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formPDPcontext(pdpPid, PdpType.IP, apn), "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\d\\d\\d\"", "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formDialString(dialString), "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\c\"", "CONNECT"));
+
+        return modemXchange;
+    }
+
+    @Override
+    public ModemXchangeScript getDisconnectScript(ModemConfig modemConfig) {
+
+        ModemXchangeScript modemXchange = new ModemXchangeScript();
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("BREAK", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ATH\"", "\"\""));
+
+        return modemXchange;
+    }
+
+    /*
+     * This method forms dial string
+     */
+    private String formDialString(String dialString) {
+        StringBuilder buf = new StringBuilder();
+        buf.append('"');
+        if (dialString != null) {
+            buf.append(dialString);
+        }
+        buf.append('"');
+        return buf.toString();
+    }
+
+    /*
+     * This method forms PDP context
+     * (e.g. AT+CGDCONT=<pid>,<pdp_type>,<apn>)
+     */
+    private String formPDPcontext(int pdpPid, PdpType pdpType, String apn) {
+
+        StringBuilder pdpcontext = new StringBuilder(QuectelEG25AtCommands.PDP_CONTEXT.getCommand());
+        pdpcontext.append('=');
+        pdpcontext.append(pdpPid);
+        pdpcontext.append(',');
+        pdpcontext.append('"');
+        pdpcontext.append(pdpType.toString());
+        pdpcontext.append('"');
+        pdpcontext.append(',');
+        pdpcontext.append('"');
+        if (apn != null) {
+            pdpcontext.append(apn);
+        }
+        pdpcontext.append('"');
+
+        return pdpcontext.toString();
+    }
+
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25ModemFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25ModemFactory.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.eg25;
+
+import org.eclipse.kura.net.admin.NetworkConfigurationService;
+import org.eclipse.kura.net.admin.util.AbstractCellularModemFactory;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.io.ConnectionFactory;
+import org.osgi.util.tracker.ServiceTracker;
+
+public class QuectelEG25ModemFactory extends AbstractCellularModemFactory<QuectelEG25> {
+
+    private static QuectelEG25ModemFactory factoryInstance = null;
+    private ConnectionFactory connectionFactory;
+
+    private BundleContext bundleContext = null;
+
+    private QuectelEG25ModemFactory() {
+        this.bundleContext = FrameworkUtil.getBundle(NetworkConfigurationService.class).getBundleContext();
+
+        ServiceTracker<ConnectionFactory, ConnectionFactory> serviceTracker = new ServiceTracker<>(this.bundleContext,
+                ConnectionFactory.class, null);
+        serviceTracker.open(true);
+        this.connectionFactory = serviceTracker.getService();
+    }
+
+    public static QuectelEG25ModemFactory getInstance() {
+        if (factoryInstance == null) {
+            factoryInstance = new QuectelEG25ModemFactory();
+        }
+        return factoryInstance;
+    }
+
+    @Override
+    @Deprecated
+    public ModemTechnologyType getType() {
+        return ModemTechnologyType.LTE;
+    }
+
+    @Override
+    protected QuectelEG25 createCellularModem(ModemDevice modemDevice, String platform) throws Exception {
+        return new QuectelEG25(modemDevice, platform, this.connectionFactory);
+    }
+}


### PR DESCRIPTION
This PR adds the support for the Quectel EG25-G cellular modem.

**Description of the solution adopted:** The `SupportedUsbModemInfo` and `SupportedUsbModemsFactoryInfo` classes have been updated with the new modem. The `QuectelEG25`, `QuectelEG25ModemFactory`, `QuectelEG25AtCommands` and `QuectelEG25ConfigGenerator` support classes have been added with all the necessary code for the modem management.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>