### PR TITLE
Fix missing validation in device certs tab

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/CommandUserTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/CommandUserTabUi.java
@@ -151,13 +151,15 @@ public class CommandUserTabUi extends AbstractServicesUi implements Tab {
 
     @Override
     public void clear() {
-        reset();
+        restoreConfiguration(originalConfig);
+        renderForm();
+        setButtonsEnabled(false);
+        setDirty(false);
     }
 
     private void apply() {
         if (isValid()) {
             if (isDirty()) {
-                // TODO ask for confirmation first
                 Modal modal = new Modal();
                 modal.setClosable(false);
                 modal.setFade(true);
@@ -219,8 +221,7 @@ public class CommandUserTabUi extends AbstractServicesUi implements Tab {
                                         public void onSuccess(Void result) {
                                             modal.hide();
                                             logger.info(MSGS.info() + ": " + MSGS.deviceConfigApplied());
-                                            CommandUserTabUi.this.apply.setEnabled(false);
-                                            CommandUserTabUi.this.reset.setEnabled(false);
+                                            setButtonsEnabled(false);
                                             setDirty(false);
                                             CommandUserTabUi.this.originalConfig = CommandUserTabUi.this.configurableComponent;
                                             EntryClassUi.hideWaitModal();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -36,8 +36,10 @@ import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.html.Span;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
@@ -124,6 +126,11 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.groupCertForm.setValidationState(ValidationState.NONE);
         this.deviceSslCertsForm.reset();
         setButtonsEnabled(false);
+    }
+
+    @UiHandler(value = { "groupStorageAliasForm", "groupPrivateKeyForm", "groupCertForm" })
+    public void onFormBlur(BlurEvent e) {
+        setDirty(true);
     }
 
     private void initForm() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -32,7 +32,6 @@ import org.gwtbootstrap3.client.ui.ModalFooter;
 import org.gwtbootstrap3.client.ui.ModalHeader;
 import org.gwtbootstrap3.client.ui.TextArea;
 import org.gwtbootstrap3.client.ui.constants.ModalBackdrop;
-import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.html.Span;
 
 import com.google.gwt.core.client.GWT;
@@ -118,14 +117,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
     public void clear() {
         setButtonsEnabled(false);
         setDirty(false);
-        this.storageAliasInput.setText("");
-        this.privateKeyInput.setText("");
-        this.certificateInput.setText("");
-        this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
-        this.groupPrivateKeyForm.setValidationState(ValidationState.NONE);
-        this.groupCertForm.setValidationState(ValidationState.NONE);
         this.deviceSslCertsForm.reset();
-        setButtonsEnabled(false);
     }
 
     @UiHandler(value = { "storageAliasInput", "privateKeyInput", "certificateInput" })

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -128,9 +128,10 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         setButtonsEnabled(false);
     }
 
-    @UiHandler(value = { "groupStorageAliasForm", "groupPrivateKeyForm", "groupCertForm" })
+    @UiHandler(value = { "storageAliasInput", "privateKeyInput", "certificateInput" })
     public void onFormBlur(BlurEvent e) {
         setDirty(true);
+        setButtonsEnabled(true);
     }
 
     private void initForm() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -104,24 +104,20 @@ public class DeviceCertsTabUi extends Composite implements Tab {
 
     @Override
     public boolean isValid() {
-        return deviceSslCertsForm.validate();
+        return this.deviceSslCertsForm.validate();
     }
 
     @Override
     public void refresh() {
-        if (isDirty()) {
-            setDirty(false);
-            this.storageAliasInput.setText("");
-            this.certificateInput.setText("");
-            this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
-            this.groupPrivateKeyForm.setValidationState(ValidationState.NONE);
-            this.groupCertForm.setValidationState(ValidationState.NONE);
-        }
+        clear();
     }
 
     @Override
     public void clear() {
+        setButtonsEnabled(false);
+        setDirty(false);
         this.storageAliasInput.setText("");
+        this.privateKeyInput.setText("");
         this.certificateInput.setText("");
         this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
         this.groupPrivateKeyForm.setValidationState(ValidationState.NONE);
@@ -188,8 +184,6 @@ public class DeviceCertsTabUi extends Composite implements Tab {
                                     @Override
                                     public void onSuccess(Integer certsStored) {
                                         clear();
-                                        setDirty(false);
-                                        setButtonsEnabled(false);
                                         EntryClassUi.hideWaitModal();
                                     }
                                 });
@@ -228,14 +222,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
             yes.addStyleName("fa fa-check");
             yes.addClickHandler(event -> {
                 modal.hide();
-                setButtonsEnabled(false);
-                this.storageAliasInput.setText("");
-                this.privateKeyInput.setText("");
-                this.certificateInput.setText("");
-                this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
-                this.groupPrivateKeyForm.setValidationState(ValidationState.NONE);
-                this.groupCertForm.setValidationState(ValidationState.NONE);
-                setDirty(false);
+                clear();
             });
             group.add(yes);
             footer.add(group);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -122,6 +122,8 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
         this.groupPrivateKeyForm.setValidationState(ValidationState.NONE);
         this.groupCertForm.setValidationState(ValidationState.NONE);
+        this.deviceSslCertsForm.reset();
+        setButtonsEnabled(false);
     }
 
     private void initForm() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/DeviceCertsTabUi.java
@@ -114,6 +114,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
             this.storageAliasInput.setText("");
             this.certificateInput.setText("");
             this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
+            this.groupPrivateKeyForm.setValidationState(ValidationState.NONE);
             this.groupCertForm.setValidationState(ValidationState.NONE);
         }
     }
@@ -123,6 +124,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         this.storageAliasInput.setText("");
         this.certificateInput.setText("");
         this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
+        this.groupPrivateKeyForm.setValidationState(ValidationState.NONE);
         this.groupCertForm.setValidationState(ValidationState.NONE);
     }
 
@@ -231,7 +233,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
                 this.privateKeyInput.setText("");
                 this.certificateInput.setText("");
                 this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
-                this.groupCertForm.setValidationState(ValidationState.NONE);
+                this.groupPrivateKeyForm.setValidationState(ValidationState.NONE);
                 this.groupCertForm.setValidationState(ValidationState.NONE);
                 setDirty(false);
             });

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
@@ -114,6 +114,8 @@ public class ServerCertsTabUi extends Composite implements Tab {
         this.certificateInput.setText("");
         this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
         this.groupCertForm.setValidationState(ValidationState.NONE);
+        this.serverSslCertsForm.reset();
+        setButtonsEnabled(false);
     }
 
     private void initForm() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
@@ -112,12 +112,7 @@ public class ServerCertsTabUi extends Composite implements Tab {
     public void clear() {
         setButtonsEnabled(false);
         setDirty(false);
-        this.storageAliasInput.setText("");
-        this.certificateInput.setText("");
-        this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
-        this.groupCertForm.setValidationState(ValidationState.NONE);
         this.serverSslCertsForm.reset();
-        setButtonsEnabled(false);
     }
 
     @UiHandler(value = { "storageAliasInput", "certificateInput" })

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
@@ -36,8 +36,10 @@ import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.html.Span;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
@@ -116,6 +118,11 @@ public class ServerCertsTabUi extends Composite implements Tab {
         this.groupCertForm.setValidationState(ValidationState.NONE);
         this.serverSslCertsForm.reset();
         setButtonsEnabled(false);
+    }
+
+    @UiHandler(value = { "groupStorageAliasForm", "groupCertForm" })
+    public void onFormBlur(BlurEvent e) {
+        setDirty(true);
     }
 
     private void initForm() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
@@ -120,9 +120,10 @@ public class ServerCertsTabUi extends Composite implements Tab {
         setButtonsEnabled(false);
     }
 
-    @UiHandler(value = { "groupStorageAliasForm", "groupCertForm" })
+    @UiHandler(value = { "storageAliasInput", "certificateInput" })
     public void onFormBlur(BlurEvent e) {
         setDirty(true);
+        setButtonsEnabled(true);
     }
 
     private void initForm() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/ServerCertsTabUi.java
@@ -103,17 +103,13 @@ public class ServerCertsTabUi extends Composite implements Tab {
 
     @Override
     public void refresh() {
-        if (isDirty()) {
-            setDirty(false);
-            this.storageAliasInput.setText("");
-            this.certificateInput.setText("");
-            this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
-            this.groupCertForm.setValidationState(ValidationState.NONE);
-        }
+        clear();
     }
 
     @Override
     public void clear() {
+        setButtonsEnabled(false);
+        setDirty(false);
         this.storageAliasInput.setText("");
         this.certificateInput.setText("");
         this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
@@ -172,8 +168,6 @@ public class ServerCertsTabUi extends Composite implements Tab {
                                     @Override
                                     public void onSuccess(Integer certsStored) {
                                         clear();
-                                        setDirty(false);
-                                        setButtonsEnabled(false);
                                         EntryClassUi.hideWaitModal();
                                     }
                                 });
@@ -212,12 +206,7 @@ public class ServerCertsTabUi extends Composite implements Tab {
             yes.addStyleName("fa fa-check");
             yes.addClickHandler(event -> {
                 modal.hide();
-                setButtonsEnabled(false);
-                this.storageAliasInput.setText("");
-                this.certificateInput.setText("");
-                this.groupStorageAliasForm.setValidationState(ValidationState.NONE);
-                this.groupCertForm.setValidationState(ValidationState.NONE);
-                setDirty(false);
+                clear();
             });
             group.add(yes);
             footer.add(group);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SettingsPanelUi.java
@@ -248,6 +248,7 @@ public class SettingsPanelUi extends Composite {
             if (getTab(SettingsPanelUi.this.currentlySelectedTab).isDirty()) {
                 showDirtyModal(newTabListItem, handler);
             } else {
+                getTab(SettingsPanelUi.this.currentlySelectedTab).clear();
                 SettingsPanelUi.this.currentlySelectedTab = newTabListItem;
                 getTab(SettingsPanelUi.this.currentlySelectedTab).setDirty(true);
                 handler.onClick(event);


### PR DESCRIPTION
This PR adds the validation for the private key field in the SSL Device certificate tab.

**Related Issue:** This PR fixes/closes #2719 

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>