### PR TITLE
Added target filter for H2DbService in the UI for the Store/Filter wire components

### DIFF
--- a/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/DbWireRecordFilterComponent.xml
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/DbWireRecordFilterComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -30,7 +30,6 @@
       <provide interface="org.osgi.service.wireadmin.Producer"/>
       <provide interface="org.osgi.service.wireadmin.Consumer"/>
    </service>
-   <property name="service.pid" value="org.eclipse.kura.wire.H2DbWireRecordFilter"/>
    <property name="kura.ui.service.hide" type="Boolean" value="true"/>
    <reference bind="bindWireHelperService"
               cardinality="1..1"
@@ -38,4 +37,10 @@
               name="WireHelperService"
               policy="static"
               unbind="unbindWireHelperService"/>
+   <reference name="H2DbService"
+           policy="dynamic"
+           bind="bindDbService"
+           unbind="unbindDbService"
+           cardinality="1..1"
+           interface="org.eclipse.kura.db.H2DbService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/DbWireRecordStoreComponent.xml
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/DbWireRecordStoreComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -30,7 +30,6 @@
       <provide interface="org.osgi.service.wireadmin.Producer"/>
       <provide interface="org.osgi.service.wireadmin.Consumer"/>
    </service>
-   <property name="service.pid" value="org.eclipse.kura.wire.H2DbWireRecordStore"/>
    <property name="kura.ui.service.hide" type="Boolean" value="true"/>
    <reference bind="bindWireHelperService"
    	          cardinality="1..1"
@@ -38,4 +37,10 @@
    	          name="WireHelperService"
    	          policy="static"
    	          unbind="unbindWireHelperService"/>
+   <reference name="H2DbService"
+           policy="dynamic"
+           bind="bindDbService"
+           unbind="unbindDbService"
+           cardinality="1..1"
+           interface="org.eclipse.kura.db.H2DbService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.H2DbWireRecordFilter.xml
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.H2DbWireRecordFilter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -38,13 +38,14 @@
         	description="This value specifies the cache validity in seconds. When cache expires, it will cause a new read in the database. A database read will be performed for every trigger received if the value is set to 0.">
         </AD>
         
-        <AD id="db.service.pid"
-            name="db.service.pid"
+        <AD id="H2DbService.target"
+            name="H2DbService Target Filter"
             type="String"
             cardinality="0"
             required="true"
-            default="org.eclipse.kura.db.H2DbService"
-            description="The Kura service pid of the H2 database instance to be used. The pid of the default instance is org.eclipse.kura.db.H2DbService."/>
+            default="(kura.service.pid=org.eclipse.kura.db.H2DbService)"
+            description="Specifies, as an OSGi target filter, the pid of the of the H2 database instance to be used.">
+        </AD>
             
         <AD id="emit.on.empty.result"
             name="emit.on.empty.result"

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.H2DbWireRecordStore.xml
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.H2DbWireRecordStore.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -45,16 +45,16 @@
             default="5000"
             description="Specifies the number of records in the table to keep while performing a cleanup operation (if set to 0 all the records will be deleted)."
             min="0">
-        </AD> 
+        </AD>
         
-        <AD id="db.service.pid"
-            name="db.service.pid"
+        <AD id="H2DbService.target"
+            name="H2DbService Target Filter"
             type="String"
             cardinality="0"
             required="true"
-            default="org.eclipse.kura.db.H2DbService"
-            description="The Kura service pid of the H2 database instance to be used. The pid of the default instance is org.eclipse.kura.db.H2DbService."/>
-            
+            default="(kura.service.pid=org.eclipse.kura.db.H2DbService)"
+            description="Specifies, as an OSGi target filter, the pid of the of the H2 database instance to be used.">
+        </AD>
     </OCD>
     
     <Designate pid="org.eclipse.kura.wire.H2DbWireRecordStore" factoryPid="org.eclipse.kura.wire.H2DbWireRecordStore">

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilterOptions.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilterOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,15 +20,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.kura.db.H2DbService;
-
 /**
  * The Class DbWireRecordFilterOptions is responsible to contain all the Db Wire
  * Record related filter options
  */
 final class H2DbWireRecordFilterOptions {
-
-    private static final String DB_SERVICE_INSTANCE = "db.service.pid";
 
     private static final String CONF_CACHE_EXPIRATION_INTERVAL = "cache.expiration.interval";
 
@@ -75,15 +71,6 @@ final class H2DbWireRecordFilterOptions {
             sqlView = String.valueOf(view);
         }
         return sqlView;
-    }
-
-    String getDbServiceInstancePid() {
-        String dbServicePid = H2DbService.DEFAULT_INSTANCE_PID;
-        final Object pid = this.properties.get(DB_SERVICE_INSTANCE);
-        if (nonNull(pid) && pid instanceof String) {
-            dbServicePid = pid.toString();
-        }
-        return dbServicePid;
     }
 
     boolean emitOnEmptyResult() {

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
@@ -140,6 +140,10 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
         this.wireSupport = this.wireHelperService.newWireSupport(this,
                 (ServiceReference<WireComponent>) componentContext.getServiceReference());
 
+        if (nonNull(this.dbService)) {
+            reconcileDB(this.wireRecordStoreOptions.getTableName());
+        }
+
         logger.debug("Activating DB Wire Record Store... Done");
     }
 
@@ -154,8 +158,7 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
 
         this.wireRecordStoreOptions = new H2DbWireRecordStoreOptions(properties);
 
-        final String tableName = this.wireRecordStoreOptions.getTableName();
-        reconcileDB(tableName);
+        reconcileDB(this.wireRecordStoreOptions.getTableName());
 
         logger.debug("Updating DB Wire Record Store... Done");
     }

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,6 @@ package org.eclipse.kura.internal.wire.h2db.store;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
-import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_PID;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -55,15 +54,9 @@ import org.eclipse.kura.wire.WireHelperService;
 import org.eclipse.kura.wire.WireReceiver;
 import org.eclipse.kura.wire.WireRecord;
 import org.eclipse.kura.wire.WireSupport;
-import org.osgi.framework.Filter;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
-import org.osgi.service.component.ComponentException;
 import org.osgi.service.wireadmin.Wire;
-import org.osgi.util.tracker.ServiceTracker;
-import org.osgi.util.tracker.ServiceTrackerCustomizer;
 
 /**
  * The Class DbWireRecordStore is a wire component which is responsible to store
@@ -98,23 +91,26 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
 
     private H2DbServiceHelper dbHelper;
 
+    private H2DbService dbService;
+
     private H2DbWireRecordStoreOptions wireRecordStoreOptions;
 
     private volatile WireHelperService wireHelperService;
 
     private WireSupport wireSupport;
 
-    private ServiceTracker<H2DbService, H2DbService> dbServiceTracker;
-
-    private ComponentContext componentContext;
-
-    public synchronized void bindDbService(final H2DbService dbService) {
-        H2DbWireRecordStore.this.dbHelper = H2DbServiceHelper.of(dbService);
+    public synchronized void bindDbService(H2DbService dbService) {
+        this.dbService = dbService;
+        this.dbHelper = H2DbServiceHelper.of(dbService);
         reconcileDB(this.wireRecordStoreOptions.getTableName());
     }
 
-    public synchronized void unbindDbService(final H2DbService dbService) {
-        H2DbWireRecordStore.this.dbHelper = null;
+    public synchronized void unbindDbService(H2DbService dbService) {
+        if (this.dbService == dbService) {
+            this.dbHelper = null;
+            this.dbService = null;
+            this.wireRecordStoreOptions = null;
+        }
     }
 
     public void bindWireHelperService(final WireHelperService wireHelperService) {
@@ -139,13 +135,11 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
      */
     protected void activate(final ComponentContext componentContext, final Map<String, Object> properties) {
         logger.debug("Activating DB Wire Record Store...");
-        this.componentContext = componentContext;
         this.wireRecordStoreOptions = new H2DbWireRecordStoreOptions(properties);
 
         this.wireSupport = this.wireHelperService.newWireSupport(this,
                 (ServiceReference<WireComponent>) componentContext.getServiceReference());
 
-        restartDbServiceTracker();
         logger.debug("Activating DB Wire Record Store... Done");
     }
 
@@ -158,16 +152,10 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
     public synchronized void updated(final Map<String, Object> properties) {
         logger.debug("Updating DB Wire Record Store...");
 
-        final String oldDbServicePid = this.wireRecordStoreOptions.getDbServiceInstancePid();
-
         this.wireRecordStoreOptions = new H2DbWireRecordStoreOptions(properties);
 
-        if (oldDbServicePid.equals(this.wireRecordStoreOptions.getDbServiceInstancePid())) {
-            final String tableName = this.wireRecordStoreOptions.getTableName();
-            reconcileDB(tableName);
-        } else {
-            restartDbServiceTracker();
-        }
+        final String tableName = this.wireRecordStoreOptions.getTableName();
+        reconcileDB(tableName);
 
         logger.debug("Updating DB Wire Record Store... Done");
     }
@@ -180,7 +168,9 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
      */
     protected void deactivate(final ComponentContext componentContext) {
         logger.debug("Deactivating DB Wire Record Store...");
-        stopDbServiceTracker();
+        this.dbHelper = null;
+        this.dbService = null;
+        this.wireRecordStoreOptions = null;
         logger.debug("Deactivating DB Wire Record Store... Done");
     }
 
@@ -250,23 +240,23 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
     @Override
     public synchronized void onWireReceive(final WireEnvelope wireEvelope) {
         requireNonNull(wireEvelope, "Wire Envelope cannot be null");
-
         final List<WireRecord> records = wireEvelope.getRecords();
 
-        if (this.dbHelper != null) {
-            try {
-                if (getTableSize() >= this.wireRecordStoreOptions.getMaximumTableSize()) {
-                    truncate();
-                }
-            } catch (SQLException e) {
-                logger.warn("Exception while trying to clean db");
-            }
+        if (this.dbHelper == null) {
+            logger.warn("H2DbService instance not attached");
+            return;
+        }
 
-            for (WireRecord wireRecord : records) {
-                store(wireRecord);
+        try {
+            if (getTableSize() >= this.wireRecordStoreOptions.getMaximumTableSize()) {
+                truncate();
             }
-        } else {
-            logger.warn("DbService instance not attached");
+        } catch (SQLException e) {
+            logger.warn("Exception while trying to clean db");
+        }
+
+        for (WireRecord wireRecord : records) {
+            store(wireRecord);
         }
 
         // emit the list of Wire Records to the downstream components
@@ -513,49 +503,6 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
         }
         return stmt;
 
-    }
-
-    protected void restartDbServiceTracker() {
-        stopDbServiceTracker();
-        try {
-            final Filter filter = FrameworkUtil.createFilter(
-                    "(" + KURA_SERVICE_PID + "=" + this.wireRecordStoreOptions.getDbServiceInstancePid() + ")");
-            this.dbServiceTracker = new ServiceTracker<>(this.componentContext.getBundleContext(), filter,
-                    new ServiceTrackerCustomizer<H2DbService, H2DbService>() {
-
-                        @Override
-                        public H2DbService addingService(ServiceReference<H2DbService> reference) {
-                            logger.info("H2DbService instance found");
-                            H2DbService h2DbService = H2DbWireRecordStore.this.componentContext.getBundleContext()
-                                    .getService(reference);
-                            bindDbService(h2DbService);
-                            return h2DbService;
-                        }
-
-                        @Override
-                        public void modifiedService(ServiceReference<H2DbService> reference, H2DbService service) {
-                            logger.info("H2DbService instance updated, recreating table if needed...");
-                            reconcileDB(H2DbWireRecordStore.this.wireRecordStoreOptions.getTableName());
-                        }
-
-                        @Override
-                        public void removedService(ServiceReference<H2DbService> reference, H2DbService service) {
-                            logger.info("H2DbService instance removed");
-                            unbindDbService(service);
-                            H2DbWireRecordStore.this.componentContext.getBundleContext().ungetService(reference);
-                        }
-                    });
-            this.dbServiceTracker.open();
-        } catch (InvalidSyntaxException e) {
-            throw new ComponentException(e);
-        }
-    }
-
-    private void stopDbServiceTracker() {
-        if (this.dbServiceTracker != null) {
-            this.dbServiceTracker.close();
-            this.dbServiceTracker = null;
-        }
     }
 
     /** {@inheritDoc} */

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreOptions.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,15 +20,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.kura.db.H2DbService;
-
 /**
  * The Class DbWireRecordStoreOptions is responsible to contain all the DB Wire
  * Record Store related options
  */
 final class H2DbWireRecordStoreOptions {
-
-    private static final String DB_SERVICE_INSTANCE = "db.service.pid";
 
     private static final int DEFAULT_MAXIMUM_TABLE_SIZE = 10000;
 
@@ -86,14 +82,5 @@ final class H2DbWireRecordStoreOptions {
             tableName = name.toString();
         }
         return tableName;
-    }
-
-    String getDbServiceInstancePid() {
-        String dbServicePid = H2DbService.DEFAULT_INSTANCE_PID;
-        final Object pid = this.properties.get(DB_SERVICE_INSTANCE);
-        if (nonNull(pid) && pid instanceof String) {
-            dbServicePid = pid.toString();
-        }
-        return dbServicePid;
     }
 }

--- a/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/h2db/store/test/H2DbWireRecordStoreTest.java
+++ b/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/h2db/store/test/H2DbWireRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/h2db/store/test/H2DbWireRecordStoreTest.java
+++ b/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/h2db/store/test/H2DbWireRecordStoreTest.java
@@ -246,7 +246,7 @@ public class H2DbWireRecordStoreTest {
         dependencyLatch.countDown();
     }
 
-    public void unbindDbSvc(WireComponent dbSvc) {
+    public void unbindDbSvc(H2DbService dbSvc) {
         H2DbWireRecordStoreTest.cfgsvc = null;
     }
 

--- a/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilterTest.java
+++ b/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilterTest.java
+++ b/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/filter/H2DbWireRecordFilterTest.java
@@ -58,16 +58,7 @@ public class H2DbWireRecordFilterTest {
 
         WireHelperService mockWireHelperService = mock(WireHelperService.class);
 
-        AtomicInteger resets = new AtomicInteger(0);
-        H2DbWireRecordFilter filter = new H2DbWireRecordFilter() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(mockDbService);
-
-                resets.set(resets.get() + 1);
-            }
-        };
+        H2DbWireRecordFilter filter = new H2DbWireRecordFilter();
         filter.bindWireHelperService(mockWireHelperService);
 
         WireSupport mockWireSupport = mock(WireSupport.class);
@@ -80,8 +71,7 @@ public class H2DbWireRecordFilterTest {
         properties.put("sql.view", expectedSqlView);
 
         filter.activate(mock(ComponentContext.class), properties);
-
-        assertEquals(1, resets.get());
+        filter.bindDbService(mockDbService);
 
         H2DbWireRecordFilterOptions options = (H2DbWireRecordFilterOptions) TestUtil.getFieldValue(filter, "options");
 
@@ -109,11 +99,7 @@ public class H2DbWireRecordFilterTest {
         expectedSqlView = "updated view";
         properties.put("cache.expiration.interval", expectedCacheExpirationInterval);
         properties.put("sql.view", expectedSqlView);
-        properties.put("db.service.pid", "newdbservicepid"); // trigger tracker reset
-
         filter.updated(properties);
-
-        assertEquals(2, resets.get());
 
         options = (H2DbWireRecordFilterOptions) TestUtil.getFieldValue(filter, "options");
 
@@ -135,13 +121,7 @@ public class H2DbWireRecordFilterTest {
 
         WireHelperService mockWireHelperService = mock(WireHelperService.class);
 
-        H2DbWireRecordFilter filter = new H2DbWireRecordFilter() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(mockDbService);
-            }
-        };
+        H2DbWireRecordFilter filter = new H2DbWireRecordFilter();
         filter.bindWireHelperService(mockWireHelperService);
 
         WireSupport mockWireSupport = mock(WireSupport.class);
@@ -152,6 +132,7 @@ public class H2DbWireRecordFilterTest {
         properties.put("sql.view", "view");
 
         filter.activate(mock(ComponentContext.class), properties);
+        filter.bindDbService(mockDbService);
 
         Wire[] wires = new Wire[2];
         wires[0] = mock(Wire.class);
@@ -170,13 +151,7 @@ public class H2DbWireRecordFilterTest {
 
         WireHelperService mockWireHelperService = mock(WireHelperService.class);
 
-        H2DbWireRecordFilter filter = new H2DbWireRecordFilter() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(mockDbService);
-            }
-        };
+        H2DbWireRecordFilter filter = new H2DbWireRecordFilter();
         filter.bindWireHelperService(mockWireHelperService);
 
         WireSupport mockWireSupport = mock(WireSupport.class);
@@ -187,6 +162,7 @@ public class H2DbWireRecordFilterTest {
         properties.put("sql.view", "sql command");
 
         filter.activate(mock(ComponentContext.class), properties);
+        filter.bindDbService(mockDbService);
 
         ResultSetMetaData mockResultSetMetaData = mock(ResultSetMetaData.class);
         when(mockResultSetMetaData.getColumnCount()).thenReturn(1);
@@ -213,13 +189,7 @@ public class H2DbWireRecordFilterTest {
 
         WireHelperService mockWireHelperService = mock(WireHelperService.class);
 
-        H2DbWireRecordFilter filter = new H2DbWireRecordFilter() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(mockDbService);
-            }
-        };
+        H2DbWireRecordFilter filter = new H2DbWireRecordFilter();
         filter.bindWireHelperService(mockWireHelperService);
 
         WireSupport mockWireSupport = mock(WireSupport.class);
@@ -230,6 +200,7 @@ public class H2DbWireRecordFilterTest {
         properties.put("sql.view", "view");
 
         filter.activate(mock(ComponentContext.class), properties);
+        filter.bindDbService(mockDbService);
 
         Wire mockWire = mock(Wire.class);
         filter.polled(mockWire);
@@ -243,13 +214,7 @@ public class H2DbWireRecordFilterTest {
 
         WireHelperService mockWireHelperService = mock(WireHelperService.class);
 
-        H2DbWireRecordFilter filter = new H2DbWireRecordFilter() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(mockDbService);
-            }
-        };
+        H2DbWireRecordFilter filter = new H2DbWireRecordFilter();
         filter.bindWireHelperService(mockWireHelperService);
 
         WireSupport mockWireSupport = mock(WireSupport.class);
@@ -260,6 +225,7 @@ public class H2DbWireRecordFilterTest {
         properties.put("sql.view", "view");
 
         filter.activate(mock(ComponentContext.class), properties);
+        filter.bindDbService(mockDbService);
 
         Wire[] wires = new Wire[2];
         wires[0] = mock(Wire.class);
@@ -276,13 +242,7 @@ public class H2DbWireRecordFilterTest {
 
         WireHelperService mockWireHelperService = mock(WireHelperService.class);
 
-        H2DbWireRecordFilter filter = new H2DbWireRecordFilter() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(mockDbService);
-            }
-        };
+        H2DbWireRecordFilter filter = new H2DbWireRecordFilter();
         filter.bindWireHelperService(mockWireHelperService);
 
         WireSupport mockWireSupport = mock(WireSupport.class);
@@ -293,6 +253,7 @@ public class H2DbWireRecordFilterTest {
         properties.put("sql.view", "view");
 
         filter.activate(mock(ComponentContext.class), properties);
+        filter.bindDbService(mockDbService);
 
         Wire mockWire = mock(Wire.class);
         filter.updated(mockWire, 42);

--- a/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreTest.java
+++ b/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreTest.java
+++ b/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreTest.java
@@ -29,7 +29,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.db.H2DbService;
+import org.eclipse.kura.internal.wire.h2db.common.H2DbServiceHelper;
 import org.eclipse.kura.type.BooleanValue;
 import org.eclipse.kura.type.ByteArrayValue;
 import org.eclipse.kura.type.DoubleValue;
@@ -80,17 +82,8 @@ public class H2DbWireRecordStoreTest {
 
         H2DbService dbServiceMock = createMockH2DbService(connection);
 
-        AtomicInteger resets = new AtomicInteger(0);
-        H2DbWireRecordStore store = new H2DbWireRecordStore() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(dbServiceMock);
-
-                resets.set(resets.get() + 1);
-            }
-        };
-
+        H2DbWireRecordStore store = new H2DbWireRecordStore();
+        
         WireHelperService whsMock = mock(WireHelperService.class);
         WireSupport wireSupportMock = mock(WireSupport.class);
         when(whsMock.newWireSupport(store, null)).thenReturn(wireSupportMock);
@@ -104,8 +97,7 @@ public class H2DbWireRecordStoreTest {
 
         // init
         store.activate(ctx, props);
-
-        assertEquals(1, resets.get());
+        store.bindDbService(dbServiceMock);
 
         String emitterPid = "emitter";
         List<WireRecord> wireRecords = new ArrayList<WireRecord>();
@@ -191,16 +183,7 @@ public class H2DbWireRecordStoreTest {
 
         // update the configuration
         store.updated(props);
-
-        assertEquals(1, resets.get()); // reset didn't happen
-
-        // update the configuration with a new DB service pid
-        props.put("db.service.pid", "newPid"); // trigger tracker reset
-
-        store.updated(props);
-
-        assertEquals(2, resets.get()); // reset happened
-
+        
         // deinit
         store.deactivate(null);
         connection.prepareStatement("SHUTDOWN").execute();
@@ -213,13 +196,7 @@ public class H2DbWireRecordStoreTest {
 
         H2DbService dbServiceMock = createMockH2DbService(connection);
 
-        H2DbWireRecordStore store = new H2DbWireRecordStore() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(dbServiceMock);
-            }
-        };
+        H2DbWireRecordStore store = new H2DbWireRecordStore();
 
         WireHelperService whsMock = mock(WireHelperService.class);
         WireSupport wireSupportMock = mock(WireSupport.class);
@@ -236,6 +213,7 @@ public class H2DbWireRecordStoreTest {
 
         // init
         store.activate(ctx, props);
+        store.bindDbService(dbServiceMock);
 
         String emitterPid = "emitter";
         List<WireRecord> wireRecords = new ArrayList<WireRecord>();
@@ -291,13 +269,7 @@ public class H2DbWireRecordStoreTest {
 
         H2DbService dbServiceMock = createMockH2DbService(connection);
 
-        H2DbWireRecordStore store = new H2DbWireRecordStore() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(dbServiceMock);
-            }
-        };
+        H2DbWireRecordStore store = new H2DbWireRecordStore();
 
         WireHelperService whsMock = mock(WireHelperService.class);
         WireSupport wireSupportMock = mock(WireSupport.class);
@@ -314,6 +286,7 @@ public class H2DbWireRecordStoreTest {
 
         // init
         store.activate(ctx, props);
+        store.bindDbService(dbServiceMock);
 
         String emitterPid = "emitter";
         List<WireRecord> wireRecords = new ArrayList<WireRecord>();
@@ -369,13 +342,7 @@ public class H2DbWireRecordStoreTest {
 
         H2DbService dbServiceMock = createMockH2DbService(connection);
 
-        H2DbWireRecordStore store = new H2DbWireRecordStore() {
-
-            @Override
-            protected void restartDbServiceTracker() {
-                bindDbService(dbServiceMock);
-            }
-        };
+        H2DbWireRecordStore store = new H2DbWireRecordStore();
 
         WireHelperService whsMock = mock(WireHelperService.class);
         WireSupport wireSupportMock = mock(WireSupport.class);
@@ -392,6 +359,7 @@ public class H2DbWireRecordStoreTest {
 
         // init
         store.activate(ctx, props);
+        store.bindDbService(dbServiceMock);
 
         String emitterPid = "emitter";
         List<WireRecord> wireRecords = new ArrayList<WireRecord>();


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Constrained the user to choose a proper target when creating a Store/Filter wire component for the H2DB service.

**Related Issue:** This PR closes #3353.

**Description of the solution adopted:** The UI in the configuration of the Filter/Store wire components is modified to display a list of targets instead of asking the user for the service.pid string. This prevents the user from inserting wrong pids. Corrected Filter's result cache behaviour. Before this PR, if the user changed the query to a wrong one, the previous results are returned. This is fine in some cases. It is not an expected behaviour when, for example, the user changes the query to read from a table that does not exist. So he gets results that seem to be related to the new query, even if they are not. Removed ServiceTracker calls since no more necessary and modified tests.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
