### PR TITLE
Added missing icon to few buttons

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/CommandTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/CommandTabUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -51,8 +51,8 @@
                     </b:FormGroup>
 
                     <b:ButtonGroup pull="RIGHT">
-                    	<b:Button ui:field="execute">Execute</b:Button>
-                        <b:Button ui:field="reset">Reset</b:Button>
+                    	<b:Button ui:field="execute" addStyleNames="fa fa-check">Execute</b:Button>
+                        <b:Button ui:field="reset" addStyleNames="fa fa-times">Reset</b:Button>
                     </b:ButtonGroup>
                     <g:Hidden ui:field="xsrfTokenField"></g:Hidden>
                 </b:FieldSet>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2019 Eurotech and/or its affiliates
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -30,7 +30,7 @@
                         <b:FormLabel ui:field="logLabel" />
                     </b:Row>
                     <b:ButtonGroup pull="LEFT">
-                    	<b:Button ui:field="execute">Download</b:Button>
+                    	<b:Button ui:field="execute" addStyleNames="fa fa-download">Download</b:Button>
                     </b:ButtonGroup>
                 </b:FieldSet>
             </gwt:FormPanel>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.ui.xml
@@ -89,7 +89,7 @@
                             </b:FormGroup>
 
                             <b:FormGroup>
-                                <b:Button ui:field="renew" />
+                                <b:Button ui:field="renew" addStyleNames="fa fa-refresh"/>
                             </b:FormGroup>
 
                             <b:FormGroup ui:field="groupDns">


### PR DESCRIPTION
This PR simply add some missing icons to buttons.

**Related Issue:** This PR fixes/closes #2716 

**Description of the solution adopted:** The following buttons are completed with icons:

- Execute and Reset buttons in Command tab
- Download button in System Logs tab
- Renew DHCP lease button in Network tab

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>