### PR TITLE
Updated clock service bundle execution environment target to 1.8

### DIFF
--- a/kura/org.eclipse.kura.linux.clock/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.linux.clock/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.eclipse.kura.linux.clock
 Bundle-SymbolicName: org.eclipse.kura.linux.clock;singleton:=true
 Bundle-Version: 1.0.501
 Bundle-Vendor: Eclipse Kura
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

Fixes the reference that caused the RC3 build failure