### PR TITLE
Quectel modems squashed

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/modem/SupportedUsbModemInfo.java
@@ -9,6 +9,7 @@
  * Contributors:
  *     Eurotech
  *     3 PORT d.o.o.
+ *     Sterwen Technologies
  *******************************************************************************/
 package org.eclipse.kura.linux.net.modem;
 
@@ -53,9 +54,15 @@ public enum SupportedUsbModemInfo {
             ModemTechnologyType.UMTS), Arrays.asList(new OptionModemDriver("19d2", "1476")), ""),
     SimTech_SIM7000("SIM7000", "1e0e", "9001", 5, 0, 3, 2, 3, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.GSM_GPRS), Arrays.asList(new OptionModemDriver("1e0e", "9001")), ""),
-    QUECTEL_EG25("EG25", "2c7c", "0125", 4, 0, 2, 3, -1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
+    QUECTEL_EG25("EG25", "2c7c", "0125", 4, 0, 3, 3, 1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.HSPA,
             ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0125")), ""),
+    QUECTEL_EC25("EC25", "2c7c", "0125", 4, 0, 3, 3, 1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
+            ModemTechnologyType.HSPA,
+            ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0125")), ""),
+    QUECTEL_BG96("BG96", "2c7c", "0296", 4, 0, 3, 3, 1, 5000, 10000, Arrays.asList(ModemTechnologyType.LTE,
+            ModemTechnologyType.HSPA,
+            ModemTechnologyType.UMTS), Arrays.asList(new UsbModemDriver("cdc_acm", "2c7c", "0296")), ""),
     HUAWEI_MS2372("MS2372", "12d1", "1506", 3, 0, 2, 0, -1, 5000, 15000, Arrays.asList(ModemTechnologyType.LTE,
             ModemTechnologyType.HSPA, ModemTechnologyType.HSDPA, ModemTechnologyType.UMTS,
             ModemTechnologyType.GSM_GPRS), Arrays.asList(new UsbModemDriver("option", "12d1", "1506")), ""),

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/SupportedUsbModemsFactoryInfo.java
@@ -9,6 +9,7 @@
  * Contributors:
  *     Eurotech
  *     3 PORT d.o.o.
+ *     Sterwen-Technology
  *******************************************************************************/
 package org.eclipse.kura.net.admin.modem;
 
@@ -16,16 +17,21 @@ import java.util.List;
 
 import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
 import org.eclipse.kura.linux.net.modem.UsbModemDriver;
-import org.eclipse.kura.net.admin.modem.quectel.eg25.QuectelEG25ConfigGenerator;
-import org.eclipse.kura.net.admin.modem.quectel.eg25.QuectelEG25ModemFactory;
 import org.eclipse.kura.net.admin.modem.hspa.HspaModemConfigGenerator;
 import org.eclipse.kura.net.admin.modem.huawei.HuaweiModemFactory;
+import org.eclipse.kura.net.admin.modem.quectel.bg96.QuectelBG96ConfigGenerator;
+import org.eclipse.kura.net.admin.modem.quectel.bg96.QuectelBG96ModemFactory;
+import org.eclipse.kura.net.admin.modem.quectel.ec25.QuectelEC25ConfigGenerator;
+import org.eclipse.kura.net.admin.modem.quectel.ec25.QuectelEC25ModemFactory;
+import org.eclipse.kura.net.admin.modem.quectel.eg25.QuectelEG25ConfigGenerator;
+import org.eclipse.kura.net.admin.modem.quectel.eg25.QuectelEG25ModemFactory;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxConfigGenerator;
 import org.eclipse.kura.net.admin.modem.sierra.mc87xx.SierraMc87xxModemFactory;
 import org.eclipse.kura.net.admin.modem.sierra.usb598.SierraUsb598ConfigGenerator;
 import org.eclipse.kura.net.admin.modem.sierra.usb598.SierraUsb598ModemFactory;
 import org.eclipse.kura.net.admin.modem.simtech.sim7000.SimTechSim7000ConfigGenerator;
 import org.eclipse.kura.net.admin.modem.simtech.sim7000.SimTechSim7000ModemFactory;
+import org.eclipse.kura.net.admin.modem.telefonica.TelefonicaModemFactory;
 import org.eclipse.kura.net.admin.modem.telit.de910.TelitDe910ConfigGenerator;
 import org.eclipse.kura.net.admin.modem.telit.de910.TelitDe910ModemFactory;
 import org.eclipse.kura.net.admin.modem.telit.he910.TelitHe910ConfigGenerator;
@@ -38,7 +44,6 @@ import org.eclipse.kura.net.admin.modem.ublox.generic.UbloxModemConfigGenerator;
 import org.eclipse.kura.net.admin.modem.ublox.generic.UbloxModemFactory;
 import org.eclipse.kura.net.admin.modem.zte.me3630.ZteMe3630ConfigGenerator;
 import org.eclipse.kura.net.admin.modem.zte.me3630.ZteMe3630ModemFactory;
-import org.eclipse.kura.net.admin.modem.telefonica.TelefonicaModemFactory;
 
 public class SupportedUsbModemsFactoryInfo {
 
@@ -60,6 +65,8 @@ public class SupportedUsbModemsFactoryInfo {
         Zte_ME3630(SupportedUsbModemInfo.Zte_ME3630, ZteMe3630ModemFactory.class, ZteMe3630ConfigGenerator.class),
         SimTech_SIM7000(SupportedUsbModemInfo.SimTech_SIM7000, SimTechSim7000ModemFactory.class, SimTechSim7000ConfigGenerator.class),
         QUECTEL_EG25(SupportedUsbModemInfo.QUECTEL_EG25, QuectelEG25ModemFactory.class, QuectelEG25ConfigGenerator.class),
+        QUECTEL_EC25(SupportedUsbModemInfo.QUECTEL_EC25, QuectelEC25ModemFactory.class, QuectelEC25ConfigGenerator.class),
+        QUECTEL_BG96(SupportedUsbModemInfo.QUECTEL_BG96, QuectelBG96ModemFactory.class, QuectelBG96ConfigGenerator.class),
         HUAWEI_MS2372(SupportedUsbModemInfo.HUAWEI_MS2372, HuaweiModemFactory.class, HspaModemConfigGenerator.class),
         TELEFONICA_IK41VE(SupportedUsbModemInfo.TELEFONICA_IK41VE, TelefonicaModemFactory.class, HspaModemConfigGenerator.class);
 
@@ -86,9 +93,9 @@ public class SupportedUsbModemsFactoryInfo {
             return this.configClass;
         }
     }
-    
+
     private SupportedUsbModemsFactoryInfo() {
-        
+
     }
 
     public static UsbModemFactoryInfo getModem(SupportedUsbModemInfo modemInfo) {
@@ -115,6 +122,7 @@ public class SupportedUsbModemsFactoryInfo {
                 break;
             }
         }
+
         return modemFactoryInfo;
     }
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96.java
@@ -1,0 +1,338 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sterwen Technology and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Sterwen-Technology
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.bg96;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.comm.CommConnection;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemsInfo;
+import org.eclipse.kura.linux.net.modem.UsbModemDriver;
+import org.eclipse.kura.net.admin.modem.HspaCellularModem;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModem;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemRegistrationStatus;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.eclipse.kura.usb.UsbModemDevice;
+import org.osgi.service.io.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Defines Quectel BG96 modem
+ */
+public class QuectelBG96 extends HspaModem implements HspaCellularModem {
+
+    private static final Logger logger = LoggerFactory.getLogger(QuectelBG96.class);
+    private static final String MODEM_NOT_AVAILABLE = "Modem not available for AT commands: ";
+
+    public QuectelBG96(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
+
+        super(device, platform, connectionFactory);
+
+        try {
+            String atPort = getAtPort();
+            String gpsPort = getGpsPort();
+            if (atPort != null && (atPort.equals(getDataPort()) || atPort.equals(gpsPort))) {
+                this.serialNumber = getSerialNumber();
+                this.imsi = getMobileSubscriberIdentity();
+                this.iccid = getIntegratedCirquitCardId();
+                this.model = getModel();
+                this.manufacturer = getManufacturer();
+                this.revisionId = getRevisionID();
+                this.gpsSupported = isGpsSupported();
+                this.rssi = getSignalStrength();
+
+                logger.trace("{} :: Serial Number={}", getClass().getName(), this.serialNumber);
+                logger.trace("{} :: IMSI={}", getClass().getName(), this.imsi);
+                logger.trace("{} :: ICCID={}", getClass().getName(), this.iccid);
+                logger.trace("{} :: Model={}", getClass().getName(), this.model);
+                logger.trace("{} :: Manufacturer={}", getClass().getName(), this.manufacturer);
+                logger.trace("{} :: Revision ID={}", getClass().getName(), this.revisionId);
+                logger.trace("{} :: GPS Supported={}", getClass().getName(), this.gpsSupported);
+                logger.trace("{} :: RSSI={}", getClass().getName(), this.rssi);
+            }
+        } catch (KuraException e) {
+            logger.error("Failed to initialize " + QuectelBG96.class.getName(), e);
+        }
+    }
+
+    @Override
+    public boolean isSimCardReady() throws KuraException {
+
+        boolean simReady = false;
+        String port = null;
+
+        if (isGpsEnabled() && getAtPort().equals(getGpsPort()) && !getAtPort().equals(getDataPort())) {
+            port = getDataPort();
+        } else {
+            port = getAtPort();
+        }
+
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getSimStatus :: {} command to port {}",
+                    QuectelBG96AtCommands.GET_SIM_STATUS.getCommand(), port);
+            byte[] reply = null;
+            CommConnection commAtConnection = null;
+            try {
+
+                commAtConnection = openSerialPort(port);
+                if (!isAtReachable(commAtConnection)) {
+                    throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                            MODEM_NOT_AVAILABLE + QuectelBG96.class.getName());
+                }
+
+                reply = commAtConnection.sendCommand(QuectelBG96AtCommands.GET_SIM_STATUS.getCommand().getBytes(), 1000,
+                        100);
+                if (reply != null) {
+                    String simStatus = getResponseString(reply);
+                    String[] simStatusSplit = simStatus.split(",");
+                    if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
+                        simReady = true;
+                    }
+                }
+            } catch (IOException e) {
+                throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, e);
+            } catch (KuraException e) {
+                throw e;
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+        }
+        return simReady;
+
+    }
+
+    @Override
+    public ModemRegistrationStatus getRegistrationStatus() throws KuraException {
+
+        ModemRegistrationStatus modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getRegistrationStatus :: {}",
+                    QuectelBG96AtCommands.GET_REGISTRATION_STATUS.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelBG96.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelBG96AtCommands.GET_REGISTRATION_STATUS.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sRegStatus = getResponseString(reply);
+                String[] regStatusSplit = sRegStatus.split(",");
+                if (regStatusSplit.length >= 2) {
+                    int status = Integer.parseInt(regStatusSplit[1]);
+                    switch (status) {
+                    case 0:
+                        modemRegistrationStatus = ModemRegistrationStatus.NOT_REGISTERED;
+                        break;
+                    case 1:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_HOME;
+                        break;
+                    case 3:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTRATION_DENIED;
+                        break;
+                    case 4:
+                        modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
+                        break;
+                    case 5:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_ROAMING;
+                        break;
+                    default:
+                    }
+                }
+            }
+        }
+        return modemRegistrationStatus;
+    }
+
+    @Override
+    public long getCallTxCounter() throws KuraException {
+
+        long txCnt = 0;
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelBG96AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelBG96.class.getName());
+            }
+            try {
+                reply = commAtConnection.sendCommand(
+                        QuectelBG96AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] sDataVolume = this.getResponseString(reply).split(" ");
+                if (sDataVolume.length >= 2) {
+                    txCnt = Integer.parseInt(sDataVolume[1].split(",")[0]);
+                }
+            }
+        }
+        return txCnt;
+    }
+
+    @Override
+    public long getCallRxCounter() throws KuraException {
+        long rxCnt = 0;
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelBG96AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelBG96.class.getName());
+            }
+            try {
+                reply = commAtConnection.sendCommand(
+                        QuectelBG96AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] sDataVolume = this.getResponseString(reply).split(" ");
+                if (sDataVolume.length >= 2) {
+                    rxCnt = Integer.parseInt(sDataVolume[1].split(",")[1]);
+                }
+            }
+        }
+        return rxCnt;
+    }
+
+    @Override
+    public String getServiceType() throws KuraException {
+        String serviceType = null;
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getMobileStationClass :: {}",
+                    QuectelBG96AtCommands.GET_MOBILESTATION_CLASS.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelBG96.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelBG96AtCommands.GET_MOBILESTATION_CLASS.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sCgclass = this.getResponseString(reply);
+                if (sCgclass.startsWith("+CGCLASS:")) {
+                    sCgclass = sCgclass.substring("+CGCLASS:".length()).trim();
+                    if (sCgclass.equals("\"A\"")) {
+                        serviceType = "UMTS";
+                    } else if (sCgclass.equals("\"B\"")) {
+                        serviceType = "GSM/GPRS";
+                    } else if (sCgclass.equals("\"CG\"")) {
+                        serviceType = "GPRS";
+                    } else if (sCgclass.equals("\"CC\"")) {
+                        serviceType = "GSM";
+                    }
+                }
+            }
+        }
+
+        return serviceType;
+    }
+
+    @Override
+    public List<ModemTechnologyType> getTechnologyTypes() throws KuraException {
+
+        List<ModemTechnologyType> modemTechnologyTypes = null;
+        ModemDevice device = getModemDevice();
+        if (device == null) {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "No modem device");
+        }
+        if (device instanceof UsbModemDevice) {
+            SupportedUsbModemInfo usbModemInfo = SupportedUsbModemsInfo.getModem((UsbModemDevice) device);
+            if (usbModemInfo != null) {
+                modemTechnologyTypes = usbModemInfo.getTechnologyTypes();
+            } else {
+                throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "No usbModemInfo available");
+            }
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "Unsupported modem device");
+        }
+        return modemTechnologyTypes;
+    }
+
+    @Override
+    public boolean isGpsSupported() throws KuraException {
+        return false; // Will be activated later
+    }
+
+    @Override
+    public void enableGps() throws KuraException {
+        throw new UnsupportedOperationException("Modem GPS not supported");
+    }
+
+    @Override
+    public void disableGps() throws KuraException {
+        throw new UnsupportedOperationException("Modem GPS not supported");
+    }
+
+    @Override
+    public void reset() throws KuraException {
+        while (true) {
+            sleep(5000);
+            try {
+                turnOff();
+                sleep(1000);
+                turnOn();
+                logger.info("reset() :: modem reset successful");
+                break;
+            } catch (Exception e) {
+                logger.error("Failed to reset the modem", e);
+            }
+        }
+    }
+
+    private void turnOff() throws KuraException {
+        UsbModemDriver modemDriver = getModemDriver();
+        if (modemDriver != null) {
+            modemDriver.disable();
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE);
+        }
+    }
+
+    private void turnOn() throws KuraException {
+        UsbModemDriver modemDriver = getModemDriver();
+        if (modemDriver != null) {
+            modemDriver.enable();
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE);
+        }
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96AtCommands.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sterwen Technology and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Sterwen-Technology
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.bg96;
+
+public enum QuectelBG96AtCommands {
+
+    GET_SIM_STATUS("at+qsimstat?\r\n"),
+    GET_SIM_PIN_STATUS("at+cpin?\r\n"),
+    GET_MOBILESTATION_CLASS("at+cgclass?\r\n"),
+    GET_REGISTRATION_STATUS("at+cgreg?\r\n"),
+    GET_GPRS_SESSION_DATA_VOLUME("at+qgdcnt?\r\n"),
+    PDP_CONTEXT("at+cgdcont\r\n");
+
+    private String command;
+
+    private QuectelBG96AtCommands(String atCommand) {
+        this.command = atCommand;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ConfigGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 3 PORT d.o.o. and/or its affiliates
+ * Copyright (c) 2019 Sterwen Technology and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,10 +7,9 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     3 PORT d.o.o.
+ *     Sterwen-Technology
  *******************************************************************************/
-
-package org.eclipse.kura.net.admin.modem.zte.me3630;
+package org.eclipse.kura.net.admin.modem.quectel.bg96;
 
 import org.eclipse.kura.net.admin.modem.ModemPppConfigGenerator;
 import org.eclipse.kura.net.admin.modem.PppPeer;
@@ -19,10 +18,7 @@ import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangeScript;
 import org.eclipse.kura.net.modem.ModemConfig;
 import org.eclipse.kura.net.modem.ModemConfig.PdpType;
 
-public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
-
-    private static final String OK = "OK";
-    private static final String ABORT = "ABORT";
+public class QuectelBG96ConfigGenerator implements ModemPppConfigGenerator {
 
     @Override
     public PppPeer getPppPeer(String deviceId, ModemConfig modemConfig, String logFile, String connectScript,
@@ -72,7 +68,6 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
 
     @Override
     public ModemXchangeScript getConnectScript(ModemConfig modemConfig) {
-        // PDP context is fixed to 1 for this modem
         int pdpPid = 1;
         String apn = "";
         String dialString = "";
@@ -83,18 +78,16 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
         }
 
         ModemXchangeScript modemXchange = new ModemXchangeScript();
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"ERROR\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\\rAT", "\"\""));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("1", "TIMEOUT"));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("ATH0", "\"OK-+++\\c-OK\""));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("45", "TIMEOUT"));
-        modemXchange.addmodemXchangePair(new ModemXchangePair(formPDPcontext(pdpPid, PdpType.IP, apn), OK));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\d\\d\\d\"", OK));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"ERROR\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ath\"", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"AT\"", "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formPDPcontext(pdpPid, PdpType.IP, apn), "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\d\\d\\d\"", "OK"));
         modemXchange.addmodemXchangePair(new ModemXchangePair(formDialString(dialString), "\"\""));
         modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\c\"", "CONNECT"));
 
@@ -105,11 +98,11 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
     public ModemXchangeScript getDisconnectScript(ModemConfig modemConfig) {
 
         ModemXchangeScript modemXchange = new ModemXchangeScript();
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
         modemXchange.addmodemXchangePair(new ModemXchangePair("BREAK", "\"\""));
         modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ATH\"", "\"\""));
 
@@ -120,7 +113,7 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
      * This method forms dial string
      */
     private String formDialString(String dialString) {
-        StringBuilder buf = new StringBuilder();
+        StringBuffer buf = new StringBuffer();
         buf.append('"');
         if (dialString != null) {
             buf.append(dialString);
@@ -135,7 +128,7 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
      */
     private String formPDPcontext(int pdpPid, PdpType pdpType, String apn) {
 
-        StringBuilder pdpcontext = new StringBuilder(ZteMe3630AtCommands.pdpContext.getCommand());
+        StringBuffer pdpcontext = new StringBuffer(QuectelBG96AtCommands.PDP_CONTEXT.getCommand());
         pdpcontext.append('=');
         pdpcontext.append(pdpPid);
         pdpcontext.append(',');

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ModemFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96ModemFactory.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Sterwen Technology and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Sterwen-Technology
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.bg96;
+
+import org.eclipse.kura.net.admin.NetworkConfigurationService;
+import org.eclipse.kura.net.admin.util.AbstractCellularModemFactory;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.io.ConnectionFactory;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * Defines Quectel BG96 Modem Factory
+ *
+ * @author ilya.binshtok
+ *
+ */
+public class QuectelBG96ModemFactory extends AbstractCellularModemFactory<QuectelBG96> {
+
+    private static QuectelBG96ModemFactory factoryInstance = null;
+    private ConnectionFactory connectionFactory;
+
+    private BundleContext bundleContext = null;
+
+    private QuectelBG96ModemFactory() {
+        this.bundleContext = FrameworkUtil.getBundle(NetworkConfigurationService.class).getBundleContext();
+
+        ServiceTracker<ConnectionFactory, ConnectionFactory> serviceTracker = new ServiceTracker<>(this.bundleContext,
+                ConnectionFactory.class, null);
+        serviceTracker.open(true);
+        this.connectionFactory = serviceTracker.getService();
+    }
+
+    public static QuectelBG96ModemFactory getInstance() {
+        if (factoryInstance == null) {
+            factoryInstance = new QuectelBG96ModemFactory();
+        }
+        return factoryInstance;
+    }
+
+    @Override
+    @Deprecated
+    public ModemTechnologyType getType() {
+        return ModemTechnologyType.LTE;
+    }
+
+    @Override
+    protected QuectelBG96 createCellularModem(ModemDevice modemDevice, String platform) throws Exception {
+        return new QuectelBG96(modemDevice, platform, this.connectionFactory);
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25.java
@@ -1,0 +1,364 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Sterwen Technology and/or its affiliates
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Sterwen-Technology
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.ec25;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.comm.CommConnection;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemInfo;
+import org.eclipse.kura.linux.net.modem.SupportedUsbModemsInfo;
+import org.eclipse.kura.linux.net.modem.UsbModemDriver;
+import org.eclipse.kura.net.admin.modem.HspaCellularModem;
+import org.eclipse.kura.net.admin.modem.hspa.HspaModem;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemRegistrationStatus;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.eclipse.kura.usb.UsbModemDevice;
+import org.osgi.service.io.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Defines Quectel EC25 modem
+ */
+public class QuectelEC25 extends HspaModem implements HspaCellularModem {
+
+    private static final Logger logger = LoggerFactory.getLogger(QuectelEC25.class);
+    private static final String MODEM_NOT_AVAILABLE = "Modem not available for AT commands: ";
+
+    /**
+     * Quectel EC25 modem constructor
+     *
+     * @param usbDevice
+     *                              - modem USB device as {@link UsbModemDevice}
+     * @param platform
+     *                              - hardware platform as {@link String}
+     * @param connectionFactory
+     *                              - connection factory {@link ConnectionFactory}
+     */
+    public QuectelEC25(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
+        super(device, platform, connectionFactory);
+        try {
+            String atPort = getAtPort();
+            String gpsPort = getGpsPort();
+            if (atPort != null && (atPort.equals(getDataPort()) || atPort.equals(gpsPort))) {
+                this.serialNumber = getSerialNumber();
+                this.imsi = getMobileSubscriberIdentity();
+                this.iccid = getIntegratedCirquitCardId();
+                this.model = getModel();
+                this.manufacturer = getManufacturer();
+                this.revisionId = getRevisionID();
+                this.gpsSupported = Boolean.valueOf(isGpsSupported());
+                this.rssi = getSignalStrength();
+                logger.trace("{} :: Serial Number={}", getClass().getName(), this.serialNumber);
+                logger.trace("{} :: IMSI={}", getClass().getName(), this.imsi);
+                logger.trace("{} :: ICCID={}", getClass().getName(), this.iccid);
+                logger.trace("{} :: Model={}", getClass().getName(), this.model);
+                logger.trace("{} :: Manufacturer={}", getClass().getName(), this.manufacturer);
+                logger.trace("{} :: Revision ID={}", getClass().getName(), this.revisionId);
+                logger.trace("{} :: GPS Supported={}", getClass().getName(), this.gpsSupported);
+                logger.trace("{} :: RSSI={}", getClass().getName(), Integer.valueOf(this.rssi));
+            }
+        } catch (KuraException e) {
+            logger.error("Failed to initialize QuectelEC25", (Throwable) e);
+        }
+    }
+
+    @Override
+    public boolean isSimCardReady() throws KuraException {
+
+        boolean simReady = false;
+        String port = null;
+
+        if (isGpsEnabled() && getAtPort().equals(getGpsPort()) && !getAtPort().equals(getDataPort())) {
+            port = getDataPort();
+        } else {
+            port = getAtPort();
+        }
+
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getSimStatus :: {} command to port {}",
+                    QuectelEC25AtCommands.GET_SIM_STATUS.getCommand(), port);
+            byte[] reply = null;
+            CommConnection commAtConnection = null;
+            try {
+
+                commAtConnection = openSerialPort(port);
+                if (!isAtReachable(commAtConnection)) {
+                    throw new KuraException(KuraErrorCode.NOT_CONNECTED,
+                            MODEM_NOT_AVAILABLE + QuectelEC25.class.getName());
+                }
+
+                reply = commAtConnection.sendCommand(QuectelEC25AtCommands.GET_SIM_STATUS.getCommand().getBytes(), 1000,
+                        100);
+                if (reply != null) {
+                    String simStatus = getResponseString(reply);
+                    String[] simStatusSplit = simStatus.split(",");
+                    if (simStatusSplit.length > 1 && Integer.valueOf(simStatusSplit[1]) > 0) {
+                        simReady = true;
+                    }
+                }
+            } catch (IOException e) {
+                throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, e);
+            } catch (KuraException e) {
+                throw e;
+            } finally {
+                closeSerialPort(commAtConnection);
+            }
+        }
+        return simReady;
+    }
+
+    @Override
+    public ModemRegistrationStatus getRegistrationStatus() throws KuraException {
+
+        ModemRegistrationStatus modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getRegistrationStatus :: {}",
+                    QuectelEC25AtCommands.GET_REGISTRATION_STATUS.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelEC25.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelEC25AtCommands.GET_REGISTRATION_STATUS.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sRegStatus = getResponseString(reply);
+                String[] regStatusSplit = sRegStatus.split(",");
+                if (regStatusSplit.length >= 2) {
+                    int status = Integer.parseInt(regStatusSplit[1]);
+                    switch (status) {
+                    case 0:
+                        modemRegistrationStatus = ModemRegistrationStatus.NOT_REGISTERED;
+                        break;
+                    case 1:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_HOME;
+                        break;
+                    case 3:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTRATION_DENIED;
+                        break;
+                    case 4:
+                        modemRegistrationStatus = ModemRegistrationStatus.UNKNOWN;
+                        break;
+                    case 5:
+                        modemRegistrationStatus = ModemRegistrationStatus.REGISTERED_ROAMING;
+                        break;
+                    default:
+                    }
+                }
+            }
+        }
+        return modemRegistrationStatus;
+    }
+
+    @Override
+    public long getCallTxCounter() throws KuraException {
+
+        long txCnt = 0;
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelEC25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelEC25.class.getName());
+            }
+            try {
+                reply = commAtConnection.sendCommand(
+                        QuectelEC25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] sDataVolume = this.getResponseString(reply).split(" ");
+                if (sDataVolume.length >= 2) {
+                    txCnt = Integer.parseInt(sDataVolume[1].split(",")[0]);
+                }
+            }
+        }
+        return txCnt;
+    }
+
+    @Override
+    public long getCallRxCounter() throws KuraException {
+        long rxCnt = 0;
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getGprsSessionDataVolume :: {}",
+                    QuectelEC25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelEC25.class.getName());
+            }
+            try {
+                reply = commAtConnection.sendCommand(
+                        QuectelEC25AtCommands.GET_GPRS_SESSION_DATA_VOLUME.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String[] sDataVolume = this.getResponseString(reply).split(" ");
+                if (sDataVolume.length >= 2) {
+                    rxCnt = Integer.parseInt(sDataVolume[1].split(",")[1]);
+                }
+            }
+        }
+        return rxCnt;
+    }
+
+    @Override
+    public String getServiceType() throws KuraException {
+        String serviceType = null;
+        synchronized (this.atLock) {
+            logger.debug("sendCommand getMobileStationClass :: {}",
+                    QuectelEC25AtCommands.GET_MOBILESTATION_CLASS.getCommand());
+            byte[] reply = null;
+            CommConnection commAtConnection = openSerialPort(getAtPort());
+            if (!isAtReachable(commAtConnection)) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.NOT_CONNECTED, MODEM_NOT_AVAILABLE + QuectelEC25.class.getName());
+            }
+            try {
+                reply = commAtConnection
+                        .sendCommand(QuectelEC25AtCommands.GET_MOBILESTATION_CLASS.getCommand().getBytes(), 1000, 100);
+            } catch (IOException e) {
+                closeSerialPort(commAtConnection);
+                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
+            }
+            closeSerialPort(commAtConnection);
+            if (reply != null) {
+                String sCgclass = this.getResponseString(reply);
+                if (sCgclass.startsWith("+CGCLASS:")) {
+                    sCgclass = sCgclass.substring("+CGCLASS:".length()).trim();
+                    if (sCgclass.equals("\"A\"")) {
+                        serviceType = "UMTS";
+                    } else if (sCgclass.equals("\"B\"")) {
+                        serviceType = "GSM/GPRS";
+                    } else if (sCgclass.equals("\"CG\"")) {
+                        serviceType = "GPRS";
+                    } else if (sCgclass.equals("\"CC\"")) {
+                        serviceType = "GSM";
+                    }
+                }
+            }
+        }
+
+        return serviceType;
+    }
+
+    @Override
+    public List<ModemTechnologyType> getTechnologyTypes() throws KuraException {
+
+        List<ModemTechnologyType> modemTechnologyTypes = null;
+        ModemDevice device = getModemDevice();
+        if (device == null) {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "No modem device");
+        }
+        if (device instanceof UsbModemDevice) {
+            SupportedUsbModemInfo usbModemInfo = SupportedUsbModemsInfo.getModem((UsbModemDevice) device);
+            if (usbModemInfo != null) {
+                modemTechnologyTypes = usbModemInfo.getTechnologyTypes();
+            } else {
+                throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "No usbModemInfo available");
+            }
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE, "Unsupported modem device");
+        }
+        return modemTechnologyTypes;
+    }
+
+    @Override
+    public boolean isGpsSupported() throws KuraException {
+        return false; // Will be activated later
+    }
+
+    @Override
+    public void enableGps() throws KuraException {
+        throw new UnsupportedOperationException("Modem GPS not supported");
+    }
+
+    @Override
+    public void disableGps() throws KuraException {
+        throw new UnsupportedOperationException("Modem GPS not supported");
+    }
+
+    @Override
+    public void reset() throws KuraException {
+        while (true) {
+            sleep(5000);
+            try {
+                turnOff();
+                sleep(1000);
+                turnOn();
+                logger.info("reset() :: modem reset successful");
+                break;
+            } catch (Exception e) {
+                logger.error("Failed to reset the modem", e);
+            }
+        }
+    }
+
+    private void turnOff() throws KuraException {
+        UsbModemDriver modemDriver = getModemDriver();
+        if (modemDriver != null) {
+            modemDriver.disable();
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE);
+        }
+    }
+
+    private void turnOn() throws KuraException {
+        UsbModemDriver modemDriver = getModemDriver();
+        if (modemDriver != null) {
+            modemDriver.enable();
+        } else {
+            throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE);
+        }
+    }
+
+    @Override
+    public boolean hasDiversityAntenna() {
+        return false; // To be activated later
+    }
+
+    @Override
+    public boolean isDiversityEnabled() {
+        return false;
+    }
+
+    @Override
+    public void enableDiversity() throws KuraException {
+        throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void disableDiversity() throws KuraException {
+        throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED);
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25AtCommands.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25AtCommands.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Sterwen-Technology
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Sterwen-Technology
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.ec25;
+
+/**
+ * Defines AT commands for the Quectel EC25 modem.
+ *
+ *
+ */
+public enum QuectelEC25AtCommands {
+    GET_SIM_STATUS("at+qsimstat?\r\n"),
+    GET_SIM_PIN_STATUS("at+cpin?\r\n"),
+    GET_MOBILESTATION_CLASS("at+cgclass?\r\n"),
+    GET_REGISTRATION_STATUS("at+cgreg?\r\n"),
+    GET_GPRS_SESSION_DATA_VOLUME("at+qgdcnt?\r\n"),
+    PDP_CONTEXT("at+cgdcont\r\n");
+    
+    private String command;
+
+    private QuectelEC25AtCommands(String atCommand) {
+        this.command = atCommand;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+}

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ConfigGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 3 PORT d.o.o. and/or its affiliates
+ * Copyright (c) 2020 Sterwen Technology and/or its affiliates
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,10 +7,9 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     3 PORT d.o.o.
+ *     Sterwen-Technology
  *******************************************************************************/
-
-package org.eclipse.kura.net.admin.modem.zte.me3630;
+package org.eclipse.kura.net.admin.modem.quectel.ec25;
 
 import org.eclipse.kura.net.admin.modem.ModemPppConfigGenerator;
 import org.eclipse.kura.net.admin.modem.PppPeer;
@@ -19,10 +18,7 @@ import org.eclipse.kura.net.admin.visitor.linux.util.ModemXchangeScript;
 import org.eclipse.kura.net.modem.ModemConfig;
 import org.eclipse.kura.net.modem.ModemConfig.PdpType;
 
-public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
-
-    private static final String OK = "OK";
-    private static final String ABORT = "ABORT";
+public class QuectelEC25ConfigGenerator implements ModemPppConfigGenerator {
 
     @Override
     public PppPeer getPppPeer(String deviceId, ModemConfig modemConfig, String logFile, String connectScript,
@@ -72,7 +68,6 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
 
     @Override
     public ModemXchangeScript getConnectScript(ModemConfig modemConfig) {
-        // PDP context is fixed to 1 for this modem
         int pdpPid = 1;
         String apn = "";
         String dialString = "";
@@ -83,18 +78,16 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
         }
 
         ModemXchangeScript modemXchange = new ModemXchangeScript();
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"ERROR\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\\rAT", "\"\""));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("1", "TIMEOUT"));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("ATH0", "\"OK-+++\\c-OK\""));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("45", "TIMEOUT"));
-        modemXchange.addmodemXchangePair(new ModemXchangePair(formPDPcontext(pdpPid, PdpType.IP, apn), OK));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\d\\d\\d\"", OK));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"ERROR\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ath\"", "\"\""));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"AT\"", "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair(formPDPcontext(pdpPid, PdpType.IP, apn), "OK"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\d\\d\\d\"", "OK"));
         modemXchange.addmodemXchangePair(new ModemXchangePair(formDialString(dialString), "\"\""));
         modemXchange.addmodemXchangePair(new ModemXchangePair("\"\\c\"", "CONNECT"));
 
@@ -105,11 +98,11 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
     public ModemXchangeScript getDisconnectScript(ModemConfig modemConfig) {
 
         ModemXchangeScript modemXchange = new ModemXchangeScript();
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", ABORT));
-        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", ABORT));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"BUSY\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"VOICE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO CARRIER\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIALTONE\"", "ABORT"));
+        modemXchange.addmodemXchangePair(new ModemXchangePair("\"NO DIAL TONE\"", "ABORT"));
         modemXchange.addmodemXchangePair(new ModemXchangePair("BREAK", "\"\""));
         modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ATH\"", "\"\""));
 
@@ -120,7 +113,7 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
      * This method forms dial string
      */
     private String formDialString(String dialString) {
-        StringBuilder buf = new StringBuilder();
+        StringBuffer buf = new StringBuffer();
         buf.append('"');
         if (dialString != null) {
             buf.append(dialString);
@@ -135,7 +128,7 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
      */
     private String formPDPcontext(int pdpPid, PdpType pdpType, String apn) {
 
-        StringBuilder pdpcontext = new StringBuilder(ZteMe3630AtCommands.pdpContext.getCommand());
+        StringBuffer pdpcontext = new StringBuffer(QuectelEC25AtCommands.PDP_CONTEXT.getCommand());
         pdpcontext.append('=');
         pdpcontext.append(pdpPid);
         pdpcontext.append(',');

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ModemFactory.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ec25/QuectelEC25ModemFactory.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Sterwen Technology
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Sterwen-Technology
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.modem.quectel.ec25;
+
+import org.eclipse.kura.net.admin.NetworkConfigurationService;
+import org.eclipse.kura.net.admin.util.AbstractCellularModemFactory;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.net.modem.ModemTechnologyType;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.io.ConnectionFactory;
+import org.osgi.util.tracker.ServiceTracker;
+
+public class QuectelEC25ModemFactory extends AbstractCellularModemFactory<QuectelEC25> {
+
+    private static QuectelEC25ModemFactory factoryInstance = null;
+    private ConnectionFactory connectionFactory;
+
+    private BundleContext bundleContext = null;
+
+    private QuectelEC25ModemFactory() {
+        this.bundleContext = FrameworkUtil.getBundle(NetworkConfigurationService.class).getBundleContext();
+
+        ServiceTracker<ConnectionFactory, ConnectionFactory> serviceTracker = new ServiceTracker<>(this.bundleContext,
+                ConnectionFactory.class, null);
+        serviceTracker.open(true);
+        this.connectionFactory = serviceTracker.getService();
+    }
+
+    public static QuectelEC25ModemFactory getInstance() {
+        if (factoryInstance == null) {
+            factoryInstance = new QuectelEC25ModemFactory();
+        }
+        return factoryInstance;
+    }
+
+    @Override
+    @Deprecated
+    public ModemTechnologyType getType() {
+        return ModemTechnologyType.LTE;
+    }
+
+    @Override
+    protected QuectelEC25 createCellularModem(ModemDevice modemDevice, String platform) throws Exception {
+        return new QuectelEC25(modemDevice, platform, this.connectionFactory);
+    }
+}


### PR DESCRIPTION
Added support for Quectel EC25 and BG96.
Quectel EG25 already exists. 
Update in kura.net.admin.modem and kura.linux.net.

**Related Issue:** This PR fixes/closes {issue number}
Issue 2598.
