### PR TITLE
Deployment agent NPE fix

### DIFF
--- a/kura/org.eclipse.kura.deployment.agent/OSGI-INF/deploymentagent.xml
+++ b/kura/org.eclipse.kura.deployment.agent/OSGI-INF/deploymentagent.xml
@@ -14,7 +14,7 @@
     Red Hat Inc 
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" name="org.eclipse.kura.deployment.agent">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.deployment.agent">
    <implementation class="org.eclipse.kura.deployment.agent.impl.DeploymentAgent"/>
    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
    <reference bind="setDeploymentAdmin" cardinality="1..1" interface="org.osgi.service.deploymentadmin.DeploymentAdmin" name="DeploymentAdmin" policy="static" unbind="unsetDeploymentAdmin"/>

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.kura.deployment.agent.impl;
 
+import static java.util.Objects.isNull;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -187,7 +189,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
     protected void deactivate(ComponentContext componentContext) {
         if (installerTask != null && !installerTask.isDone()) {
             logger.debug("Cancelling DeploymentAgent task ...");
-            installerTask.cancel(true);
+            installerTask.cancel(false);
             logger.info("DeploymentAgent task cancelled? = {}", installerTask.isDone());
             installerTask = null;
         }
@@ -207,7 +209,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
 
         if (uninstallerTask != null && !uninstallerTask.isDone()) {
             logger.debug("Cancelling DeploymentAgent:Uninstall task ...");
-            uninstallerTask.cancel(true);
+            uninstallerTask.cancel(false);
             logger.info("DeploymentAgent:Uninstall task cancelled? = {}", uninstallerTask.isDone());
             uninstallerTask = null;
         }
@@ -323,7 +325,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
             } catch (Exception e) {
                 logger.error("Unexpected exception", e);
             }
-        } while (true);
+        } while (!isNull(this.instPackageUrls));
     }
 
     private void execInstall(String url) {
@@ -364,7 +366,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
             } catch (Throwable t) {
                 logger.error("Unexpected throwable", t);
             }
-        } while (true);
+        } while (!isNull(this.uninstPackageNames));
     }
 
     private void execUninstall(String name) {

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -232,6 +232,11 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         this.instPackageUrls = null;
     }
 
+    public void updated(ComponentContext componentContext) {
+        logger.debug("Updating DeploymentAgent...");
+        logger.debug("DeploymentAgent updated");
+    }
+
     public void setDeploymentAdmin(DeploymentAdmin deploymentAdmin) {
         this.deploymentAdmin = deploymentAdmin;
     }


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Removed while(true) during installation and uninstallation in the DeploymentAgent.

**Related Issue:** This PR fixes #3378.

**Description of the solution adopted:** Added a condition to make the loop terminate. This avoids an infinite loop during the installation/uninstallation of packages.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
