### PR TITLE
Update UI to display certificate validity info

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
@@ -12,10 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui.security;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -201,6 +202,7 @@ public class CertificateListTabUi extends Composite implements Tab, CertificateM
         this.certificatesGrid.addColumn(col3, MSGS.certificateKeystoreName());
         
         TextColumn<GwtKeystoreEntry> col4 = new TextColumn<GwtKeystoreEntry>() {
+        	
         	@Override
         	public String getValue(GwtKeystoreEntry object) {
         		Date date = object.getValidityStartDate();
@@ -211,6 +213,7 @@ public class CertificateListTabUi extends Composite implements Tab, CertificateM
         col4.setSortable(true);
         
         TextColumn<GwtKeystoreEntry> col5 = new TextColumn<GwtKeystoreEntry>() {
+        	
         	@Override
         	public String getValue(GwtKeystoreEntry object) {
         		Date date = object.getValidityEndDate();
@@ -234,111 +237,63 @@ public class CertificateListTabUi extends Composite implements Tab, CertificateM
         this.certificatesGrid.setSelectionModel(this.selectionModel);
     }
 
+    private <U extends Comparable<U>> Comparator<GwtKeystoreEntry> getComparator(Function<GwtKeystoreEntry, U> comparableElementSupplier) {
+    	return new Comparator<GwtKeystoreEntry>() {
+
+			@Override
+			public int compare(GwtKeystoreEntry o1, GwtKeystoreEntry o2) {
+				if(o1 == o2)
+					return 0;
+				if(o1 == null)
+					return -1;
+				if(o2 == null)
+					return 1;
+				
+				U item1 = comparableElementSupplier.apply(o1);
+				U item2 = comparableElementSupplier.apply(o2);
+				
+				return item1.compareTo(item2);
+			}
+    	};
+    }
+    
     private ListHandler<GwtKeystoreEntry> getNameSortHandler(TextColumn<GwtKeystoreEntry> col3) {
         ListHandler<GwtKeystoreEntry> nameSortHandler = new ListHandler<>(certificatesDataProvider.getList());
-        nameSortHandler.setComparator(col3, (o1, o2) -> {
-            if (o1 == o2) {
-                return 0;
-            }
 
-            // Compare the name columns.
-            if (o1 != null) {
-                return o2 != null ? o1.getKeystoreName().compareTo(o2.getKeystoreName()) : 1;
-            }
-            return -1;
-        });
+        nameSortHandler.setComparator(col3, getComparator(GwtKeystoreEntry::getKeystoreName));
+        
         return nameSortHandler;
     }
 
     private ListHandler<GwtKeystoreEntry> getTypeSortHandler(TextColumn<GwtKeystoreEntry> col2) {
         ListHandler<GwtKeystoreEntry> typeSortHandler = new ListHandler<>(certificatesDataProvider.getList());
-        typeSortHandler.setComparator(col2, (o1, o2) -> {
-            if (o1 == o2) {
-                return 0;
-            }
 
-            // Compare the type columns.
-            if (o1 != null) {
-                return o2 != null ? o1.getKind().name().compareTo(o2.getKind().name()) : 1;
-            }
-            return -1;
-        });
+        typeSortHandler.setComparator(col2, getComparator(entry -> entry.getKind().name()));
+        
         return typeSortHandler;
     }
 
     private ListHandler<GwtKeystoreEntry> getAliasSortHandler(TextColumn<GwtKeystoreEntry> col1) {
         ListHandler<GwtKeystoreEntry> aliasSortHandler = new ListHandler<>(certificatesDataProvider.getList());
-        aliasSortHandler.setComparator(col1, (o1, o2) -> {
-            if (o1 == o2) {
-                return 0;
-            }
 
-            // Compare the alias columns.
-            if (o1 != null) {
-                return o2 != null ? o1.getAlias().compareTo(o2.getAlias()) : 1;
-            }
-            return -1;
-        });
+        aliasSortHandler.setComparator(col1, getComparator(GwtKeystoreEntry::getAlias));
+        
         return aliasSortHandler;
     }
     
     private ListHandler<GwtKeystoreEntry> getStartDateSortHandler(TextColumn<GwtKeystoreEntry> col4) {
         ListHandler<GwtKeystoreEntry> startDateSortHandler = new ListHandler<>(certificatesDataProvider.getList());
-        startDateSortHandler.setComparator(col4, (o1, o2) -> {
-            if (o1 == o2) {
-                return 0;
-            }
-
-            if (o1 == null) {
-            	return -1;
-            }
-            if(o2 == null) {
-            	return 1;
-            }
-            
-            // Compare the validity from columns
-            Date d1 = o1.getValidityStartDate();
-            Date d2 = o2.getValidityStartDate();
-            
-            if(d1 == null) {
-            	return -1;
-            }
-            if(d2 == null) {
-            	return 1;
-            }
-            
-            return d1.compareTo(d2);
-        });
+        
+        startDateSortHandler.setComparator(col4, getComparator(GwtKeystoreEntry::getValidityStartDate));
+ 
         return startDateSortHandler;
     }
     
     private ListHandler<GwtKeystoreEntry> getEndDateSortHandler(TextColumn<GwtKeystoreEntry> col5) {
         ListHandler<GwtKeystoreEntry> endDateSortHandler = new ListHandler<>(certificatesDataProvider.getList());
-        endDateSortHandler.setComparator(col5, (o1, o2) -> {
-            if (o1 == o2) {
-                return 0;
-            }
 
-            if (o1 == null) {
-            	return -1;
-            }
-            if(o2 == null) {
-            	return 1;
-            }
-            
-            // Compare the validity to columns
-            Date d1 = o1.getValidityEndDate();
-            Date d2 = o2.getValidityEndDate();
-            
-            if(d1 == null) {
-            	return -1;
-            }
-            if(d2 == null) {
-            	return 1;
-            }
-            
-            return d1.compareTo(d2);
-        });
+        endDateSortHandler.setComparator(col5, getComparator(GwtKeystoreEntry::getValidityEndDate));
+        
         return endDateSortHandler;
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
@@ -252,6 +252,13 @@ public class CertificateListTabUi extends Composite implements Tab, CertificateM
 				U item1 = comparableElementSupplier.apply(o1);
 				U item2 = comparableElementSupplier.apply(o2);
 				
+				if(item1 == item2)
+					return 0;
+				if(item1 == null)
+					return -1;
+				if(item2 == null)
+					return 1;
+				
 				return item1.compareTo(item2);
 			}
     	};

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
@@ -20,8 +20,11 @@ import java.security.KeyStore.Entry;
 import java.security.KeyStore.PrivateKeyEntry;
 import java.security.KeyStore.SecretKeyEntry;
 import java.security.KeyStore.TrustedCertificateEntry;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Date;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -138,18 +141,43 @@ public class GwtCertificatesServiceImpl extends OsgiRemoteServiceServlet impleme
                 for (final Map.Entry<String, Entry> e : service.getEntries().entrySet()) {
 
                     final Kind kind;
+                    
+                    Date validityStartDate = null;
+                    Date validityEndDate = null;
 
                     if (e.getValue() instanceof PrivateKeyEntry) {
                         kind = Kind.KEY_PAIR;
+                        
+                        PrivateKeyEntry pke = (PrivateKeyEntry) e.getValue();
+                        Certificate[] chain = pke.getCertificateChain();
+                        // retrieving the leaf of the chain
+                        if(chain.length > 0) {
+                        	Certificate leaf = chain[chain.length - 1];
+                        	
+                        	// downcast to X509 certificate for retrieving validity dates
+                        	if(leaf instanceof X509Certificate) {
+                        		validityStartDate = ((X509Certificate) leaf).getNotBefore();
+                        		validityEndDate = ((X509Certificate) leaf).getNotAfter();
+                        	}
+                        }
                     } else if (e.getValue() instanceof TrustedCertificateEntry) {
                         kind = Kind.TRUSTED_CERT;
+
+                        // downcast series to X509 certificate for retrieving validity dates
+                        TrustedCertificateEntry tce = (TrustedCertificateEntry) e.getValue();
+                        Certificate cert = tce.getTrustedCertificate();
+                        
+                        if(cert instanceof X509Certificate) {
+                        	validityStartDate = ((X509Certificate) cert).getNotBefore();
+                            validityEndDate = ((X509Certificate) cert).getNotAfter();
+                        }
                     } else if (e.getValue() instanceof SecretKeyEntry) {
                         kind = Kind.SECRET_KEY;
                     } else {
                         continue;
                     }
 
-                    result.add(new GwtKeystoreEntry(e.getKey(), (String) kuraServicePid, kind));
+                    result.add(new GwtKeystoreEntry(e.getKey(), (String) kuraServicePid, kind, validityStartDate, validityEndDate));
                 }
             } finally {
                 context.ungetService(ref);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
@@ -150,11 +150,10 @@ public class GwtCertificatesServiceImpl extends OsgiRemoteServiceServlet impleme
                         
                         PrivateKeyEntry pke = (PrivateKeyEntry) e.getValue();
                         Certificate[] chain = pke.getCertificateChain();
-                        // retrieving the leaf of the chain
+                        
                         if(chain.length > 0) {
                         	Certificate leaf = chain[chain.length - 1];
                         	
-                        	// downcast to X509 certificate for retrieving validity dates
                         	if(leaf instanceof X509Certificate) {
                         		validityStartDate = ((X509Certificate) leaf).getNotBefore();
                         		validityEndDate = ((X509Certificate) leaf).getNotAfter();
@@ -163,9 +162,7 @@ public class GwtCertificatesServiceImpl extends OsgiRemoteServiceServlet impleme
                     } else if (e.getValue() instanceof TrustedCertificateEntry) {
                         kind = Kind.TRUSTED_CERT;
 
-                        // downcast series to X509 certificate for retrieving validity dates
-                        TrustedCertificateEntry tce = (TrustedCertificateEntry) e.getValue();
-                        Certificate cert = tce.getTrustedCertificate();
+                        Certificate cert = ((TrustedCertificateEntry) e.getValue()).getTrustedCertificate();
                         
                         if(cert instanceof X509Certificate) {
                         	validityStartDate = ((X509Certificate) cert).getNotBefore();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/DateUtils.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/DateUtils.java
@@ -52,7 +52,7 @@ public class DateUtils {
         // return something like "Tomorrow 10:30 am"
         else if (dDayDiff >= 1) {
             DateTimeFormat dtf = DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.TIME_MEDIUM);
-            date = "Tomorrow" + dtf.format(d);
+            date = "Tomorrow " + dtf.format(d);
         }
 
         // if the modification time is still today, or it is midnight
@@ -60,7 +60,7 @@ public class DateUtils {
         // return something like "Today 10:30 am"
         else if (dDayDiff >= 0) {
             DateTimeFormat dtf = DateTimeFormat.getFormat(DateTimeFormat.PredefinedFormat.TIME_MEDIUM);
-            date = "Today" + dtf.format(d);
+            date = "Today " + dtf.format(d);
         }
 
         // if the modification time is yesterday,

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/DateUtils.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/DateUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtKeystoreEntry.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtKeystoreEntry.java
@@ -13,6 +13,7 @@
 package org.eclipse.kura.web.shared.model;
 
 import java.io.Serializable;
+import java.util.Date;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
 
@@ -29,10 +30,12 @@ public class GwtKeystoreEntry extends GwtBaseModel implements IsSerializable, Se
     public GwtKeystoreEntry() {
     }
 
-    public GwtKeystoreEntry(final String alias, final String keystoreName, final Kind kind) {
+    public GwtKeystoreEntry(final String alias, final String keystoreName, final Kind kind, final Date validityStart, final Date validityEnd) {
         set("alias", alias);
         set("keystoreName", keystoreName);
         set("kind", kind.toString());
+        set("validityStart", validityStart);
+        set("validityEnd", validityEnd);
     }
 
     public String getAlias() {
@@ -41,6 +44,14 @@ public class GwtKeystoreEntry extends GwtBaseModel implements IsSerializable, Se
 
     public String getKeystoreName() {
         return get("keystoreName");
+    }
+    
+    public Date getValidityStartDate() {
+    	return get("validityStart");
+    }
+    
+    public Date getValidityEndDate() {
+    	return get("validityEnd");
     }
 
     public Kind getKind() {

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -275,6 +275,8 @@ settingsReloadStartupFingerprintDescription=Allows to change the startup command
 certificateAlias=Alias
 certificateKeystoreName=Keystore Service Name
 certificateKind=Type
+certificateValidityStart=Valid from
+certificateValidityEnd=Valid to
 
 settingsSnapshots=Snapshots
 deviceSnapshotId=Snapshot Id


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Updated UI to display certificates validity information.

**Related Issue:** N/A.

**Description of the solution adopted:** Modified GwtKeystoreServiceImpl to be able to retrieve validity dates: inside the listEntries() method; downcast to X509Certificate type for retrieving the validity dates to pass in the GwtKeystoreEntry. Added two columns in CertificateListTabUi to display the new information and relative handlers to order the rows.

**Screenshots:** N/A.

**Any side note on the changes made:** Added new UI messages in Messages.properties (org.eclipse.kura.web.client.messages). In DateUtils (org.eclipse.kura.web.shared), added whitespaces for better date formatting when strings like "Today" are used.
