### PR TITLE
Changed directory check during unzip of compressed files

### DIFF
--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/cloud/app/command/UnZip.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/cloud/app/command/UnZip.java
@@ -95,7 +95,7 @@ public class UnZip {
                 String fileName = validateFileName(expectedFilePath, folder.getPath());
                 File newFile = new File(fileName);
 
-                if (newFile.isDirectory()) {
+                if (expectedFilePath.endsWith("/")) {
                     newFile.mkdirs();
                     ze = zis.getNextEntry();
                     continue;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
@@ -346,7 +346,7 @@ public class FileServlet extends HttpServlet {
                             .append(ze.getName()).toString();
                     String fileName = validateFileName(expectedFilePath, localFolder.getPath());
                     File newFile = new File(fileName);
-                    if (newFile.isDirectory()) {
+                    if (expectedFilePath.endsWith("/")) {
                         newFile.mkdirs();
                         ze = zis.getNextEntry();
                         continue;


### PR DESCRIPTION
This PR changes the directory check that is performed during the unzip of compressed files.

**Related Issue:** This PR fixes/closes #3107 

**Description of the solution adopted:** 
The `file.isDirectory()` method checks whether the file is a regular one or a directory. However, it returns false if the file doesn't exist. So, during the decompression of a zip archive, the method cannot be used since the resource is not copied to the filesystem yet. 
According to [this](https://stackoverflow.com/questions/23920684/java-extracting-zip-file-with-multiple-subdirectories) a safe way to check if the resource is a file is a folder or not, is to test the last character of the path: a folder path always ends with '/'.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>