### PR TITLE
Removed cross button in firewall dirty modal

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.java
@@ -16,13 +16,8 @@ import org.eclipse.kura.web.client.ui.Tab;
 import org.eclipse.kura.web.client.ui.Tab.RefreshHandler;
 import org.gwtbootstrap3.client.ui.Anchor;
 import org.gwtbootstrap3.client.ui.Button;
-import org.gwtbootstrap3.client.ui.ButtonGroup;
 import org.gwtbootstrap3.client.ui.Modal;
-import org.gwtbootstrap3.client.ui.ModalBody;
-import org.gwtbootstrap3.client.ui.ModalFooter;
-import org.gwtbootstrap3.client.ui.ModalHeader;
 import org.gwtbootstrap3.client.ui.TabListItem;
-import org.gwtbootstrap3.client.ui.constants.ModalBackdrop;
 import org.gwtbootstrap3.client.ui.html.Span;
 
 import com.google.gwt.core.client.GWT;
@@ -58,6 +53,13 @@ public class FirewallPanelUi extends Composite {
     @UiField
     TabListItem ipForwarding;
 
+    @UiField
+    Modal dirtyModal;
+    @UiField
+    Button yes;
+    @UiField
+    Button no;
+
     private TabListItem currentlySelectedTab;
     private Tab.RefreshHandler openPortsHandler;
     private Tab.RefreshHandler portForwardingHandler;
@@ -72,17 +74,11 @@ public class FirewallPanelUi extends Composite {
         this.ipForwarding.setText(MSGS.firewallNat());
 
         this.openPortsHandler = new Tab.RefreshHandler(this.openPortsPanel);
-        this.openPorts.addClickHandler(event -> {
-            handleEvent(event, this.openPortsHandler);
-        });
+        this.openPorts.addClickHandler(event -> handleEvent(event, this.openPortsHandler));
         this.portForwardingHandler = new Tab.RefreshHandler(this.portForwardingPanel);
-        this.portForwarding.addClickHandler(event -> {
-            handleEvent(event, this.portForwardingHandler);
-        });
+        this.portForwarding.addClickHandler(event -> handleEvent(event, this.portForwardingHandler));
         this.ipForwardingHandler = new Tab.RefreshHandler(this.ipForwardingPanel);
-        this.ipForwarding.addClickHandler(event -> {
-            handleEvent(event, this.ipForwardingHandler);
-        });
+        this.ipForwarding.addClickHandler(event -> handleEvent(event, this.ipForwardingHandler));
     }
 
     public void initFirewallPanel() {
@@ -104,44 +100,18 @@ public class FirewallPanelUi extends Composite {
     }
 
     private void showDirtyModal(TabListItem newTabListItem, RefreshHandler newTabRefreshHandler) {
-        final Modal modal = new Modal();
-        modal.setClosable(false);
-        modal.setFade(true);
-        modal.setDataKeyboard(true);
-        modal.setDataBackdrop(ModalBackdrop.STATIC);
-
-        ModalHeader header = new ModalHeader();
-        header.setTitle(MSGS.confirm());
-        modal.add(header);
-
-        ModalBody body = new ModalBody();
-        body.add(new Span(MSGS.deviceConfigDirty()));
-        modal.add(body);
-
-        ModalFooter footer = new ModalFooter();
-        ButtonGroup group = new ButtonGroup();
-        Button yes = new Button();
-        yes.setText(MSGS.yesButton());
-        yes.addStyleName("fa fa-check");
-        yes.addClickHandler(event -> {
-            modal.hide();
+        this.yes.addClickHandler(event -> {
+            this.dirtyModal.hide();
             FirewallPanelUi.this.getTab(this.currentlySelectedTab).clear();
             FirewallPanelUi.this.currentlySelectedTab = newTabListItem;
             newTabRefreshHandler.onClick(event);
         });
-        Button no = new Button();
-        no.setText(MSGS.noButton());
-        no.addStyleName("fa fa-times");
-        no.addClickHandler(event -> {
+        this.no.addClickHandler(event -> {
             FirewallPanelUi.this.currentlySelectedTab.showTab();
-            modal.hide();
+            this.dirtyModal.hide();
         });
-        group.add(no);
-        group.add(yes);
-        footer.add(group);
-        modal.add(footer);
-        modal.show();
-        no.setFocus(true);
+        this.no.setFocus(true);
+        this.dirtyModal.show();
     }
 
     private void handleEvent(ClickEvent event, Tab.RefreshHandler handler) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.ui.xml
@@ -19,6 +19,8 @@
     xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt"
     xmlns:firewall="urn:import:org.eclipse.kura.web.client.ui.firewall">
 
+	<ui:with field="msgs" type="org.eclipse.kura.web.client.messages.Messages"></ui:with>
+
     <ui:style>
     .important {
     	font-weight: bold;
@@ -59,5 +61,20 @@
             </b:Well>
         </b:Row>
 
+	    <b:Modal closable="false" fade="true" dataBackdrop="STATIC"
+	        dataKeyboard="true" ui:field="dirtyModal" b:id="dirtyModal" title="{msgs.confirm}" >
+	        <b:ModalBody>
+	            <b:Panel>
+	                <b:PanelBody>
+	                    <b.html:Span text="{msgs.deviceConfigDirty}" />
+	                </b:PanelBody>
+	            </b:Panel>
+	        </b:ModalBody>
+	        <b:ModalFooter>
+	            <b:Button ui:field="yes" addStyleNames="fa fa-check" text="{msgs.yesButton}" />
+	            <b:Button ui:field="no" addStyleNames="fa fa-times" text="{msgs.noButton}" />
+	        </b:ModalFooter>
+	    </b:Modal>
+    
     </b:Container>
 </ui:UiBinder> 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2019 Eurotech and/or its affiliates
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.ui.xml
@@ -62,7 +62,7 @@
         </b:Row>
 
 	    <b:Modal closable="false" fade="true" dataBackdrop="STATIC"
-	        dataKeyboard="true" ui:field="dirtyModal" b:id="dirtyModal" title="{msgs.confirm}" >
+	        dataKeyboard="false" ui:field="dirtyModal" b:id="dirtyModal" title="{msgs.confirm}" >
 	        <b:ModalBody>
 	            <b:Panel>
 	                <b:PanelBody>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/NatTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/NatTabUi.ui.xml
@@ -39,7 +39,7 @@
 
 		<!--******Modals***** -->
         <b:Modal closable="false" fade="true" dataBackdrop="STATIC"
-            dataKeyboard="true" ui:field="natForm" b:id="natForm">
+            dataKeyboard="false" ui:field="natForm" b:id="natForm">
             <b:ModalBody>
                 <b:Form>
                     <b:FieldSet>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.ui.xml
@@ -36,7 +36,7 @@
         </b:Column>
 
         <b:Modal closable="false" fade="true" dataBackdrop="STATIC"
-            dataKeyboard="true" ui:field="openPortsForm" b:id="openPortsForm">
+            dataKeyboard="false" ui:field="openPortsForm" b:id="openPortsForm">
             <b:ModalBody>
                 <b:Form>
                     <b:FieldSet>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/PortForwardingTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/PortForwardingTabUi.ui.xml
@@ -36,7 +36,7 @@
         </b:Column>
 
         <b:Modal closable="false" fade="true" dataBackdrop="STATIC"
-            dataKeyboard="true" ui:field="portForwardingForm" b:id="portForwardingForm">
+            dataKeyboard="false" ui:field="portForwardingForm" b:id="portForwardingForm">
             <b:ModalBody>
                 <b:Form>
                     <b:FieldSet>


### PR DESCRIPTION
To fix the #3057, the modal should have the `isClosable` flag set to false. However, setting this in the java code has no effect. So, this PR defines the modal for unsaved firewall tabs in the xml file, setting the closable to false from there.

**Related Issue:** This PR fixes/closes #3057 

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>