### PR TITLE
Backport - Adding support for Telefonica modem IK41VE (#3083)

### DIFF
--- a/kura/distrib/RELEASE_NOTES.txt
+++ b/kura/distrib/RELEASE_NOTES.txt
@@ -8,6 +8,7 @@ Changes:
   * Enhancements
     * Enhanced the modem support with Ublox LARA R2
     * Improved and uniformed the Web UI Response Headers
+    * Added support for the Telefonica modem IK41VE
 
   * Bug fixes and cleanups
     * Fixed issue with possible stale threads left by Paho during reconnections
@@ -41,6 +42,7 @@ Bug Fixes :
     * #2983: UI Target selection is not working in all cases
 
   * Merged no issue-related Pull Requests:
+    * #3086: Backport - Adding support for Telefonica modem IK41VE (#3083)
     * #3078: Capitalize cloudservice, publisher and subscriber names - Backport
     * #2991: Backport of #2957 to release-4.1.0  
     

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
@@ -58,7 +58,10 @@ public enum SupportedUsbModemInfo {
             ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0125")), ""),
     HUAWEI_MS2372("MS2372", "12d1", "1506", 3, 0, 2, 0, -1, 5000, 15000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.HSPA, ModemTechnologyType.HSDPA, ModemTechnologyType.UMTS,
-            ModemTechnologyType.GSM_GPRS), Arrays.asList(new UsbModemDriver("option", "12d1", "1506")), "");
+            ModemTechnologyType.GSM_GPRS), Arrays.asList(new UsbModemDriver("option", "12d1", "1506")), ""),
+    TELEFONICA_IK41VE("IK41VE", "1bbb", "00b6", 3, 0, 2, 0, -1, 5000, 15000, Arrays.asList(ModemTechnologyType.LTE,
+            ModemTechnologyType.HSPA, ModemTechnologyType.HSDPA, ModemTechnologyType.UMTS,
+            ModemTechnologyType.GSM_GPRS), Arrays.asList(new UsbModemDriver("option", "1bbb", "00b6")), "");
 
     private String deviceName;
     private String vendorId;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
@@ -38,6 +38,7 @@ import org.eclipse.kura.net.admin.modem.ublox.generic.UbloxModemConfigGenerator;
 import org.eclipse.kura.net.admin.modem.ublox.generic.UbloxModemFactory;
 import org.eclipse.kura.net.admin.modem.zte.me3630.ZteMe3630ConfigGenerator;
 import org.eclipse.kura.net.admin.modem.zte.me3630.ZteMe3630ModemFactory;
+import org.eclipse.kura.net.admin.modem.telefonica.TelefonicaModemFactory;
 
 public class SupportedUsbModemsFactoryInfo {
 
@@ -59,7 +60,8 @@ public class SupportedUsbModemsFactoryInfo {
         Zte_ME3630(SupportedUsbModemInfo.Zte_ME3630, ZteMe3630ModemFactory.class, ZteMe3630ConfigGenerator.class),
         SimTech_SIM7000(SupportedUsbModemInfo.SimTech_SIM7000, SimTechSim7000ModemFactory.class, SimTechSim7000ConfigGenerator.class),
         QUECTEL_EG25(SupportedUsbModemInfo.QUECTEL_EG25, QuectelEG25ModemFactory.class, QuectelEG25ConfigGenerator.class),
-        HUAWEI_MS2372(SupportedUsbModemInfo.HUAWEI_MS2372, HuaweiModemFactory.class, HspaModemConfigGenerator.class);
+        HUAWEI_MS2372(SupportedUsbModemInfo.HUAWEI_MS2372, HuaweiModemFactory.class, HspaModemConfigGenerator.class),
+        TELEFONICA_IK41VE(SupportedUsbModemInfo.TELEFONICA_IK41VE, TelefonicaModemFactory.class, HspaModemConfigGenerator.class);
 
         private final SupportedUsbModemInfo m_usbModemInfo;
         private final Class<? extends CellularModemFactory> m_factoryClass;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telefonica/TelefonicaModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telefonica/TelefonicaModem.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.net.admin.modem.telefonica;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.comm.CommConnection;
+import org.eclipse.kura.linux.net.modem.UsbModemDriver;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModem;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.osgi.service.io.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TelefonicaModem extends HspaModem {
+    
+    private static final Logger logger = LoggerFactory.getLogger(TelefonicaModem.class);
+
+    private boolean initialized;
+
+    public TelefonicaModem(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
+        super(device, platform, connectionFactory);
+    }
+
+    @Override
+    public String getIntegratedCirquitCardId() throws KuraException {
+        synchronized (this.atLock) {
+            if (this.iccid == null && isSimCardReady()) {
+                logger.debug("sendCommand getICCID :: {}", TelefonicaModemAtCommands.getICCID.getCommand());
+
+                final byte[] reply;
+                CommConnection commAtConnection = openSerialPort(getAtPort());
+                if (!isAtReachable(commAtConnection)) {
+                    closeSerialPort(commAtConnection);
+                    throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
+                }
+
+                try {
+                    reply = commAtConnection.sendCommand(TelefonicaModemAtCommands.getICCID.getCommand().getBytes(), 1000,
+                            100);
+                } catch (IOException e) {
+                    closeSerialPort(commAtConnection);
+                    throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+                } finally {
+                    closeSerialPort(commAtConnection);
+                }
+
+                if (reply == null) {
+                    throw new KuraException(KuraErrorCode.TIMED_OUT, TelefonicaModemAtCommands.getICCID.getCommand());
+                }
+                final String response = getResponseString(reply);
+                if (response.startsWith("ICCID:")) {
+                    this.iccid = response.substring("ICCID:".length()).trim();
+                } else {
+                    throw new KuraException(KuraErrorCode.BAD_REQUEST, response);
+                }
+            }
+        }
+        return this.iccid;
+    }
+
+    @Override
+    public boolean isSimCardReady() throws KuraException {
+        if (!this.initialized) {
+            disableURC();
+            this.initialized = true;
+        }
+
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getSimType :: {}", TelefonicaModemAtCommands.getSimType.getCommand());
+
+            final byte[] reply;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE_FOR_AT_CMDS_MSG);
+            }
+
+            try {
+                reply = commAtConnection.sendCommand(TelefonicaModemAtCommands.getSimType.getCommand().getBytes(), 1000,
+                        100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+
+            if (reply == null) {
+                throw new KuraException(KuraErrorCode.TIMED_OUT, TelefonicaModemAtCommands.getSimType.getCommand());
+            }
+            final String response = this.getResponseString(reply);
+            if (response.startsWith("^CARDMODE:")) {
+                return !"0".equals(response.substring("^CARDMODE:".length()).trim());
+            } else {
+                throw new KuraException(KuraErrorCode.BAD_REQUEST, response);
+            }
+        }
+    }
+
+    @Override
+    public void reset() throws KuraException {
+        UsbModemDriver modemDriver = getModemDriver();
+        modemDriver.disable();
+        modemDriver.enable();
+    }
+
+    private void disableURC() throws KuraException {
+        synchronized (this.atLock) {
+            logger.debug("sendCommand disableURC :: {}", TelefonicaModemAtCommands.disableURC.getCommand());
+
+            final byte[] reply;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            try {
+                reply = commAtConnection.sendCommand(TelefonicaModemAtCommands.disableURC.getCommand().getBytes(), 1000,
+                        100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+
+            if (reply == null) {
+                throw new KuraException(KuraErrorCode.TIMED_OUT, TelefonicaModemAtCommands.disableURC.getCommand());
+            }
+            final String response = new String(reply, StandardCharsets.US_ASCII);
+            if (!response.contains("OK")) {
+                throw new KuraException(KuraErrorCode.BAD_REQUEST, response);
+            }
+        }
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telefonica/TelefonicaModemAtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telefonica/TelefonicaModemAtCommands.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.net.admin.modem.telefonica;
+
+public enum TelefonicaModemAtCommands {
+    
+    getICCID("at+iccid\r\n"),
+    getSimType("at^cardmode\r\n"),
+    disableURC("at^dsci=0\r\n");
+
+    private String command;
+
+    TelefonicaModemAtCommands(String command) {
+        this.command = command;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telefonica/TelefonicaModemFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telefonica/TelefonicaModemFactory.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ *******************************************************************************/
+
+package org.eclipse.kura.net.admin.modem.telefonica;
+
+import org.eclipse.kura.net.admin.NetworkConfigurationService;
+import org.eclipse.kura.net.admin.util.AbstractCellularModemFactory;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.io.ConnectionFactory;
+import org.osgi.util.tracker.ServiceTracker;
+
+public class TelefonicaModemFactory extends AbstractCellularModemFactory<TelefonicaModem> {
+    
+    private static TelefonicaModemFactory factoryInstance = null;
+    private ConnectionFactory connectionFactory = null;
+
+    private TelefonicaModemFactory() {
+        final BundleContext bundleContext = FrameworkUtil.getBundle(NetworkConfigurationService.class)
+                .getBundleContext();
+
+        ServiceTracker<ConnectionFactory, ConnectionFactory> serviceTracker = new ServiceTracker<>(bundleContext,
+                ConnectionFactory.class, null);
+        serviceTracker.open(true);
+        this.connectionFactory = serviceTracker.getService();
+    }
+
+    @Override
+    protected TelefonicaModem createCellularModem(ModemDevice modemDevice, String platform) throws Exception {
+        return new TelefonicaModem(modemDevice, platform, this.connectionFactory);
+    }
+
+    public static TelefonicaModemFactory getInstance() {
+        if (factoryInstance == null) {
+            factoryInstance = new TelefonicaModemFactory();
+        }
+        return factoryInstance;
+    }
+
+    @Override
+    public ModemTechnologyType getType() {
+        return ModemTechnologyType.LTE;
+    }
+}


### PR DESCRIPTION
* Signed-off-by: Javad Akhlaghinia <javad.akhlaghinia@eurotech.com>

Adding support for Telefonica modem IK41VE

* Signed-off-by: Javad Akhlaghinia <javad.akhlaghinia@eurotech.com>

Added support for Telefonica Modem IK41VE
Fixed code enum lines

* Signed-off-by: Javad Akhlaghinia <javad.akhlaghinia@eurotech.com>

Addressed formatting issues

* Changed AT commands to support Telefonica modem

Signed-off-by: Javad Akhlaghinia <javad.akhlaghinia@eurotech.com>

* Uses TELEFONICA_IK41VE to meet the new code requirements for constants

Signed-off-by: Javad Akhlaghinia <javad.akhlaghinia@eurotech.com>

* Reverted changes made on a wrong file

Signed-off-by: Javad Akhlaghinia <javad.akhlaghinia@eurotech.com>
