### PR TITLE
Clear validation states in reset methods

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -200,6 +200,9 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.storageAliasInput.setText("");
         this.privateKeyInput.setText("");
         this.certificateInput.setText("");
+        this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
+        this.groupCertForm.setValidationState(ValidationState.NONE);
+        this.groupCertForm.setValidationState(ValidationState.NONE);
     }
 
     private boolean isAliasValid() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -98,10 +98,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
 
     @Override
     public boolean isValid() {
-        boolean validAlias = isAliasValid();
-        boolean validPrivateKey = isPrivateKeyValid();
-        boolean validDeviceCert = isDeviceCertValid();
-        return validAlias && validPrivateKey && validDeviceCert;
+        return deviceSslCertsForm.validate();
     }
 
     @Override
@@ -128,7 +125,6 @@ public class DeviceCertsTabUi extends Composite implements Tab {
 
         this.storageAliasLabel.setText(MSGS.settingsStorageAliasLabel());
         this.storageAliasInput.addChangeHandler(event -> {
-            isAliasValid();
             setDirty(true);
             setButtonsEnabled(true);
         });
@@ -136,7 +132,6 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.privateKeyLabel.setText(MSGS.settingsPrivateCertLabel());
         this.privateKeyInput.setVisibleLines(20);
         this.privateKeyInput.addChangeHandler(event -> {
-            isPrivateKeyValid();
             setDirty(true);
             setButtonsEnabled(true);
         });
@@ -144,7 +139,6 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.certificateLabel.setText(MSGS.settingsPublicCertLabel());
         this.certificateInput.setVisibleLines(20);
         this.certificateInput.addChangeHandler(event -> {
-            isDeviceCertValid();
             setDirty(true);
             setButtonsEnabled(true);
         });
@@ -203,36 +197,6 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
         this.groupCertForm.setValidationState(ValidationState.NONE);
         this.groupCertForm.setValidationState(ValidationState.NONE);
-    }
-
-    private boolean isAliasValid() {
-        if (this.storageAliasInput.getText() == null || "".equals(this.storageAliasInput.getText().trim())) {
-            this.groupStorageAliasForm.setValidationState(ValidationState.ERROR);
-            return false;
-        } else {
-            this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
-            return true;
-        }
-    }
-
-    private boolean isPrivateKeyValid() {
-        if (this.certificateInput.getText() == null || "".equals(this.certificateInput.getText().trim())) {
-            this.groupCertForm.setValidationState(ValidationState.ERROR);
-            return false;
-        } else {
-            this.groupCertForm.setValidationState(ValidationState.NONE);
-            return true;
-        }
-    }
-
-    private boolean isDeviceCertValid() {
-        if (this.certificateInput.getText() == null || "".equals(this.certificateInput.getText().trim())) {
-            this.groupCertForm.setValidationState(ValidationState.ERROR);
-            return false;
-        } else {
-            this.groupCertForm.setValidationState(ValidationState.NONE);
-            return true;
-        }
     }
 
     private void setButtonsEnabled(boolean state) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.ui.xml
@@ -54,25 +54,28 @@
                     <b:FieldSet>
                         <b:FormGroup ui:field="groupStorageAliasForm">
                             <b:FormLabel for="storageAliasInput"
-                                ui:field="storageAliasLabel" />
+                                ui:field="storageAliasLabel" showRequiredIndicator="true"/>
+                            <b:InlineHelpBlock iconType="EXCLAMATION_TRIANGLE" />
                             <b:Input type="TEXT" b:id="storageAlias"
-                                ui:field="storageAliasInput" />
+                                ui:field="storageAliasInput" allowBlank="false" validateOnBlur="true"/>
                         </b:FormGroup>
 
                         <b:FormGroup ui:field="groupPrivateKeyForm">
                             <b:FormLabel for="privateKeyInput"
-                                ui:field="privateKeyLabel" />
+                                ui:field="privateKeyLabel" showRequiredIndicator="true"/>
+                            <b:InlineHelpBlock iconType="EXCLAMATION_TRIANGLE" />
                             <b:TextArea b:id="privateKeyInput"
                                 addStyleNames="{style.center-panel}"
-                                ui:field="privateKeyInput" />
+                                ui:field="privateKeyInput" allowBlank="false" validateOnBlur="true"/>
                         </b:FormGroup>
 
                         <b:FormGroup ui:field="groupCertForm">
                             <b:FormLabel for="certificateInput"
-                                ui:field="certificateLabel" />
+                                ui:field="certificateLabel" showRequiredIndicator="true"/>
+                            <b:InlineHelpBlock iconType="EXCLAMATION_TRIANGLE" />
                             <b:TextArea b:id="certificateInput"
                                 addStyleNames="{style.center-panel}"
-                                ui:field="certificateInput" />
+                                ui:field="certificateInput" allowBlank="false" validateOnBlur="true"/>
                         </b:FormGroup>
                     </b:FieldSet>
                 </b:Form>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
@@ -187,6 +187,8 @@ public class ServerCertsTabUi extends Composite implements Tab {
         setButtonsEnabled(false);
         this.storageAliasInput.setText("");
         this.certificateInput.setText("");
+        this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
+        this.groupCertForm.setValidationState(ValidationState.NONE);
     }
 
     private boolean isAliasValid() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
@@ -92,13 +92,7 @@ public class ServerCertsTabUi extends Composite implements Tab {
 
     @Override
     public boolean isValid() {
-        boolean validAlias = isAliasValid();
-        boolean validAppCert = isServerCertValid();
-        boolean result = false;
-        if (validAlias && validAppCert) {
-            result = true;
-        }
-        return result;
+        return this.serverSslCertsForm.validate();
     }
 
     @Override
@@ -125,7 +119,6 @@ public class ServerCertsTabUi extends Composite implements Tab {
 
         this.storageAliasLabel.setText(MSGS.settingsStorageAliasLabel());
         this.storageAliasInput.addChangeHandler(event -> {
-            isAliasValid();
             setDirty(true);
             setButtonsEnabled(true);
         });
@@ -133,7 +126,6 @@ public class ServerCertsTabUi extends Composite implements Tab {
         this.certificateLabel.setText(MSGS.settingsPublicCertLabel());
         this.certificateInput.setVisibleLines(20);
         this.certificateInput.addChangeHandler(event -> {
-            isServerCertValid();
             setDirty(true);
             setButtonsEnabled(true);
         });
@@ -189,26 +181,6 @@ public class ServerCertsTabUi extends Composite implements Tab {
         this.certificateInput.setText("");
         this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
         this.groupCertForm.setValidationState(ValidationState.NONE);
-    }
-
-    private boolean isAliasValid() {
-        if (this.storageAliasInput.getText() == null || "".equals(this.storageAliasInput.getText().trim())) {
-            this.groupStorageAliasForm.setValidationState(ValidationState.ERROR);
-            return false;
-        } else {
-            this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
-            return true;
-        }
-    }
-
-    private boolean isServerCertValid() {
-        if (this.certificateInput.getText() == null || "".equals(this.certificateInput.getText().trim())) {
-            this.groupCertForm.setValidationState(ValidationState.ERROR);
-            return false;
-        } else {
-            this.groupCertForm.setValidationState(ValidationState.NONE);
-            return true;
-        }
     }
 
     private void setButtonsEnabled(boolean state) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.ui.xml
@@ -55,17 +55,19 @@
                     <b:FieldSet>
                         <b:FormGroup ui:field="groupStorageAliasForm">
                             <b:FormLabel for="storageAliasInput"
-                                ui:field="storageAliasLabel" />
+                                ui:field="storageAliasLabel" showRequiredIndicator="true"/>
+                            <b:InlineHelpBlock iconType="EXCLAMATION_TRIANGLE" />
                             <b:Input type="TEXT" b:id="storageAlias"
-                                ui:field="storageAliasInput" />
+                                ui:field="storageAliasInput" allowBlank="false" validateOnBlur="true"/>
                         </b:FormGroup>
 
                         <b:FormGroup ui:field="groupCertForm">
                             <b:FormLabel for="certificateInput"
-                                ui:field="certificateLabel" />
+                                ui:field="certificateLabel" showRequiredIndicator="true"/>
+                            <b:InlineHelpBlock iconType="EXCLAMATION_TRIANGLE" />
                             <b:TextArea b:id="certificateInput"
                                 addStyleNames="{style.center-panel}"
-                                ui:field="certificateInput" />
+                                ui:field="certificateInput" allowBlank="false" validateOnBlur="true"/>
                         </b:FormGroup>
                     </b:FieldSet>
                 </b:Form>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
Added clear of the validation state of GroupForms in reset method for the Settings tabs.

**Related Issue:** This PR fixes/closes #2719 

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>