### PR TITLE
More firewall enahncements

### DIFF
--- a/kura/distrib/src/main/resources/common/kura.service
+++ b/kura/distrib/src/main/resources/common/kura.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Kura
 Wants=networking.service dbus.service
-After=networking.service dbus.service docker.service multi-user.target
+After=networking.service dbus.service
 
 [Service]
 User=kurad

--- a/kura/distrib/src/main/resources/intel-up2-centos-7/firewall.init
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7/firewall.init
@@ -4,35 +4,53 @@ iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
 
-iptables-restore < $iptables_config_file
+if [ -f $iptables_config_file ]; then
+	iptables-restore < $iptables_config_file
+fi
 
 # create custom chains if needed
 custom_filter_chains=(input-kura output-kura forward-kura)
 for custom_chain in ${custom_filter_chains[@]}; do
     chain=(${custom_chain//-/ })
-    iptables -C ${chain[0]^^} -j $custom_chain> /dev/null 2>&1
+    iptables -C ${chain[0]^^} -j $custom_chain-t filter > /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
         iptables -N $custom_chain -t filter > /dev/null 2>&1
-        iptables -A ${chain[0]^^} -j $custom_chain > /dev/null 2>&1
+        iptables -I ${chain[0]^^} -t filter -j $custom_chain > /dev/null 2>&1
     fi
 done
-custom_nat_chains=(prerouting-kura postrouting-kura)
+custom_nat_chains=(prerouting-kura postrouting-kura input-kura output-kura)
 for custom_chain in ${custom_nat_chains[@]}; do
     chain=(${custom_chain//-/ }[0])
-    iptables -C ${chain[0]^^} -j $custom_chain> /dev/null 2>&1
+    iptables -C ${chain[0]^^} -j $custom_chain -t nat > /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
         iptables -N $custom_chain -t nat > /dev/null 2>&1
-        iptables -A ${chain[0]^^} -j $custom_chain > /dev/null 2>&1
+        iptables -I ${chain[0]^^} -t nat -j $custom_chain > /dev/null 2>&1
     fi
 done
 
+# configure policies for standard chains
+policy=$(iptables -nL -t filter | grep policy | grep INPUT)
+if [[ "$policy" == *ACCEPT* ]]; then
+	iptables -P INPUT DROP
+fi
+policy=$(iptables -nL -t filter | grep policy | grep OUTPUT)
+if [[ "$policy" == *DROP* ]]; then
+	iptables -P OUTPUT ACCEPT
+fi
+policy=$(iptables -nL -t filter | grep policy | grep FORWARD)
+if [[ "$policy" == *ACCEPT* ]]; then
+	iptables -P FORWARD DROP
+fi
+
 # enable ip forwarding if needed
-while IFS='' read -r line || [[ -n "$line" ]]; do
-    if [[ $line =~ "-A forward-kura" ]]; then
-        enable_ipforwarding=true
-        break
-    fi
-done < $iptables_config_file
+if [ -f $iptables_config_file ]; then
+	while IFS='' read -r line || [[ -n "$line" ]]; do
+	    if [[ $line =~ "-A forward-kura" ]]; then
+	        enable_ipforwarding=true
+	        break
+	    fi
+	done < $iptables_config_file
+fi
 if [ $enable_ipforwarding = true ]; then
     echo "1" > $ipforward_file
 else

--- a/kura/distrib/src/main/resources/intel-up2-centos-7/iptables.init
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7/iptables.init
@@ -7,10 +7,10 @@
 :output-kura - [0:0]
 :postrouting-kura - [0:0]
 :prerouting-kura - [0:0]
--A PREROUTING -j prerouting-kura
--A INPUT -j input-kura
--A OUTPUT -j output-kura
--A POSTROUTING -j postrouting-kura
+-I PREROUTING -j prerouting-kura
+-I INPUT -j input-kura
+-I OUTPUT -j output-kura
+-I POSTROUTING -j postrouting-kura
 -A prerouting-kura -j RETURN
 -A input-kura -j RETURN
 -A output-kura -j RETURN
@@ -24,9 +24,9 @@ COMMIT
 :input-kura - [0:0]
 :forward-kura - [0:0]
 :output-kura - [0:0]
--A INPUT -j input-kura
--A FORWARD -j forward-kura
--A OUTPUT -j output-kura
+-I INPUT -j input-kura
+-I FORWARD -j forward-kura
+-I OUTPUT -j output-kura
 -A input-kura -i wlp4s0 -p tcp -m tcp --dport 8000 -j ACCEPT
 -A input-kura -i enp2s0 -p tcp -m tcp --dport 8000 -j ACCEPT
 -A input-kura -i enp3s0 -p tcp -m tcp --dport 8000 -j ACCEPT

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/firewall.init
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/firewall.init
@@ -13,35 +13,53 @@ iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
 
-iptables-restore < $iptables_config_file
+if [ -f $iptables_config_file ]; then
+	iptables-restore < $iptables_config_file
+fi
 
 # create custom chains if needed
 custom_filter_chains=(input-kura output-kura forward-kura)
 for custom_chain in ${custom_filter_chains[@]}; do
     chain=(${custom_chain//-/ })
-    iptables -C ${chain[0]^^} -j $custom_chain> /dev/null 2>&1
+    iptables -C ${chain[0]^^} -j $custom_chain -t filter > /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
         iptables -N $custom_chain -t filter > /dev/null 2>&1
-        iptables -A ${chain[0]^^} -j $custom_chain > /dev/null 2>&1
+        iptables -I ${chain[0]^^} -t filter -j $custom_chain > /dev/null 2>&1
     fi
 done
-custom_nat_chains=(prerouting-kura postrouting-kura)
+custom_nat_chains=(prerouting-kura postrouting-kura input-kura output-kura)
 for custom_chain in ${custom_nat_chains[@]}; do
     chain=(${custom_chain//-/ }[0])
-    iptables -C ${chain[0]^^} -j $custom_chain> /dev/null 2>&1
+    iptables -C ${chain[0]^^} -j $custom_chain -t nat > /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
         iptables -N $custom_chain -t nat > /dev/null 2>&1
-        iptables -A ${chain[0]^^} -j $custom_chain > /dev/null 2>&1
+        iptables -I ${chain[0]^^} -t nat -j $custom_chain > /dev/null 2>&1
     fi
 done
 
+# configure policies for standard chains
+policy=$(iptables -nL -t filter | grep policy | grep INPUT)
+if [[ "$policy" == *ACCEPT* ]]; then
+	iptables -P INPUT DROP
+fi
+policy=$(iptables -nL -t filter | grep policy | grep OUTPUT)
+if [[ "$policy" == *DROP* ]]; then
+	iptables -P OUTPUT ACCEPT
+fi
+policy=$(iptables -nL -t filter | grep policy | grep FORWARD)
+if [[ "$policy" == *ACCEPT* ]]; then
+	iptables -P FORWARD DROP
+fi
+
 # enable ip forwarding if needed
-while IFS='' read -r line || [[ -n "$line" ]]; do
-    if [[ $line =~ "-A forward-kura" ]]; then
-        enable_ipforwarding=true
-        break
-    fi
-done < $iptables_config_file
+if [ -f $iptables_config_file ]; then
+	while IFS='' read -r line || [[ -n "$line" ]]; do
+	    if [[ $line =~ "-A forward-kura" ]]; then
+	        enable_ipforwarding=true
+	        break
+	    fi
+	done < $iptables_config_file
+fi
 if [ $enable_ipforwarding = true ]; then
     echo "1" > $ipforward_file
 else

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/iptables.init
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/iptables.init
@@ -7,10 +7,10 @@
 :output-kura - [0:0]
 :postrouting-kura - [0:0]
 :prerouting-kura - [0:0]
--A PREROUTING -j prerouting-kura
--A INPUT -j input-kura
--A OUTPUT -j output-kura
--A POSTROUTING -j postrouting-kura
+-I PREROUTING -j prerouting-kura
+-I INPUT -j input-kura
+-I OUTPUT -j output-kura
+-I POSTROUTING -j postrouting-kura
 -A prerouting-kura -j RETURN
 -A input-kura -j RETURN
 -A output-kura -j RETURN
@@ -24,9 +24,9 @@ COMMIT
 :input-kura - [0:0]
 :forward-kura - [0:0]
 :output-kura - [0:0]
--A INPUT -j input-kura
--A FORWARD -j forward-kura
--A OUTPUT -j output-kura
+-I INPUT -j input-kura
+-I FORWARD -j forward-kura
+-I OUTPUT -j output-kura
 -A input-kura -i enp3s0 -p tcp -m tcp --dport 8000 -j ACCEPT
 -A input-kura -i enp2s0 -p tcp -m tcp --dport 8000 -j ACCEPT
 -A input-kura -i wlp4s0 -p tcp -m tcp --dport 8000 -j ACCEPT

--- a/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
@@ -12,21 +12,35 @@ fi
 custom_filter_chains=(input-kura output-kura forward-kura)
 for custom_chain in ${custom_filter_chains[@]}; do
     chain=(${custom_chain//-/ })
-    iptables -C ${chain[0]^^} -j $custom_chain> /dev/null 2>&1
+    iptables -C ${chain[0]^^} -j $custom_chain -t filter > /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
         iptables -N $custom_chain -t filter > /dev/null 2>&1
-        iptables -A ${chain[0]^^} -t filter -j $custom_chain > /dev/null 2>&1
+        iptables -I ${chain[0]^^} -t filter -j $custom_chain > /dev/null 2>&1
     fi
 done
-custom_nat_chains=(prerouting-kura postrouting-kura)
+custom_nat_chains=(prerouting-kura postrouting-kura input-kura output-kura)
 for custom_chain in ${custom_nat_chains[@]}; do
     chain=(${custom_chain//-/ }[0])
-    iptables -C ${chain[0]^^} -j $custom_chain> /dev/null 2>&1
+    iptables -C ${chain[0]^^} -j $custom_chain -t nat > /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
         iptables -N $custom_chain -t nat > /dev/null 2>&1
-        iptables -A ${chain[0]^^} -t nat -j $custom_chain > /dev/null 2>&1
+        iptables -I ${chain[0]^^} -t nat -j $custom_chain > /dev/null 2>&1
     fi
 done
+
+# configure policies for standard chains
+policy=$(iptables -nL -t filter | grep policy | grep INPUT)
+if [[ "$policy" == *ACCEPT* ]]; then
+	iptables -P INPUT DROP
+fi
+policy=$(iptables -nL -t filter | grep policy | grep OUTPUT)
+if [[ "$policy" == *DROP* ]]; then
+	iptables -P OUTPUT ACCEPT
+fi
+policy=$(iptables -nL -t filter | grep policy | grep FORWARD)
+if [[ "$policy" == *ACCEPT* ]]; then
+	iptables -P FORWARD DROP
+fi
 
 # enable ip forwarding if needed
 if [ -f $iptables_config_file ]; then

--- a/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
@@ -4,7 +4,9 @@ iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
 enable_ipforwarding=false;
 
-iptables-restore < $iptables_config_file
+if [ -f $iptables_config_file ]; then
+	iptables-restore < $iptables_config_file
+fi
 
 # create custom chains if needed
 custom_filter_chains=(input-kura output-kura forward-kura)
@@ -13,7 +15,7 @@ for custom_chain in ${custom_filter_chains[@]}; do
     iptables -C ${chain[0]^^} -j $custom_chain> /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
         iptables -N $custom_chain -t filter > /dev/null 2>&1
-        iptables -A ${chain[0]^^} -j $custom_chain > /dev/null 2>&1
+        iptables -A ${chain[0]^^} -t filter -j $custom_chain > /dev/null 2>&1
     fi
 done
 custom_nat_chains=(prerouting-kura postrouting-kura)
@@ -22,17 +24,19 @@ for custom_chain in ${custom_nat_chains[@]}; do
     iptables -C ${chain[0]^^} -j $custom_chain> /dev/null 2>&1
     if [[ $? -ne 0 ]]; then
         iptables -N $custom_chain -t nat > /dev/null 2>&1
-        iptables -A ${chain[0]^^} -j $custom_chain > /dev/null 2>&1
+        iptables -A ${chain[0]^^} -t nat -j $custom_chain > /dev/null 2>&1
     fi
 done
 
 # enable ip forwarding if needed
-while IFS='' read -r line || [[ -n "$line" ]]; do
-    if [[ $line =~ "-A forward-kura" ]]; then
-        enable_ipforwarding=true
-        break
-    fi
-done < $iptables_config_file
+if [ -f $iptables_config_file ]; then
+	while IFS='' read -r line || [[ -n "$line" ]]; do
+	    if [[ $line =~ "-A forward-kura" ]]; then
+	        enable_ipforwarding=true
+	        break
+	    fi
+	done < $iptables_config_file
+fi
 if [ $enable_ipforwarding = true ]; then
     echo "1" > $ipforward_file
 else

--- a/kura/distrib/src/main/resources/raspberry-pi-2/iptables.init
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/iptables.init
@@ -7,10 +7,10 @@
 :output-kura - [0:0]
 :postrouting-kura - [0:0]
 :prerouting-kura - [0:0]
--A PREROUTING -j prerouting-kura
--A INPUT -j input-kura
--A OUTPUT -j output-kura
--A POSTROUTING -j postrouting-kura
+-I PREROUTING -j prerouting-kura
+-I INPUT -j input-kura
+-I OUTPUT -j output-kura
+-I POSTROUTING -j postrouting-kura
 -A prerouting-kura -j RETURN
 -A input-kura -j RETURN
 -A output-kura -j RETURN
@@ -24,9 +24,9 @@ COMMIT
 :input-kura - [0:0]
 :forward-kura - [0:0]
 :output-kura - [0:0]
--A INPUT -j input-kura
--A FORWARD -j forward-kura
--A OUTPUT -j output-kura
+-I INPUT -j input-kura
+-I FORWARD -j forward-kura
+-I OUTPUT -j output-kura
 -A input-kura -i wlan0 -p tcp -m tcp --dport 8000 -j ACCEPT
 -A input-kura -i eth0 -p tcp -m tcp --dport 8000 -j ACCEPT
 -A input-kura -i wlan0 -p udp -m udp --dport 67 -j ACCEPT

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfigConstants.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfigConstants.java
@@ -1,0 +1,93 @@
+package org.eclipse.kura.linux.net.iptables;
+
+public class IptablesConfigConstants {
+
+    protected static final String FIREWALL_CONFIG_FILE_NAME = "/etc/sysconfig/iptables";
+    protected static final String FIREWALL_TMP_CONFIG_FILE_NAME = "/tmp/iptables";
+    protected static final String FILTER = "filter";
+    protected static final String NAT = "nat";
+    protected static final String STAR_NAT = "*" + NAT;
+    protected static final String STAR_FILTER = "*" + FILTER;
+    protected static final String COMMIT = "COMMIT";
+    protected static final String IPTABLES_COMMAND = "iptables";
+    protected static final String FORWARD = "FORWARD";
+    protected static final String INPUT = "INPUT";
+    protected static final String OUTPUT = "OUTPUT";
+    protected static final String PREROUTING = "PREROUTING";
+    protected static final String POSTROUTING = "POSTROUTING";
+    protected static final String RETURN = "RETURN";
+    protected static final String INPUT_KURA_CHAIN = "input-kura";
+    protected static final String OUTPUT_KURA_CHAIN = "output-kura";
+    protected static final String FORWARD_KURA_CHAIN = "forward-kura";
+    protected static final String PREROUTING_KURA_CHAIN = "prerouting-kura";
+    protected static final String POSTROUTING_KURA_CHAIN = "postrouting-kura";
+    protected static final String ADD_INPUT_KURA_CHAIN = "-I INPUT -j input-kura";
+    protected static final String ADD_OUTPUT_KURA_CHAIN = "-I OUTPUT -j output-kura";
+    protected static final String ADD_FORWARD_KURA_CHAIN = "-I FORWARD -j forward-kura";
+    protected static final String ADD_PREROUTING_KURA_CHAIN = "-I PREROUTING -j prerouting-kura";
+    protected static final String ADD_POSTROUTING_KURA_CHAIN = "-I POSTROUTING -j postrouting-kura";
+    protected static final String RETURN_PREROUTING_KURA_CHAIN = "-A prerouting-kura -j RETURN";
+    protected static final String RETURN_POSTROUTING_KURA_CHAIN = "-A postrouting-kura -j RETURN";
+    protected static final String RETURN_INPUT_KURA_CHAIN = "-A input-kura -j RETURN";
+    protected static final String RETURN_OUTPUT_KURA_CHAIN = "-A output-kura -j RETURN";
+    protected static final String RETURN_FORWARD_KURA_CHAIN = "-A forward-kura -j RETURN";
+    protected static final String ALLOW_ALL_TRAFFIC_TO_LOOPBACK = "-A input-kura -i lo -j ACCEPT";
+    protected static final String ALLOW_ONLY_INCOMING_TO_OUTGOING = "-A input-kura -m state --state RELATED,ESTABLISHED -j ACCEPT";
+    protected static final String POSTROUTING_KURA_POLICY = ":postrouting-kura - [0:0]";
+    protected static final String PREROUTING_KURA_POLICY = ":prerouting-kura - [0:0]";
+    protected static final String FORWARD_KURA_POLICY = ":forward-kura - [0:0]";
+    protected static final String OUTPUT_KURA_POLICY = ":output-kura - [0:0]";
+    protected static final String INPUT_KURA_POLICY = ":input-kura - [0:0]";
+    protected static final String POSTROUTING_ACCEPT_POLICY = ":POSTROUTING ACCEPT [0:0]";
+    protected static final String PREROUTING_ACCEPT_POLICY = ":PREROUTING ACCEPT [0:0]";
+    protected static final String INPUT_ACCEPT_POLICY = ":INPUT ACCEPT [0:0]";
+    protected static final String OUTPUT_ACCEPT_POLICY = ":OUTPUT ACCEPT [0:0]";
+    protected static final String FORWARD_DROP_POLICY = ":FORWARD DROP [0:0]";
+    protected static final String INPUT_DROP_POLICY = ":INPUT DROP [0:0]";
+    protected static final String[] IPTABLES_CREATE_INPUT_KURA_CHAIN = { IPTABLES_COMMAND, "-N", INPUT_KURA_CHAIN, "-t",
+            FILTER };
+    protected static final String[] IPTABLES_CREATE_FORWARD_KURA_CHAIN = { IPTABLES_COMMAND, "-N", FORWARD_KURA_CHAIN,
+            "-t", FILTER };
+    protected static final String[] IPTABLES_CREATE_OUTPUT_KURA_CHAIN = { IPTABLES_COMMAND, "-N", OUTPUT_KURA_CHAIN,
+            "-t", FILTER };
+    protected static final String[] IPTABLES_INPUT_DROP_POLICY = { IPTABLES_COMMAND, "-P", INPUT, "DROP" };
+    protected static final String[] IPTABLES_FORWARD_DROP_POLICY = { IPTABLES_COMMAND, "-P", FORWARD, "DROP" };
+    protected static final String[] IPTABLES_CHECK_INPUT_KURA_CHAIN = { IPTABLES_COMMAND, "-C", INPUT, "-j",
+            INPUT_KURA_CHAIN, "-t", FILTER };
+    protected static final String[] IPTABLES_CHECK_OUTPUT_KURA_CHAIN = { IPTABLES_COMMAND, "-C", OUTPUT, "-j",
+            OUTPUT_KURA_CHAIN, "-t", FILTER };
+    protected static final String[] IPTABLES_CHECK_FORWARD_KURA_CHAIN = { IPTABLES_COMMAND, "-C", FORWARD, "-j",
+            FORWARD_KURA_CHAIN, "-t", FILTER };
+    protected static final String[] IPTABLES_CREATE_INPUT_KURA_CHAIN_NAT = { IPTABLES_COMMAND, "-N", INPUT_KURA_CHAIN,
+            "-t", NAT };
+    protected static final String[] IPTABLES_CREATE_OUTPUT_KURA_CHAIN_NAT = { IPTABLES_COMMAND, "-N", OUTPUT_KURA_CHAIN,
+            "-t", NAT };
+    protected static final String[] IPTABLES_CREATE_PREROUTING_KURA_CHAIN = { IPTABLES_COMMAND, "-N",
+            PREROUTING_KURA_CHAIN, "-t", NAT };
+    protected static final String[] IPTABLES_CREATE_POSTROUTING_KURA_CHAIN = { IPTABLES_COMMAND, "-N",
+            POSTROUTING_KURA_CHAIN, "-t", NAT };
+    protected static final String[] IPTABLES_CHECK_INPUT_KURA_CHAIN_NAT = { IPTABLES_COMMAND, "-C", INPUT, "-j",
+            INPUT_KURA_CHAIN, "-t", NAT };
+    protected static final String[] IPTABLES_CHECK_OUTPUT_KURA_CHAIN_NAT = { IPTABLES_COMMAND, "-C", OUTPUT, "-j",
+            OUTPUT_KURA_CHAIN, "-t", NAT };
+    protected static final String[] IPTABLES_CHECK_PREROUTING_KURA_CHAIN = { IPTABLES_COMMAND, "-C", PREROUTING, "-j",
+            PREROUTING_KURA_CHAIN, "-t", NAT };
+    protected static final String[] IPTABLES_CHECK_POSTROUTING_KURA_CHAIN = { IPTABLES_COMMAND, "-C", POSTROUTING, "-j",
+            POSTROUTING_KURA_CHAIN, "-t", NAT };
+
+    protected static final String COMMAND_EXECUTOR_SERVICE_MESSAGE = "CommandExecutorService not set.";
+    protected static final String CHAIN_CREATION_FAILED_MESSAGE = "Failed to create chain";
+    protected static final String CHAIN_RETURN_RULE_FAILED_MESSAGE = "Failed to add return rule";
+
+    protected static final String[] ALLOW_ICMP = {
+            "-A input-kura -p icmp -m icmp --icmp-type 8 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT",
+            "-A output-kura -p icmp -m icmp --icmp-type 0 -m state --state RELATED,ESTABLISHED -j ACCEPT" };
+
+    protected static final String[] DO_NOT_ALLOW_ICMP = {
+            "-A input-kura -p icmp -m icmp --icmp-type 8 -m state --state NEW,RELATED,ESTABLISHED -j DROP",
+            "-A output-kura -p icmp -m icmp --icmp-type 0 -m state --state RELATED,ESTABLISHED -j DROP" };
+
+    protected IptablesConfigConstants() {
+        // Empty constructor
+    }
+}

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/LinuxFirewall.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/LinuxFirewall.java
@@ -24,10 +24,7 @@ import java.util.Set;
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.KuraIOException;
-import org.eclipse.kura.KuraProcessExecutionErrorException;
-import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
-import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.net.IP4Address;
 import org.eclipse.kura.net.IPAddress;
 import org.eclipse.kura.net.NetworkPair;
@@ -46,7 +43,7 @@ public class LinuxFirewall {
     private static Object lock = new Object();
 
     private static final String IP_FORWARD_FILE_NAME = "/proc/sys/net/ipv4/ip_forward";
-    private static final String CUSTOM_FIREWALL_SCRIPT_NAME = "/etc/init.d/firewall_cust";
+    // private static final String CUSTOM_FIREWALL_SCRIPT_NAME = "/etc/init.d/firewall_cust";
 
     private Set<LocalRule> localRules = new LinkedHashSet<>();
     private Set<PortForwardRule> portForwardRules = new LinkedHashSet<>();
@@ -63,10 +60,10 @@ public class LinuxFirewall {
         try {
             File cfgFile = new File(IptablesConfig.FIREWALL_CONFIG_FILE_NAME);
             if (!cfgFile.exists()) {
-                this.iptables.applyBlockPolicy();
+                this.iptables.applyBlockPolicy();  // <-- serve veramente? oppure solo check custom rules e policies
             }
             // Update iptables config in the filesystem
-            this.iptables.save();
+            // this.iptables.save();
             initialize();
         } catch (KuraException e) {
             logger.error("failed to initialize LinuxFirewall", e);
@@ -82,7 +79,7 @@ public class LinuxFirewall {
         this.natRules = this.iptables.getNatRules();
         this.allowIcmp = true;
         this.allowForwarding = false;
-        logger.debug("initialize() :: Parsing current firewall configuraion");
+        logger.debug("initialize() :: Parsing current firewall configuration");
     }
 
     @SuppressWarnings("checkstyle:parameterNumber")
@@ -387,7 +384,7 @@ public class LinuxFirewall {
         newIptables.restore(IptablesConfig.FIREWALL_TMP_CONFIG_FILE_NAME);
         logger.debug("Managing port forwarding...");
         enableForwarding(this.allowForwarding);
-        runCustomFirewallScript();
+        // runCustomFirewallScript();
     }
 
     private static void enableForwarding(boolean allow) throws KuraException {
@@ -402,21 +399,21 @@ public class LinuxFirewall {
         }
     }
 
-    /*
-     * Runs custom firewall script
-     */
-    private void runCustomFirewallScript() throws KuraException {
-        File file = new File(CUSTOM_FIREWALL_SCRIPT_NAME);
-        if (file.exists()) {
-            logger.info("Running custom firewall script - {}", CUSTOM_FIREWALL_SCRIPT_NAME);
-            Command command = new Command(new String[] { "sh", CUSTOM_FIREWALL_SCRIPT_NAME });
-            CommandStatus status = this.executorService.execute(command);
-            if (!status.getExitStatus().isSuccessful()) {
-                throw new KuraProcessExecutionErrorException("Failed to apply custom firewall script");
-            }
-        }
-
-    }
+    // /*
+    // * Runs custom firewall script
+    // */
+    // private void runCustomFirewallScript() throws KuraException {
+    // File file = new File(CUSTOM_FIREWALL_SCRIPT_NAME);
+    // if (file.exists()) {
+    // logger.info("Running custom firewall script - {}", CUSTOM_FIREWALL_SCRIPT_NAME);
+    // Command command = new Command(new String[] { "sh", CUSTOM_FIREWALL_SCRIPT_NAME });
+    // CommandStatus status = this.executorService.execute(command);
+    // if (!status.getExitStatus().isSuccessful()) {
+    // throw new KuraProcessExecutionErrorException("Failed to apply custom firewall script");
+    // }
+    // }
+    //
+    // }
 
     public void enable() throws KuraException {
         update();
@@ -445,7 +442,7 @@ public class LinuxFirewall {
     private void update() throws KuraException {
         synchronized (lock) {
             // Write down the current config in the filesystem before adding/removing rules
-            this.iptables.save();
+            // this.iptables.save();
             this.iptables.flush();
             applyRules();
             this.iptables.save();

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/iptables/FirewallTestUtils.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/iptables/FirewallTestUtils.java
@@ -27,6 +27,9 @@ import static org.mockito.Mockito.mock;
  *******************************************************************************/
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
@@ -47,6 +50,7 @@ public class FirewallTestUtils {
     protected static Command commandFlushOutputNat;
     protected static Command commandFlushPreroutingNat;
     protected static Command commandFlushPostroutingNat;
+    protected static List<Command> commandApplyList;
 
     protected static void setUpMock() {
         executorServiceMock = mock(CommandExecutorService.class);
@@ -81,6 +85,32 @@ public class FirewallTestUtils {
         commandFlushPostroutingNat = new Command(new String[] { "iptables", "-F", "postrouting-kura", "-t", "nat" });
         commandFlushPostroutingNat.setExecuteInAShell(true);
         when(executorServiceMock.execute(commandFlushPostroutingNat)).thenReturn(successStatus);
+        commandApplyList = new ArrayList<>();
+        commandApplyList.add(new Command("iptables -P INPUT DROP".split(" ")));
+        commandApplyList.add(new Command("iptables -P FORWARD DROP".split(" ")));
+        commandApplyList.add(new Command("iptables -N input-kura -t filter".split(" ")));
+        commandApplyList.add(new Command("iptables -N output-kura -t filter".split(" ")));
+        commandApplyList.add(new Command("iptables -N forward-kura -t filter".split(" ")));
+        commandApplyList.add(new Command("iptables -N input-kura -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -N output-kura -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -N prerouting-kura -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -N postrouting-kura -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -C INPUT -j input-kura -t filter".split(" ")));
+        commandApplyList.add(new Command("iptables -C OUTPUT -j output-kura -t filter".split(" ")));
+        commandApplyList.add(new Command("iptables -C FORWARD -j forward-kura -t filter".split(" ")));
+        commandApplyList.add(new Command("iptables -C INPUT -j input-kura -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -C OUTPUT -j output-kura -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -C PREROUTING -j prerouting-kura -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -C POSTROUTING -j postrouting-kura -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -A input-kura -j RETURN".split(" ")));
+        commandApplyList.add(new Command("iptables -A output-kura -j RETURN".split(" ")));
+        commandApplyList.add(new Command("iptables -A forward-kura -j RETURN".split(" ")));
+        commandApplyList.add(new Command("iptables -A input-kura -j RETURN -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -A output-kura -j RETURN -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -A prerouting-kura -j RETURN -t nat".split(" ")));
+        commandApplyList.add(new Command("iptables -A postrouting-kura -j RETURN -t nat".split(" ")));
+        commandApplyList.stream().forEach(c -> c.setExecuteInAShell(true));
+        commandApplyList.stream().forEach(c -> when(executorServiceMock.execute(c)).thenReturn(successStatus));
     }
 
 }

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/iptables/LinuxFirewallTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/iptables/LinuxFirewallTest.java
@@ -31,16 +31,6 @@ import org.junit.Test;
 
 public class LinuxFirewallTest extends FirewallTestUtils {
 
-    // @SuppressWarnings("unused")
-    // @Test
-    // public void LinuxFirewallConstructorTest() {
-    // setUpMock();
-    // new LinuxFirewall(executorServiceMock);
-    //
-    // verify(executorServiceMock, atLeast(1)).execute(commandRestore);
-    // verify(executorServiceMock, times(1)).execute(commandSave);
-    // }
-
     @Test
     public void addLocalRuleTest() throws KuraException {
         setUpMock();

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/iptables/LinuxFirewallTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/iptables/LinuxFirewallTest.java
@@ -15,7 +15,6 @@ package org.eclipse.kura.linux.net.iptables;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -32,15 +31,15 @@ import org.junit.Test;
 
 public class LinuxFirewallTest extends FirewallTestUtils {
 
-    @SuppressWarnings("unused")
-    @Test
-    public void LinuxFirewallConstructorTest() {
-        setUpMock();
-        new LinuxFirewall(executorServiceMock);
-
-        verify(executorServiceMock, atLeast(1)).execute(commandRestore);
-        verify(executorServiceMock, times(1)).execute(commandSave);
-    }
+    // @SuppressWarnings("unused")
+    // @Test
+    // public void LinuxFirewallConstructorTest() {
+    // setUpMock();
+    // new LinuxFirewall(executorServiceMock);
+    //
+    // verify(executorServiceMock, atLeast(1)).execute(commandRestore);
+    // verify(executorServiceMock, times(1)).execute(commandSave);
+    // }
 
     @Test
     public void addLocalRuleTest() throws KuraException {
@@ -74,8 +73,12 @@ public class LinuxFirewallTest extends FirewallTestUtils {
             // do nothing...
         }
 
-        verify(executorServiceMock, atLeast(1)).execute(commandRestore);
-        verify(executorServiceMock, times(2)).execute(commandSave);
+        assertTrue(linuxFirewall.getLocalRules().stream().anyMatch(rule -> {
+            return rule.getPort() == 5400 && rule.getProtocol().equals("tcp")
+                    && rule.getPermittedInterfaceName().equals("eth0")
+                    && rule.getPermittedMAC().equals("00:11:22:33:44:55:66")
+                    && rule.getSourcePortRange().equals("10100:10200");
+        }));
         verify(executorServiceMock, times(1)).execute(commandFlushInputFilter);
         verify(executorServiceMock, times(1)).execute(commandFlushOutputFilter);
         verify(executorServiceMock, times(1)).execute(commandFlushForwardFilter);
@@ -119,8 +122,14 @@ public class LinuxFirewallTest extends FirewallTestUtils {
             // do nothing...
         }
 
-        verify(executorServiceMock, atLeast(1)).execute(commandRestore);
-        verify(executorServiceMock, times(2)).execute(commandSave);
+        assertTrue(linuxFirewall.getPortForwardRules().stream().anyMatch(rule -> {
+            return rule.getInboundIface().equals("eth0") && rule.getOutboundIface().equals("eth1")
+                    && rule.getAddress().equals("172.16.0.1") && rule.getProtocol().equals("tcp")
+                    && rule.getInPort() == 3040 && rule.getOutPort() == 4050 && rule.isMasquerade()
+                    && rule.getPermittedNetwork().equals("172.16.0.100") && rule.getPermittedNetworkMask() == 32
+                    && rule.getPermittedMAC().equals("00:11:22:33:44:55:66")
+                    && rule.getSourcePortRange().equals("10100:10200");
+        }));
         verify(executorServiceMock, times(1)).execute(commandFlushInputFilter);
         verify(executorServiceMock, times(1)).execute(commandFlushOutputFilter);
         verify(executorServiceMock, times(1)).execute(commandFlushForwardFilter);
@@ -158,8 +167,10 @@ public class LinuxFirewallTest extends FirewallTestUtils {
             // do nothing...
         }
 
-        verify(executorServiceMock, atLeast(1)).execute(commandRestore);
-        verify(executorServiceMock, times(2)).execute(commandSave);
+        assertTrue(linuxFirewall.getAutoNatRules().stream().anyMatch(rule -> {
+            return rule.getSourceInterface().equals("eth0") && rule.getDestinationInterface().equals("eth1")
+                    && rule.isMasquerade();
+        }));
         verify(executorServiceMock, times(1)).execute(commandFlushInputFilter);
         verify(executorServiceMock, times(1)).execute(commandFlushOutputFilter);
         verify(executorServiceMock, times(1)).execute(commandFlushForwardFilter);
@@ -174,14 +185,14 @@ public class LinuxFirewallTest extends FirewallTestUtils {
         setUpMock();
         LinuxFirewall linuxFirewall = new LinuxFirewall(executorServiceMock);
         try {
-            linuxFirewall.addNatRule("eth0", "eth1", "tcp", "172.16.0.1", "172.16.0.2", true);
+            linuxFirewall.addNatRule("eth0", "eth1", "tcp", "172.16.0.1/32", "172.16.0.2/32", true);
         } catch (KuraIOException e) {
             // do nothing...
         }
 
         assertTrue(linuxFirewall.getNatRules().stream().anyMatch(rule -> {
             return rule.getSourceInterface().equals("eth0") && rule.getDestinationInterface().equals("eth1")
-                    && rule.getSource().equals("172.16.0.1") && rule.getDestination().equals("172.16.0.2")
+                    && rule.getSource().equals("172.16.0.1/32") && rule.getDestination().equals("172.16.0.2/32")
                     && rule.isMasquerade();
         }));
     }
@@ -192,14 +203,17 @@ public class LinuxFirewallTest extends FirewallTestUtils {
         LinuxFirewall linuxFirewall = new LinuxFirewall(executorServiceMock);
         List<NATRule> rules = new ArrayList<>();
         try {
-            rules.add(new NATRule("eth0", "eth1", "tcp", "172.16.0.1", "172.16.0.2", true));
-            linuxFirewall.addAutoNatRules(rules);
+            rules.add(new NATRule("eth0", "eth1", "tcp", "172.16.0.1/32", "172.16.0.2/32", true));
+            linuxFirewall.addNatRules(rules);
         } catch (KuraIOException e) {
             // do nothing...
         }
 
-        verify(executorServiceMock, atLeast(1)).execute(commandRestore);
-        verify(executorServiceMock, times(2)).execute(commandSave);
+        assertTrue(linuxFirewall.getNatRules().stream().anyMatch(rule -> {
+            return rule.getSourceInterface().equals("eth0") && rule.getDestinationInterface().equals("eth1")
+                    && rule.getSource().equals("172.16.0.1/32") && rule.getDestination().equals("172.16.0.2/32")
+                    && rule.isMasquerade();
+        }));
         verify(executorServiceMock, times(1)).execute(commandFlushInputFilter);
         verify(executorServiceMock, times(1)).execute(commandFlushOutputFilter);
         verify(executorServiceMock, times(1)).execute(commandFlushForwardFilter);
@@ -345,7 +359,7 @@ public class LinuxFirewallTest extends FirewallTestUtils {
         setUpMock();
         LinuxFirewall linuxFirewall = new LinuxFirewall(executorServiceMock);
         try {
-            linuxFirewall.addNatRule("eth0", "eth1", "tcp", "172.16.0.1", "172.16.0.2", true);
+            linuxFirewall.addNatRule("eth0", "eth1", "tcp", "172.16.0.1/32", "172.16.0.2/32", true);
         } catch (KuraIOException e) {
             // do nothing...
         }


### PR DESCRIPTION
Starting from #3210, this PR tries to improve the firewall to make it more robust when external services modify the configuration.

The `firewall.service` is modified to check if the Kura custom chains are present and the policy for INPUT and FORWARD chains are set to DROP.
The `LinuxFirewall` and `IptablesConfig` classes are modified to ignore all the rules that don't belong to the Kura chains and to save only the ones needed by Kura. Every time that the a modification is applied, Kura checks for the presence of the needed chains and the correct policies.
The `firewall_cust` script now is launched only by the `firewall.service`. The idea is that the custom firewall script will be used only for rules that are not in the Kura chains.

In this way, `kura.service` can start independently from external services.