### PR TITLE
Fixed fields validation in webUI

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -554,6 +554,9 @@ public abstract class AbstractServicesUi extends Composite {
 
             final String text = currentText.getText();
 
+            if ((text == null || text.isEmpty()) && !param.isRequired()) {
+                return editorErrors;
+            }
             ValidationUtil.validateParameter(param, text, errorDescription -> {
                 AbstractServicesUi.this.valid.put(param.getId(), false);
                 editorErrors.add(new BasicEditorError(currentText, text, errorDescription));

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1024,16 +1024,18 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             @Override
             public List<EditorError> validate(Editor<String> editor, String value) {
                 List<EditorError> result = new ArrayList<>();
-                try {
-                    if (field.getText().trim().contains(".") || field.getText().trim().contains("-")
-                            || !field.getText().trim().matches("[0-9]+")) {
-                        result.add(new BasicEditorError(field, value, MSGS.netWifiBgScanInterval()));
-                    } else if (Integer.parseInt(TabWirelessUi.this.shortI.getText().trim()) >= Integer
-                            .parseInt(TabWirelessUi.this.longI.getText().trim())) {
-                        result.add(new BasicEditorError(field, value, MSGS.netWifiBgScanIntervalValues()));
+                if (TabWirelessUi.this.shortI.isEnabled() && TabWirelessUi.this.longI.isEnabled()) {
+                    try {
+                        if (field.getText().trim().contains(".") || field.getText().trim().contains("-")
+                                || !field.getText().trim().matches("[0-9]+")) {
+                            result.add(new BasicEditorError(field, value, MSGS.netWifiBgScanInterval()));
+                        } else if (Integer.parseInt(TabWirelessUi.this.shortI.getText().trim()) >= Integer
+                                .parseInt(TabWirelessUi.this.longI.getText().trim())) {
+                            result.add(new BasicEditorError(field, value, MSGS.netWifiBgScanIntervalValues()));
+                        }
+                    } catch (NumberFormatException e) {
+                        result.add(new BasicEditorError(field, value, MSGS.deviceConfigError()));
                     }
-                } catch (NumberFormatException e) {
-                    result.add(new BasicEditorError(field, value, MSGS.deviceConfigError()));
                 }
                 return result;
             }


### PR DESCRIPTION
In the `TabWirelessUi` the bgscan parameters are validated even if the fields aren't enabled. 
In the `AbstractServicesUi`, instead, the validation is performed even if the fields are empty, but not required.

**Related Issue:** This PR fixes/closes #3014 
