### PR TITLE
Fix firewall rules parsing

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfig.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfig.java
@@ -652,15 +652,16 @@ public class IptablesConfig extends IptablesConfigConstants {
 
     private void parseNatTable(String line, List<NatPreroutingChainRule> natPreroutingChain,
             List<NatPostroutingChainRule> natPostroutingChain) throws KuraException {
-        if (line.startsWith("-A prerouting-kura")) {
+        if (line.startsWith("-A prerouting-kura") && !line.startsWith("-A prerouting-kura -j prerouting-kura-")) {
             natPreroutingChain.add(new NatPreroutingChainRule(line));
-        } else if (line.startsWith("-A postrouting-kura")) {
+        } else if (line.startsWith("-A postrouting-kura")
+                && !line.startsWith("-A postrouting-kura -j postrouting-kura-")) {
             natPostroutingChain.add(new NatPostroutingChainRule(line));
         }
     }
 
     private void parseFilterTable(String line, List<FilterForwardChainRule> filterForwardChain) throws KuraException {
-        if (line.startsWith("-A forward-kura")) {
+        if (line.startsWith("-A forward-kura") && !line.startsWith("-A forward-kura -j forward-kura-")) {
             filterForwardChain.add(new FilterForwardChainRule(line));
         } else if (line.startsWith("-A input-kura")) {
             readInputChain(line);

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfig.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/IptablesConfig.java
@@ -675,6 +675,10 @@ public class IptablesConfig extends IptablesConfigConstants {
         if (ALLOW_ONLY_INCOMING_TO_OUTGOING.equals(line)) {
             return;
         }
+        // Ignore flooding protection rules
+        if (line.contains("connlimit") || line.contains("tcp-flags") || line.contains("conntrack")) {
+            return;
+        }
         final String lineFinal = line;
         String match = Arrays.stream(ALLOW_ICMP).filter(s -> s.equals(lineFinal)).findFirst().orElse("");
         if (match != null && !match.isEmpty()) {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -115,6 +115,7 @@ public class FirewallConfigurationServiceImpl
         }
 
         this.firewall = getLinuxFirewall();
+        setFloodingProtectionConfiguration();
 
         Dictionary<String, Object> props = new Hashtable<>();
         String[] eventTopics = { FloodingProtectionConfigurationChangeEvent.FP_EVENT_CONFIG_CHANGE_TOPIC };


### PR DESCRIPTION
This PR fixes the parsing of firewall rules.

**Description of the solution adopted:** The parsing of the firewall rules from a file was broken, since the code tries to parse some rules related to flooding protection in the input table.
In particular, the parsing of the following rules are bypassed:

- `-A forward-kura -j forward-kura-pf`, `-A forward-kura -j forward-kura-ipf`, `-A postrouting-kura -j postrouting-kura-ipf`, `-A postrouting-kura -j postrouting-kura-pf` and `-A prerouting-kura -j prerouting-kura-pf`
- all the rules containing the `connlimit`, `tcp-flags` and `conntrack` keywords

