### PR TITLE
The banner content cannot be empty.

### DIFF
--- a/kura/org.eclipse.kura.web2/OSGI-INF/metatype/org.eclipse.kura.web.Console.xml
+++ b/kura/org.eclipse.kura.web2/OSGI-INF/metatype/org.eclipse.kura.web.Console.xml
@@ -69,9 +69,9 @@
             name="Access Banner Content"
             type="String"
             cardinality="0"
-            required="false"
-            default=""
-            description="Access banner content. To be displayed at every user access, if the feature is enabled.">
+            required="true"
+            default="Sample Banner Content"
+            description="Access banner content. To be displayed at every user access, if the feature is enabled.|TextArea">
         </AD>
         
         <AD id="new.password.min.length"


### PR DESCRIPTION
The banner content field is now a text area

Signed-off-by: Maiero <matteo.maiero@eurotech.com>

Closes #2852