### PR TITLE
Added confirmation window when switching between tabs in Settings section

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -86,9 +86,9 @@ public abstract class AbstractServicesUi extends Composite {
 
     protected HashMap<String, Boolean> valid = new HashMap<>();
 
-    protected abstract void setDirty(boolean flag);
+    public abstract void setDirty(boolean flag);
 
-    protected abstract boolean isDirty();
+    public abstract boolean isDirty();
 
     protected abstract void reset();
 
@@ -132,7 +132,7 @@ public abstract class AbstractServicesUi extends Composite {
     }
 
     // Checks if all the fields are valid according to the Validate() method
-    protected boolean isValid() {
+    public boolean isValid() {
         // check if all fields are valid
         for (Map.Entry<String, Boolean> entry : this.valid.entrySet()) {
             if (!entry.getValue()) {
@@ -239,7 +239,7 @@ public abstract class AbstractServicesUi extends Composite {
             textBox.validate(true);
         });
         textBox.addValueChangeHandler(event -> {
-        	setDirty(true);
+            setDirty(true);
         });
 
         if (param.getId().endsWith(TARGET_SUFFIX)) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ConfigurableComponentUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ConfigurableComponentUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ConfigurableComponentUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ConfigurableComponentUi.java
@@ -72,7 +72,7 @@ public class ConfigurableComponentUi extends AbstractServicesUi implements HasCo
     }
 
     @Override
-    protected void reset() {
+    public void reset() {
         // Nothing to do
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/cloudconnection/CloudConnectionConfigurationUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/cloudconnection/CloudConnectionConfigurationUi.java
@@ -81,7 +81,7 @@ public class CloudConnectionConfigurationUi extends AbstractServicesUi {
     }
 
     @Override
-    protected void setDirty(boolean flag) {
+    public void setDirty(boolean flag) {
         this.dirty = flag;
         if (this.dirty && this.initialized) {
             this.applyConnectionEdit.setEnabled(true);
@@ -95,7 +95,7 @@ public class CloudConnectionConfigurationUi extends AbstractServicesUi {
     }
 
     @Override
-    protected void reset() {
+    public void reset() {
         if (isDirty()) {
             this.alertDialog.show(MSGS.deviceConfigDirty(), this::resetVisualization);
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
@@ -356,7 +356,7 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
     }
 
     @Override
-    protected void reset() {
+    public void reset() {
         // Not needed
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.java
@@ -117,6 +117,7 @@ public class FirewallPanelUi extends Composite {
         ButtonGroup group = new ButtonGroup();
         Button yes = new Button();
         yes.setText(MSGS.yesButton());
+        yes.addStyleName("fa fa-check");
         yes.addClickHandler(event -> {
             modal.hide();
             FirewallPanelUi.this.getTab(this.currentlySelectedTab).clear();
@@ -125,6 +126,7 @@ public class FirewallPanelUi extends Composite {
         });
         Button no = new Button();
         no.setText(MSGS.noButton());
+        no.addStyleName("fa fa-times");
         no.addClickHandler(event -> {
             FirewallPanelUi.this.currentlySelectedTab.showTab();
             modal.hide();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ApplicationCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ApplicationCertsTabUi.java
@@ -77,8 +77,7 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
         initForm();
 
         setDirty(false);
-        this.apply.setEnabled(false);
-        this.reset.setEnabled(false);
+        setButtonsEnabled(false);
     }
 
     @Override
@@ -106,6 +105,11 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
         }
     }
 
+    @Override
+    public void clear() {
+        reset();
+    }
+
     private void initForm() {
         this.description.add(new Span("<p>" + MSGS.settingsAddBundleCertsDescription() + "</p>"));
 
@@ -113,8 +117,7 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
         this.formStorageAlias.addChangeHandler(event -> {
             isAliasValid();
             setDirty(true);
-            ApplicationCertsTabUi.this.apply.setEnabled(true);
-            ApplicationCertsTabUi.this.reset.setEnabled(true);
+            setButtonsEnabled(true);
         });
 
         this.certificateLabel.setText(MSGS.settingsPublicCertLabel());
@@ -122,16 +125,14 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
         this.formCert.addChangeHandler(event -> {
             isAppCertValid();
             setDirty(true);
-            ApplicationCertsTabUi.this.apply.setEnabled(true);
-            ApplicationCertsTabUi.this.reset.setEnabled(true);
+            setButtonsEnabled(true);
         });
 
         this.reset.setText(MSGS.reset());
         this.reset.addClickHandler(event -> {
             reset();
             setDirty(false);
-            ApplicationCertsTabUi.this.apply.setEnabled(false);
-            ApplicationCertsTabUi.this.reset.setEnabled(false);
+            setButtonsEnabled(false);
         });
 
         this.apply.setText(MSGS.apply());
@@ -162,8 +163,7 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
                                     public void onSuccess(Integer certsStored) {
                                         reset();
                                         setDirty(false);
-                                        ApplicationCertsTabUi.this.apply.setEnabled(false);
-                                        ApplicationCertsTabUi.this.reset.setEnabled(false);
+                                        setButtonsEnabled(false);
                                         EntryClassUi.hideWaitModal();
                                     }
                                 });
@@ -174,6 +174,7 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
     }
 
     private void reset() {
+        setButtonsEnabled(false);
         this.formStorageAlias.setText("");
         this.formCert.setText("");
     }
@@ -198,9 +199,9 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
         }
     }
 
-    @Override
-    public void clear() {
-        reset();
+    private void setButtonsEnabled(boolean state) {
+        ApplicationCertsTabUi.this.apply.setEnabled(state);
+        ApplicationCertsTabUi.this.reset.setEnabled(state);
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ApplicationCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ApplicationCertsTabUi.java
@@ -200,7 +200,7 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
 
     @Override
     public void clear() {
-        // Not needed
+        reset();
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/CommandUserTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/CommandUserTabUi.java
@@ -124,8 +124,7 @@ public class CommandUserTabUi extends AbstractServicesUi implements Tab {
                                     initInvalidDataModal();
 
                                     setDirty(false);
-                                    CommandUserTabUi.this.apply.setEnabled(false);
-                                    CommandUserTabUi.this.reset.setEnabled(false);
+                                    setButtonsEnabled(false);
                                 }
                             }
                         });
@@ -137,14 +136,23 @@ public class CommandUserTabUi extends AbstractServicesUi implements Tab {
     public void setDirty(boolean flag) {
         this.dirty = flag;
         if (this.dirty && this.initialized) {
-            this.apply.setEnabled(true);
-            this.reset.setEnabled(true);
+            setButtonsEnabled(true);
         }
     }
 
     @Override
     public boolean isDirty() {
         return this.dirty;
+    }
+
+    @Override
+    public void refresh() {
+        load();
+    }
+
+    @Override
+    public void clear() {
+        reset();
     }
 
     private void apply() {
@@ -236,8 +244,7 @@ public class CommandUserTabUi extends AbstractServicesUi implements Tab {
         if (isDirty()) {
             restoreConfiguration(CommandUserTabUi.this.originalConfig);
             renderForm();
-            CommandUserTabUi.this.apply.setEnabled(false);
-            CommandUserTabUi.this.reset.setEnabled(false);
+            setButtonsEnabled(false);
             setDirty(false);
         }
     }
@@ -297,13 +304,8 @@ public class CommandUserTabUi extends AbstractServicesUi implements Tab {
         return this.configurableComponent;
     }
 
-    @Override
-    public void refresh() {
-        load();
-    }
-
-    @Override
-    public void clear() {
-        reset();
+    private void setButtonsEnabled(boolean state) {
+        CommandUserTabUi.this.apply.setEnabled(state);
+        CommandUserTabUi.this.reset.setEnabled(state);
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/CommandUserTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/CommandUserTabUi.java
@@ -18,6 +18,7 @@ import java.util.logging.Level;
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.AbstractServicesUi;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
+import org.eclipse.kura.web.client.ui.Tab;
 import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter;
@@ -45,7 +46,7 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 
-public class CommandUserTabUi extends AbstractServicesUi {
+public class CommandUserTabUi extends AbstractServicesUi implements Tab {
 
     private static final SslTabUiUiBinder uiBinder = GWT.create(SslTabUiUiBinder.class);
 
@@ -233,40 +234,11 @@ public class CommandUserTabUi extends AbstractServicesUi {
     @Override
     public void reset() {
         if (isDirty()) {
-            // Modal
-            this.modal = new Modal();
-
-            ModalHeader header = new ModalHeader();
-            header.setTitle(MSGS.confirm());
-            this.modal.add(header);
-
-            ModalBody body = new ModalBody();
-            body.add(new Span(MSGS.deviceConfigDirty()));
-            this.modal.add(body);
-
-            ModalFooter footer = new ModalFooter();
-            ButtonGroup group = new ButtonGroup();
-            Button no = new Button();
-            no.setText(MSGS.noButton());
-            no.addStyleName("fa fa-times");
-            no.addClickHandler(event -> CommandUserTabUi.this.modal.hide());
-            group.add(no);
-            Button yes = new Button();
-            yes.setText(MSGS.yesButton());
-            yes.addStyleName("fa fa-check");
-            yes.addClickHandler(event -> {
-                CommandUserTabUi.this.modal.hide();
-                restoreConfiguration(CommandUserTabUi.this.originalConfig);
-                renderForm();
-                CommandUserTabUi.this.apply.setEnabled(false);
-                CommandUserTabUi.this.reset.setEnabled(false);
-                setDirty(false);
-            });
-            group.add(yes);
-            footer.add(group);
-            this.modal.add(footer);
-            this.modal.show();
-            no.setFocus(true);
+            restoreConfiguration(CommandUserTabUi.this.originalConfig);
+            renderForm();
+            CommandUserTabUi.this.apply.setEnabled(false);
+            CommandUserTabUi.this.reset.setEnabled(false);
+            setDirty(false);
         }
     }
 
@@ -323,5 +295,15 @@ public class CommandUserTabUi extends AbstractServicesUi {
             }
         }
         return this.configurableComponent;
+    }
+
+    @Override
+    public void refresh() {
+        load();
+    }
+
+    @Override
+    public void clear() {
+        reset();
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/CommandUserTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/CommandUserTabUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -234,6 +234,6 @@ public class DeviceCertsTabUi extends Composite implements Tab {
 
     @Override
     public void clear() {
-        // Not needed
+        reset();
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -83,8 +83,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         initForm();
 
         setDirty(false);
-        this.apply.setEnabled(false);
-        this.reset.setEnabled(false);
+        setButtonsEnabled(false);
     }
 
     @Override
@@ -113,6 +112,11 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         }
     }
 
+    @Override
+    public void clear() {
+        reset();
+    }
+
     private void initForm() {
         StringBuilder title = new StringBuilder();
         title.append("<p>");
@@ -126,8 +130,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.storageAliasInput.addChangeHandler(event -> {
             isAliasValid();
             setDirty(true);
-            DeviceCertsTabUi.this.apply.setEnabled(true);
-            DeviceCertsTabUi.this.reset.setEnabled(true);
+            setButtonsEnabled(true);
         });
 
         this.privateKeyLabel.setText(MSGS.settingsPrivateCertLabel());
@@ -135,8 +138,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.privateKeyInput.addChangeHandler(event -> {
             isPrivateKeyValid();
             setDirty(true);
-            DeviceCertsTabUi.this.apply.setEnabled(true);
-            DeviceCertsTabUi.this.reset.setEnabled(true);
+            setButtonsEnabled(true);
         });
 
         this.certificateLabel.setText(MSGS.settingsPublicCertLabel());
@@ -144,16 +146,14 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.certificateInput.addChangeHandler(event -> {
             isDeviceCertValid();
             setDirty(true);
-            DeviceCertsTabUi.this.apply.setEnabled(true);
-            DeviceCertsTabUi.this.reset.setEnabled(true);
+            setButtonsEnabled(true);
         });
 
         this.reset.setText(MSGS.reset());
         this.reset.addClickHandler(event -> {
             reset();
             setDirty(false);
-            DeviceCertsTabUi.this.apply.setEnabled(false);
-            DeviceCertsTabUi.this.reset.setEnabled(false);
+            setButtonsEnabled(false);
         });
 
         this.apply.setText(MSGS.apply());
@@ -185,8 +185,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
                                     public void onSuccess(Integer certsStored) {
                                         reset();
                                         setDirty(false);
-                                        DeviceCertsTabUi.this.apply.setEnabled(false);
-                                        DeviceCertsTabUi.this.reset.setEnabled(false);
+                                        setButtonsEnabled(false);
                                         EntryClassUi.hideWaitModal();
                                     }
                                 });
@@ -197,6 +196,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
     }
 
     private void reset() {
+        setButtonsEnabled(false);
         this.storageAliasInput.setText("");
         this.privateKeyInput.setText("");
         this.certificateInput.setText("");
@@ -232,8 +232,8 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         }
     }
 
-    @Override
-    public void clear() {
-        reset();
+    private void setButtonsEnabled(boolean state) {
+        DeviceCertsTabUi.this.apply.setEnabled(state);
+        DeviceCertsTabUi.this.reset.setEnabled(state);
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
@@ -77,8 +77,7 @@ public class ServerCertsTabUi extends Composite implements Tab {
         initForm();
 
         setDirty(false);
-        this.apply.setEnabled(false);
-        this.reset.setEnabled(false);
+        setButtonsEnabled(false);
     }
 
     @Override
@@ -128,8 +127,7 @@ public class ServerCertsTabUi extends Composite implements Tab {
         this.storageAliasInput.addChangeHandler(event -> {
             isAliasValid();
             setDirty(true);
-            ServerCertsTabUi.this.apply.setEnabled(true);
-            ServerCertsTabUi.this.reset.setEnabled(true);
+            setButtonsEnabled(true);
         });
 
         this.certificateLabel.setText(MSGS.settingsPublicCertLabel());
@@ -137,16 +135,14 @@ public class ServerCertsTabUi extends Composite implements Tab {
         this.certificateInput.addChangeHandler(event -> {
             isServerCertValid();
             setDirty(true);
-            ServerCertsTabUi.this.apply.setEnabled(true);
-            ServerCertsTabUi.this.reset.setEnabled(true);
+            setButtonsEnabled(true);
         });
 
         this.reset.setText(MSGS.reset());
         this.reset.addClickHandler(event -> {
             reset();
             setDirty(false);
-            ServerCertsTabUi.this.apply.setEnabled(false);
-            ServerCertsTabUi.this.reset.setEnabled(false);
+            setButtonsEnabled(false);
         });
 
         this.apply.setText(MSGS.apply());
@@ -177,8 +173,7 @@ public class ServerCertsTabUi extends Composite implements Tab {
                                     public void onSuccess(Integer certsStored) {
                                         reset();
                                         setDirty(false);
-                                        ServerCertsTabUi.this.apply.setEnabled(false);
-                                        ServerCertsTabUi.this.reset.setEnabled(false);
+                                        setButtonsEnabled(false);
                                         EntryClassUi.hideWaitModal();
                                     }
                                 });
@@ -189,6 +184,7 @@ public class ServerCertsTabUi extends Composite implements Tab {
     }
 
     private void reset() {
+        setButtonsEnabled(false);
         this.storageAliasInput.setText("");
         this.certificateInput.setText("");
     }
@@ -211,5 +207,10 @@ public class ServerCertsTabUi extends Composite implements Tab {
             this.groupCertForm.setValidationState(ValidationState.NONE);
             return true;
         }
+    }
+
+    private void setButtonsEnabled(boolean state) {
+        ServerCertsTabUi.this.apply.setEnabled(state);
+        ServerCertsTabUi.this.reset.setEnabled(state);
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
@@ -112,7 +112,7 @@ public class ServerCertsTabUi extends Composite implements Tab {
 
     @Override
     public void clear() {
-        // Not needed
+        reset();
     }
 
     private void initForm() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
@@ -102,9 +102,11 @@ public class SettingsPanelUi extends Composite {
 
     private TabListItem currentlySelectedTab;
     private Tab.RefreshHandler snapshotsHandler;
+    private Tab.RefreshHandler sslConfigHandler;
     private Tab.RefreshHandler serverCertHandler;
     private Tab.RefreshHandler deviceCertHandler;
     private Tab.RefreshHandler securityHandler;
+    private Tab.RefreshHandler commandUserHandler;
 
     public SettingsPanelUi() {
         logger.log(Level.FINER, "Initiating SettingsPanelUI...");
@@ -135,14 +137,16 @@ public class SettingsPanelUi extends Composite {
 
         this.snapshotsHandler = new Tab.RefreshHandler(this.snapshotsPanel);
         this.snapshots.addClickHandler(event -> handleEvent(event, this.snapshotsHandler));
-        this.sslConfig.addClickHandler(event -> SettingsPanelUi.this.sslConfigPanel.load());
+        this.sslConfigHandler = new Tab.RefreshHandler(this.sslConfigPanel);
+        this.sslConfig.addClickHandler(event -> handleEvent(event, this.sslConfigHandler));
         this.serverCertHandler = new Tab.RefreshHandler(this.serverCertPanel);
         this.serverCert.addClickHandler(event -> handleEvent(event, this.serverCertHandler));
         this.deviceCertHandler = new Tab.RefreshHandler(this.deviceCertPanel);
         this.deviceCert.addClickHandler(event -> handleEvent(event, this.deviceCertHandler));
         this.securityHandler = new Tab.RefreshHandler(this.securityPanel);
         this.security.addClickHandler(event -> handleEvent(event, this.securityHandler));
-        this.commandUser.addClickHandler(event -> SettingsPanelUi.this.commandUserPanel.load());
+        this.commandUserHandler = new Tab.RefreshHandler(this.commandUserPanel);
+        this.commandUser.addClickHandler(event -> handleEvent(event, this.commandUserHandler));
 
         this.currentlySelectedTab = this.snapshots;
     }
@@ -216,6 +220,7 @@ public class SettingsPanelUi extends Composite {
         ButtonGroup group = new ButtonGroup();
         Button yes = new Button();
         yes.setText(MSGS.yesButton());
+        yes.addStyleName("fa fa-check");
         yes.addClickHandler(event -> {
             modal.hide();
             SettingsPanelUi.this.getTab(this.currentlySelectedTab).clear();
@@ -223,6 +228,7 @@ public class SettingsPanelUi extends Composite {
             newTabRefreshHandler.onClick(event);
         });
         Button no = new Button();
+        no.addStyleName("fa fa-times");
         no.setText(MSGS.noButton());
         no.addClickHandler(event -> {
             SettingsPanelUi.this.currentlySelectedTab.showTab();
@@ -255,16 +261,16 @@ public class SettingsPanelUi extends Composite {
             return this.snapshotsPanel;
         } else if (item.getDataTarget().equals("#appCertPanel")) {
             return this.appCertPanel;
-            // } else if (item.getDataTarget().equals("#sslConfigPanel")) {
-            // return this.sslConfigPanel;
+        } else if (item.getDataTarget().equals("#sslConfigPanel")) {
+            return this.sslConfigPanel;
         } else if (item.getDataTarget().equals("#serverCertPanel")) {
             return this.serverCertPanel;
         } else if (item.getDataTarget().equals("#deviceCertPanel")) {
             return this.deviceCertPanel;
         } else if (item.getDataTarget().equals("#securityPanel")) {
             return this.securityPanel;
-            // } else if (item.getDataTarget().equals("commandUserPanel")) {
-            // return this.commandUserPanel;
+        } else if (item.getDataTarget().equals("#commandUserPanel")) {
+            return this.commandUserPanel;
         } else {
             return this.snapshotsPanel;
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
@@ -102,6 +102,7 @@ public class SettingsPanelUi extends Composite {
 
     private TabListItem currentlySelectedTab;
     private Tab.RefreshHandler snapshotsHandler;
+    private Tab.RefreshHandler appCertHandler;
     private Tab.RefreshHandler sslConfigHandler;
     private Tab.RefreshHandler serverCertHandler;
     private Tab.RefreshHandler deviceCertHandler;
@@ -137,6 +138,8 @@ public class SettingsPanelUi extends Composite {
 
         this.snapshotsHandler = new Tab.RefreshHandler(this.snapshotsPanel);
         this.snapshots.addClickHandler(event -> handleEvent(event, this.snapshotsHandler));
+        this.appCertHandler = new Tab.RefreshHandler(this.appCertPanel);
+        this.appCert.addClickHandler(event -> handleEvent(event, this.appCertHandler));
         this.sslConfigHandler = new Tab.RefreshHandler(this.sslConfigPanel);
         this.sslConfig.addClickHandler(event -> handleEvent(event, this.sslConfigHandler));
         this.serverCertHandler = new Tab.RefreshHandler(this.serverCertPanel);
@@ -153,9 +156,12 @@ public class SettingsPanelUi extends Composite {
 
     public void load() {
         this.currentlySelectedTab = this.snapshots;
+        this.appCertPanel.clear();
+        this.sslConfigPanel.clear();
         this.serverCertPanel.clear();
         this.deviceCertPanel.clear();
         this.securityPanel.clear();
+        this.commandUserPanel.clear();
         this.snapshotsPanel.refresh();
         this.snapshots.showTab();
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
@@ -16,17 +16,27 @@ import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.Tab;
+import org.eclipse.kura.web.client.ui.Tab.RefreshHandler;
 import org.eclipse.kura.web.shared.model.GwtSession;
 import org.eclipse.kura.web.shared.service.GwtSecurityService;
 import org.eclipse.kura.web.shared.service.GwtSecurityServiceAsync;
 import org.eclipse.kura.web2.ext.WidgetFactory;
+import org.gwtbootstrap3.client.ui.Anchor;
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.ButtonGroup;
+import org.gwtbootstrap3.client.ui.Modal;
+import org.gwtbootstrap3.client.ui.ModalBody;
+import org.gwtbootstrap3.client.ui.ModalFooter;
+import org.gwtbootstrap3.client.ui.ModalHeader;
 import org.gwtbootstrap3.client.ui.NavTabs;
 import org.gwtbootstrap3.client.ui.TabContent;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.gwtbootstrap3.client.ui.TabPane;
 import org.gwtbootstrap3.client.ui.html.Paragraph;
+import org.gwtbootstrap3.client.ui.html.Span;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -90,6 +100,12 @@ public class SettingsPanelUi extends Composite {
     @UiField
     HTMLPanel settingsIntro;
 
+    private TabListItem currentlySelectedTab;
+    private Tab.RefreshHandler snapshotsHandler;
+    private Tab.RefreshHandler serverCertHandler;
+    private Tab.RefreshHandler deviceCertHandler;
+    private Tab.RefreshHandler securityHandler;
+
     public SettingsPanelUi() {
         logger.log(Level.FINER, "Initiating SettingsPanelUI...");
 
@@ -117,18 +133,27 @@ public class SettingsPanelUi extends Composite {
         };
         this.gwtSecurityService.isSecurityServiceAvailable(callback);
 
-        this.snapshots.addClickHandler(new Tab.RefreshHandler(this.snapshotsPanel));
+        this.snapshotsHandler = new Tab.RefreshHandler(this.snapshotsPanel);
+        this.snapshots.addClickHandler(event -> handleEvent(event, this.snapshotsHandler));
         this.sslConfig.addClickHandler(event -> SettingsPanelUi.this.sslConfigPanel.load());
-        this.serverCert.addClickHandler(new Tab.RefreshHandler(this.serverCertPanel));
-        this.deviceCert.addClickHandler(new Tab.RefreshHandler(this.deviceCertPanel));
-        this.security.addClickHandler(new Tab.RefreshHandler(this.securityPanel));
+        this.serverCertHandler = new Tab.RefreshHandler(this.serverCertPanel);
+        this.serverCert.addClickHandler(event -> handleEvent(event, this.serverCertHandler));
+        this.deviceCertHandler = new Tab.RefreshHandler(this.deviceCertPanel);
+        this.deviceCert.addClickHandler(event -> handleEvent(event, this.deviceCertHandler));
+        this.securityHandler = new Tab.RefreshHandler(this.securityPanel);
+        this.security.addClickHandler(event -> handleEvent(event, this.securityHandler));
         this.commandUser.addClickHandler(event -> SettingsPanelUi.this.commandUserPanel.load());
+
+        this.currentlySelectedTab = this.snapshots;
     }
 
     public void load() {
-        if (!this.snapshotsPanel.isDirty()) {
-            this.snapshotsPanel.refresh();
-        }
+        this.currentlySelectedTab = this.snapshots;
+        this.serverCertPanel.clear();
+        this.deviceCertPanel.clear();
+        this.securityPanel.clear();
+        this.snapshotsPanel.refresh();
+        this.snapshots.showTab();
     }
 
     public void setSession(GwtSession currentSession) {
@@ -175,4 +200,74 @@ public class SettingsPanelUi extends Composite {
         this.securityPanel.setDirty(b);
         this.commandUserPanel.setDirty(b);
     }
+
+    private void showDirtyModal(TabListItem newTabListItem, RefreshHandler newTabRefreshHandler) {
+        final Modal modal = new Modal();
+
+        ModalHeader header = new ModalHeader();
+        header.setTitle(MSGS.confirm());
+        modal.add(header);
+
+        ModalBody body = new ModalBody();
+        body.add(new Span(MSGS.deviceConfigDirty()));
+        modal.add(body);
+
+        ModalFooter footer = new ModalFooter();
+        ButtonGroup group = new ButtonGroup();
+        Button yes = new Button();
+        yes.setText(MSGS.yesButton());
+        yes.addClickHandler(event -> {
+            modal.hide();
+            SettingsPanelUi.this.getTab(this.currentlySelectedTab).clear();
+            SettingsPanelUi.this.currentlySelectedTab = newTabListItem;
+            newTabRefreshHandler.onClick(event);
+        });
+        Button no = new Button();
+        no.setText(MSGS.noButton());
+        no.addClickHandler(event -> {
+            SettingsPanelUi.this.currentlySelectedTab.showTab();
+            modal.hide();
+        });
+        group.add(no);
+        group.add(yes);
+        footer.add(group);
+        modal.add(footer);
+        modal.show();
+        no.setFocus(true);
+    }
+
+    private void handleEvent(ClickEvent event, Tab.RefreshHandler handler) {
+        TabListItem newTabListItem = (TabListItem) ((Anchor) event.getSource()).getParent();
+        if (newTabListItem != SettingsPanelUi.this.currentlySelectedTab) {
+            if (getTab(SettingsPanelUi.this.currentlySelectedTab).isDirty()) {
+                showDirtyModal(newTabListItem, handler);
+            } else {
+                SettingsPanelUi.this.currentlySelectedTab = newTabListItem;
+                getTab(SettingsPanelUi.this.currentlySelectedTab).setDirty(true);
+                handler.onClick(event);
+            }
+        }
+    }
+
+    // This is not very clean...
+    private Tab getTab(TabListItem item) {
+        if (item.getDataTarget().equals("#snapshotsPanel")) {
+            return this.snapshotsPanel;
+        } else if (item.getDataTarget().equals("#appCertPanel")) {
+            return this.appCertPanel;
+            // } else if (item.getDataTarget().equals("#sslConfigPanel")) {
+            // return this.sslConfigPanel;
+        } else if (item.getDataTarget().equals("#serverCertPanel")) {
+            return this.serverCertPanel;
+        } else if (item.getDataTarget().equals("#deviceCertPanel")) {
+            return this.deviceCertPanel;
+        } else if (item.getDataTarget().equals("#securityPanel")) {
+            return this.securityPanel;
+            // } else if (item.getDataTarget().equals("commandUserPanel")) {
+            // return this.commandUserPanel;
+        } else {
+            return this.snapshotsPanel;
+        }
+    }
+
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SslTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SslTabUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SslTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SslTabUi.java
@@ -123,8 +123,7 @@ public class SslTabUi extends AbstractServicesUi implements Tab {
                                     initInvalidDataModal();
 
                                     setDirty(false);
-                                    SslTabUi.this.apply.setEnabled(false);
-                                    SslTabUi.this.reset.setEnabled(false);
+                                    setButtonsEnabled(false);
                                 }
                             }
                         });
@@ -136,14 +135,23 @@ public class SslTabUi extends AbstractServicesUi implements Tab {
     public void setDirty(boolean flag) {
         this.dirty = flag;
         if (this.dirty && this.initialized) {
-            this.apply.setEnabled(true);
-            this.reset.setEnabled(true);
+            setButtonsEnabled(true);
         }
     }
 
     @Override
     public boolean isDirty() {
         return this.dirty;
+    }
+
+    @Override
+    public void refresh() {
+        load();
+    }
+
+    @Override
+    public void clear() {
+        reset();
     }
 
     private void apply() {
@@ -207,8 +215,7 @@ public class SslTabUi extends AbstractServicesUi implements Tab {
                                         public void onSuccess(Void result) {
                                             SslTabUi.this.modal.hide();
                                             logger.info(MSGS.info() + ": " + MSGS.deviceConfigApplied());
-                                            SslTabUi.this.apply.setEnabled(false);
-                                            SslTabUi.this.reset.setEnabled(false);
+                                            setButtonsEnabled(false);
                                             setDirty(false);
                                             SslTabUi.this.originalConfig = SslTabUi.this.configurableComponent;
                                             EntryClassUi.hideWaitModal();
@@ -235,8 +242,7 @@ public class SslTabUi extends AbstractServicesUi implements Tab {
         if (isDirty()) {
             restoreConfiguration(SslTabUi.this.originalConfig);
             renderForm();
-            SslTabUi.this.apply.setEnabled(false);
-            SslTabUi.this.reset.setEnabled(false);
+            setButtonsEnabled(false);
             setDirty(false);
         }
     }
@@ -296,13 +302,9 @@ public class SslTabUi extends AbstractServicesUi implements Tab {
         return this.configurableComponent;
     }
 
-    @Override
-    public void refresh() {
-        load();
+    private void setButtonsEnabled(boolean state) {
+        SslTabUi.this.apply.setEnabled(state);
+        SslTabUi.this.reset.setEnabled(state);
     }
 
-    @Override
-    public void clear() {
-        reset();
-    }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SslTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SslTabUi.java
@@ -18,6 +18,7 @@ import java.util.logging.Level;
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.AbstractServicesUi;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
+import org.eclipse.kura.web.client.ui.Tab;
 import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter;
@@ -45,7 +46,7 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 
-public class SslTabUi extends AbstractServicesUi {
+public class SslTabUi extends AbstractServicesUi implements Tab {
 
     private static final SslTabUiUiBinder uiBinder = GWT.create(SslTabUiUiBinder.class);
 
@@ -232,40 +233,11 @@ public class SslTabUi extends AbstractServicesUi {
     @Override
     public void reset() {
         if (isDirty()) {
-            // Modal
-            this.modal = new Modal();
-
-            ModalHeader header = new ModalHeader();
-            header.setTitle(MSGS.confirm());
-            this.modal.add(header);
-
-            ModalBody body = new ModalBody();
-            body.add(new Span(MSGS.deviceConfigDirty()));
-            this.modal.add(body);
-
-            ModalFooter footer = new ModalFooter();
-            ButtonGroup group = new ButtonGroup();
-            Button no = new Button();
-            no.setText(MSGS.noButton());
-            no.addStyleName("fa fa-times");
-            no.addClickHandler(event -> SslTabUi.this.modal.hide());
-            group.add(no);
-            Button yes = new Button();
-            yes.setText(MSGS.yesButton());
-            yes.addStyleName("fa fa-check");
-            yes.addClickHandler(event -> {
-                SslTabUi.this.modal.hide();
-                restoreConfiguration(SslTabUi.this.originalConfig);
-                renderForm();
-                SslTabUi.this.apply.setEnabled(false);
-                SslTabUi.this.reset.setEnabled(false);
-                setDirty(false);
-            });
-            group.add(yes);
-            footer.add(group);
-            this.modal.add(footer);
-            this.modal.show();
-            no.setFocus(true);
+            restoreConfiguration(SslTabUi.this.originalConfig);
+            renderForm();
+            SslTabUi.this.apply.setEnabled(false);
+            SslTabUi.this.reset.setEnabled(false);
+            setDirty(false);
         }
     }
 
@@ -322,5 +294,15 @@ public class SslTabUi extends AbstractServicesUi {
             }
         }
         return this.configurableComponent;
+    }
+
+    @Override
+    public void refresh() {
+        load();
+    }
+
+    @Override
+    public void clear() {
+        reset();
     }
 }


### PR DESCRIPTION
This PR modifies the behavior of the Settings section, adding messages for alerting the user that he'll lose the filled data when switch to another tab.

**Related Issue:** This PR fixes/closes #2717 
