### PR TITLE
Partial rollback on a previous PR to restore empty string support

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *  Red Hat
@@ -643,8 +643,8 @@ public abstract class AbstractServicesUi extends Composite {
             case STRING:
                 TextBoxBase tb = (TextBoxBase) wg;
                 String value = tb.getText();
-                if (value != null && !value.trim().isEmpty()) {
-                    return value.trim();
+                if (value != null) {
+                    return value;
                 } else {
                     return null;
                 }


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

This PR fixes an error in the local UI that prevented to set a value to "". For example, once the client id was set, from the local UI it was not possible to remove the defined value, setting the entry as empty.
