### PR TITLE
Modem classes clean up

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/bg96/QuectelBG96.java
@@ -14,16 +14,11 @@ package org.eclipse.kura.net.admin.modem.quectel.bg96;
 import org.eclipse.kura.net.admin.modem.quectel.generic.QuectelGeneric;
 import org.eclipse.kura.net.modem.ModemDevice;
 import org.osgi.service.io.ConnectionFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Defines Quectel BG96 modem
  */
 public class QuectelBG96 extends QuectelGeneric {
-
-    private static final Logger logger = LoggerFactory.getLogger(QuectelBG96.class);
-    private static final String MODEM_NOT_AVAILABLE = "Modem not available for AT commands: ";
 
     public QuectelBG96(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
         super(device, platform, connectionFactory);

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ex25/QuectelEX25.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/ex25/QuectelEX25.java
@@ -14,13 +14,8 @@ package org.eclipse.kura.net.admin.modem.quectel.ex25;
 import org.eclipse.kura.net.admin.modem.quectel.generic.QuectelGeneric;
 import org.eclipse.kura.net.modem.ModemDevice;
 import org.osgi.service.io.ConnectionFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class QuectelEX25 extends QuectelGeneric {
-
-    private static final Logger logger = LoggerFactory.getLogger(QuectelEX25.class);
-    private static final String MODEM_NOT_AVAILABLE = "Modem not available for AT commands: ";
 
     public QuectelEX25(ModemDevice device, String platform, ConnectionFactory connectionFactory) {
         super(device, platform, connectionFactory);

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/zte/me3630/ZteMe3630ConfigGenerator.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/zte/me3630/ZteMe3630ConfigGenerator.java
@@ -72,7 +72,6 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
 
     @Override
     public ModemXchangeScript getConnectScript(ModemConfig modemConfig) {
-        // PDP context is fixed to 1 for this modem
         int pdpPid = 1;
         String apn = "";
         String dialString = "";
@@ -80,6 +79,7 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
         if (modemConfig != null) {
             apn = modemConfig.getApn();
             dialString = modemConfig.getDialString();
+            pdpPid = getPdpContextNumber(dialString);
         }
 
         ModemXchangeScript modemXchange = new ModemXchangeScript();
@@ -114,6 +114,14 @@ public class ZteMe3630ConfigGenerator implements ModemPppConfigGenerator {
         modemXchange.addmodemXchangePair(new ModemXchangePair("\"+++ATH\"", "\"\""));
 
         return modemXchange;
+    }
+
+    private int getPdpContextNumber(String dialString) {
+        int pdpPid = 1;
+        if (!dialString.isEmpty() && dialString.contains("atd*99***")) {
+            pdpPid = Integer.parseInt(dialString.substring("atd*99***".length(), dialString.length() - 1));
+        }
+        return pdpPid;
     }
 
     /*


### PR DESCRIPTION
This PR does the following:

- removes not used fields from `QuectelEX25` and `QuectelBG96` classes;
- adds the pdpPid parsing for ZteMe3630 modem configuration.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>