### PR TITLE
Modified bluetooth flags capitalization

### DIFF
--- a/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeGattCharacteristicImpl.java
+++ b/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeGattCharacteristicImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeGattCharacteristicImpl.java
+++ b/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeGattCharacteristicImpl.java
@@ -131,7 +131,7 @@ public class BluetoothLeGattCharacteristicImpl implements BluetoothLeGattCharact
     public List<BluetoothLeGattCharacteristicProperties> getProperties() {
         List<BluetoothLeGattCharacteristicProperties> properties = new ArrayList<>();
         for (String flag : this.characteristic.getFlags()) {
-            properties.add(BluetoothLeGattCharacteristicProperties.valueOf(flag));
+            properties.add(BluetoothLeGattCharacteristicProperties.valueOf(flag.toUpperCase()));
         }
         return properties;
     }


### PR DESCRIPTION
Modified the capitalization of the flags passed to the `BluetoothLeGattCharacteristicProperties.valueOf` method.

**Related Issue:** This PR fixes/closes #3017 

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>