### PR TITLE
[Backport] The connection exception is now logged if the connect button is used.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCloudConnectionServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCloudConnectionServiceImpl.java
@@ -527,7 +527,7 @@ public class GwtCloudConnectionServiceImpl extends OsgiRemoteServiceServlet impl
                                 counter--;
                             }
                         } catch (KuraConnectException e) {
-                            logger.warn("Error connecting");
+                            logger.warn("Error connecting", e);
                             gwtKuraException = new GwtKuraException(GwtKuraErrorCode.CONNECTION_FAILURE, e,
                                     "Error connecting. Please review your configuration.");
                         } catch (InterruptedException e) {
@@ -535,7 +535,7 @@ public class GwtCloudConnectionServiceImpl extends OsgiRemoteServiceServlet impl
                             gwtKuraException = new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e,
                                     "Interrupt Exception");
                         } catch (IllegalStateException e) {
-                            logger.warn("Illegal client state");
+                            logger.warn("Illegal client state", e);
                             gwtKuraException = new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e,
                                     "Illegal client state");
                         }


### PR DESCRIPTION
As of now, if the data service tries to connect as part of the auto-retry
task, the exception related is displayed.
Such exception is not displayed if the connect button is used.
A GwtKuraException is thown and sent to the client part but it is not
anymore logged.

Signed-off-by: Maiero <matteo.maiero@eurotech.com>
