### PR TITLE
Fix Oomph installation Maven error

### DIFF
--- a/kura/setups/kura.setup
+++ b/kura/setups/kura.setup
@@ -87,7 +87,7 @@
         name="org.sonarlint.eclipse.feature.feature.group"
         optional="true"/>
     <repository
-        url="http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST/"/>
+        url="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST/"/>
     <repository
         url="http://mtoolkit-neon.s3-website-us-east-1.amazonaws.com"/>
     <repository


### PR DESCRIPTION
Replace http://repo1.maven.org/maven2/... with https://repo1.maven.org/maven2/...

**Related Issue:** This PR fixes/closes {#2661, #2632}

**Description of the solution adopted:** The Maven Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.

https://support.sonatype.com/hc/en-us/articles/360041287334