### PR TITLE
Improve CommandExecutorService

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/executor/CommandStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/executor/CommandStatus.java
@@ -23,6 +23,7 @@ import org.apache.commons.io.output.NullOutputStream;
  * <p>
  * The parameters are the following:
  * <ul>
+ * <li>command : the command run by the {@link CommandExecutorService}</li>
  * <li>exitStatus : the {@link ExitStatus} of the command. A value other than 0 means an error. When the command is
  * stopped by timeout the exit value is 124.</li>
  * <li>isTimedout : a flag that signals that the command was stopped by timeout</li>
@@ -34,17 +35,27 @@ import org.apache.commons.io.output.NullOutputStream;
  */
 public class CommandStatus {
 
+    private Command command;
     private ExitStatus exitStatus;
     private OutputStream outputStream;
     private OutputStream errorStream;
     private InputStream inputStream;
     private boolean isTimedout;
 
-    public CommandStatus(ExitStatus exitStatus) {
+    public CommandStatus(Command command, ExitStatus exitStatus) {
+        this.command = command;
         this.exitStatus = exitStatus;
         this.outputStream = new NullOutputStream();
         this.errorStream = new NullOutputStream();
         this.isTimedout = false;
+    }
+
+    public Command getCommand() {
+        return command;
+    }
+
+    public void setCommand(Command command) {
+        this.command = command;
     }
 
     public ExitStatus getExitStatus() {

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/linux/executor/ExecutorUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/linux/executor/ExecutorUtil.java
@@ -200,7 +200,7 @@ public class ExecutorUtil {
             }
         }
         // Sort pids in reverse order (useful when stop processes...)
-        return pids.entrySet().stream().sorted(Map.Entry.<String, Integer> comparingByValue().reversed())
+        return pids.entrySet().stream().sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> new LinuxPid(e.getValue()), (e1, e2) -> e1,
                         LinkedHashMap::new));
     }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/linux/executor/ExecutorUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/internal/linux/executor/ExecutorUtil.java
@@ -200,7 +200,7 @@ public class ExecutorUtil {
             }
         }
         // Sort pids in reverse order (useful when stop processes...)
-        return pids.entrySet().stream().sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+        return pids.entrySet().stream().sorted(Map.Entry.<String, Integer> comparingByValue().reversed())
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> new LinuxPid(e.getValue()), (e1, e2) -> e1,
                         LinkedHashMap::new));
     }
@@ -210,7 +210,7 @@ public class ExecutorUtil {
     }
 
     private static CommandStatus executeSync(Command command, CommandLine commandLine) {
-        CommandStatus commandStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus commandStatus = new CommandStatus(command, new LinuxExitStatus(0));
         commandStatus.setOutputStream(command.getOutputStream());
         commandStatus.setErrorStream(command.getErrorStream());
         commandStatus.setInputStream(command.getInputStream());
@@ -271,7 +271,7 @@ public class ExecutorUtil {
     }
 
     private static void executeAsync(Command command, CommandLine commandLine, Consumer<CommandStatus> callback) {
-        CommandStatus commandStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus commandStatus = new CommandStatus(command, new LinuxExitStatus(0));
         commandStatus.setOutputStream(command.getOutputStream());
         commandStatus.setErrorStream(command.getErrorStream());
         commandStatus.setInputStream(command.getInputStream());

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/privileged/PrivilegedExecutorServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/privileged/PrivilegedExecutorServiceImpl.java
@@ -50,7 +50,7 @@ public class PrivilegedExecutorServiceImpl implements PrivilegedExecutorService 
     @Override
     public CommandStatus execute(Command command) {
         if (command.getCommandLine() == null || command.getCommandLine().length == 0) {
-            return buildErrorStatus();
+            return buildErrorStatus(command);
         }
         if (command.getSignal() == null) {
             command.setSignal(DEFAULT_SIGNAL);
@@ -61,7 +61,7 @@ public class PrivilegedExecutorServiceImpl implements PrivilegedExecutorService 
     @Override
     public void execute(Command command, Consumer<CommandStatus> callback) {
         if (command.getCommandLine() == null || command.getCommandLine().length == 0) {
-            callback.accept(buildErrorStatus());
+            callback.accept(buildErrorStatus(command));
         }
         if (command.getSignal() == null) {
             command.setSignal(DEFAULT_SIGNAL);
@@ -106,8 +106,8 @@ public class PrivilegedExecutorServiceImpl implements PrivilegedExecutorService 
         return ExecutorUtil.getPids(commandLine);
     }
 
-    private CommandStatus buildErrorStatus() {
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
+    private CommandStatus buildErrorStatus(Command command) {
+        CommandStatus status = new CommandStatus(command, new LinuxExitStatus(1));
         ByteArrayOutputStream err = new ByteArrayOutputStream();
         try {
             err.write("The commandLine cannot be empty or not defined".getBytes(Charsets.UTF_8));

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/unprivileged/UnprivilegedExecutorServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/unprivileged/UnprivilegedExecutorServiceImpl.java
@@ -62,7 +62,7 @@ public class UnprivilegedExecutorServiceImpl implements UnprivilegedExecutorServ
     @Override
     public CommandStatus execute(Command command) {
         if (command.getCommandLine() == null || command.getCommandLine().length == 0) {
-            return buildErrorStatus();
+            return buildErrorStatus(command);
         }
         if (command.getSignal() == null) {
             command.setSignal(DEFAULT_SIGNAL);
@@ -73,7 +73,7 @@ public class UnprivilegedExecutorServiceImpl implements UnprivilegedExecutorServ
     @Override
     public void execute(Command command, Consumer<CommandStatus> callback) {
         if (command.getCommandLine() == null || command.getCommandLine().length == 0) {
-            callback.accept(buildErrorStatus());
+            callback.accept(buildErrorStatus(command));
         }
         if (command.getSignal() == null) {
             command.setSignal(DEFAULT_SIGNAL);
@@ -118,8 +118,8 @@ public class UnprivilegedExecutorServiceImpl implements UnprivilegedExecutorServ
         return ExecutorUtil.getPids(commandLine);
     }
 
-    private CommandStatus buildErrorStatus() {
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
+    private CommandStatus buildErrorStatus(Command command) {
+        CommandStatus status = new CommandStatus(command, new LinuxExitStatus(1));
         ByteArrayOutputStream err = new ByteArrayOutputStream();
         try {
             err.write("The commandLine cannot be empty or not defined".getBytes(Charsets.UTF_8));

--- a/kura/test/org.eclipse.kura.cloud.test/src/test/java/org/eclipse/kura/cloud/app/command/CommandCloudAppTest.java
+++ b/kura/test/org.eclipse.kura.cloud.test/src/test/java/org/eclipse/kura/cloud/app/command/CommandCloudAppTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
@@ -41,8 +41,9 @@ import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.crypto.CryptoService;
-import org.eclipse.kura.executor.CommandStatus;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.message.KuraPayload;
 import org.eclipse.kura.message.KuraRequestPayload;
 import org.eclipse.kura.message.KuraResponsePayload;
@@ -369,7 +370,7 @@ public class CommandCloudAppTest {
         int exitVal = 0;
 
         KuraCommandResponsePayload resp = new KuraCommandResponsePayload(KuraResponsePayload.RESPONSE_CODE_OK);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -396,7 +397,7 @@ public class CommandCloudAppTest {
         baes.write(err.getBytes(UTF_8));
 
         KuraCommandResponsePayload resp = new KuraCommandResponsePayload(KuraResponsePayload.RESPONSE_CODE_OK);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(1));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -423,7 +424,7 @@ public class CommandCloudAppTest {
         baes.write(err.getBytes(UTF_8));
 
         KuraCommandResponsePayload resp = new KuraCommandResponsePayload(KuraResponsePayload.RESPONSE_CODE_OK);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(true);
@@ -565,7 +566,7 @@ public class CommandCloudAppTest {
         baos.write("OK".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("err".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -618,7 +619,7 @@ public class CommandCloudAppTest {
         baos.write("NOK".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("err".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -663,7 +664,7 @@ public class CommandCloudAppTest {
         baos.write("OK".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("err".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);
@@ -732,7 +733,7 @@ public class CommandCloudAppTest {
         baos.write("OK".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("err".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);

--- a/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
+++ b/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
@@ -35,8 +35,9 @@ import org.eclipse.kura.core.deployment.InstallStatus;
 import org.eclipse.kura.core.deployment.download.DeploymentPackageDownloadOptions;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.testutil.TestUtil;
-import org.eclipse.kura.executor.CommandStatus;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.message.KuraResponsePayload;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -307,7 +308,7 @@ public class InstallImplTest {
     @Test
     public void testSendInstallConfirmations() throws IOException, KuraException {
         CloudDeploymentHandlerV2 callbackMock = mock(CloudDeploymentHandlerV2.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         String kuraDataDir = "/tmp";
@@ -387,7 +388,7 @@ public class InstallImplTest {
     @Test
     public void testSendInstallConfirmationsError() throws IOException, KuraException {
         CloudDeploymentHandlerV2 callbackMock = mock(CloudDeploymentHandlerV2.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(1));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         String kuraDataDir = "/tmp";

--- a/kura/test/org.eclipse.kura.internal.ble.test/src/test/java/org/eclipse/kura/internal/ble/util/BluetoothProcessTest.java
+++ b/kura/test/org.eclipse.kura.internal.ble.test/src/test/java/org/eclipse/kura/internal/ble/util/BluetoothProcessTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
@@ -21,8 +21,9 @@ import java.io.IOException;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
-import org.eclipse.kura.executor.CommandStatus;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.executor.CommandStatus;
 import org.junit.Test;
 
 public class BluetoothProcessTest {
@@ -66,7 +67,7 @@ public class BluetoothProcessTest {
         baos.write("test\\r?\\n".getBytes(UTF_8));
         ByteArrayOutputStream baes = new ByteArrayOutputStream(3);
         baes.write("testerror\\r?\\n".getBytes(UTF_8));
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         status.setErrorStream(baes);
         status.setOutputStream(baos);
         status.setTimedout(false);

--- a/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/ClockServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/ClockServiceImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
@@ -32,6 +32,7 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.clock.ClockEvent;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.executor.CommandStatus;
 import org.junit.Test;
@@ -182,7 +183,7 @@ public class ClockServiceImplTest {
         assumeTrue("Only run this test on Linux", System.getProperty("os.name").matches("[Ll]inux"));
         assumeTrue("Only run this test as root", "root".equals(System.getProperty("user.name")));
 
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         ClockServiceImpl svc = new ClockServiceImpl();
@@ -205,7 +206,7 @@ public class ClockServiceImplTest {
     public void testClockUpdateErrors() throws Throwable {
         // test the service's onClockUpdate() with clock update failures; test of proper logging, mostly
 
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(1));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         ClockServiceImpl svc = new ClockServiceImpl();
@@ -228,7 +229,7 @@ public class ClockServiceImplTest {
     public void testClockUpdate() throws Throwable {
         // test the service's onClockUpdate()
 
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         ClockServiceImpl svc = new ClockServiceImpl();

--- a/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/NtpdClockSyncProviderTest.java
+++ b/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/NtpdClockSyncProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
@@ -20,8 +20,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.core.testutil.TestUtil;
-import org.eclipse.kura.executor.CommandStatus;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.executor.CommandStatus;
 import org.junit.Test;
 
 public class NtpdClockSyncProviderTest {
@@ -29,7 +30,7 @@ public class NtpdClockSyncProviderTest {
     @Test
     public void testSynch() throws KuraException, NoSuchFieldException {
 
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         NtpdClockSyncProvider provider = new NtpdClockSyncProvider(serviceMock);
@@ -55,7 +56,7 @@ public class NtpdClockSyncProviderTest {
     @Test
     public void testSynchError() throws KuraException, NoSuchFieldException {
 
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(1));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(1));
         CommandExecutorService serviceMock = mock(CommandExecutorService.class);
         when(serviceMock.execute(anyObject())).thenReturn(status);
         NtpdClockSyncProvider provider = new NtpdClockSyncProvider(serviceMock);

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImplTest.java
@@ -202,7 +202,7 @@ public class ModemMonitorServiceImplTest {
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
 
-        CommandStatus linkStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus linkStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(outputStream);
         out.write(
@@ -216,7 +216,7 @@ public class ModemMonitorServiceImplTest {
         linkStatusCommand.setTimeout(60);
         when(esMock.execute(linkStatusCommand)).thenReturn(linkStatus);
         
-        CommandStatus addrStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus addrStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         outputStream = new ByteArrayOutputStream();
         out = new DataOutputStream(outputStream);
         out.write(
@@ -230,13 +230,13 @@ public class ModemMonitorServiceImplTest {
         addrStatusCommand.setTimeout(60);
         when(esMock.execute(addrStatusCommand)).thenReturn(addrStatus);
 
-        CommandStatus infoStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus infoStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         cmd = new String[] {"iw", "dev", "ppp1", "info"};
         Command infoCommand = new Command(cmd);
         infoCommand.setTimeout(60);
         when(esMock.execute(infoCommand)).thenReturn(infoStatus);
         
-        CommandStatus iwconfigStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus iwconfigStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         cmd = new String[] {"iwconfig", "ppp1"};
         Command iwconfigCommand = new Command(cmd);
         iwconfigCommand.setTimeout(60);
@@ -248,7 +248,7 @@ public class ModemMonitorServiceImplTest {
         iwconfigStatus.setOutputStream(outputStream);
         when(esMock.execute(iwconfigCommand)).thenReturn(iwconfigStatus);
         
-        CommandStatus ethtoolStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus ethtoolStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         cmd = new String[] {"ethtool", "-i", "ppp1"};
         Command ethtoolCommand = new Command(cmd);
         ethtoolCommand.setTimeout(60);
@@ -964,7 +964,7 @@ public class ModemMonitorServiceImplTest {
         org.eclipse.kura.executor.CommandExecutorService esMock = mock(
                 org.eclipse.kura.executor.CommandExecutorService.class);
 
-        CommandStatus linkStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus linkStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(outputStream);
         out.write(
@@ -978,7 +978,7 @@ public class ModemMonitorServiceImplTest {
         linkStatusCommand.setTimeout(60);
         when(esMock.execute(linkStatusCommand)).thenReturn(linkStatus);
 
-        CommandStatus addrStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus addrStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         outputStream = new ByteArrayOutputStream();
         out = new DataOutputStream(outputStream);
         out.write(
@@ -992,13 +992,13 @@ public class ModemMonitorServiceImplTest {
         addrStatusCommand.setTimeout(60);
         when(esMock.execute(addrStatusCommand)).thenReturn(addrStatus);
 
-        CommandStatus infoStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus infoStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         cmd = new String[] {"iw", "dev", "ppp0", "info"};
         Command infoCommand = new Command(cmd);
         infoCommand.setTimeout(60);
         when(esMock.execute(infoCommand)).thenReturn(infoStatus);
 
-        CommandStatus iwconfigStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus iwconfigStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         cmd = new String[] {"iwconfig", "ppp0"};
         Command iwconfigCommand = new Command(cmd);
         iwconfigCommand.setTimeout(60);
@@ -1012,7 +1012,7 @@ public class ModemMonitorServiceImplTest {
         iwconfigStatus.setOutputStream(outputStream);
         when(esMock.execute(iwconfigCommand)).thenReturn(iwconfigStatus);
 
-        CommandStatus ethtoolStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus ethtoolStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         cmd = new String[] {"ethtool", "-i", "ppp0"};
         Command ethtoolCommand = new Command(cmd);
         ethtoolCommand.setTimeout(60);

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImplTest.java
@@ -651,8 +651,10 @@ public class WifiMonitorServiceImplTest {
         String wlan2 = "wlan2";
         String wlan3 = "wlan3";
 
-        InterfaceState wlan3OldState = new InterfaceState(wlan3, true, true, IPAddress.parseHostAddress("10.10.0.3"), 2);
-        InterfaceState wlan3NewState = new InterfaceState(wlan3, true, true, IPAddress.parseHostAddress("10.10.0.4"), 2);
+        InterfaceState wlan3OldState = new InterfaceState(wlan3, true, true, IPAddress.parseHostAddress("10.10.0.3"),
+                2);
+        InterfaceState wlan3NewState = new InterfaceState(wlan3, true, true, IPAddress.parseHostAddress("10.10.0.4"),
+                2);
 
         EventAdmin eaMock = mock(EventAdmin.class);
         svc.setEventAdmin(eaMock);
@@ -805,7 +807,7 @@ public class WifiMonitorServiceImplTest {
         String ssid = "mySSID";
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(outputStream);
         out.write(
@@ -962,7 +964,7 @@ public class WifiMonitorServiceImplTest {
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
 
-        CommandStatus linkStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus linkStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(outputStream);
         out.write(
@@ -976,7 +978,7 @@ public class WifiMonitorServiceImplTest {
         linkStatusCommand.setTimeout(60);
         when(esMock.execute(linkStatusCommand)).thenReturn(linkStatus);
 
-        CommandStatus addrStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus addrStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         outputStream = new ByteArrayOutputStream();
         out = new DataOutputStream(outputStream);
         out.write(
@@ -990,13 +992,13 @@ public class WifiMonitorServiceImplTest {
         addrStatusCommand.setTimeout(60);
         when(esMock.execute(addrStatusCommand)).thenReturn(addrStatus);
 
-        CommandStatus infoStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus infoStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         cmd = new String[] { "iw", "dev", "wlan3", "info" };
         Command infoCommand = new Command(cmd);
         infoCommand.setTimeout(60);
         when(esMock.execute(infoCommand)).thenReturn(infoStatus);
 
-        CommandStatus iwconfigStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus iwconfigStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         cmd = new String[] { "iwconfig", "wlan3" };
         Command iwconfigCommand = new Command(cmd);
         iwconfigCommand.setTimeout(60);
@@ -1010,7 +1012,7 @@ public class WifiMonitorServiceImplTest {
         iwconfigStatus.setOutputStream(outputStream);
         when(esMock.execute(iwconfigCommand)).thenReturn(iwconfigStatus);
 
-        CommandStatus ethtoolStatus = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus ethtoolStatus = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         cmd = new String[] { "ethtool", "-i", "wlan3" };
         Command ethtoolCommand = new Command(cmd);
         ethtoolCommand.setTimeout(60);

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/FirewallAutoNatConfigTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/FirewallAutoNatConfigTest.java
@@ -33,6 +33,7 @@ import org.eclipse.kura.core.net.NetworkConfiguration;
 import org.eclipse.kura.core.net.WifiInterfaceAddressConfigImpl;
 import org.eclipse.kura.core.net.WifiInterfaceConfigImpl;
 import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.linux.net.iptables.NATRule;
@@ -82,7 +83,7 @@ public class FirewallAutoNatConfigTest {
         NetworkConfiguration config = prepareNetworkConfiguration(intfName, destinationInterface, false, false);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);
@@ -252,7 +253,7 @@ public class FirewallAutoNatConfigTest {
         NetworkConfiguration config = prepareNetworkConfiguration(intfName, destinationInterface, false, true);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         reader.setExecutorService(esMock);
@@ -296,16 +297,7 @@ public class FirewallAutoNatConfigTest {
         NetworkConfiguration config = prepareNetworkConfiguration(intfName, destinationInterface, false, true);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
-        // ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        // DataOutputStream out = new DataOutputStream(outputStream);
-        // out.write(
-        // "wlan1 IEEE 802.11 Mode:Master Tx-Power=31 dBm\n Retry short limit:7 RTS thr:off Fragment thr:off\n Power
-        // Management:on"
-        // .getBytes());
-        // outputStream.flush();
-        // outputStream.close();
-        // status.setOutputStream(outputStream);
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         reader.setExecutorService(esMock);
@@ -417,7 +409,7 @@ public class FirewallAutoNatConfigTest {
         NetworkConfiguration config = prepareNetworkConfiguration(intfName, destinationInterface, false, true);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         reader.setExecutorService(esMock);

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigTest.java
@@ -32,6 +32,7 @@ import org.eclipse.kura.core.net.WifiInterfaceAddressConfigImpl;
 import org.eclipse.kura.core.net.WifiInterfaceConfigImpl;
 import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.core.util.IOUtil;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.net.NetConfig;
@@ -93,7 +94,7 @@ public class HostapdConfigTest {
         netInterfaceConfig.setNetInterfaceAddresses(interfaceAddressConfigs);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);
@@ -144,7 +145,7 @@ public class HostapdConfigTest {
 
         try {
             CommandExecutorService esMock = mock(CommandExecutorService.class);
-            CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+            CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
             when(esMock.execute(anyObject())).thenReturn(status);
 
             writer.setExecutorService(esMock);
@@ -224,7 +225,7 @@ public class HostapdConfigTest {
         netInterfaceConfig.setNetInterfaceAddresses(interfaceAddressConfigs);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);
@@ -341,7 +342,7 @@ public class HostapdConfigTest {
         netInterfaceConfig.setNetInterfaceAddresses(interfaceAddressConfigs);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);
@@ -569,7 +570,7 @@ public class HostapdConfigTest {
         netInterfaceConfig.setNetInterfaceAddresses(interfaceAddressConfigs);
 
         CommandExecutorService esMock = mock(CommandExecutorService.class);
-        CommandStatus status = new CommandStatus(new LinuxExitStatus(0));
+        CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         when(esMock.execute(anyObject())).thenReturn(status);
 
         writer.setExecutorService(esMock);


### PR DESCRIPTION
This PR improves the CommandExecutorService adding the Command on the returned CommandStatus.

**Related Issue:** This PR fixes/closes #2673 

**Description of the solution adopted:** The Command instance is added to he CommandStatus object in order to bind the result of an operation with the operation itself. It is useful when the commands are run in an asynchronous way and the callback can discriminate between different commands results. 
