### PR TITLE
Changed packages tab behavior

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -125,6 +125,9 @@ public class PackagesPanelUi extends Composite {
 
     @UiField
     TabListItem fileLabel;
+
+    @UiField
+    TabListItem urlLabel;
 
     @UiField
     Alert notification;
@@ -287,8 +290,6 @@ public class PackagesPanelUi extends Composite {
                             PackagesPanelUi.this.packagesFormFile.submit();
                         } else {
                             PackagesPanelUi.this.packagesGroupFile.setValidationState(ValidationState.ERROR);
-                            // PackagesPanelUi.this.uploadModal.hide();
-                            // PackagesPanelUi.this.uploadErrorModal.show();
                         }
                     }
                 }));
@@ -309,8 +310,6 @@ public class PackagesPanelUi extends Composite {
                             PackagesPanelUi.this.xsrfTokenFieldUrl.setValue(token.getToken());
                             PackagesPanelUi.this.packagesFormUrl.submit();
                         } else {
-                            // PackagesPanelUi.this.uploadModal.hide();
-                            // PackagesPanelUi.this.uploadErrorModal.show();
                             PackagesPanelUi.this.packagesGroupUrl.setValidationState(ValidationState.ERROR);
                         }
                     }
@@ -344,6 +343,8 @@ public class PackagesPanelUi extends Composite {
 
         // ******FILE TAB ****//
         this.fileLabel.setText(MSGS.fileLabel());
+        this.fileLabel.addClickHandler(
+                event -> PackagesPanelUi.this.packagesGroupFile.setValidationState(ValidationState.NONE));
 
         this.filePath.setName("uploadedFile");
 
@@ -364,6 +365,10 @@ public class PackagesPanelUi extends Composite {
         });
 
         // ******URL TAB ****//
+        this.urlLabel.setText(MSGS.urlLabel());
+        this.urlLabel.addClickHandler(
+                event -> PackagesPanelUi.this.packagesGroupUrl.setValidationState(ValidationState.NONE));
+
         this.formUrl.setName("packageUrl");
 
         this.xsrfTokenFieldUrl.setID(XSRF_TOKEN);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
@@ -239,6 +239,8 @@ public class PackagesPanelUi extends Composite {
 
     public void refresh() {
         refresh(100);
+        PackagesPanelUi.this.selectionModel.setSelected(PackagesPanelUi.this.selected, false);
+        PackagesPanelUi.this.packagesUninstall.setEnabled(false);
     }
 
     private void initTabButtons() {
@@ -265,6 +267,8 @@ public class PackagesPanelUi extends Composite {
                 modalFooter.add(new Button("Yes", event12 -> {
                     modal.hide();
                     uninstall(PackagesPanelUi.this.selected);
+                    PackagesPanelUi.this.selectionModel.setSelected(PackagesPanelUi.this.selected, false);
+                    PackagesPanelUi.this.packagesUninstall.setEnabled(false);
                 }));
 
                 modal.add(modalBody);
@@ -359,6 +363,8 @@ public class PackagesPanelUi extends Composite {
             String result = event.getResults();
             if (result == null || result.isEmpty()) {
                 PackagesPanelUi.this.uploadModal.hide();
+                PackagesPanelUi.this.selectionModel.setSelected(PackagesPanelUi.this.selected, false);
+                PackagesPanelUi.this.packagesUninstall.setEnabled(false);
             } else {
                 logger.log(Level.SEVERE, "Error uploading package!");
             }
@@ -381,6 +387,8 @@ public class PackagesPanelUi extends Composite {
             String result = event.getResults();
             if (result == null || result.isEmpty()) {
                 PackagesPanelUi.this.uploadModal.hide();
+                PackagesPanelUi.this.selectionModel.setSelected(PackagesPanelUi.this.selected, false);
+                PackagesPanelUi.this.packagesUninstall.setEnabled(false);
             } else {
                 String errMsg = result;
                 int startIdx = result.indexOf("<pre>");

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
@@ -35,6 +35,7 @@ import org.eclipse.kura.web.shared.service.GwtSecurityTokenService;
 import org.eclipse.kura.web.shared.service.GwtSecurityTokenServiceAsync;
 import org.gwtbootstrap3.client.ui.Alert;
 import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.FormGroup;
 import org.gwtbootstrap3.client.ui.Modal;
 import org.gwtbootstrap3.client.ui.ModalBody;
 import org.gwtbootstrap3.client.ui.ModalFooter;
@@ -42,6 +43,7 @@ import org.gwtbootstrap3.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.gwtbootstrap3.client.ui.Well;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.gwt.CellTable;
 import org.gwtbootstrap3.client.ui.html.Paragraph;
 import org.gwtbootstrap3.client.ui.html.Span;
@@ -100,6 +102,11 @@ public class PackagesPanelUi extends Composite {
     FormPanel packagesFormFile;
     @UiField
     FormPanel packagesFormUrl;
+
+    @UiField
+    FormGroup packagesGroupUrl;
+    @UiField
+    FormGroup packagesGroupFile;
 
     @UiField
     Button fileCancel;
@@ -183,6 +190,10 @@ public class PackagesPanelUi extends Composite {
         this.packagesIntro.add(description);
 
         this.packagesGrid.setSelectionModel(this.selectionModel);
+        this.selectionModel.addSelectionChangeHandler(event -> {
+            PackagesPanelUi.this.packagesUninstall
+                    .setEnabled(PackagesPanelUi.this.selectionModel.getSelectedObject() != null);
+        });
         initTable();
 
         initTabButtons();
@@ -237,6 +248,7 @@ public class PackagesPanelUi extends Composite {
 
         // Uninstall Button
         this.packagesUninstall.setText(MSGS.packageDeleteButton());
+        this.packagesUninstall.setEnabled(false);
         this.packagesUninstall.addClickHandler(event -> {
             PackagesPanelUi.this.selected = PackagesPanelUi.this.selectionModel.getSelectedObject();
             if (PackagesPanelUi.this.selected != null && PackagesPanelUi.this.selected.getVersion() != null) {
@@ -274,8 +286,9 @@ public class PackagesPanelUi extends Composite {
                         if (!"".equals(PackagesPanelUi.this.filePath.getFilename())) {
                             PackagesPanelUi.this.packagesFormFile.submit();
                         } else {
-                            PackagesPanelUi.this.uploadModal.hide();
-                            PackagesPanelUi.this.uploadErrorModal.show();
+                            PackagesPanelUi.this.packagesGroupFile.setValidationState(ValidationState.ERROR);
+                            // PackagesPanelUi.this.uploadModal.hide();
+                            // PackagesPanelUi.this.uploadErrorModal.show();
                         }
                     }
                 }));
@@ -296,8 +309,9 @@ public class PackagesPanelUi extends Composite {
                             PackagesPanelUi.this.xsrfTokenFieldUrl.setValue(token.getToken());
                             PackagesPanelUi.this.packagesFormUrl.submit();
                         } else {
-                            PackagesPanelUi.this.uploadModal.hide();
-                            PackagesPanelUi.this.uploadErrorModal.show();
+                            // PackagesPanelUi.this.uploadModal.hide();
+                            // PackagesPanelUi.this.uploadErrorModal.show();
+                            PackagesPanelUi.this.packagesGroupUrl.setValidationState(ValidationState.ERROR);
                         }
                     }
                 }));
@@ -324,6 +338,8 @@ public class PackagesPanelUi extends Composite {
     }
 
     private void upload() {
+        PackagesPanelUi.this.packagesGroupUrl.setValidationState(ValidationState.NONE);
+        PackagesPanelUi.this.packagesGroupFile.setValidationState(ValidationState.NONE);
         this.uploadModal.show();
 
         // ******FILE TAB ****//

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
@@ -519,7 +519,7 @@ public class PackagesPanelUi extends Composite {
     }
 
     private void initUploadErrorModal() {
-        this.uploadErrorModal.setTitle(MSGS.warning());
+        this.uploadErrorModal.setTitle(MSGS.error());
         this.uploadErrorText.setText(MSGS.missingFileUpload());
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
@@ -81,15 +81,17 @@
                             <b:TabPane fade="true" in="true" active="true" b:id="tab1">
                                 <g:FormPanel ui:field="packagesFormFile">
                                     <b:FieldSet>
-                                        <b:FormLabel addStyleNames="{style.upload-label}">Select the deployment package file:</b:FormLabel>
-                                        <b:Well>
-                                            <g:FileUpload ui:field="filePath"></g:FileUpload>
-                                        </b:Well>
-                                        <b:ButtonGroup pull="RIGHT">
-                                            <b:Button ui:field="fileCancel" b:id="btnCancel1">Cancel</b:Button>
-                                            <b:Button ui:field="fileSubmit" b:id="btnSubmit1">Submit</b:Button>
-                                        </b:ButtonGroup>
-                                        <g:Hidden ui:field="xsrfTokenFieldFile"></g:Hidden>
+                                        <b:FormGroup ui:field="packagesGroupFile">
+	                                        <b:FormLabel addStyleNames="{style.upload-label}">Select the deployment package file:</b:FormLabel>
+	                                        <b:Well>
+	                                            <g:FileUpload ui:field="filePath"></g:FileUpload>
+	                                        </b:Well>
+	                                        <b:ButtonGroup pull="RIGHT">
+	                                            <b:Button ui:field="fileCancel" b:id="btnCancel1">Cancel</b:Button>
+	                                            <b:Button ui:field="fileSubmit" b:id="btnSubmit1">Submit</b:Button>
+	                                        </b:ButtonGroup>
+	                                        <g:Hidden ui:field="xsrfTokenFieldFile"></g:Hidden>
+                                        </b:FormGroup>
                                     </b:FieldSet>
                                 </g:FormPanel>
                             </b:TabPane>
@@ -97,13 +99,15 @@
                             <b:TabPane fade="true" b:id="tab2">
                                 <g:FormPanel ui:field="packagesFormUrl">
                                     <b:FieldSet>
-                                        <b:FormLabel addStyleNames="{style.upload-label}" for="formUrl">Enter the URL of the deployment package:</b:FormLabel>
-                                        <b:TextBox b:id="formUrl" ui:field="formUrl" />
-                                        <b:ButtonGroup pull="RIGHT">
-                                            <b:Button ui:field="urlCancel" b:id="btnCancel2">Cancel</b:Button>
-                                            <b:Button ui:field="urlSubmit" b:id="btnSubmit2">Submit</b:Button>
-                                        </b:ButtonGroup>
-                                        <g:Hidden ui:field="xsrfTokenFieldUrl"></g:Hidden>
+                                        <b:FormGroup ui:field="packagesGroupUrl">
+	                                        <b:FormLabel addStyleNames="{style.upload-label}" for="formUrl">Enter the URL of the deployment package:</b:FormLabel>
+	                                        <b:TextBox b:id="formUrl" ui:field="formUrl" />
+	                                        <b:ButtonGroup pull="RIGHT">
+	                                            <b:Button ui:field="urlCancel" b:id="btnCancel2">Cancel</b:Button>
+	                                            <b:Button ui:field="urlSubmit" b:id="btnSubmit2">Submit</b:Button>
+	                                        </b:ButtonGroup>
+	                                        <g:Hidden ui:field="xsrfTokenFieldUrl"></g:Hidden>
+                                        </b:FormGroup>
                                     </b:FieldSet>
                                 </g:FormPanel>
                             </b:TabPane>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -74,7 +74,7 @@
 
                         <b:NavTabs>
                             <b:TabListItem active="true" dataTarget="#tab1" ui:field="fileLabel" />
-                            <b:TabListItem dataTarget="#tab2" text="URL" />
+                            <b:TabListItem dataTarget="#tab2" ui:field="urlLabel" />
                         </b:NavTabs>
                         <b:TabContent>
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
@@ -129,7 +129,7 @@
             <b:ModalBody>
                 <b:Panel>
                     <b:PanelBody>
-                        <b:Alert type="WARNING">
+                        <b:Alert type="DANGER">
                             <b.html:Text ui:field="uploadErrorText" />
                         </b:Alert>
                     </b:PanelBody>


### PR DESCRIPTION
This PR tries modifies the packages tab behavior.

**Related Issue:** This PR 
closes #2706 
closes #2707 

**Description of the solution adopted:** The present PR modifies the packages tab as follows:

- the "Uninstall" button is greyed when nothing is selected;
- in the "Install/Upgrade Package" modal the fields are shown in red if they are empty;
- the "Warning" modal about the missing file is removed.