### PR TITLE
Managed exceptions in firewall ports value conversion

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUtils.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUtils.java
@@ -25,32 +25,27 @@ public class FirewallPanelUtils {
     }
 
     public static boolean isPortInRange(String ports) {
-        boolean isInRange = false;
+        boolean result = false;
         try {
             String[] portRange = ports.split(":");
             if (portRange.length == 2) {
-                portRange[0] = portRange[0].trim();
-                portRange[1] = portRange[1].trim();
-                isInRange = checkPort(portRange[0]) && checkPort(portRange[1])
-                        && Integer.parseInt(portRange[0]) < Integer.parseInt(portRange[1]);
+                int lowerPort = Integer.parseInt(portRange[0].trim());
+                int upperPort = Integer.parseInt(portRange[1].trim());
+                result = isInRange(lowerPort) && isInRange(upperPort) && lowerPort < upperPort;
             } else if (portRange.length == 1) {
-                isInRange = checkPort(portRange[0].trim());
+                int port = Integer.parseInt(portRange[0].trim());
+                result = isInRange(port);
             }
-        } catch (Exception e) {
+        } catch (NumberFormatException e) {
             // do nothing
         }
-        return isInRange;
+        return result;
     }
 
-    private static boolean checkPort(String port) {
+    private static boolean isInRange(int port) {
         boolean isInRange = false;
-        try {
-            Integer portInt = Integer.parseInt(port);
-            if (!port.startsWith("0") && portInt > 0 && portInt <= 65535) {
-                isInRange = true;
-            }
-        } catch (Exception e) {
-            // do nothing
+        if (port > 0 && port <= 65535) {
+            isInRange = true;
         }
         return isInRange;
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUtils.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUtils.java
@@ -20,21 +20,37 @@ public class FirewallPanelUtils {
 
     public static final int INTERFACE_NAME_MAX_LENGTH = 15;
 
+    private FirewallPanelUtils() {
+        // Not needed
+    }
+
     public static boolean isPortInRange(String ports) {
-        String[] portRange = ports.trim().split(":");
-        if (portRange.length == 2) {
-            return checkPort(portRange[0]) && checkPort(portRange[1])
-                    && Integer.parseInt(portRange[0]) < Integer.parseInt(portRange[1]);
-        } else {
-            return checkPort(portRange[0]);
+        boolean isInRange = false;
+        try {
+            String[] portRange = ports.split(":");
+            if (portRange.length == 2) {
+                portRange[0] = portRange[0].trim();
+                portRange[1] = portRange[1].trim();
+                isInRange = checkPort(portRange[0]) && checkPort(portRange[1])
+                        && Integer.parseInt(portRange[0]) < Integer.parseInt(portRange[1]);
+            } else if (portRange.length == 1) {
+                isInRange = checkPort(portRange[0].trim());
+            }
+        } catch (Exception e) {
+            // do nothing
         }
+        return isInRange;
     }
 
     private static boolean checkPort(String port) {
         boolean isInRange = false;
-        Integer portInt = Integer.parseInt(port);
-        if (!port.startsWith("0") && portInt > 0 && portInt <= 65535) {
-            isInRange = true;
+        try {
+            Integer portInt = Integer.parseInt(port);
+            if (!port.startsWith("0") && portInt > 0 && portInt <= 65535) {
+                isInRange = true;
+            }
+        } catch (Exception e) {
+            // do nothing
         }
         return isInRange;
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.java
@@ -162,10 +162,8 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
 
     public OpenPortsTabUi() {
         initWidget(uiBinder.createAndBindUi(this));
-        this.selectionModel.addSelectionChangeHandler(event -> {
-            OpenPortsTabUi.this.buttonBar
-                    .setEditDeleteButtonsDirty(OpenPortsTabUi.this.selectionModel.getSelectedObject() != null);
-        });
+        this.selectionModel.addSelectionChangeHandler(event -> OpenPortsTabUi.this.buttonBar
+                .setEditDeleteButtonsDirty(OpenPortsTabUi.this.selectionModel.getSelectedObject() != null));
         this.openPortsGrid.setSelectionModel(this.selectionModel);
 
         initTable();
@@ -514,14 +512,14 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
 
             // create a new entry
             this.openPortEntry = new GwtFirewallOpenPortEntry();
-            this.openPortEntry.setPortRange(this.port.getText());
+            this.openPortEntry.setPortRange(this.port.getText().trim());
             this.openPortEntry.setProtocol(this.protocol.getSelectedItemText());
 
             this.openPortEntry.setPermittedNetwork(validOrDefault(this.permittedNw.getText(), "0.0.0.0/0"));
             this.openPortEntry.setPermittedInterfaceName(validOrDefault(this.permittedI.getText(), null));
             this.openPortEntry.setUnpermittedInterfaceName(validOrDefault(this.unpermittedI.getText(), null));
             this.openPortEntry.setPermittedMAC(validOrDefault(this.permittedMac.getText(), null));
-            this.openPortEntry.setSourcePortRange(validOrDefault(this.source.getText(), null));
+            this.openPortEntry.setSourcePortRange(validOrDefault(this.source.getText().trim(), null));
 
             if (OpenPortsTabUi.this.submit.getId().equals("new")) {
                 OpenPortsTabUi.this.newOpenPortEntry = OpenPortsTabUi.this.openPortEntry;
@@ -598,21 +596,17 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
     }
 
     private void setModalFieldsHandlers() {
-        this.permittedI.addChangeHandler(event -> {
-            setEnableUnpermittedInterface();
-        });
+        this.permittedI.addChangeHandler(event -> setEnableUnpermittedInterface());
 
-        this.unpermittedI.addChangeHandler(event -> {
-            setEnablePermittedInterface();
-        });
+        this.unpermittedI.addChangeHandler(event -> setEnablePermittedInterface());
 
         // set up validation
         this.port.addBlurHandler(event -> {
             if (OpenPortsTabUi.this.port.getText() == null || "".equals(OpenPortsTabUi.this.port.getText().trim())
                     || OpenPortsTabUi.this.port.getText().trim().length() == 0
-                    || !(FirewallPanelUtils.checkPortRegex(OpenPortsTabUi.this.port.getText())
-                            || FirewallPanelUtils.checkPortRangeRegex(OpenPortsTabUi.this.port.getText()))
-                    || !FirewallPanelUtils.isPortInRange(OpenPortsTabUi.this.port.getText())) {
+                    || !(FirewallPanelUtils.checkPortRegex(OpenPortsTabUi.this.port.getText().trim())
+                            || FirewallPanelUtils.checkPortRangeRegex(OpenPortsTabUi.this.port.getText().trim()))
+                    || !FirewallPanelUtils.isPortInRange(OpenPortsTabUi.this.port.getText().trim())) {
                 OpenPortsTabUi.this.groupPort.setValidationState(ValidationState.ERROR);
             } else {
                 OpenPortsTabUi.this.groupPort.setValidationState(ValidationState.NONE);
@@ -657,9 +651,9 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
         });
         this.source.addBlurHandler(event -> {
             if (OpenPortsTabUi.this.source.getText().trim().length() > 0
-                    && (!(FirewallPanelUtils.checkPortRegex(OpenPortsTabUi.this.source.getText())
-                            || FirewallPanelUtils.checkPortRangeRegex(OpenPortsTabUi.this.source.getText()))
-                            || !FirewallPanelUtils.isPortInRange(OpenPortsTabUi.this.source.getText()))) {
+                    && (!(FirewallPanelUtils.checkPortRegex(OpenPortsTabUi.this.source.getText().trim())
+                            || FirewallPanelUtils.checkPortRangeRegex(OpenPortsTabUi.this.source.getText().trim()))
+                            || !FirewallPanelUtils.isPortInRange(OpenPortsTabUi.this.source.getText().trim()))) {
                 OpenPortsTabUi.this.groupSource.setValidationState(ValidationState.ERROR);
             } else {
                 OpenPortsTabUi.this.groupSource.setValidationState(ValidationState.NONE);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.java
@@ -622,8 +622,8 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
             }
         });
         this.permittedI.addBlurHandler(event -> {
-            if ((!OpenPortsTabUi.this.permittedI.getText().trim().matches(FieldType.ALPHANUMERIC.getRegex())
-                    && OpenPortsTabUi.this.permittedI.getText().trim().length() > 0)
+            if (!OpenPortsTabUi.this.permittedI.getText().trim().matches(FieldType.ALPHANUMERIC.getRegex())
+                    && OpenPortsTabUi.this.permittedI.getText().trim().length() > 0
                     || OpenPortsTabUi.this.permittedI.getText().trim()
                             .length() > FirewallPanelUtils.INTERFACE_NAME_MAX_LENGTH) {
                 OpenPortsTabUi.this.groupPermittedI.setValidationState(ValidationState.ERROR);
@@ -632,8 +632,8 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
             }
         });
         this.unpermittedI.addBlurHandler(event -> {
-            if ((!OpenPortsTabUi.this.unpermittedI.getText().trim().matches(FieldType.ALPHANUMERIC.getRegex())
-                    && OpenPortsTabUi.this.unpermittedI.getText().trim().length() > 0)
+            if (!OpenPortsTabUi.this.unpermittedI.getText().trim().matches(FieldType.ALPHANUMERIC.getRegex())
+                    && OpenPortsTabUi.this.unpermittedI.getText().trim().length() > 0
                     || OpenPortsTabUi.this.unpermittedI.getText().trim()
                             .length() > FirewallPanelUtils.INTERFACE_NAME_MAX_LENGTH) {
                 OpenPortsTabUi.this.groupUnpermittedI.setValidationState(ValidationState.ERROR);


### PR DESCRIPTION
This PR adds the management of the exception thrown during ports value conversion. Moreover, `trim()` method is added when the port value is applied.

**Related Issue:** This PR fixes/closes #3000 

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>