### PR TITLE
Fixed missing post-up command

### DIFF
--- a/kura/org.eclipse.kura.linux.debian.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.debian.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -460,7 +460,7 @@ public class NetInterfaceConfigSerializationServiceImpl implements NetInterfaceC
                 sb.append("dhcp\n");
                 if (netConfigIP4.getStatus() == NetInterfaceStatus.netIPv4StatusEnabledLAN) {
                     // delete default route if configured as LAN
-                    sb.append("\t").append(REMOVE_ROUTE_COMMAND).append("\n");
+                    sb.append("\t post-up ").append(REMOVE_ROUTE_COMMAND).append("\n");
                 }
             } else {
                 logger.debug("new config is STATIC for {}", interfaceName);


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

Adds missing `post-up` rule in `/etc/network/interfaces`.
