### PR TITLE
Removed kurad user from sudoers

### DIFF
--- a/kura/distrib/src/main/resources/common/manage_kura_users.sh
+++ b/kura/distrib/src/main/resources/common/manage_kura_users.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  Copyright (c) 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2020, 2021 Eurotech and/or its affiliates and others
 #
 #  This program and the accompanying materials are made
 #  available under the terms of the Eclipse Public License 2.0
@@ -23,8 +23,6 @@ function create_users {
     useradd -r kurad
     # disable login for kurad user
     passwd -l kurad
-    # grant kurad root privileges
-    echo "kurad ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/kurad
     # add kurad to dialout group (for managing serial ports)
     gpasswd -a kurad dialout
     

--- a/kura/distrib/src/main/resources/common/manage_kura_users.sh
+++ b/kura/distrib/src/main/resources/common/manage_kura_users.sh
@@ -19,8 +19,8 @@ function create_users {
     KURA_USER_ENTRY=`cat /etc/passwd | grep kura:`
     sed -i "s@${KURA_USER_ENTRY}@${KURA_USER_ENTRY%:*}:/sbin/nologin@" /etc/passwd
     
-    # create kurad system user
-    useradd -r kurad
+    # create kurad system user without home directory
+    useradd -M -r kurad
     # disable login for kurad user
     passwd -l kurad
     # add kurad to dialout group (for managing serial ports)


### PR DESCRIPTION
During the installation of Kura, the `kurad` user is created and added to sudoers group. Since Kura already has several capabilities, it is useless (and potentially dangerous) that `kurad` user could escalate its privileges with the `sudo` command. So, this PR removes the addition of `kurad` user to sudoers during installation.

**Related Issue:** This PR fixes/closes N/A
