### PR TITLE
Kura on a no-root linux user

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2011, 2019 Eurotech and others
+    Copyright (c) 2011, 2020 Eurotech and others
 
      All rights reserved. This program and the accompanying materials
      are made available under the terms of the Eclipse Public License v1.0
@@ -454,6 +454,10 @@ fi]]>
 				file="${project.build.directory}/${build.output.name}/kura_install.sh"
 				prefix="${build.output.name}/${install.folder}/" filemode="700" />
 
+			<zipfileset
+				file="src/main/resources/common/manage_kura_users.sh"
+				prefix="${build.output.name}/${install.folder}/" filemode="700" />
+					
 			<zipfileset file="src/main/resources/${build.name}/kuranet.conf"
 				prefix="${build.output.name}/${install.folder}/" />
 

--- a/kura/distrib/src/main/deb/control/prerm
+++ b/kura/distrib/src/main/deb/control/prerm
@@ -75,6 +75,7 @@ function preRemove {
     rm -rf /tmp/kura
 
     if [ -d "${INSTALL_DIR}/kura" ] ; then
+      ${INSTALL_DIR}/kura/.data/manage_kura_users.sh -u
       PARENT=`readlink -f ${INSTALL_DIR}/kura`
       rm -rf ${INSTALL_DIR}/kura
       rm -rf $PARENT

--- a/kura/distrib/src/main/resources/common/kura.service
+++ b/kura/distrib/src/main/resources/common/kura.service
@@ -1,15 +1,20 @@
 [Unit]
 Description=Kura
-Wants=networking.service
-After=networking.service
+Wants=networking.service dbus.service
+After=networking.service dbus.service
 
 [Service]
+User=kurad
+Group=kurad
 Type=forking
 ExecStart=/bin/sh INSTALL_DIR/kura/bin/start_kura_background.sh
 ExecStopPost=/bin/sh -c 'if [ -f /tmp/watchdog ]; then echo w > `cat /tmp/watchdog`; fi'
 PIDFile=/var/run/kura.pid
 Restart=on-failure
 RestartSec=5
+SuccessExitStatus=143
+KillMode=process
+AmbientCapabilities=cap_net_admin cap_net_raw cap_dac_override cap_dac_read_search cap_net_bind_service cap_sys_boot cap_kill cap_sys_module cap_sys_time cap_sys_tty_config cap_syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/kura/distrib/src/main/resources/common/manage_kura_users.sh
+++ b/kura/distrib/src/main/resources/common/manage_kura_users.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Eurotech and/or its affiliates
+#
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Eurotech
+#
+
+function create_users {
+    # create kura user without home directory
+    useradd -M kura
+    # disable login for kura user
+    KURA_USER_ENTRY=`cat /etc/passwd | grep kura:`
+    sed -i "s@${KURA_USER_ENTRY}@${KURA_USER_ENTRY%:*}:/sbin/nologin@" /etc/passwd
+    
+    # create kurad system user
+    useradd -r kurad
+    # disable login for kurad user
+    passwd -l kurad
+    # grant kurad root privileges
+    echo "kurad ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/kurad
+    # add kurad to dialout group (for managing serial ports)
+    gpasswd -a kurad dialout
+    
+	# get polkit package version
+	POLKIT=`apt list --installed | grep libpolkit`
+	IFS=" " POLKIT_ARRAY=($POLKIT)
+	POLKIT_VERSION=${POLKIT_ARRAY[1]}
+	
+    # add polkit policy
+	if [[ ${POLKIT_VERSION} < 0.106 ]]; then
+		if [ ! -f /etc/polkit-1/localauthority/50-local.d/51-org.freedesktop.systemd1.pkla ]; then
+		    echo "[No password prompt for kurad user]
+Identity=unix-user:kurad
+Action=org.freedesktop.systemd1.manage-units
+ResultInactive=no
+ResultActive=no
+ResultAny=yes" > /etc/polkit-1/localauthority/50-local.d/51-org.freedesktop.systemd1.pkla
+	    fi
+	else  
+	    if [ ! -f /usr/share/polkit-1/rules.d/kura.rules ]; then
+	    	if [[ $NN == "NO" ]]; then
+	            echo "polkit.addRule(function(action, subject) {
+    if (action.id == \"org.freedesktop.systemd1.manage-units\" &&
+        subject.user == \"kurad\" &&
+        (action.lookup(\"unit\") == \"named.service\" ||
+        action.lookup(\"unit\") == \"bluetooth.service\")) {
+        return polkit.Result.YES;
+    }
+});" > /usr/share/polkit-1/rules.d/kura.rules
+			else
+			    echo "polkit.addRule(function(action, subject) {
+    if (action.id == \"org.freedesktop.systemd1.manage-units\" &&
+        subject.user == \"kurad\" &&
+        action.lookup(\"unit\") == \"bluetooth.service\") {
+        return polkit.Result.YES;
+    }
+});" > /usr/share/polkit-1/rules.d/kura.rules
+			fi
+	    fi
+	fi
+        
+    # grant kurad user the privileges to manage ble via dbus
+    grep -lR kurad /etc/dbus-1/system.d/bluetooth.conf
+    if [ $? != 0 ]; then
+        cp /etc/dbus-1/system.d/bluetooth.conf /etc/dbus-1/system.d/bluetooth.conf.save
+        awk 'done != 1 && /^<\/busconfig>/ {
+            print "  <policy user=\"kurad\">"
+            print "    <allow own=\"org.bluez\"/>"
+            print "    <allow send_destination=\"org.bluez\"/>"
+            print "    <allow send_interface=\"org.bluez.Agent1\"/>"
+            print "    <allow send_interface=\"org.bluez.MediaEndpoint1\"/>"
+            print "    <allow send_interface=\"org.bluez.MediaPlayer1\"/>"
+            print "    <allow send_interface=\"org.bluez.Profile1\"/>"
+            print "    <allow send_interface=\"org.bluez.GattCharacteristic1\"/>"
+            print "    <allow send_interface=\"org.bluez.GattDescriptor1\"/>"
+            print "    <allow send_interface=\"org.bluez.LEAdvertisement1\"/>"
+            print "    <allow send_interface=\"org.freedesktop.DBus.ObjectManager\"/>"
+            print "    <allow send_interface=\"org.freedesktop.DBus.Properties\"/>"
+            print "  </policy>\n"
+            done = 1
+        } 1' /etc/dbus-1/system.d/bluetooth.conf >tempfile && mv tempfile /etc/dbus-1/system.d/bluetooth.conf
+    fi
+    
+    # Change kura folder ownership and permission
+    chown -R kurad:kurad /opt/eclipse
+    chmod -R +X /opt/eclipse
+}
+
+function delete_users {
+	# delete kura user
+	userdel kura
+	
+	# we cannot delete kurad system user because there should be several process owned by this user,
+	# so only try to remove it from sudoers.
+	if [ -f /etc/sudoers.d/kurad ]; then
+		rm -f /etc/sudoers.d/kurad
+	fi
+	# remove kurad from dialout group
+	gpasswd -d kurad dialout
+	
+	# remove polkit policy
+	if [ -f /usr/share/polkit-1/rules.d/kura.rules ]; then
+		rm -f /usr/share/polkit-1/rules.d/kura.rules
+	fi
+	if [ -f /etc/polkit-1/localauthority/50-local.d/51-org.freedesktop.systemd1.pkla ]; then
+		rm -f /etc/polkit-1/localauthority/50-local.d/51-org.freedesktop.systemd1.pkla
+	fi
+	
+	# recover old dbus config
+	mv /etc/dbus-1/system.d/bluetooth.conf.save /etc/dbus-1/system.d/bluetooth.conf
+}
+
+INSTALL=YES
+NN=NO
+
+while [[ $# > 0 ]]
+do
+key="$1"
+
+case $key in
+    -i|--install)
+    INSTALL=YES
+    ;;
+    -u|--uninstall)
+    INSTALL=NO
+    ;;
+    -nn)
+    NN=YES
+    ;;
+    -h|--help)
+    echo
+    echo "Options:"
+    echo "    -i | --install    create kura default users"
+    echo "    -u | --uninstall  delete kura default users"
+    echo "    -nn               set kura no network version"
+    echo "Default: --install"
+    exit 0
+    ;;
+    *)
+    echo "Unknown option."
+    exit 1
+    ;;
+esac
+shift # past argument or value
+done
+
+if [[ $INSTALL == "YES" ]]
+then
+    create_users
+else
+	delete_users
+fi

--- a/kura/distrib/src/main/resources/intel-up2-centos-7-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7-nn/kura_install.sh
@@ -30,6 +30,11 @@ if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
     mkdir ${INSTALL_DIR}/kura/.data
 fi
 
+#set up users and grant permissions to them
+cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i -nn 
+
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 chmod +x ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh

--- a/kura/distrib/src/main/resources/intel-up2-centos-7/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7/kura_install.sh
@@ -30,6 +30,11 @@ if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
     mkdir ${INSTALL_DIR}/kura/.data
 fi
 
+#set up users and grant permissions to them
+cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i 
+
 # disable network manager
 systemctl stop NetworkManager.service
 systemctl disable NetworkManager.service || true

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
@@ -37,6 +37,11 @@ if [ ! -d /etc/sysconfig ]; then
     mkdir /etc/sysconfig
 fi
 
+#set up users and grant permissions to them
+cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i 
+
 systemctl stop apparmor
 systemctl disable apparmor
 

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
@@ -29,6 +29,11 @@ if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
     mkdir ${INSTALL_DIR}/kura/.data
 fi
 
+#set up users and grant permissions to them
+cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i -nn
+
 #copy snapshot_0.xml
 cp ${INSTALL_DIR}/kura/user/snapshots/snapshot_0.xml ${INSTALL_DIR}/kura/.data/snapshot_0.xml
 

--- a/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
@@ -15,7 +15,7 @@ INSTALL_DIR=/opt/eclipse
 
 #create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
-
+        
 #set up Kura init
 sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
 systemctl daemon-reload
@@ -33,6 +33,11 @@ mkdir -p ${INSTALL_DIR}/kura/data
 if [ ! -d /etc/sysconfig ]; then
     mkdir /etc/sysconfig
 fi
+
+#set up users and grant permissions to them
+cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i 
 
 #set up default networking file
 cp ${INSTALL_DIR}/kura/install/network.interfaces /etc/network/interfaces

--- a/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
@@ -34,6 +34,11 @@ if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
     mkdir ${INSTALL_DIR}/kura/.data
 fi
 
+#set up users and grant permissions to them
+cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i 
+
 #copy snapshot_0.xml
 cp ${INSTALL_DIR}/kura/user/snapshots/snapshot_0.xml ${INSTALL_DIR}/kura/.data/snapshot_0.xml
 


### PR DESCRIPTION
This PR modifies Kura to run under a no-root linux user.

**Related Issue:** This PR fixes/closes #3138 

**Description of the solution adopted:** In order to improve Kura security and satisfy the Principle of Least Privilege [POLP](https://digitalguardian.com/blog/what-principle-least-privilege-polp-best-practice-information-security-and-compliance), Kura has to run under a user different from root. Using systemd system it's straightforward to start a service like Kura under a standard Linux user. However, this will strongly reduce the Kura functionality since many operations performed by Kura need root privileges. To avoid this, the [Linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) are used. This Linux feature allows to assign to a process only a subset of root privileges, the ones that are really needed by the process to work properly.

This PR modifies the `kura_install.sh` script to create the users needed by Kura and to assign to them some privileges. Moreover, the `kura.service` unit is updated, adding a list of linux capabilities that allow to Kura to run properly.


Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>