### PR TITLE
Fix misc UI issues

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -983,6 +983,17 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
         userNameLarge.setText(userData.getUserName());
         userNameSmall.setText(userData.getUserName());
 
+        final EventService.Handler userAdminEventHandler = e -> {
+            userConfigReloadTimer.schedule(1000);
+        };
+
+        EventService.subscribe(ForwardedEventTopic.ROLE_CHANGED, userAdminEventHandler);
+        EventService.subscribe(ForwardedEventTopic.ROLE_CREATED, userAdminEventHandler);
+        EventService.subscribe(ForwardedEventTopic.ROLE_CHANGED, userAdminEventHandler);
+        EventService.subscribe(ForwardedEventTopic.ROLE_CHANGED_SHORT, userAdminEventHandler);
+        EventService.subscribe(ForwardedEventTopic.ROLE_CREATED_SHORT, userAdminEventHandler);
+        EventService.subscribe(ForwardedEventTopic.ROLE_CHANGED_SHORT, userAdminEventHandler);
+
         if (userData.getPermissions().isEmpty()) {
             alertDialog.show("The current user has no permissions", Severity.ALERT, (ConfirmListener) null);
             return;
@@ -1002,16 +1013,6 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
             }
         });
 
-        final EventService.Handler userAdminEventHandler = e -> {
-            userConfigReloadTimer.schedule(1000);
-        };
-
-        EventService.subscribe(ForwardedEventTopic.ROLE_CHANGED, userAdminEventHandler);
-        EventService.subscribe(ForwardedEventTopic.ROLE_CREATED, userAdminEventHandler);
-        EventService.subscribe(ForwardedEventTopic.ROLE_CHANGED, userAdminEventHandler);
-        EventService.subscribe(ForwardedEventTopic.ROLE_CHANGED_SHORT, userAdminEventHandler);
-        EventService.subscribe(ForwardedEventTopic.ROLE_CREATED_SHORT, userAdminEventHandler);
-        EventService.subscribe(ForwardedEventTopic.ROLE_CHANGED_SHORT, userAdminEventHandler);
     }
 
     private void showStatusPanel() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/Picker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -181,6 +181,7 @@ public class Picker extends Composite implements HasId {
             Picker.this.inputPanel.add(input);
 
             input.validate();
+            input.reset();
             Picker.this.modal.show();
         }
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/ApplicationCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/ApplicationCertsTabUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,6 @@ import org.gwtbootstrap3.client.ui.FormLabel;
 import org.gwtbootstrap3.client.ui.Input;
 import org.gwtbootstrap3.client.ui.TextArea;
 import org.gwtbootstrap3.client.ui.form.error.BasicEditorError;
-import org.gwtbootstrap3.client.ui.form.validator.ValidationChangedEvent.ValidationChangedHandler;
 import org.gwtbootstrap3.client.ui.form.validator.Validator;
 import org.gwtbootstrap3.client.ui.html.Span;
 
@@ -100,7 +99,7 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
     public void setDirty(boolean flag) {
         this.dirty = flag;
         this.reset.setEnabled(flag);
-        this.apply.setEnabled(isValid());
+        this.apply.setEnabled(flag);
     }
 
     @Override
@@ -138,11 +137,6 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
             }
         };
 
-        final ValidationChangedHandler validationChangeHandler = e -> this.apply.setEnabled(isValid());
-
-        this.formCert.addValidationChangedHandler(validationChangeHandler);
-        this.formStorageAlias.addValidationChangedHandler(validationChangeHandler);
-
         this.formCert.addValidator(validator);
         this.formStorageAlias.addValidator(validator);
 
@@ -156,17 +150,8 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
         });
 
         this.storageAliasLabel.setText(MSGS.settingsStorageAliasLabel());
-        this.formStorageAlias.addChangeHandler(event -> {
-            this.formStorageAlias.validate();
-            setDirty(true);
-        });
-
         this.certificateLabel.setText(MSGS.settingsPublicCertLabel());
         this.formCert.setVisibleLines(20);
-        this.formCert.addChangeHandler(event -> {
-            this.formCert.validate();
-            setDirty(true);
-        });
 
         this.reset.setText(MSGS.reset());
         this.reset.addClickHandler(event -> {
@@ -176,8 +161,9 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
 
         this.apply.setText(MSGS.apply());
         this.apply.addClickHandler(event -> {
+            final boolean isValid = isValid();
+            this.listener.onApply(isValid);
             if (isValid()) {
-                this.listener.onApply();
                 RequestQueue.submit(c -> this.gwtXSRFService.generateSecurityToken(
                         c.callback(token -> this.gwtCertificatesService.storeApplicationPublicChain(token,
                                 this.formCert.getValue(), this.formStorageAlias.getValue(), c.callback(ok -> {
@@ -188,14 +174,11 @@ public class ApplicationCertsTabUi extends Composite implements Tab {
 
             }
         });
-
-        this.formCert.validate();
-        this.formStorageAlias.validate();
     }
 
     private void reset() {
-        this.formStorageAlias.setText("");
-        this.formCert.setText("");
+        this.formStorageAlias.reset();
+        this.formCert.reset();
     }
 
     @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.messages.Messages;
+import org.eclipse.kura.web.client.ui.AlertDialog;
+import org.eclipse.kura.web.client.ui.AlertDialog.ConfirmListener;
 import org.eclipse.kura.web.client.ui.Tab;
 import org.eclipse.kura.web.client.util.request.RequestQueue;
 import org.eclipse.kura.web.shared.model.GwtCertificate;
@@ -71,6 +73,8 @@ public class CertificateListTabUi extends Composite implements Tab, CertificateM
     Button nextStepButton;
     @UiField
     Button closeModalButton;
+    @UiField
+    AlertDialog alertDialog;
 
     @UiField
     CellTable<GwtCertificate> certificatesGrid;
@@ -283,8 +287,12 @@ public class CertificateListTabUi extends Composite implements Tab, CertificateM
     }
 
     @Override
-    public void onApply() {
-        this.certAddModal.hide();
+    public void onApply(final boolean isValid) {
+        if (isValid) {
+            this.certAddModal.hide();
+        } else {
+            alertDialog.show(MSGS.formWithErrorsOrIncomplete(), AlertDialog.Severity.ERROR, (ConfirmListener) null);
+        }
     }
 
     @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2020, 2021 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,8 @@
 
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
     xmlns:b="urn:import:org.gwtbootstrap3.client.ui" xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-    xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt">
+    xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt"
+    xmlns:kura="urn:import:org.eclipse.kura.web.client.ui">
 
     <ui:style>
     .important {
@@ -58,5 +59,6 @@
   				</b:ModalFooter>
   			</b:Modal>
         </b:Column>
+        <kura:AlertDialog ui:field="alertDialog"/>
     </b:Container>
 </ui:UiBinder> 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateModalListener.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateModalListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,7 @@ package org.eclipse.kura.web.client.ui.security;
 
 public interface CertificateModalListener {
 
-    public void onApply();
+    public void onApply(final boolean isConfigurationValid);
 
     public void onKeystoreChanged();
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/DeviceCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/DeviceCertsTabUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,6 @@ import org.gwtbootstrap3.client.ui.FormLabel;
 import org.gwtbootstrap3.client.ui.Input;
 import org.gwtbootstrap3.client.ui.TextArea;
 import org.gwtbootstrap3.client.ui.form.error.BasicEditorError;
-import org.gwtbootstrap3.client.ui.form.validator.ValidationChangedEvent.ValidationChangedHandler;
 import org.gwtbootstrap3.client.ui.form.validator.Validator;
 import org.gwtbootstrap3.client.ui.html.Span;
 
@@ -99,7 +98,7 @@ public class DeviceCertsTabUi extends Composite implements Tab {
     public void setDirty(boolean flag) {
         this.dirty = flag;
         this.reset.setEnabled(flag);
-        this.apply.setEnabled(isValid());
+        this.apply.setEnabled(flag);
     }
 
     @Override
@@ -152,12 +151,6 @@ public class DeviceCertsTabUi extends Composite implements Tab {
             }
         };
 
-        final ValidationChangedHandler validationChangeHandler = e -> this.apply.setEnabled(isValid());
-
-        this.storageAliasInput.addValidationChangedHandler(validationChangeHandler);
-        this.privateKeyInput.addValidationChangedHandler(validationChangeHandler);
-        this.certificateInput.addValidationChangedHandler(validationChangeHandler);
-
         this.storageAliasInput.addValidator(validator);
         this.privateKeyInput.addValidator(validator);
         this.certificateInput.addValidator(validator);
@@ -176,24 +169,12 @@ public class DeviceCertsTabUi extends Composite implements Tab {
         });
 
         this.storageAliasLabel.setText(MSGS.settingsStorageAliasLabel());
-        this.storageAliasInput.addChangeHandler(event -> {
-            this.storageAliasInput.validate();
-            setDirty(true);
-        });
 
         this.privateKeyLabel.setText(MSGS.settingsPrivateCertLabel());
         this.privateKeyInput.setVisibleLines(20);
-        this.privateKeyInput.addChangeHandler(event -> {
-            this.privateKeyInput.validate();
-            setDirty(true);
-        });
 
         this.certificateLabel.setText(MSGS.settingsPublicCertLabel());
         this.certificateInput.setVisibleLines(20);
-        this.certificateInput.addChangeHandler(event -> {
-            this.certificateInput.validate();
-            setDirty(true);
-        });
 
         this.reset.setText(MSGS.reset());
         this.reset.addClickHandler(event -> {
@@ -203,8 +184,9 @@ public class DeviceCertsTabUi extends Composite implements Tab {
 
         this.apply.setText(MSGS.apply());
         this.apply.addClickHandler(event -> {
-            if (isValid()) {
-                this.listener.onApply();
+            final boolean isValid = isValid();
+            this.listener.onApply(isValid);
+            if (isValid) {
                 RequestQueue.submit(c -> this.gwtXSRFService.generateSecurityToken(
                         c.callback(token -> this.gwtCertificatesService.storeSSLPublicPrivateKeys(token,
                                 this.privateKeyInput.getValue(), this.certificateInput.getValue(), null,
@@ -215,16 +197,12 @@ public class DeviceCertsTabUi extends Composite implements Tab {
                                 })))));
             }
         });
-
-        this.storageAliasInput.validate();
-        this.privateKeyInput.validate();
-        this.certificateInput.validate();
     }
 
     private void reset() {
-        this.storageAliasInput.setText("");
-        this.privateKeyInput.setText("");
-        this.certificateInput.setText("");
+        this.storageAliasInput.reset();
+        this.privateKeyInput.reset();
+        this.certificateInput.reset();
     }
 
     @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/HttpsServerCertsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/HttpsServerCertsTabUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,6 @@ import org.gwtbootstrap3.client.ui.FormLabel;
 import org.gwtbootstrap3.client.ui.Input;
 import org.gwtbootstrap3.client.ui.TextArea;
 import org.gwtbootstrap3.client.ui.form.error.BasicEditorError;
-import org.gwtbootstrap3.client.ui.form.validator.ValidationChangedEvent.ValidationChangedHandler;
 import org.gwtbootstrap3.client.ui.form.validator.Validator;
 import org.gwtbootstrap3.client.ui.html.Span;
 
@@ -99,7 +98,7 @@ public class HttpsServerCertsTabUi extends Composite implements Tab {
     public void setDirty(boolean flag) {
         this.dirty = flag;
         this.reset.setEnabled(flag);
-        this.apply.setEnabled(isValid());
+        this.apply.setEnabled(flag);
     }
 
     @Override
@@ -151,12 +150,6 @@ public class HttpsServerCertsTabUi extends Composite implements Tab {
             }
         };
 
-        final ValidationChangedHandler validationChangeHandler = e -> this.apply.setEnabled(isValid());
-
-        this.storageAliasInput.addValidationChangedHandler(validationChangeHandler);
-        this.privateKeyInput.addValidationChangedHandler(validationChangeHandler);
-        this.certificateInput.addValidationChangedHandler(validationChangeHandler);
-
         this.storageAliasInput.addValidator(validator);
         this.privateKeyInput.addValidator(validator);
         this.certificateInput.addValidator(validator);
@@ -175,24 +168,12 @@ public class HttpsServerCertsTabUi extends Composite implements Tab {
         });
 
         this.storageAliasLabel.setText(MSGS.settingsStorageAliasLabel());
-        this.storageAliasInput.addChangeHandler(event -> {
-            this.storageAliasInput.validate();
-            setDirty(true);
-        });
 
         this.privateKeyLabel.setText(MSGS.settingsPrivateCertLabel());
         this.privateKeyInput.setVisibleLines(20);
-        this.privateKeyInput.addChangeHandler(event -> {
-            this.privateKeyInput.validate();
-            setDirty(true);
-        });
 
         this.certificateLabel.setText(MSGS.settingsPublicCertLabel());
         this.certificateInput.setVisibleLines(20);
-        this.certificateInput.addChangeHandler(event -> {
-            this.certificateInput.validate();
-            setDirty(true);
-        });
 
         this.reset.setText(MSGS.reset());
         this.reset.addClickHandler(event -> {
@@ -202,8 +183,9 @@ public class HttpsServerCertsTabUi extends Composite implements Tab {
 
         this.apply.setText(MSGS.apply());
         this.apply.addClickHandler(event -> {
-            if (isValid()) {
-                this.listener.onApply();
+            final boolean isValid = isValid();
+            this.listener.onApply(isValid);
+            if (isValid) {
                 RequestQueue.submit(c -> this.gwtXSRFService.generateSecurityToken(
                         c.callback(token -> this.gwtCertificatesService.storeLoginPublicPrivateKeys(token,
                                 HttpsServerCertsTabUi.this.privateKeyInput.getValue(),
@@ -215,16 +197,12 @@ public class HttpsServerCertsTabUi extends Composite implements Tab {
                                 })))));
             }
         });
-
-        this.storageAliasInput.validate();
-        this.privateKeyInput.validate();
-        this.certificateInput.validate();
     }
 
     private void reset() {
-        this.storageAliasInput.setText("");
-        this.privateKeyInput.setText("");
-        this.certificateInput.setText("");
+        this.storageAliasInput.reset();
+        this.privateKeyInput.reset();
+        this.certificateInput.reset();
     }
 
     @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UsersPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UsersPanelUi.ui.xml
@@ -35,6 +35,10 @@
     .small-text {
     	font-size: 0.90em;
     }
+    
+    .spaces-visible {
+    	white-space: pre
+    }
     </ui:style>
 
     <b:Container fluid="true" b:id="users-panel">
@@ -67,7 +71,7 @@
 					<b:PanelBody>
 	                	<gwt:CellTable bordered="true" condensed="true"
 	                    striped="true" hover="true" height="100%" width="100%"
-	                    ui:field="userTable" />
+	                    ui:field="userTable" addStyleNames="{style.spaces-visible}"/>
 	                </b:PanelBody>
                 </b:Column>
                 <b:Column size="MD_8">

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/FailureHandler.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/FailureHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,8 +39,9 @@ public class FailureHandler {
     public static void handle(Throwable caught, String name) {
         if (caught instanceof StatusCodeException) {
             final StatusCodeException statusCodeException = (StatusCodeException) caught;
-            if (statusCodeException.getStatusCode() == 401) {
-                showErrorMessage("The session has expired", null);
+            if (statusCodeException.getStatusCode() == 401 || statusCodeException.getStatusCode() == 403) {
+                showErrorMessage(statusCodeException.getStatusCode() == 401 ? MSGS.sessionExpiredError()
+                        : MSGS.unauthorizedError(), null);
                 Timer timer = new Timer() {
 
                     @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/OsgiRemoteServiceServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/OsgiRemoteServiceServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -227,7 +227,7 @@ public class OsgiRemoteServiceServlet extends KuraRemoteServiceServlet {
     protected void doUnexpectedFailure(Throwable e) {
         if (e instanceof KuraPermissionException) {
             try {
-                getThreadLocalResponse().sendError(401);
+                getThreadLocalResponse().sendError(403);
                 return;
             } catch (IOException e1) {
                 // ignore

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
 #
 #  This program and the accompanying materials are made
 #  available under the terms of the Eclipse Public License 2.0
@@ -83,6 +83,8 @@ genericError=A generic unrecoverable error happened. Please refer to the device 
 duplicateNameError=The provided name is already used! Please review the information provided.
 illegalArgumentError=The provided information cannot be accepted. Please review.
 illegalNullArgumentError=Null argument provided. Please review.
+unauthorizedError=The current identity is not allowed to perform the requested operation.
+sessionExpiredError=The session has expired.
 
 enable=Enable
 disable=Disable


### PR DESCRIPTION
Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}
Closes #3168
Closes #3169
Closes #3218
Closes #3230

**Description of the solution adopted:**
#3168: The **Apply** button is now always enabled after some form parameter has been changed, even if some of the parameter values are invalid. Clicking it performs a validation of all parameters and shows a warning message in case of invalid parameters
#3128: Fixed white space trimming in GWT table. All spaces provided when the identity has been defined should now be shown.
#3230: The session expired message is misleading. In case described in the issue the user performed an operation that is not permitted because a permission has been removed. The web ui should now show a more specific message, refreshing the web ui in this case will not log out the user, after the refresh the web ui will be aligned. 
We can discuss if this behavior is fine or if it is better to invalidate the session in this case.

