### PR TITLE
Fixed RoleRepositoryStore behavior in case of ConfigurationService s…

### DIFF
--- a/kura/org.eclipse.kura.useradmin.store/src/main/java/org/eclipse/kura/internal/useradmin/store/RoleRepositoryStoreImpl.java
+++ b/kura/org.eclipse.kura.useradmin.store/src/main/java/org/eclipse/kura/internal/useradmin/store/RoleRepositoryStoreImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020, 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -78,7 +78,12 @@ public class RoleRepositoryStoreImpl implements RoleRepositoryStore, UserAdminLi
     public synchronized void update(final Map<String, Object> properties) {
 
         if (isSelfUpdate(properties)) {
-            logger.info("ignoring self update");
+            logger.info("Ignoring self update");
+            return;
+        }
+
+        if (storeTask.isPresent() || !updateIds.isEmpty()) {
+            logger.info("Ignoring update since there are uncommitted changes");
             return;
         }
 


### PR DESCRIPTION
…purious update

Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

Modifies the `RoleRepositoryStore` to ignore configuration updates from the `ConfigurationService` if there are changes made through UserAdmin APIs that have not been committed yet.

It should prevent unwanted modifications originated from the spurious updated performed by `ConfigurationService` during startup, this might also cause the loss of desired modifications performed through `ConfigurationService` (e.g. a config change from the cloud) if the component is not "idle".
