### PR TITLE
Allow using GwtComponentService.getPidsFromTarget to all identities

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtComponentService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtComponentService.java
@@ -195,5 +195,6 @@ public interface GwtComponentService extends RemoteService {
      */
     public List<String> getDriverFactoriesList(GwtXSRFToken xsrfToken) throws GwtKuraException;
 
+    @RequiredPermissions({})
     public List<String> getPidsFromTarget(GwtXSRFToken xsrfToken, String pid, String targetRef) throws GwtKuraException;
 }


### PR DESCRIPTION
Fixed configuration views containing target filters not working for a non-admin identity

Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

