### PR TITLE
Removed loop in telit modem reset that could cause an infinite execution

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25.java
@@ -301,16 +301,20 @@ public class QuectelEG25 extends HspaModem implements HspaCellularModem {
 
     @Override
     public void reset() throws KuraException {
-        sleep(5000);
-        while (true) {
+        int offOnDelay = 1000;
+        int resetRetries = 10;
+
+        while (resetRetries > 0) {
+            sleep(5000);
             try {
                 turnOff();
-                sleep(1000);
+                sleep(offOnDelay);
                 turnOn();
                 logger.info("reset() :: modem reset successful");
                 break;
             } catch (Exception e) {
                 logger.error("Failed to reset the modem", e);
+                resetRetries--;
             }
         }
     }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
@@ -67,19 +67,18 @@ public abstract class TelitModem {
         int offOnDelay = 1000;
 
         sleep(5000);
-        while (true) {
-            try {
-                turnOff();
 
-                this.gpsEnabled = false;
-                sleep(offOnDelay);
-                turnOn();
-                logger.info("reset() :: modem reset successful");
-                break;
-            } catch (Exception e) {
-                logger.error("Failed to reset the modem", e);
-            }
+        try {
+            turnOff();
+
+            this.gpsEnabled = false;
+            sleep(offOnDelay);
+            turnOn();
+            logger.info("reset() :: modem reset successful");
+        } catch (Exception e) {
+            logger.error("Failed to reset the modem", e);
         }
+
     }
 
     public String getModel() throws KuraException {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
@@ -65,20 +65,23 @@ public abstract class TelitModem {
 
     public void reset() {
         int offOnDelay = 1000;
+        int resetRetries = 10;
 
-        sleep(5000);
+        while (resetRetries > 0) {
+            sleep(5000);
+            try {
+                turnOff();
 
-        try {
-            turnOff();
-
-            this.gpsEnabled = false;
-            sleep(offOnDelay);
-            turnOn();
-            logger.info("reset() :: modem reset successful");
-        } catch (Exception e) {
-            logger.error("Failed to reset the modem", e);
+                this.gpsEnabled = false;
+                sleep(offOnDelay);
+                turnOn();
+                logger.info("reset() :: modem reset successful");
+                break;
+            } catch (Exception e) {
+                logger.error("Failed to reset the modem", e);
+                resetRetries--;
+            }
         }
-
     }
 
     public String getModel() throws KuraException {


### PR DESCRIPTION
Brief description of the PR. Removed an unconditional loop in Telit modem reset that could prevent correct execution in case of an exception encountered while resetting the modem.

**Related Issue:** N/A

**Description of the solution adopted:** N/A

**Screenshots:** N/A

**Any side note on the changes made:** N/A
