### PR TITLE
Fixed at context command for Quectel modem

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/eg25/QuectelEG25AtCommands.java
@@ -18,7 +18,7 @@ public enum QuectelEG25AtCommands {
     GET_MOBILESTATION_CLASS("at+cgclass?\r\n"),
     GET_REGISTRATION_STATUS("at+cgreg?\r\n"),
     GET_GPRS_SESSION_DATA_VOLUME("at+qgdcnt?\r\n"),
-    PDP_CONTEXT("at+cgdcont\r\n");
+    PDP_CONTEXT("at+cgdcont");
 
     private String command;
 


### PR DESCRIPTION
This PR fixes the **at+cgdcont** command for the Quectel EG-25 modem. The newline is removed at the end of the command definition.

**Related Issue:** This PR fixes/closes #2992 
