### PR TITLE
Removed packages-panel style

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
@@ -37,7 +37,7 @@
     </ui:style>
 
 
-    <b:Container fluid="true" addStyleNames="packages-panel">
+    <b:Container fluid="true">
         <b:Row>
             <g:HTMLPanel ui:field="packagesIntro">
             </g:HTMLPanel>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -1041,13 +1041,6 @@ Packages panel dropzone START
     color:  white;
 }
 
-.packages-panel {
-    position: absolute;
-    height: 100vh;
-    width: 100%;
-    padding-right: 30px !important;
-}
-
 /**********************
 Packages panel dropzone END
 ***********************/

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
This PR removes the packages-panel style that causes the "Copyright" Footer to interfere with other contents of the page.

**Related Issue:** This PR fixes/closes #2709 

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>

