### PR TITLE
Refactoring flooding protection configurator

### DIFF
--- a/kura/org.eclipse.kura.net.admin/OSGI-INF/firewallConfigurationService.xml
+++ b/kura/org.eclipse.kura.net.admin/OSGI-INF/firewallConfigurationService.xml
@@ -28,5 +28,4 @@
    </service>
    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
    <reference bind="setExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static" unbind="unsetExecutorService"/>
-   <reference bind="setFloodingProtectionConfigurationService" cardinality="0..1" interface="org.eclipse.kura.security.FloodingProtectionConfigurationService" name="FloodingProtectionConfigurationService" policy="static" unbind="unsetFloodingProtectionConfigurationService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationService.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
 package org.eclipse.kura.net.admin;
 
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.net.FirewallConfiguration;
@@ -61,5 +62,13 @@ public interface FirewallConfigurationService {
      * @throws KuraException
      */
     public void setFirewallNatConfiguration(List<FirewallNatConfig> natConfigs) throws KuraException;
+
+    /**
+     * Adds flooding protection rules to the firewall configuration.
+     * 
+     * @param floodingRules
+     *            Set of rules specified as Strings to protect against flooding attacks
+     */
+    public void addFloodingProtectionRules(Set<String> floodingRules);
 
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -52,14 +52,11 @@ import org.eclipse.kura.net.firewall.FirewallPortForwardConfigIP;
 import org.eclipse.kura.net.firewall.FirewallPortForwardConfigIP4;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
-import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
-import org.osgi.service.event.EventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FirewallConfigurationServiceImpl
-        implements FirewallConfigurationService, SelfConfiguringComponent, EventHandler {
+public class FirewallConfigurationServiceImpl implements FirewallConfigurationService, SelfConfiguringComponent {
 
     private static final Logger logger = LoggerFactory.getLogger(FirewallConfigurationServiceImpl.class);
 
@@ -306,12 +303,6 @@ public class FirewallConfigurationServiceImpl
         addNatRules(natRules);
     }
 
-    @Override
-    public void handleEvent(Event event) {
-        logger.debug("Received event: {}", event.getTopic());
-        // no events managed
-    }
-
     protected void addLocalRules(ArrayList<LocalRule> localRules) throws KuraException {
         this.firewall.addLocalRules(localRules);
     }
@@ -408,15 +399,8 @@ public class FirewallConfigurationServiceImpl
 
     @Override
     public void addFloodingProtectionRules(Set<String> floodingRules) {
-        if (this.firewall instanceof LinuxFirewall) {
-            addIpTablesFloodingProtectionRules(floodingRules);
-        }
-        // other firewall types here
-    }
-
-    private void addIpTablesFloodingProtectionRules(Set<String> floodingMangleRules) {
         try {
-            this.firewall.setAdditionalRules(new HashSet<String>(), new HashSet<String>(), floodingMangleRules);
+            this.firewall.setAdditionalRules(new HashSet<>(), new HashSet<>(), floodingRules);
         } catch (KuraException e) {
             logger.error("Failed to set Firewall Flooding Protection Configuration", e);
         }

--- a/kura/org.eclipse.kura.network.threat.manager/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.network.threat.manager/META-INF/MANIFEST.MF
@@ -19,4 +19,4 @@ Import-Package: javax.ws.rs;version="2.0.1",
  org.osgi.service.component;version="1.4.0",
  org.osgi.service.event;version="1.4.0",
  org.slf4j;version="1.7.25",
- org.eclipse.kura.net.admin;version="1.4.0"
+ org.eclipse.kura.net.admin;version="[1.4.0,2.0)"

--- a/kura/org.eclipse.kura.network.threat.manager/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.network.threat.manager/META-INF/MANIFEST.MF
@@ -18,4 +18,5 @@ Import-Package: javax.ws.rs;version="2.0.1",
  org.osgi.framework;version="1.10.0",
  org.osgi.service.component;version="1.4.0",
  org.osgi.service.event;version="1.4.0",
- org.slf4j;version="1.7.25"
+ org.slf4j;version="1.7.25",
+ org.eclipse.kura.net.admin;version="1.4.0"

--- a/kura/org.eclipse.kura.network.threat.manager/OSGI-INF/flooding_configuration_service.xml
+++ b/kura/org.eclipse.kura.network.threat.manager/OSGI-INF/flooding_configuration_service.xml
@@ -23,5 +23,5 @@
       <provide interface="org.eclipse.kura.security.FloodingProtectionConfigurationService"/>
    </service>
    <property name="kura.ui.service.hide" type="Boolean" value="true"/>
-   <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
+   <reference bind="setFirewallConfigurationService" unbind="unsetFirewallConfigurationService" cardinality="1..1" interface="org.eclipse.kura.net.admin.FirewallConfigurationService" name="FirewallConfigurationService" policy="static"/> 
 </scr:component>

--- a/kura/org.eclipse.kura.network.threat.manager/pom.xml
+++ b/kura/org.eclipse.kura.network.threat.manager/pom.xml
@@ -30,5 +30,6 @@
 
 	<properties>
 		<kura.basedir>${project.basedir}/..</kura.basedir>
+		<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test/*/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 </project>

--- a/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionConfigurator.java
+++ b/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionConfigurator.java
@@ -35,16 +35,12 @@ public class FloodingProtectionConfigurator
     private FirewallConfigurationService firewallService;
 
     public synchronized void setFirewallConfigurationService(FirewallConfigurationService firewallService) {
-        logger.info("Binding FirewallConfigurationService...");
         this.firewallService = firewallService;
-        logger.info("Binding FirewallConfigurationService... Done.");
     }
 
     public synchronized void unsetFirewallConfigurationService(FirewallConfigurationService firewallService) {
         if (this.firewallService == firewallService) {
-            logger.info("Unbinding FirewallConfigurationService...");
             this.firewallService = null;
-            logger.info("Unbinding FirewallConfigurationService... Done.");
         }
     }
 

--- a/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionConfigurator.java
+++ b/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionConfigurator.java
@@ -35,42 +35,42 @@ public class FloodingProtectionConfigurator
     private FirewallConfigurationService firewallService;
 
     public synchronized void setFirewallConfigurationService(FirewallConfigurationService firewallService) {
-        logger.debug("Binding FirewallConfigurationService...");
+        logger.info("Binding FirewallConfigurationService...");
         this.firewallService = firewallService;
-        logger.debug("Binding FirewallConfigurationService... Done.");
+        logger.info("Binding FirewallConfigurationService... Done.");
     }
 
     public synchronized void unsetFirewallConfigurationService(FirewallConfigurationService firewallService) {
         if (this.firewallService == firewallService) {
-            logger.debug("Unbinding FirewallConfigurationService...");
+            logger.info("Unbinding FirewallConfigurationService...");
             this.firewallService = null;
-            logger.debug("Unbinding FirewallConfigurationService... Done.");
+            logger.info("Unbinding FirewallConfigurationService... Done.");
         }
     }
 
     public void activate(ComponentContext componentContext, Map<String, Object> properties) {
-        logger.debug("Activating FloodingConfigurator...");
+        logger.info("Activating FloodingConfigurator...");
         doUpdate(properties);
-        logger.debug("Activating FloodingConfigurator... Done.");
+        logger.info("Activating FloodingConfigurator... Done.");
     }
 
     public void updated(Map<String, Object> properties) {
-        logger.debug("Updating FloodingConfigurator...");
+        logger.info("Updating FloodingConfigurator...");
         doUpdate(properties);
-        logger.debug("Updating FloodingConfigurator... Done.");
+        logger.info("Updating FloodingConfigurator... Done.");
     }
 
     public void deactivate(ComponentContext componentContext) {
-        logger.debug("Deactivating FloodingConfigurator...");
-        logger.debug("Deactivating FloodingConfigurator... Done.");
+        logger.info("Deactivating FloodingConfigurator...");
+        logger.info("Deactivating FloodingConfigurator... Done.");
     }
 
     private void doUpdate(Map<String, Object> properties) {
-        logger.debug("Updating firewall configuration...");
+        logger.info("Updating firewall configuration...");
         this.floodingProtectionOptions = new FloodingProtectionOptions(properties);
         this.firewallService
                 .addFloodingProtectionRules(this.floodingProtectionOptions.getFloodingProtectionMangleRules());
-        logger.debug("Updating firewall configuration... Done.");
+        logger.info("Updating firewall configuration... Done.");
     }
 
     @Override

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Map.Entry;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
@@ -43,6 +44,7 @@ import org.eclipse.kura.net.IP4Address;
 import org.eclipse.kura.net.IPAddress;
 import org.eclipse.kura.net.NetProtocol;
 import org.eclipse.kura.net.NetworkPair;
+import org.eclipse.kura.net.admin.event.FirewallConfigurationChangeEvent;
 import org.eclipse.kura.net.firewall.FirewallAutoNatConfig;
 import org.eclipse.kura.net.firewall.FirewallNatConfig;
 import org.eclipse.kura.net.firewall.FirewallOpenPortConfigIP;
@@ -515,16 +517,22 @@ public class FirewallConfigurationServiceImplTest {
         final LinuxFirewall mockFirewall = mock(LinuxFirewall.class);
         
         FirewallConfigurationServiceImpl svc = new FirewallConfigurationServiceImpl() {
+            
             @Override
             protected LinuxFirewall getLinuxFirewall() {
                 return mockFirewall;
-            }   
+            }
+            
+            @Override
+            public synchronized void updated(Map<String, Object> properties) {
+                // don't care about the properties in this test
+                // update is not called when adding flooding protection rules,
+                // it is called just during activate
+            }
         };
         
         ComponentContext mockContext = mock(ComponentContext.class);
-        Map<String, Object> floodingProperties = new HashMap<>();
-        floodingProperties.put("test", "test");
-        svc.activate(mockContext, floodingProperties);
+        svc.activate(mockContext, new HashMap<String, Object>());
         
         String[] floodingRules = {
                 "-A prerouting-kura -m conntrack --ctstate INVALID -j DROP",

--- a/kura/test/org.eclipse.kura.network.threat.manager.test/src/test/java/org/eclipse/kura/network/threat/manager/FloodingProtectionConfiguratorTest.java
+++ b/kura/test/org.eclipse.kura.network.threat.manager.test/src/test/java/org/eclipse/kura/network/threat/manager/FloodingProtectionConfiguratorTest.java
@@ -56,7 +56,6 @@ public class FloodingProtectionConfiguratorTest {
 
     private FloodingProtectionConfigurator floodingProtectionConfigurator;
     private FirewallConfigurationService mockFirewallService;
-    //private EventAdmin eaMock;
     private final Map<String, Object> properties = new HashMap<>();
 
     @Before

--- a/kura/test/org.eclipse.kura.network.threat.manager.test/src/test/java/org/eclipse/kura/network/threat/manager/FloodingProtectionConfiguratorTest.java
+++ b/kura/test/org.eclipse.kura.network.threat.manager.test/src/test/java/org/eclipse/kura/network/threat/manager/FloodingProtectionConfiguratorTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.internal.floodingprotection.FloodingProtectionConfigurator;
+import org.eclipse.kura.net.admin.FirewallConfigurationService;
 import org.eclipse.kura.security.FloodingProtectionConfigurationChangeEvent;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,21 +54,21 @@ public class FloodingProtectionConfiguratorTest {
             "-A prerouting-kura -p icmp -j DROP", "-A prerouting-kura -f -j DROP" };
 
     private FloodingProtectionConfigurator floodingProtectionConfigurator;
-    private EventAdmin eaMock;
+    private FirewallConfigurationService mockFirewallService;
+    //private EventAdmin eaMock;
     private final Map<String, Object> properties = new HashMap<>();
 
     @Before
     public void setupTests() {
-        this.eaMock = mock(EventAdmin.class);
         this.floodingProtectionConfigurator = new FloodingProtectionConfigurator();
-        this.floodingProtectionConfigurator.setEventAdmin(this.eaMock);
+        this.mockFirewallService = mock(FirewallConfigurationService.class);
+        this.floodingProtectionConfigurator.setFirewallConfigurationService(this.mockFirewallService);
         this.properties.put("flooding.protection.enabled", true);
     }
 
     @Test
     public void activateTest() throws KuraException, NoSuchFieldException {
         this.floodingProtectionConfigurator.activate(null, this.properties);
-        verify(this.eaMock, times(1)).postEvent(new FloodingProtectionConfigurationChangeEvent(this.properties));
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.network.threat.manager.test/src/test/java/org/eclipse/kura/network/threat/manager/FloodingProtectionConfiguratorTest.java
+++ b/kura/test/org.eclipse.kura.network.threat.manager.test/src/test/java/org/eclipse/kura/network/threat/manager/FloodingProtectionConfiguratorTest.java
@@ -100,7 +100,7 @@ public class FloodingProtectionConfiguratorTest {
                 .containsAll(Arrays.asList(FLOODING_PROTECTION_MANGLE_RULES)));
     }
     
-    @Test
+    @Test(expected = NullPointerException.class)
     public void addFloodingRulesTest() {
         this.floodingProtectionConfigurator = new FloodingProtectionConfigurator();
         this.floodingProtectionConfigurator.setFirewallConfigurationService(mockFirewallService);
@@ -118,11 +118,6 @@ public class FloodingProtectionConfiguratorTest {
         
         this.floodingProtectionConfigurator.unsetFirewallConfigurationService(mockFirewallService);
         
-        try {
-            this.floodingProtectionConfigurator.updated(this.properties);
-            assert(false);
-        } catch(Exception e) {
-            // exception is correct
-        }
+        this.floodingProtectionConfigurator.updated(this.properties);
     }
 }


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Review of the flooding protection rules management.

**Related Issue:** N/A.

**Description of the solution adopted:** The FirewallConfigurationService now exposes a method to add flooding protection rules to the underlying iptables. This methods are very specific to iptables, so this solution is not as general as it could be. With this PR, FloodingProtectionConfigurator do not use events anymore to signal the FirewallConfigurationService that configuration has changed. Instead, communication is done by referencing the previously cited method of the FirewallConfigurationService. Modified tests to accommodate these new changes.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
