### PR TITLE
Reworked the SSL Manager keystore code

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -323,15 +323,19 @@ public class SslManagerServiceImpl implements SslManagerService, ConfigurableCom
 
         if (isFirstBoot()) {
             changeDefaultKeystorePassword();
-        } else {
-            char[] oldPassword = getOldKeystorePassword(keystorePath);
+            return;
+        }
 
-            char[] newPassword = null;
-            try {
-                newPassword = this.cryptoService.decryptAes(this.options.getSslKeystorePassword().toCharArray());
-            } catch (KuraException e) {
-                logger.warn("Failed to decrypt keystore password");
-            }
+        char[] oldPassword = getOldKeystorePassword(keystorePath);
+        char[] newPassword = null;
+
+        try {
+            newPassword = this.cryptoService.decryptAes(this.options.getSslKeystorePassword().toCharArray());
+        } catch (KuraException e) {
+            logger.warn("Failed to decrypt keystore password");
+        }
+
+        if (newPassword != null && !Arrays.equals(oldPassword, newPassword)) {
             updateKeystorePassword(oldPassword, newPassword);
         }
     }

--- a/kura/test/org.eclipse.kura.core.ssl.test/src/test/java/org/eclipse/kura/core/ssl/SslManagerServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.ssl.test/src/test/java/org/eclipse/kura/core/ssl/SslManagerServiceImplTest.java
@@ -704,7 +704,7 @@ public class SslManagerServiceImplTest {
 
         assertTrue(visited.get());
 
-        verify(csMock, times(1)).setKeyStorePassword(anyString(), (char[]) anyObject());
+        verify(csMock, times(0)).setKeyStorePassword(anyString(), (char[]) anyObject());
     }
 
     @Test


### PR DESCRIPTION
Added a check to prevent the password update if the password has not changed.
This prevents the case, for example during boot, where the SSL SslManagerServiceImpl
triggers a keystore and a security manager password update even if the password was
not actually changed.

Signed-off-by: Maiero <matteo.maiero@eurotech.com>
