### PR TITLE
Improved CSV channel download

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtAssetServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtAssetServiceImpl.java
@@ -14,6 +14,9 @@ package org.eclipse.kura.web.server;
 import static java.lang.String.format;
 import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_PID;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Base64.Decoder;
@@ -22,14 +25,22 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.eclipse.kura.asset.Asset;
 import org.eclipse.kura.channel.ChannelFlag;
 import org.eclipse.kura.channel.ChannelRecord;
 import org.eclipse.kura.channel.ChannelStatus;
+import org.eclipse.kura.configuration.metatype.AD;
+import org.eclipse.kura.driver.Driver;
+import org.eclipse.kura.internal.wire.asset.WireAssetChannelDescriptor;
 import org.eclipse.kura.type.DataType;
 import org.eclipse.kura.type.TypedValue;
 import org.eclipse.kura.type.TypedValues;
@@ -40,6 +51,7 @@ import org.eclipse.kura.web.shared.GwtKuraException;
 import org.eclipse.kura.web.shared.model.GwtChannelOperationResult;
 import org.eclipse.kura.web.shared.model.GwtChannelRecord;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
+import org.eclipse.kura.web.shared.model.GwtConfigParameter;
 import org.eclipse.kura.web.shared.model.GwtXSRFToken;
 import org.eclipse.kura.web.shared.service.GwtAssetService;
 import org.osgi.framework.BundleContext;
@@ -56,6 +68,7 @@ public class GwtAssetServiceImpl extends OsgiRemoteServiceServlet implements Gwt
 
     private static final Decoder BASE64_DECODER = Base64.getDecoder();
     private static final Encoder BASE64_ENCODER = Base64.getEncoder();
+    private static final AtomicInteger nextId = new AtomicInteger();
 
     @Override
     public GwtChannelOperationResult readAllChannels(GwtXSRFToken xsrfToken, String assetPid) throws GwtKuraException {
@@ -265,5 +278,79 @@ public class GwtAssetServiceImpl extends OsgiRemoteServiceServlet implements Gwt
             return BASE64_ENCODER.encodeToString((byte[]) typedValue.getValue());
         }
         return typedValue.getValue().toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public int convertToCsv(final GwtXSRFToken token, final String driverPid, final GwtConfigComponent assetConfig)
+            throws GwtKuraException, IOException {
+
+        checkXSRFToken(token);
+
+        final List<AD> wireAssetDescriptor = (List<AD>) WireAssetChannelDescriptor.get().getDescriptor();
+
+        final List<AD> channelDescriptor = new ArrayList<>();
+
+        for (final AD ad : wireAssetDescriptor) {
+            channelDescriptor.add(ad);
+        }
+
+        ServiceLocator.withAllServices(Driver.class, "(kura.service.pid=" + driverPid + ")", d -> {
+            final List<AD> desc = (List<AD>) d.getChannelDescriptor().getDescriptor();
+
+            channelDescriptor.addAll(desc);
+        });
+
+        if (channelDescriptor.size() == wireAssetDescriptor.size()) {
+            throw new GwtKuraException("Driver not found");
+        }
+
+        final Set<String> channelNames = new TreeSet<>();
+        final Map<String, GwtConfigParameter> paramsById = new HashMap<>();
+
+        assetConfig.getParameters().forEach(p -> {
+            final String id = p.getId();
+            final int index = id.indexOf('#');
+            if (index == -1) {
+                return;
+            }
+            channelNames.add(id.substring(0, index));
+            paramsById.put(id, p);
+        });
+
+        final Writer out = new StringWriter();
+
+        try (final CSVPrinter printer = new CSVPrinter(out, CSVFormat.RFC4180)) {
+
+            for (int i = 0; i < channelDescriptor.size(); i++) {
+                final String id = channelDescriptor.get(i).getId();
+
+                if (i < wireAssetDescriptor.size()) {
+                    printer.print(id.substring(1));
+                } else {
+                    printer.print(id);
+                }
+            }
+
+            printer.println();
+
+            for (final String channel : channelNames) {
+                for (final AD ad : channelDescriptor) {
+                    final String key = channel + '#' + ad.getId();
+                    final GwtConfigParameter param = paramsById.get(key);
+                    printer.print(param != null ? param.getValue() : null);
+                }
+                printer.println();
+            }
+
+        }
+
+        final int id = nextId.getAndIncrement();
+
+        final HttpSession session = getThreadLocalRequest().getSession(false);
+
+        session.setAttribute("kura.csv.download." + id, out.toString());
+
+        return id;
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/ChannelServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/ChannelServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/ChannelServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/ChannelServlet.java
@@ -12,40 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kura.web.server.servlet;
 
-import static java.lang.String.format;
-import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_PID;
-
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.xml.ws.http.HTTPException;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.eclipse.kura.asset.Asset;
-import org.eclipse.kura.configuration.metatype.AD;
-import org.eclipse.kura.driver.Driver;
-import org.eclipse.kura.internal.wire.asset.WireAssetChannelDescriptor;
 import org.eclipse.kura.web.server.KuraRemoteServiceServlet;
-import org.eclipse.kura.web.server.util.GwtServerUtil;
-import org.eclipse.kura.web.server.util.ServiceLocator;
-import org.eclipse.kura.web.server.util.ServiceLocator.ServiceConsumer;
 import org.eclipse.kura.web.session.Attributes;
-import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtXSRFToken;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,12 +35,6 @@ public class ChannelServlet extends HttpServlet {
     private static Logger logger = LoggerFactory.getLogger(ChannelServlet.class);
     private static final Logger auditLogger = LoggerFactory.getLogger("AuditLogger");
 
-    /**
-     * Instance of Base Asset Channel Descriptor
-     */
-    private static final GwtConfigComponent WIRE_ASSET_CHANNEL_DESCRIPTOR = GwtServerUtil.toGwtConfigComponent(null,
-            WireAssetChannelDescriptor.get().getDescriptor());
-
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         HttpSession session = req.getSession(false);
@@ -71,118 +44,34 @@ public class ChannelServlet extends HttpServlet {
             KuraRemoteServiceServlet.checkXSRFToken(req, token);
             // END XSRF security check
             String assetPid = req.getParameter("assetPid");
-            String driverPid = req.getParameter("driverPid");
+            String id = req.getParameter("id");
 
-            Writer out = new StringWriter();
-            CSVPrinter printer = new CSVPrinter(out, CSVFormat.RFC4180);
+            final String attributeKey = "kura.csv.download." + id;
 
-            if (!fillCsvFields(printer, assetPid, driverPid)) {
-                resp.getWriter().write("Error generating CSV output!");
-            } else {
-                resp.setCharacterEncoding("UTF-8");
-                resp.setContentType("text/csv");
-                resp.setHeader("Content-Disposition", "attachment; filename=asset_" + assetPid + ".csv");
-                resp.setHeader("Cache-Control", "no-transform, max-age=0");
-                try (PrintWriter writer = resp.getWriter()) {
-                    writer.write(out.toString());
-                }
+            final String result = (String) session.getAttribute(attributeKey);
+
+            if (result == null) {
+                throw new HTTPException(404);
+            }
+
+            session.removeAttribute(attributeKey);
+
+            resp.setCharacterEncoding("UTF-8");
+            resp.setContentType("text/csv");
+            resp.setHeader("Content-Disposition", "attachment; filename=asset_" + assetPid + ".csv");
+            resp.setHeader("Cache-Control", "no-transform, max-age=0");
+            try (PrintWriter writer = resp.getWriter()) {
+                writer.write(result);
             }
 
             auditLogger.info(
-                    "UI Channel Servlet - Success - Successfully wrote Channel CSV description for user: {}, session: {}, asset pid: {}, driver pid: {}",
-                    session.getAttribute(Attributes.AUTORIZED_USER.getValue()), session.getId(), assetPid, driverPid);
+                    "UI Channel Servlet - Success - Successfully wrote Channel CSV description for user: {}, session: {}, asset pid: {}",
+                    session.getAttribute(Attributes.AUTORIZED_USER.getValue()), session.getId(), assetPid);
         } catch (Exception ex) {
             logger.error("Error while exporting CSV output!", ex);
             auditLogger.warn(
                     "UI Channel Servlet - Failure - Failed to write Channel CSV description for user: {}, session: {}",
                     session.getAttribute(Attributes.AUTORIZED_USER.getValue()), session.getId());
-        }
-    }
-
-    private boolean fillCsvFields(CSVPrinter printer, String assetPid, String driverPid) {
-        final AtomicBoolean error = new AtomicBoolean(false);
-        List<String> orderedFields = new ArrayList<>();
-        try {
-            WIRE_ASSET_CHANNEL_DESCRIPTOR.getParameters().forEach(i -> {
-                try {
-                    printer.print(i.getId().substring(1));
-                } catch (IOException e) {
-                    error.set(true);
-                }
-                orderedFields.add(new StringBuilder().append("+").append(i.getId().substring(1)).toString());
-            });
-
-            withDriver(driverPid, driver -> {
-                @SuppressWarnings("unchecked")
-                List<AD> descriptor = (List<AD>) driver.getChannelDescriptor().getDescriptor();
-
-                for (AD ad : descriptor) {
-                    try {
-                        printer.print(ad.getId());
-                    } catch (IOException e) {
-                        error.set(true);
-                    }
-                    orderedFields.add(ad.getId());
-                }
-            });
-            printer.println();
-
-            withAsset(assetPid, asset -> asset.getAssetConfiguration().getAssetChannels().forEach((name, channel) -> {
-                orderedFields.forEach(key -> {
-                    try {
-                        printer.print(channel.getConfiguration().get(key));
-                    } catch (IOException e) {
-                        error.set(true);
-                    }
-                });
-                try {
-                    printer.println();
-                } catch (IOException e) {
-                    error.set(true);
-                }
-            }));
-        } catch (Exception ex) {
-            error.set(true);
-        }
-
-        return !error.get();
-    }
-
-    private void withAsset(final String kuraServicePid, final ServiceConsumer<Asset> consumer) throws Exception {
-        final BundleContext ctx = FrameworkUtil.getBundle(ServiceLocator.class).getBundleContext();
-
-        final String filter = format("(%s=%s)", KURA_SERVICE_PID, kuraServicePid);
-        final Collection<ServiceReference<Asset>> refs = ctx.getServiceReferences(Asset.class, filter);
-
-        if (refs == null || refs.isEmpty()) {
-            return;
-        }
-
-        final ServiceReference<Asset> assetRef = refs.iterator().next();
-
-        try {
-            consumer.consume(ctx.getService(assetRef));
-        } finally {
-            ctx.ungetService(assetRef);
-        }
-    }
-
-    private void withDriver(final String kuraServicePid, final ServiceConsumer<Driver> consumer) throws Exception {
-        final BundleContext ctx = FrameworkUtil.getBundle(ServiceLocator.class).getBundleContext();
-
-        final String filter = format("(%s=%s)", KURA_SERVICE_PID, kuraServicePid);
-        final Collection<ServiceReference<Driver>> refs = ctx.getServiceReferences(Driver.class, filter);
-
-        if (refs == null || refs.isEmpty()) {
-            return;
-        }
-
-        final ServiceReference<Driver> driverRef = refs.iterator().next();
-
-        try {
-            consumer.consume(ctx.getService(driverRef));
-        } finally {
-            ctx.ungetService(driverRef);
         }
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtAssetService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtAssetService.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kura.web.shared.service;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.eclipse.kura.web.shared.GwtKuraException;
@@ -36,5 +37,8 @@ public interface GwtAssetService extends RemoteService {
             List<GwtChannelRecord> channelRecords) throws GwtKuraException;
 
     public GwtConfigComponent getUploadedCsvConfig(GwtXSRFToken xsrfToken, String assetPid) throws GwtKuraException;
+
+    public int convertToCsv(GwtXSRFToken token, String driverPid, GwtConfigComponent assetConfig)
+            throws GwtKuraException, IOException;
 
 }


### PR DESCRIPTION
Adopted a similar approach as #2996 for channel download.
 * Downloading channels is now possible even if an Asset does not exist on the device or if its configuration is dirty.
 * The download channel button should always be enabled, unless the channel table is empty or if Asset configuration is not valid.