### PR TITLE
Updated modem reset logic to prevent too fast resets

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/huawei/HuaweiModem.java
@@ -111,9 +111,19 @@ public class HuaweiModem extends HspaModem {
 
     @Override
     public void reset() throws KuraException {
-        UsbModemDriver modemDriver = getModemDriver();
-        modemDriver.disable();
-        modemDriver.enable();
+        while (true) {
+            sleep(5000);
+            try {
+                UsbModemDriver modemDriver = getModemDriver();
+                modemDriver.disable();
+                sleep(1000);
+                modemDriver.enable();
+                logger.info("reset() :: modem reset successful");
+                break;
+            } catch (Exception e) {
+                logger.error("Failed to reset the modem", e);
+            }
+        }
     }
 
     private void disableURC() throws KuraException {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25.java
@@ -78,7 +78,7 @@ public class QuectelEG25 extends HspaModem implements HspaCellularModem {
             port = getAtPort();
         }
 
-        synchronized (atLock) {
+        synchronized (this.atLock) {
             logger.debug("sendCommand getSimStatus :: {} command to port {}",
                     QuectelEG25AtCommands.GET_SIM_STATUS.getCommand(), port);
             byte[] reply = null;
@@ -116,7 +116,7 @@ public class QuectelEG25 extends HspaModem implements HspaCellularModem {
     public ModemRegistrationStatus getRegistrationStatus() throws KuraException {
 
         ModemRegistrationStatus modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
-        synchronized (atLock) {
+        synchronized (this.atLock) {
             logger.debug("sendCommand getRegistrationStatus :: {}",
                     QuectelEG25AtCommands.GET_REGISTRATION_STATUS.getCommand());
             byte[] reply = null;
@@ -166,7 +166,7 @@ public class QuectelEG25 extends HspaModem implements HspaCellularModem {
     public long getCallTxCounter() throws KuraException {
 
         long txCnt = 0;
-        synchronized (atLock) {
+        synchronized (this.atLock) {
             logger.debug("sendCommand getGprsSessionDataVolume :: {}",
                     QuectelEG25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand());
             byte[] reply = null;
@@ -196,7 +196,7 @@ public class QuectelEG25 extends HspaModem implements HspaCellularModem {
     @Override
     public long getCallRxCounter() throws KuraException {
         long rxCnt = 0;
-        synchronized (atLock) {
+        synchronized (this.atLock) {
             logger.debug("sendCommand getGprsSessionDataVolume :: {}",
                     QuectelEG25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand());
             byte[] reply = null;
@@ -226,7 +226,7 @@ public class QuectelEG25 extends HspaModem implements HspaCellularModem {
     @Override
     public String getServiceType() throws KuraException {
         String serviceType = null;
-        synchronized (atLock) {
+        synchronized (this.atLock) {
             logger.debug("sendCommand getMobileStationClass :: {}",
                     QuectelEG25AtCommands.GET_MOBILESTATION_CLASS.getCommand());
             byte[] reply = null;
@@ -301,8 +301,8 @@ public class QuectelEG25 extends HspaModem implements HspaCellularModem {
 
     @Override
     public void reset() throws KuraException {
-        sleep(5000);
         while (true) {
+            sleep(5000);
             try {
                 turnOff();
                 sleep(1000);

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
@@ -66,8 +66,8 @@ public abstract class TelitModem {
     public void reset() {
         int offOnDelay = 1000;
 
-        sleep(5000);
         while (true) {
+            sleep(5000);
             try {
                 turnOff();
 
@@ -416,8 +416,7 @@ public abstract class TelitModem {
                                 }
                             } else {
                                 if (isAtReachable(commAtConnection)) {
-                                    logger.warn(
-                                            "disableGps() :: Modem didn't reply with 'NO CARRIER' "
+                                    logger.warn("disableGps() :: Modem didn't reply with 'NO CARRIER' "
                                             + "to the +++ escape sequence but port is AT reachable");
                                     logger.info("disableGps() :: Will assume that GPS is disabled");
                                     this.gpsEnabled = false;


### PR DESCRIPTION
Brief description of the PR: Updated modem reset logic to prevent too fast resets

**Related Issue:** #2809

**Description of the solution adopted:** Added wait between reset cycles. Added cycle in reset logic for the Huawei modem.

**Screenshots:** N/A

**Any side note on the changes made:** N/A
