### PR TITLE
Added policies to iptables

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfig.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfig.java
@@ -43,6 +43,9 @@ public class IptablesConfig {
     public static final String FIREWALL_TMP_CONFIG_FILE_NAME = "/tmp/iptables";
     private static final String FILTER = "*filter";
     private static final String COMMIT = "COMMIT";
+    private static final String INPUT_POLICY = ":INPUT DROP [0:0]";
+    private static final String OUTPUT_POLICY = ":OUTPUT ACCEPT [0:0]";
+    private static final String FORWARD_POLICY = ":FORWARD DROP [0:0]";
     private static final String ALLOW_ALL_TRAFFIC_TO_LOOPBACK = "-A INPUT -i lo -j ACCEPT";
     private static final String ALLOW_ONLY_INCOMING_TO_OUTGOING = "-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT";
 
@@ -204,6 +207,9 @@ public class IptablesConfig {
         try (FileOutputStream fos = new FileOutputStream(FIREWALL_TMP_CONFIG_FILE_NAME);
                 PrintWriter writer = new PrintWriter(fos)) {
             writer.println(FILTER);
+            writer.println(INPUT_POLICY);
+            writer.println(FORWARD_POLICY);
+            writer.println(OUTPUT_POLICY);
             writer.println(ALLOW_ALL_TRAFFIC_TO_LOOPBACK);
             writer.println(ALLOW_ONLY_INCOMING_TO_OUTGOING);
             if (this.allowIcmp) {


### PR DESCRIPTION
Added default policies to firewall.

**Related Issue:** N/A

**Description of the solution adopted:** When Kura sets the firewall rules, it writes a temporary file containing the configuration that will be applied with `iptables-restore` command. However, the policies were missing in the file. This PR adds the default policies.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** The solution should be compatible with all platforms.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>