### PR TITLE
Add support for Huawei MS2372

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
@@ -19,7 +19,7 @@ import org.eclipse.kura.net.modem.ModemTechnologyType;
 
 public enum SupportedUsbModemInfo {
 
-    // device name, vendor, product, ttyDevs, blockDevs, AT Port, Data Port, GPS Port, Turn off delay, technology types,
+    // device name, vendor, product, ttyDevs, blockDevs, AT Port, Data Port, GPS Port, turn off delay, turn on delay, technology types,
     // device driver
     Telit_HE910_DG("HE910-DG", "1bc7", "0021", 6, 0, 3, 0, 3, 5000, 10000, Arrays.asList(ModemTechnologyType.HSPA,
             ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "1bc7", "0021")), "6 CDC-ACM"),
@@ -51,7 +51,10 @@ public enum SupportedUsbModemInfo {
             ModemTechnologyType.GSM_GPRS), Arrays.asList(new OptionModemDriver("1e0e", "9001")), ""),
     QUECTEL_EG25("EG25", "2c7c", "0125", 4, 0, 2, 3, -1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.HSPA,
-            ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0125")), "");
+            ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0125")), ""),
+    Huawei_MS2372("MS2372", "12d1", "1506", 3, 0, 2, 0, -1, 5000, 15000, Arrays.asList(ModemTechnologyType.LTE,
+            ModemTechnologyType.HSPA, ModemTechnologyType.HSDPA, ModemTechnologyType.UMTS,
+            ModemTechnologyType.GSM_GPRS), Arrays.asList(new UsbModemDriver("option", "12d1", "1506")), "");
 
     private String deviceName;
     private String vendorId;

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
@@ -52,7 +52,7 @@ public enum SupportedUsbModemInfo {
     QUECTEL_EG25("EG25", "2c7c", "0125", 4, 0, 2, 3, -1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.HSPA,
             ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0125")), ""),
-    Huawei_MS2372("MS2372", "12d1", "1506", 3, 0, 2, 0, -1, 5000, 15000, Arrays.asList(ModemTechnologyType.LTE,
+    HUAWEI_MS2372("MS2372", "12d1", "1506", 3, 0, 2, 0, -1, 5000, 15000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.HSPA, ModemTechnologyType.HSDPA, ModemTechnologyType.UMTS,
             ModemTechnologyType.GSM_GPRS), Arrays.asList(new UsbModemDriver("option", "12d1", "1506")), "");
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
@@ -57,7 +57,7 @@ public class SupportedUsbModemsFactoryInfo {
         Zte_ME3630(SupportedUsbModemInfo.Zte_ME3630, ZteMe3630ModemFactory.class, ZteMe3630ConfigGenerator.class),
         SimTech_SIM7000(SupportedUsbModemInfo.SimTech_SIM7000, SimTechSim7000ModemFactory.class, SimTechSim7000ConfigGenerator.class),
         QUECTEL_EG25(SupportedUsbModemInfo.QUECTEL_EG25, QuectelEG25ModemFactory.class, QuectelEG25ConfigGenerator.class),
-        Huawei_MS2372(SupportedUsbModemInfo.Huawei_MS2372, HuaweiModemFactory.class, HspaModemConfigGenerator.class);
+        HUAWEI_MS2372(SupportedUsbModemInfo.HUAWEI_MS2372, HuaweiModemFactory.class, HspaModemConfigGenerator.class);
 
         private final SupportedUsbModemInfo usbModemInfo;
         private final Class<? extends CellularModemFactory> factoryClass;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
@@ -18,6 +18,8 @@ import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
 import org.eclipse.kura.linux.net.modem.UsbModemDriver;
 import org.eclipse.kura.net.admin.modem.quectel.eg25.QuectelEG25ConfigGenerator;
 import org.eclipse.kura.net.admin.modem.quectel.eg25.QuectelEG25ModemFactory;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModemConfigGenerator;
+import org.eclipse.kura.net.admin.modem.huawei.HuaweiModemFactory;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxConfigGenerator;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxModemFactory;
 import org.eclipse.kura.net.admin.modem.sierra.usb598.SierraUsb598ConfigGenerator;
@@ -54,7 +56,8 @@ public class SupportedUsbModemsFactoryInfo {
         Ublox_SARA_U2(SupportedUsbModemInfo.Ublox_SARA_U2, UbloxModemFactory.class, UbloxModemConfigGenerator.class),
         Zte_ME3630(SupportedUsbModemInfo.Zte_ME3630, ZteMe3630ModemFactory.class, ZteMe3630ConfigGenerator.class),
         SimTech_SIM7000(SupportedUsbModemInfo.SimTech_SIM7000, SimTechSim7000ModemFactory.class, SimTechSim7000ConfigGenerator.class),
-        QUECTEL_EG25(SupportedUsbModemInfo.QUECTEL_EG25, QuectelEG25ModemFactory.class, QuectelEG25ConfigGenerator.class);
+        QUECTEL_EG25(SupportedUsbModemInfo.QUECTEL_EG25, QuectelEG25ModemFactory.class, QuectelEG25ConfigGenerator.class),
+        Huawei_MS2372(SupportedUsbModemInfo.Huawei_MS2372, HuaweiModemFactory.class, HspaModemConfigGenerator.class);
 
         private final SupportedUsbModemInfo usbModemInfo;
         private final Class<? extends CellularModemFactory> factoryClass;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModem.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.net.admin.modem.huawei;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.comm.CommConnection;
+import org.eclipse.kura.linux.net.modem.UsbModemDriver;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModem;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.osgi.service.io.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HuaweiModem extends HspaModem {
+
+    private static final Logger logger = LoggerFactory.getLogger(HuaweiModem.class);
+
+    private boolean initialized;
+
+    public HuaweiModem(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
+        super(device, platform, connectionFactory);
+    }
+
+    @Override
+    public String getIntegratedCirquitCardId() throws KuraException {
+        synchronized (this.atLock) {
+            if (this.iccid == null && isSimCardReady()) {
+                logger.debug("sendCommand getICCID :: {}", HuaweiModemAtCommands.getICCID.getCommand());
+
+                final byte[] reply;
+                CommConnection commAtConnection = openSerialPort(getAtPort());
+                if (!isAtReachable(commAtConnection)) {
+                    closeSerialPort(commAtConnection);
+                    throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
+                }
+
+                try {
+                    reply = commAtConnection.sendCommand(HuaweiModemAtCommands.getICCID.getCommand().getBytes(), 1000,
+                            100);
+                } catch (IOException e) {
+                    closeSerialPort(commAtConnection);
+                    throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+                } finally {
+                    closeSerialPort(commAtConnection);
+                }
+
+                if (reply == null) {
+                    throw new KuraException(KuraErrorCode.TIMED_OUT, HuaweiModemAtCommands.getICCID.getCommand());
+                }
+                final String response = getResponseString(reply);
+                if (response.startsWith("^ICCID:")) {
+                    this.iccid = response.substring("^ICCID:".length()).trim();
+                } else {
+                    throw new KuraException(KuraErrorCode.BAD_REQUEST, response);
+                }
+            }
+        }
+        return this.iccid;
+    }
+
+    @Override
+    public boolean isSimCardReady() throws KuraException {
+        if (!this.initialized) {
+            disableURC();
+            this.initialized = true;
+        }
+
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getSimType :: {}", HuaweiModemAtCommands.getSimType.getCommand());
+
+            final byte[] reply;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
+            }
+
+            try {
+                reply = commAtConnection.sendCommand(HuaweiModemAtCommands.getSimType.getCommand().getBytes(), 1000,
+                        100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+
+            if (reply == null) {
+                throw new KuraException(KuraErrorCode.TIMED_OUT, HuaweiModemAtCommands.getSimType.getCommand());
+            }
+            final String response = this.getResponseString(reply);
+            if (response.startsWith("^CARDMODE:")) {
+                return !"0".equals(response.substring("^CARDMODE:".length()).trim());
+            } else {
+                throw new KuraException(KuraErrorCode.BAD_REQUEST, response);
+            }
+        }
+    }
+
+    @Override
+    public void reset() throws KuraException {
+        UsbModemDriver modemDriver = getModemDriver();
+        modemDriver.disable();
+        modemDriver.enable();
+    }
+
+    private void disableURC() throws KuraException {
+        synchronized (this.atLock) {
+            logger.debug("sendCommand disableURC :: {}", HuaweiModemAtCommands.disableURC.getCommand());
+
+            final byte[] reply;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            try {
+                reply = commAtConnection.sendCommand(HuaweiModemAtCommands.disableURC.getCommand().getBytes(), 1000,
+                        100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+
+            if (reply == null) {
+                throw new KuraException(KuraErrorCode.TIMED_OUT, HuaweiModemAtCommands.disableURC.getCommand());
+            }
+            final String response = new String(reply, StandardCharsets.US_ASCII);
+            if (!response.contains("OK")) {
+                throw new KuraException(KuraErrorCode.BAD_REQUEST, response);
+            }
+        }
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModem.java
@@ -37,7 +37,7 @@ public class HuaweiModem extends HspaModem {
     public String getIntegratedCirquitCardId() throws KuraException {
         synchronized (this.atLock) {
             if (this.iccid == null && isSimCardReady()) {
-                logger.debug("sendCommand getICCID :: {}", HuaweiModemAtCommands.getICCID.getCommand());
+                logger.debug("sendCommand getICCID :: {}", HuaweiModemAtCommands.GET_ICCID.getCommand());
 
                 final byte[] reply;
                 CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -47,7 +47,7 @@ public class HuaweiModem extends HspaModem {
                 }
 
                 try {
-                    reply = commAtConnection.sendCommand(HuaweiModemAtCommands.getICCID.getCommand().getBytes(), 1000,
+                    reply = commAtConnection.sendCommand(HuaweiModemAtCommands.GET_ICCID.getCommand().getBytes(), 1000,
                             100);
                 } catch (IOException e) {
                     closeSerialPort(commAtConnection);
@@ -57,7 +57,7 @@ public class HuaweiModem extends HspaModem {
                 }
 
                 if (reply == null) {
-                    throw new KuraException(KuraErrorCode.TIMED_OUT, HuaweiModemAtCommands.getICCID.getCommand());
+                    throw new KuraException(KuraErrorCode.TIMED_OUT, HuaweiModemAtCommands.GET_ICCID.getCommand());
                 }
                 final String response = getResponseString(reply);
                 if (response.startsWith("^ICCID:")) {
@@ -78,7 +78,7 @@ public class HuaweiModem extends HspaModem {
         }
 
         synchronized (this.atLock) {
-            logger.debug("sendCommand getSimType :: {}", HuaweiModemAtCommands.getSimType.getCommand());
+            logger.debug("sendCommand getSimType :: {}", HuaweiModemAtCommands.GET_SIM_TYPE.getCommand());
 
             final byte[] reply;
             CommConnection commAtConnection = openSerialPort(getAtPort());
@@ -88,7 +88,7 @@ public class HuaweiModem extends HspaModem {
             }
 
             try {
-                reply = commAtConnection.sendCommand(HuaweiModemAtCommands.getSimType.getCommand().getBytes(), 1000,
+                reply = commAtConnection.sendCommand(HuaweiModemAtCommands.GET_SIM_TYPE.getCommand().getBytes(), 1000,
                         100);
             } catch (IOException e) {
                 closeSerialPort(commAtConnection);
@@ -98,7 +98,7 @@ public class HuaweiModem extends HspaModem {
             }
 
             if (reply == null) {
-                throw new KuraException(KuraErrorCode.TIMED_OUT, HuaweiModemAtCommands.getSimType.getCommand());
+                throw new KuraException(KuraErrorCode.TIMED_OUT, HuaweiModemAtCommands.GET_SIM_TYPE.getCommand());
             }
             final String response = this.getResponseString(reply);
             if (response.startsWith("^CARDMODE:")) {
@@ -118,12 +118,12 @@ public class HuaweiModem extends HspaModem {
 
     private void disableURC() throws KuraException {
         synchronized (this.atLock) {
-            logger.debug("sendCommand disableURC :: {}", HuaweiModemAtCommands.disableURC.getCommand());
+            logger.debug("sendCommand disableURC :: {}", HuaweiModemAtCommands.DISABLE_URC.getCommand());
 
             final byte[] reply;
             CommConnection commAtConnection = openSerialPort(getAtPort());
             try {
-                reply = commAtConnection.sendCommand(HuaweiModemAtCommands.disableURC.getCommand().getBytes(), 1000,
+                reply = commAtConnection.sendCommand(HuaweiModemAtCommands.DISABLE_URC.getCommand().getBytes(), 1000,
                         100);
             } catch (IOException e) {
                 closeSerialPort(commAtConnection);
@@ -133,7 +133,7 @@ public class HuaweiModem extends HspaModem {
             }
 
             if (reply == null) {
-                throw new KuraException(KuraErrorCode.TIMED_OUT, HuaweiModemAtCommands.disableURC.getCommand());
+                throw new KuraException(KuraErrorCode.TIMED_OUT, HuaweiModemAtCommands.DISABLE_URC.getCommand());
             }
             final String response = new String(reply, StandardCharsets.US_ASCII);
             if (!response.contains("OK")) {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModemAtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModemAtCommands.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.net.admin.modem.huawei;
+
+public enum HuaweiModemAtCommands {
+
+    getICCID("at^iccid?\r\n"),
+    getSimType("at^cardmode\r\n"),
+    disableURC("at^curc=0\r\n");
+
+    private String command;
+
+    HuaweiModemAtCommands(String command) {
+        this.command = command;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModemAtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModemAtCommands.java
@@ -12,9 +12,9 @@ package org.eclipse.kura.net.admin.modem.huawei;
 
 public enum HuaweiModemAtCommands {
 
-    getICCID("at^iccid?\r\n"),
-    getSimType("at^cardmode\r\n"),
-    disableURC("at^curc=0\r\n");
+    GET_ICCID("at^iccid?\r\n"),
+    GET_SIM_TYPE("at^cardmode\r\n"),
+    DISABLE_URC("at^curc=0\r\n");
 
     private String command;
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModemFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModemFactory.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.net.admin.modem.huawei;
+
+import org.eclipse.kura.net.admin.NetworkConfigurationService;
+import org.eclipse.kura.net.admin.util.AbstractCellularModemFactory;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.io.ConnectionFactory;
+import org.osgi.util.tracker.ServiceTracker;
+
+public class HuaweiModemFactory extends AbstractCellularModemFactory<HuaweiModem> {
+
+    private static HuaweiModemFactory factoryInstance = null;
+    private ConnectionFactory connectionFactory = null;
+
+    private HuaweiModemFactory() {
+        final BundleContext bundleContext = FrameworkUtil.getBundle(NetworkConfigurationService.class)
+                .getBundleContext();
+
+        ServiceTracker<ConnectionFactory, ConnectionFactory> serviceTracker = new ServiceTracker<>(bundleContext,
+                ConnectionFactory.class, null);
+        serviceTracker.open(true);
+        this.connectionFactory = serviceTracker.getService();
+    }
+
+    @Override
+    protected HuaweiModem createCellularModem(ModemDevice modemDevice, String platform) throws Exception {
+        return new HuaweiModem(modemDevice, platform, this.connectionFactory);
+    }
+
+    public static HuaweiModemFactory getInstance() {
+        if (factoryInstance == null) {
+            factoryInstance = new HuaweiModemFactory();
+        }
+        return factoryInstance;
+    }
+
+    @Override
+    public ModemTechnologyType getType() {
+        return ModemTechnologyType.LTE;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Cristiano De Alti <cristiano.dealti@eurotech.com>

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Add support for the Huawei MS2372 IoT USB cellular modem dongle.

**Related Issue:** This PR fixes/closes {issue number}

This PR closes #2437.

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

The USB dongle is supported as any other modem in Kura through `pppd` and serial ports over USB.

This modem boots as a mass storage device and requires the package `usb-modeswitch` to switch to a more suitable device; it is listed as follows by `lsusb`

```
Bus 001 Device 012: ID 12d1:1506 Huawei Technologies Co., Ltd. Modem/Networkcard
```

or by `usb-devices`

```
T:  Bus=01 Lev=04 Prnt=06 Port=00 Cnt=01 Dev#= 12 Spd=480 MxCh= 0
D:  Ver= 2.10 Cls=00(>ifc ) Sub=00 Prot=00 MxPS=64 #Cfgs=  1
P:  Vendor=12d1 ProdID=1506 Rev=01.02
S:  Manufacturer=HUAWEI_MOBILE
S:  Product=HUAWEI_MOBILE
C:  #Ifs= 4 Cfg#= 1 Atr=80 MxPwr=2mA
I:  If#=0x0 Alt= 0 #EPs= 3 Cls=ff(vend.) Sub=02 Prot=01 Driver=option
I:  If#=0x1 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=02 Prot=03 Driver=option
I:  If#=0x2 Alt= 0 #EPs= 2 Cls=ff(vend.) Sub=02 Prot=12 Driver=option
I:  If#=0x3 Alt= 1 #EPs= 3 Cls=ff(vend.) Sub=02 Prot=16 Driver=huawei_cdc_ncm
```

On Raspbian the switch happens automatically if the `usb-modeswitch` package is installed.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
