### PR TITLE
Fixed port forwarding duplicateEntry comparison

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/PortForwardingTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/PortForwardingTabUi.java
@@ -808,8 +808,8 @@ public class PortForwardingTabUi extends Composite implements Tab, ButtonBar.Lis
                         && entry.getOutboundInterface().equals(portForwardEntry.getOutboundInterface())
                         && entry.getAddress().equals(portForwardEntry.getAddress())
                         && entry.getProtocol().equals(portForwardEntry.getProtocol())
-                        && entry.getOutPort() == portForwardEntry.getOutPort()
-                        && entry.getInPort() == portForwardEntry.getInPort()) {
+                        && entry.getOutPort().equals(portForwardEntry.getOutPort())
+                        && entry.getInPort().equals(portForwardEntry.getInPort())) {
 
                     String permittedNetwork = entry.getPermittedNetwork() != null ? entry.getPermittedNetwork()
                             : "0.0.0.0/0";

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtFirewallPortForwardEntry.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtFirewallPortForwardEntry.java
@@ -110,4 +110,28 @@ public class GwtFirewallPortForwardEntry extends KuraBaseModel implements Serial
     public void setSourcePortRange(String sourcePortRange) {
         set("sourcePortRange", sourcePortRange);
     }
+
+    @Override
+    public String toString() {
+        StringBuilder output = new StringBuilder();
+        output.append("inboudInterface : ").append(getInboundInterface());
+        output.append(" ");
+        output.append("outboudInterface : ").append(getOutboundInterface());
+        output.append(" ");
+        output.append("addess : ").append(getAddress());
+        output.append(" ");
+        output.append("protocol : ").append(getProtocol());
+        output.append(" ");
+        output.append("inputPort : ").append(getInPort());
+        output.append(" ");
+        output.append("outputPort : ").append(getOutPort());
+        output.append(" ");
+        output.append("network : ").append(getPermittedNetwork());
+        output.append(" ");
+        output.append("permittedMAC : ").append(getPermittedMAC());
+        output.append(" ");
+        output.append("sourcePortRange : ").append(getSourcePortRange());
+
+        return output.toString();
+    }
 }


### PR DESCRIPTION
This PR changes the way the ports in PortForwarding tab are compared. The commented method is an alternative way to compare the port forward entry, but it takes into account also the masquerading field. Can this also be applied to the IP forwarding tab?

**Related Issue:** This PR fixes/closes #2948 

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>