### PR TITLE
Fixed empty target filters in wire composer before save

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -259,7 +259,7 @@ public abstract class AbstractServicesUi extends Composite {
 
             RequestQueue.submit(context -> this.gwtXSRFService.generateSecurityToken(
                     context.callback(token -> AbstractServicesUi.this.gwtComponentService.getPidsFromTarget(token,
-                            this.configurableComponent.getComponentId(), targetedService, context.callback(data -> {
+                            getSCRComponentName(this.configurableComponent), targetedService, context.callback(data -> {
                                 if (data.isEmpty()) {
                                     dropDownHeader.setText(MSGS.noTargetsAvailable());
                                 } else {
@@ -276,6 +276,16 @@ public abstract class AbstractServicesUi extends Composite {
         }
 
         textBox.validate(true);
+    }
+
+    private static final String getSCRComponentName(final GwtConfigComponent component) {
+        final String factoryPid = component.getFactoryId();
+
+        if (factoryPid != null) {
+            return factoryPid;
+        }
+
+        return component.getComponentId();
     }
 
     private AnchorListItem createListItem(final TextBoxBase textBox, String targetEntry) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtComponentServiceInternal.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtComponentServiceInternal.java
@@ -668,7 +668,7 @@ public class GwtComponentServiceInternal {
         return driverFactoriesPids;
     }
 
-    public static List<String> getPidsFromTarget(String pid, String targetRef) {
+    public static List<String> getPidsFromTarget(final String componentName, final String targetRef) {
 
         List<String> result = new ArrayList<>();
 
@@ -679,12 +679,7 @@ public class GwtComponentServiceInternal {
             final ServiceComponentRuntime scrService = context.getService(scrServiceRef);
 
             final Set<String> referenceInterfaces = scrService.getComponentDescriptionDTOs().stream()
-                    .filter(componentDescription -> scrService.getComponentConfigurationDTOs(componentDescription)
-                            .stream().anyMatch(componentConfiguration -> {
-                                String kuraServicePid = (String) componentConfiguration.properties
-                                        .get(ConfigurationService.KURA_SERVICE_PID);
-                                return kuraServicePid != null && kuraServicePid.equals(pid);
-                            }))
+                    .filter(componentDescription -> componentDescription.name.equals(componentName))
                     .map(componentDescription -> {
                         ReferenceDTO[] references = componentDescription.references;
                         for (ReferenceDTO reference : references) {


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

Fixed empty target filters in wire composer before changes are saved.
Change assume that the `ConfigurableComponent`s  that define the configurable reverence have a DS component definition whose name matches either its factory pid (in case of factory component) of the kura.service.pid otherwise.
