### PR TITLE
Forced clear of validation states on modal fields

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/NatTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/NatTabUi.java
@@ -501,6 +501,8 @@ public class NatTabUi extends Composite implements Tab, ButtonBar.Listener {
     }
 
     private void showModal(final GwtFirewallNatEntry existingEntry) {
+        resetValidationStates();
+
         if (existingEntry == null) {
             this.natForm.setTitle(MSGS.firewallNatFormInformation());
         } else {
@@ -516,6 +518,13 @@ public class NatTabUi extends Composite implements Tab, ButtonBar.Listener {
         }
 
         this.natForm.show();
+    }
+
+    private void resetValidationStates() {
+        NatTabUi.this.groupInput.setValidationState(ValidationState.NONE);
+        NatTabUi.this.groupOutput.setValidationState(ValidationState.NONE);
+        NatTabUi.this.groupSource.setValidationState(ValidationState.NONE);
+        NatTabUi.this.groupDestination.setValidationState(ValidationState.NONE);
     }
 
     private void setModalFieldsHandlers() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.java
@@ -545,6 +545,8 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
     }
 
     private void showModal(final GwtFirewallOpenPortEntry existingEntry) {
+        resetValidationStates();
+
         if (existingEntry == null) {
             // new
             this.openPortsForm.setTitle(MSGS.firewallOpenPortFormInformation());
@@ -583,6 +585,16 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
         } else {
             OpenPortsTabUi.this.unpermittedI.setEnabled(true);
         }
+    }
+
+    private void resetValidationStates() {
+        OpenPortsTabUi.this.groupPort.setValidationState(ValidationState.NONE);
+        OpenPortsTabUi.this.groupPermittedNw.setValidationState(ValidationState.NONE);
+        OpenPortsTabUi.this.groupPermittedI.setValidationState(ValidationState.NONE);
+        OpenPortsTabUi.this.groupPermittedI.setValidationState(ValidationState.NONE);
+        OpenPortsTabUi.this.groupUnpermittedI.setValidationState(ValidationState.NONE);
+        OpenPortsTabUi.this.groupPermittedMac.setValidationState(ValidationState.NONE);
+        OpenPortsTabUi.this.groupSource.setValidationState(ValidationState.NONE);
     }
 
     private void setModalFieldsHandlers() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/PortForwardingTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/PortForwardingTabUi.java
@@ -614,6 +614,8 @@ public class PortForwardingTabUi extends Composite implements Tab, ButtonBar.Lis
     }
 
     private void showModal(final GwtFirewallPortForwardEntry existingEntry) {
+        resetValidationStates();
+
         if (existingEntry == null) {
             // new
             this.portForwardingForm.setTitle(MSGS.firewallPortForwardFormInformation());
@@ -633,6 +635,17 @@ public class PortForwardingTabUi extends Composite implements Tab, ButtonBar.Lis
 
         this.portForwardingForm.show();
     }// end initModal
+
+    private void resetValidationStates() {
+        PortForwardingTabUi.this.groupInput.setValidationState(ValidationState.NONE);
+        PortForwardingTabUi.this.groupOutput.setValidationState(ValidationState.NONE);
+        PortForwardingTabUi.this.groupLan.setValidationState(ValidationState.NONE);
+        PortForwardingTabUi.this.groupInternal.setValidationState(ValidationState.NONE);
+        PortForwardingTabUi.this.groupExternal.setValidationState(ValidationState.NONE);
+        PortForwardingTabUi.this.groupPermittedNw.setValidationState(ValidationState.NONE);
+        PortForwardingTabUi.this.groupPermittedMac.setValidationState(ValidationState.NONE);
+        PortForwardingTabUi.this.groupSource.setValidationState(ValidationState.NONE);
+    }
 
     private void setModalFieldsHandlers() {
         // Set validations


### PR DESCRIPTION
This PR adds the reset of the validation states of the modal fields in all the firewall tabs.

**Related Issue:** This PR fixes/closes #2792 

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>