### PR TITLE
Capitalize cloudservice, publisher and subscriber names

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/cloudconnection/CloudConnectionConfigurationsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/cloudconnection/CloudConnectionConfigurationsUi.java
@@ -199,6 +199,6 @@ public class CloudConnectionConfigurationsUi extends Composite {
         } else {
             tempName = selectedCloudServicePid;
         }
-        return tempName;
+        return tempName.substring(0, 1).toUpperCase() + tempName.substring(1);
     }
 }


### PR DESCRIPTION
The cloudservice, publisher and subscriber names shown in the CloudConnections tabs are now capitalized.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>