### PR TITLE
Disable automatic ui refresh on network config change

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkButtonBarUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkButtonBarUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!-- 
     
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,8 @@
 
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
     xmlns:b="urn:import:org.gwtbootstrap3.client.ui" xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-    xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt">
+    xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt"
+    xmlns:kura="urn:import:org.eclipse.kura.web.client.ui">
 
     <ui:style>
     .important {
@@ -64,5 +65,6 @@
                 </b:Panel>
             </b:ModalBody>
         </b:Modal>
+        <kura:AlertDialog ui:field="alertDialog" />
     </b:Column>
 </ui:UiBinder> 

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -284,9 +284,9 @@ netIPv4ToolTipSubnetMask=For static configuration, enter the subnet mask that wi
 netIPv4ToolTipGateway=For static configuration, enter the default gateway for the device.
 netIPv4ToolTipRenew=For DHCP configuration, clicking this button will release the current IP address and acquire a new lease from the server.
 netIPv4ToolTipDns=List of DNS servers. New servers can be added by entering an address and clicking apply. To remove a server, delete the address from the list and click apply.<br/><br/>When configured for DHCP, manually entered DNS entries will replace the ones provided by the DHCP server.  Removing them will restore the DHCP entries.
-netConfigChangeConfirm=Are you sure you want to apply the network configuration change?  
+netConfigChangeConfirm=You are about to perform a network configuration change. Please be aware that:  
 netConfigConsoleUnavailable=The Web Console might be unavailable for a few seconds.
-netConfigURLChange=Depending on the applied configuration change, the device might change IP address. For this reason it could be necessary to update the browser URL.
+netConfigURLChange=Depending on the applied configuration change, the device might change its IP address: it could be necessary to update the browser URL.
 
 firewallIntro=Enable ports to be opened and port forwarding
 firewallOpenPorts=Open Ports

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -284,6 +284,9 @@ netIPv4ToolTipSubnetMask=For static configuration, enter the subnet mask that wi
 netIPv4ToolTipGateway=For static configuration, enter the default gateway for the device.
 netIPv4ToolTipRenew=For DHCP configuration, clicking this button will release the current IP address and acquire a new lease from the server.
 netIPv4ToolTipDns=List of DNS servers. New servers can be added by entering an address and clicking apply. To remove a server, delete the address from the list and click apply.<br/><br/>When configured for DHCP, manually entered DNS entries will replace the ones provided by the DHCP server.  Removing them will restore the DHCP entries.
+netConfigChangeConfirm=Are you sure you want to apply the network configuration change?  
+netConfigConsoleUnavailable=The Web Console might be unavailable for a few seconds.
+netConfigURLChange=Depending on the applied configuration change, the device might change IP address. For this reason it could be necessary to update the browser URL.
 
 firewallIntro=Enable ports to be opened and port forwarding
 firewallOpenPorts=Open Ports


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

The Web UI contains some logic that is triggered when the user changes the network configuration that allows to point the browser to the new gateway IP, if it changes due to the config update. This logic is currently affected by the following issues:

* It only works if the interface has a static IP.
* The page refresh is blocked by the appearance of an unsaved changes dialog.
* It does not consider spurious interface reconfigurations (for example sometimes if `eth1` is reconfigured, `eth0` interface is toggled as well. If the user is accessing the ui through `eth0`, then the web ui will become unavailable for a few seconds).

This PR disables the refresh logic and adds a warning dialog that is shown before the new configuration is applied. The dialog warns the user that the web ui might become unavailable and that it might be necessary to change the browser URL.
This also resets dirty state before applying the changes to prevent the appearance of the unsaved changes dialog.