### PR TITLE
Fixed firewall service for RPi

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -460,6 +460,8 @@ fi]]>
 			<zipfileset
 				file="src/main/resources/${build.name}/recover_default_config.init"
 				prefix="${build.output.name}/${install.folder}" filemode="700" />
+			<zipfileset file="src/main/resources/${build.name}/firewall.service"
+				prefix="${build.output.name}/${install.folder}" filemode="700" />
 			<zipfileset file="src/main/resources/${build.name}/firewall.init"
 				prefix="${build.output.name}/${install.folder}" filemode="700" />
 			<zipfileset file="src/main/resources/${build.name}/iptables.init"

--- a/kura/distrib/src/main/resources/common/kura.service
+++ b/kura/distrib/src/main/resources/common/kura.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Kura
+Wants=networking.service
+After=networking.service
 
 [Service]
 Type=forking

--- a/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
@@ -1,13 +1,4 @@
 #!/bin/bash
-### BEGIN INIT INFO
-# Provides:      firewall
-# Required-Start:   $network $remote_fs $syslog
-# Required-Stop:
-# Default-Start:   2 3 4 5
-# Default-Stop:    0 1 6
-# Short-Description:   Activate iptables.
-### END INIT INFO
-
 # iptables-restore script
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward

--- a/kura/distrib/src/main/resources/raspberry-pi-2/firewall.service
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/firewall.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Firewall configuration
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh KURA_DIR/bin/firewall
+
+[Install]
+WantedBy=multi-user.target

--- a/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
@@ -49,9 +49,14 @@ cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/b
 chmod +x ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 
 #set up default firewall configuration
-cp /etc/sysconfig/iptables /etc/sysconfig/iptables.esfsave
-cp ${BASE_DIR}/${KURA_SYMLINK}/.data/iptables /etc/sysconfig/iptables
-sed -i "s|/bin/sh KURA_DIR|/bin/bash ${BASE_DIR}/${KURA_SYMLINK}|" /lib/systemd/system/firewall.service
+cp ${INSTALL_DIR}/kura/install/iptables.init ${INSTALL_DIR}/kura/.data/iptables
+chmod 644 ${INSTALL_DIR}/kura/.data/iptables
+cp ${INSTALL_DIR}/kura/.data/iptables /etc/sysconfig/iptables
+cp ${INSTALL_DIR}/kura/install/firewall.init ${INSTALL_DIR}/kura/bin/firewall
+chmod 755 ${INSTALL_DIR}/kura/bin/firewall
+cp ${INSTALL_DIR}/kura/install/firewall.service /lib/systemd/system/firewall.service
+chmod 644 /lib/systemd/system/firewall.service
+sed -i "s|/bin/sh KURA_DIR|/bin/bash ${INSTALL_DIR}/kura|" /lib/systemd/system/firewall.service
 systemctl daemon-reload
 systemctl enable firewall
 
@@ -94,14 +99,14 @@ ${INSTALL_DIR}/kura/install/patch_sysctl.sh ${INSTALL_DIR}/kura/install/sysctl.k
 
 if ! [ -d /sys/class/net ]
 then
- sysctl -p || true
+    sysctl -p || true
 else
- sysctl -w net.ipv6.conf.all.disable_ipv6=1
- sysctl -w net.ipv6.conf.default.disable_ipv6=1
- for INTERFACE in $(ls /sys/class/net)
- do
- 	sysctl -w net.ipv6.conf.${INTERFACE}.disable_ipv6=1
- done
+    sysctl -w net.ipv6.conf.all.disable_ipv6=1
+    sysctl -w net.ipv6.conf.default.disable_ipv6=1
+    for INTERFACE in $(ls /sys/class/net)
+    do
+ 	    sysctl -w net.ipv6.conf.${INTERFACE}.disable_ipv6=1
+    done
 fi
 
 keytool -genkey -alias localhost -keyalg RSA -keysize 2048 -keystore /opt/eclipse/kura/user/security/httpskeystore.ks -deststoretype pkcs12 -dname "CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, S=Ontario, C=CA" -validity 1000 -storepass changeit -keypass changeit  


### PR DESCRIPTION
This PR updates the firewall script for the RPi with systemd.

**Related Issue:** N/A

**Description of the solution adopted:** A firewall.service is added to apply iptables rules at startup.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>