### PR TITLE
Fixed issue where deployment admin incorrectly deleted package after install

### DIFF
--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -477,7 +477,8 @@ public class DeploymentAgent implements DeploymentAgentService {
         } finally {
             // The file from which we have installed the deployment package will be deleted
             // unless it's a persistent deployment package file.
-            if (!dpFile.getCanonicalPath().startsWith(this.packagesPath)) {
+            File packagesFolder = new File(this.packagesPath);
+            if (!dpFile.getCanonicalPath().startsWith(packagesFolder.getCanonicalPath())) {
                 Files.delete(dpFile.toPath());
                 logger.debug("Deleted file: {}", dpFile.getName());
             }


### PR DESCRIPTION
Brief description of the PR: Deployment admin was incorrectly deleting an installed deployment package at framework start

**Related Issue:** This PR fixes/closes #2799 

**Description of the solution adopted:** Due to symlinks, the file canonical path was not matching with the packages folder path provided. This mismatch was causing an incorrect file delete from the packages folder

**Screenshots:** N/A

**Any side note on the changes made:** N/A
