### PR TITLE
Fixed configuration reset error when uploading csv config.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
@@ -485,12 +485,12 @@ public class FileServlet extends HttpServlet {
             if (doReplace) {
                 Map<String, Object> oldConfigProps = cs.getComponentConfiguration(assetPid)
                         .getConfigurationProperties();
-                Map<String, Object> filteredConfigProps = oldConfigProps.entrySet().stream()
-                        .filter(entry -> !entry.getKey().contains("#+"))
+                Map<String, Object> oldNonChannelProps = oldConfigProps.entrySet().stream()
+                        .filter(entry -> !entry.getKey().contains("#"))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
                 String fp = oldConfigProps.get("service.factoryPid").toString();
                 cs.deleteFactoryConfiguration(assetPid, false);
-                newProps.putAll(filteredConfigProps);
+                newProps.putAll(oldNonChannelProps);
                 cs.createFactoryConfiguration(fp, assetPid, newProps, true);
             } else {
                 cs.updateConfiguration(assetPid, newProps);


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

Brief description of the PR. Fixed asset configuration reset when uploading a csv file with the channel override feature selected

**Related Issue:** This PR fixes/closes #2639 

**Description of the solution adopted:** Instead of simply deleting the component and recreating it, that was causing a configuration reset in the asset, the configuration is kept cleaning the channels.

**Screenshots:** N/A

**Any side note on the changes made:** N/A
