### PR TITLE
Make Target Filter field readonly

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -241,6 +241,7 @@ public abstract class AbstractServicesUi extends Composite {
         });
 
         if (param.getId().endsWith(TARGET_SUFFIX)) {
+            textBox.setReadOnly(true);
             String targetedService = param.getId().split(TARGET_SUFFIX)[0];
 
             DropDown dropDown = new DropDown();


### PR DESCRIPTION
Modified Target Filter field so that it is readonly. This prevents invalid Target Filters in input.
 
**Related Issue:** This PR fixes/closes #2601 

**Any side note on the changes made:** This still doesn't prevent the user from modifying the field from Kapua or EC
