### PR TITLE
Keystore first password verification failure after reboot fix

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
@@ -241,7 +241,8 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         this.selfUpdaterFuture = this.selfUpdaterExecutor.scheduleAtFixedRate(() -> {
             try {
                 if (this.componentContext.getServiceReference() != null
-                        && this.configurationService.getComponentConfiguration(pid) != null) {
+                        && this.configurationService.getComponentConfiguration(pid) != null
+                        && this.configurationService.getComponentConfiguration(pid).getDefinition() != null) {
                     this.configurationService.updateConfiguration(pid, props);
                     throw new KuraRuntimeException(KuraErrorCode.CONFIGURATION_SNAPSHOT_TAKING,
                             "Updated. The task will be terminated.");


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Fixed SSL keystore password verification error after first reboot. 

**Related Issue:** N/A.

**Description of the solution adopted:** When the Keystore starts after first reboot, it changes the default password. It can happen that the Configuration Service is updating the configurations separately. The problem was that the Keystore didn't wait for the OCD to be updated from the Configuration Service before sending the update to it. In that case, the Configuration Service gets an update and deduces that the Keystore is not a configurable component since it is not able to retrieve the OCD (figure "ignore_keystore"). The password verification then fails when trying to access that keystore.
![ignore_keystore](https://user-images.githubusercontent.com/39562568/119102075-ef7fa200-ba19-11eb-9261-25f9e6c5fed2.png)

With the PR, the Keystore now waits for the Configuration Service to update the OCD (figure "fix").
![fix](https://user-images.githubusercontent.com/39562568/119102296-28b81200-ba1a-11eb-858f-c313799d0a1b.png)



**Screenshots:** Figures "ignore_keystore" and "fix".

**Any side note on the changes made:** N/A.
