### PR TITLE
Lo interface configuration review

### DIFF
--- a/kura/distrib/src/main/resources/common/network.interfaces
+++ b/kura/distrib/src/main/resources/common/network.interfaces
@@ -2,9 +2,7 @@
  
 # The loopback interface
 auto lo
-iface lo inet static
-	address 127.0.0.1
-	netmask 255.0.0.0
+iface lo inet loopback
 
 # Wireless interfaces
 auto wlan0

--- a/kura/distrib/src/main/resources/raspberry-pi-2/network.interfaces
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/network.interfaces
@@ -2,9 +2,7 @@
  
 # The loopback interface
 auto lo
-iface lo inet static
-	address 127.0.0.1
-	netmask 255.0.0.0
+iface lo inet loopback
 
 # Wired or wireless interfaces
 auto eth0

--- a/kura/org.eclipse.kura.linux.debian.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.debian.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
@@ -37,6 +37,7 @@ import org.eclipse.kura.net.NetConfigIP4;
 import org.eclipse.kura.net.NetInterfaceAddressConfig;
 import org.eclipse.kura.net.NetInterfaceConfig;
 import org.eclipse.kura.net.NetInterfaceStatus;
+import org.eclipse.kura.net.NetInterfaceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -463,20 +464,28 @@ public class NetInterfaceConfigSerializationServiceImpl implements NetInterfaceC
                     sb.append("\t post-up ").append(REMOVE_ROUTE_COMMAND).append("\n");
                 }
             } else {
-                logger.debug("new config is STATIC for {}", interfaceName);
-                sb.append("static\n");
-                // IPADDR
-                sb.append("\taddress ").append(netConfigIP4.getAddress().getHostAddress()).append("\n");
+                // in Debian, loopback interface cannot have assigned a static address
+                if (netInterfaceConfig.getType() == NetInterfaceType.LOOPBACK) {
+                    sb.append("loopback\n");
+                } else {
 
-                // NETMASK
-                sb.append("\tnetmask ").append(netConfigIP4.getSubnetMask().getHostAddress()).append("\n");
+                    logger.debug("new config is STATIC for {}", interfaceName);
 
-                // NETWORK
-                // TODO: Handle Debian NETWORK value
+                    sb.append("static\n");
 
-                // Gateway
-                if (netConfigIP4.getGateway() != null) {
-                    sb.append("\tgateway ").append(netConfigIP4.getGateway().getHostAddress()).append("\n");
+                    // IPADDR
+                    sb.append("\taddress ").append(netConfigIP4.getAddress().getHostAddress()).append("\n");
+
+                    // NETMASK
+                    sb.append("\tnetmask ").append(netConfigIP4.getSubnetMask().getHostAddress()).append("\n");
+
+                    // NETWORK
+                    // TODO: Handle Debian NETWORK value
+
+                    // Gateway
+                    if (netConfigIP4.getGateway() != null) {
+                        sb.append("\tgateway ").append(netConfigIP4.getGateway().getHostAddress()).append("\n");
+                    }
                 }
             }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -670,8 +670,16 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
     }
 
     private void refreshForm() {
+        this.status.setEnabled(true);
+        this.configure.setEnabled(true);
+        this.ip.setEnabled(true);
+        this.subnet.setEnabled(true);
+        this.gateway.setEnabled(true);
+        this.dns.setEnabled(true);
+        this.renew.setEnabled(true);
+
+        // disabling fields based on the interface
         if (this.selectedNetIfConfig != null && this.selectedNetIfConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
-            this.status.setEnabled(true);
             this.configure.setEnabled(false);
             this.ip.setEnabled(false);
             this.subnet.setEnabled(false);
@@ -679,11 +687,10 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
             if (VMSGS.netIPv4StatusDisabled().equals(this.status.getSelectedValue())
                     || VMSGS.netIPv4StatusUnmanaged().equals(this.status.getSelectedValue())) {
                 this.dns.setEnabled(false);
-            } else {
-                this.dns.setEnabled(true);
             }
             this.configure.setSelectedIndex(this.configure.getItemText(0).equals(IPV4_MODE_DHCP_MESSAGE) ? 0 : 1);
-        } else if (this.selectedNetIfConfig.getHwTypeEnum() == GwtNetIfType.LOOPBACK) {
+        } else if (this.selectedNetIfConfig != null
+                && this.selectedNetIfConfig.getHwTypeEnum() == GwtNetIfType.LOOPBACK) {
             // loopback interface should not be editable
             this.status.setEnabled(false);
             this.configure.setEnabled(false);
@@ -708,26 +715,17 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
                 this.gateway.setText("");
                 this.dns.setText("");
             } else {
-                this.configure.setEnabled(true);
+                // this.configure.setEnabled(true);
                 String configureValue = this.configure.getSelectedValue();
                 if (configureValue.equals(IPV4_MODE_DHCP_MESSAGE)) {
                     this.ip.setEnabled(false);
                     this.subnet.setEnabled(false);
                     this.gateway.setEnabled(false);
-                    this.renew.setEnabled(true);
-                    if (this.status.getSelectedValue().equals(IPV4_STATUS_WAN_MESSAGE)) {
-                        this.dns.setEnabled(true);
-                    } else {
+                    if (!this.status.getSelectedValue().equals(IPV4_STATUS_WAN_MESSAGE)) {
                         this.dns.setEnabled(false);
                     }
                 } else {
-                    this.ip.setEnabled(true);
-                    this.subnet.setEnabled(true);
-
-                    if (this.status.getSelectedValue().equals(IPV4_STATUS_WAN_MESSAGE)) {
-                        this.gateway.setEnabled(true);
-                        this.dns.setEnabled(true);
-                    } else {
+                    if (!this.status.getSelectedValue().equals(IPV4_STATUS_WAN_MESSAGE)) {
                         this.gateway.setText("");
                         this.gateway.setEnabled(false);
                         this.dns.setEnabled(false);
@@ -746,7 +744,6 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
         } else {
             this.dnsRead.setVisible(false);
         }
-
     }
 
     private void reset() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
@@ -683,6 +683,15 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
                 this.dns.setEnabled(true);
             }
             this.configure.setSelectedIndex(this.configure.getItemText(0).equals(IPV4_MODE_DHCP_MESSAGE) ? 0 : 1);
+        } else if (this.selectedNetIfConfig.getHwTypeEnum() == GwtNetIfType.LOOPBACK) {
+            // loopback interface should not be editable
+            this.status.setEnabled(false);
+            this.configure.setEnabled(false);
+            this.ip.setEnabled(false);
+            this.subnet.setEnabled(false);
+            this.gateway.setEnabled(false);
+            this.dns.setEnabled(false);
+            this.renew.setEnabled(false);
         } else {
             if (VMSGS.netIPv4StatusDisabled().equals(this.status.getSelectedValue())
                     || VMSGS.netIPv4StatusUnmanaged().equals(this.status.getSelectedValue())

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
@@ -715,7 +715,6 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
                 this.gateway.setText("");
                 this.dns.setText("");
             } else {
-                // this.configure.setEnabled(true);
                 String configureValue = this.configure.getSelectedValue();
                 if (configureValue.equals(IPV4_MODE_DHCP_MESSAGE)) {
                     this.ip.setEnabled(false);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -139,6 +139,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
     }
 
     private List<GwtNetInterfaceConfig> privateFindNetInterfaceConfigurations() throws GwtKuraException {
+
         logger.debug("Starting");
 
         List<GwtNetInterfaceConfig> gwtNetConfigs = new ArrayList<>();
@@ -236,8 +237,14 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
                                     gwtNetConfig.setStatus(GwtNetIfStatus.netIPv4StatusDisabled.name());
                                 }
 
-                                if (((NetConfigIP4) netConfig).isDhcp()) {
-                                    gwtNetConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
+                                if (((NetConfigIP4) netConfig).isDhcp() || netIfConfig.isLoopback()) {
+                                    if (((NetConfigIP4) netConfig).isDhcp()) {
+                                        gwtNetConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
+                                    }
+
+                                    if (netIfConfig.isLoopback()) {
+                                        gwtNetConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeManual.name());
+                                    }
 
                                     // since DHCP - populate current data
                                     if (addressConfig.getAddress() != null) {
@@ -1658,7 +1665,8 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
     }
 
     @Override
-    public List<GwtWifiHotspotEntry> findFrequencies(GwtXSRFToken xsrfToken, String interfaceName) throws GwtKuraException {
+    public List<GwtWifiHotspotEntry> findFrequencies(GwtXSRFToken xsrfToken, String interfaceName)
+            throws GwtKuraException {
         logger.info("Find Frequency Network Service impl");
         List<GwtNetInterfaceConfig> result = privateFindNetInterfaceConfigurations();
         List<GwtWifiHotspotEntry> channels = new ArrayList<GwtWifiHotspotEntry>();
@@ -1693,4 +1701,3 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
         }
     }
 }
-

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -246,7 +246,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
                                         gwtNetConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeManual.name());
                                     }
 
-                                    // since DHCP - populate current data
+                                    // since DHCP or loopback - populate current data
                                     if (addressConfig.getAddress() != null) {
                                         gwtNetConfig.setIpAddress(addressConfig.getAddress().getHostAddress());
                                     } else {


### PR DESCRIPTION
Brief description of the PR. Fixed initial loopback interface configuration and modified UI to not make the loopback interface editable in the "Network" tab.

**Related Issue:** N/A.

**Description of the solution adopted:** Updated the network.interfaces files that are used when Kura is installed in the (Debian) system with the correct configuration. Fixed the class that writes to the interfaces file to correctly write the loopback configuration details. Updated the UI in the "Network" tab to display the loopback address and netmask, and to not allow the user to edit the loopback interface.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
