### PR TITLE
Added version to keystore rest apis

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/rest/provider/KeystoreRestService.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/rest/provider/KeystoreRestService.java
@@ -33,7 +33,7 @@ import org.eclipse.kura.security.keystore.KeystoreInfo;
 import org.osgi.service.useradmin.Role;
 import org.osgi.service.useradmin.UserAdmin;
 
-@Path("/keystores")
+@Path("/keystores/v1")
 public class KeystoreRestService extends KeystoreRemoteService {
 
     private static final String BAD_REQUEST_MESSAGE = "Bad request, ";

--- a/kura/org.eclipse.kura.core.tamper.detection/src/main/java/org/eclipse/kura/core/tamper/detection/TamperDetectionRestService.java
+++ b/kura/org.eclipse.kura.core.tamper.detection/src/main/java/org/eclipse/kura/core/tamper/detection/TamperDetectionRestService.java
@@ -31,7 +31,7 @@ import org.eclipse.kura.core.tamper.detection.util.TamperDetectionRemoteService;
 import org.osgi.service.useradmin.Role;
 import org.osgi.service.useradmin.UserAdmin;
 
-@Path("/tamper")
+@Path("/tamper/v1")
 public class TamperDetectionRestService extends TamperDetectionRemoteService {
 
     public void setUserAdmin(final UserAdmin userAdmin) {

--- a/kura/test/org.eclipse.kura.core.tamper.detection.test/src/main/java/org/eclipse/kura/core/tamper/detection/test/RestTransport.java
+++ b/kura/test/org.eclipse.kura.core.tamper.detection.test/src/main/java/org/eclipse/kura/core/tamper/detection/test/RestTransport.java
@@ -33,7 +33,7 @@ public class RestTransport implements Transport {
     private static final Encoder ENCODER = Base64.getEncoder();
     private static final Logger logger = LoggerFactory.getLogger(RestTransport.class);
 
-    private static final String BASE_URL = "http://localhost:8080/services/tamper/";
+    private static final String BASE_URL = "http://localhost:8080/services/tamper/v1/";
 
     private boolean initialized = false;
 


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

This PR adds a **v1** version to the rest path for keystore management in order to version also the rest apis and to allow future evolutions.
