### PR TITLE
File permission related improvements

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.regex.Matcher;
 
-import org.apache.commons.io.FileUtils;
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.net.AbstractNetInterface;
@@ -182,7 +181,7 @@ public class HostapdConfigWriter implements NetworkConfigurationVisitor {
         } else {
             logger.error(
                     "Unsupported security type: {}. It must be WifiSecurity.NONE, WifiSecurity.SECURITY_NONE, "
-                    + "WifiSecurity.SECURITY_WEP, WifiSecurity.SECURITY_WPA, or WifiSecurity.SECURITY_WPA2",
+                            + "WifiSecurity.SECURITY_WEP, WifiSecurity.SECURITY_WPA, or WifiSecurity.SECURITY_WPA2",
                     wifiConfig.getSecurity());
             throw KuraException.internalError("unsupported security type: " + wifiConfig.getSecurity());
         }
@@ -399,19 +398,15 @@ public class HostapdConfigWriter implements NetworkConfigurationVisitor {
         return new File(HOSTAPD_TMP_CONFIG_FILE);
     }
 
-    private void moveFile(String ifaceName) throws KuraException, IOException {
+    private void moveFile(String ifaceName) throws KuraException {
         File tmpFile = getTemporaryFile();
         File file = getFinalFile(ifaceName);
-        if (!FileUtils.contentEquals(tmpFile, file)) {
-            if (tmpFile.renameTo(file)) {
-                logger.trace("Successfully wrote hostapd.conf file");
-            } else {
-                logger.error("Failed to write hostapd.conf file");
-                throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,
-                        "error while building up new configuration file for hostapd");
-            }
+        if (tmpFile.renameTo(file)) {
+            logger.trace("Successfully wrote hostapd.conf file");
         } else {
-            logger.info("Not rewriting hostapd.conf file because it is the same");
+            logger.error("Failed to write hostapd.conf file");
+            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,
+                    "error while building up new configuration file for hostapd");
         }
     }
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/WpaSupplicantConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/WpaSupplicantConfigWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Matcher;
 
-import org.apache.commons.io.FileUtils;
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.net.AbstractNetInterface;
@@ -433,19 +432,10 @@ public class WpaSupplicantConfigWriter implements NetworkConfigurationVisitor {
     private void moveWpaSupplicantConf(String ifaceName, String configFile) throws KuraException {
         File outputFile = new File(configFile);
         File wpaConfigFile = new File(getFinalConfigFile(ifaceName));
-        try {
-            if (!FileUtils.contentEquals(outputFile, wpaConfigFile)) {
-                if (outputFile.renameTo(wpaConfigFile)) {
-                    logger.trace("Successfully wrote wpa_supplicant config file");
-                } else {
-                    logger.error("Failed to write wpa_supplicant config file");
-                    throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,
-                            "error while building up new configuration file for wpa_supplicant config");
-                }
-            } else {
-                logger.info("Not rewriting wpa_supplicant.conf file because it is the same");
-            }
-        } catch (IOException e) {
+        if (outputFile.renameTo(wpaConfigFile)) {
+            logger.trace("Successfully wrote wpa_supplicant config file");
+        } else {
+            logger.error("Failed to write wpa_supplicant config file");
             throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,
                     "error while building up new configuration file for wpa_supplicant config");
         }


### PR DESCRIPTION
* Ensure that `/etc/resolv.conf` and `/etc/bind/named.conf` are readable by everyone
* Ensure that `wpa_supplicant`, `hostapd` and ppp secrets files are readable only by owner

Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

