### PR TITLE
More fixes in packages tab

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
@@ -117,8 +117,6 @@ public class PackagesPanelUi extends Composite {
     @UiField
     Button urlSubmit;
     @UiField
-    Button packagesRefresh;
-    @UiField
     Button packagesInstall;
     @UiField
     Button packagesUninstall;
@@ -244,9 +242,6 @@ public class PackagesPanelUi extends Composite {
     }
 
     private void initTabButtons() {
-        // Refresh Button
-        this.packagesRefresh.setText(MSGS.refreshButton());
-        this.packagesRefresh.addClickHandler(event -> refresh());
         // Install Button
         this.packagesInstall.setText(MSGS.packageAddButton());
         this.packagesInstall.addClickHandler(event -> upload());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.java
@@ -623,6 +623,9 @@ public class PackagesPanelUi extends Composite {
                     if (isEclipseMarketplaceUrl(url)) {
                         PackagesPanelUi.this.confirmDialog.show(MSGS.packagesMarketplaceInstallConfirmMessage(),
                                 () -> eclipseMarketplaceInstall(url));
+                    } else {
+                        PackagesPanelUi.this.uploadErrorText.setText(MSGS.packagesMarketplaceInstallDpNotValid());
+                        PackagesPanelUi.this.uploadErrorModal.show();
                     }
                     return true;
                 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/packages/PackagesPanelUi.ui.xml
@@ -58,7 +58,6 @@
                  <b:ButtonGroup size="SMALL">
                     <b:Button ui:field="packagesInstall" addStyleNames="fa fa-plus"></b:Button>
                     <b:Button ui:field="packagesUninstall" addStyleNames="fa fa-minus"></b:Button>
-                    <b:Button ui:field="packagesRefresh" addStyleNames="fa fa-refresh"></b:Button>
                 </b:ButtonGroup>
                 <gwt:CellTable bordered="true" condensed="true" striped="true" hover="true" width="100%"
                     height="100%" ui:field="packagesGrid" addStyleNames="{style.center-panel}" />

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -117,6 +117,7 @@ driversAndAssetsServices=Drivers and Assets
 
 packagesMarketplaceInstallConfirmMessage=Install deployment package from Eclipse Marketplace?
 packagesDropzoneMessage=Drop the package to install
+packagesMarketplaceInstallDpNotValid=File or link not valid
 packagesIntro=Manage the Deployment Packages installed on the system
 deviceInstallNewPackage=Install New Package
 devicePackagesNone=No Packages Installed


### PR DESCRIPTION
This PR removes the Refresh button from the packages tab and adds an error messages when an invalid dp is dropped in to the drag-and-drop area.

**Related Issue:** This PR 
closes #2713 
closes #2715 

