### PR TITLE
Cast ByteBuffer to Buffer in CommConnectionImpl

### DIFF
--- a/kura/org.eclipse.kura.core.comm/src/main/java/org/eclipse/kura/core/comm/CommConnectionImpl.java
+++ b/kura/org.eclipse.kura.core.comm/src/main/java/org/eclipse/kura/core/comm/CommConnectionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.StringJoiner;
 
@@ -293,7 +294,8 @@ public class CommConnectionImpl implements CommConnection, Closeable {
             buffer.put((byte) c);
         }
 
-        buffer.flip();
+        // The buffer is casted to Buffer for Java8 compatibility
+        ((Buffer) buffer).flip();
 
         return buffer.limit() > 0 ? buffer : null;
     }
@@ -319,7 +321,8 @@ public class CommConnectionImpl implements CommConnection, Closeable {
             }
         } while (System.currentTimeMillis() - start < demark);
 
-        buffer.flip();
+        // The buffer is casted to Buffer for Java8 compatibility
+        ((Buffer) buffer).flip();
 
         return buffer.limit() > 0 ? buffer : null;
     }


### PR DESCRIPTION
This PR adds a cast to Buffer in `CommConnectionImpl`.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** According to [this post](https://stackoverflow.com/questions/61267495/exception-in-thread-main-java-lang-nosuchmethoderror-java-nio-bytebuffer-flip), the `flip` method of the `ByteBuffer` class is changed between Java 8 and 11. This PR adds a cast to `Buffer` for running Kura built with Java 11 on Java 8.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>