### PR TITLE
Backport: Fix network managing with existing conf files (#3423)

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-centos-7/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7/kura_install.sh
@@ -103,6 +103,13 @@ if [ ! -d /etc/logrotate.d/ ]; then
 fi
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#assigning possible .conf files ownership to kurad
+PATTERN="/etc/dhcpd*.conf* /etc/resolv.conf* /etc/wpa_supplicant*.conf* /etc/hostapd*.conf*"
+for FILE in $(ls $PATTERN 2>/dev/null)
+do
+  chown kurad:kurad $FILE
+done
+
 # Setup tmpfiles.d
 cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /usr/lib/tmpfiles.d/kura.conf
 

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
@@ -96,6 +96,13 @@ fi
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#assigning possible .conf files ownership to kurad
+PATTERN="/etc/dhcpd*.conf* /etc/resolv.conf* /etc/wpa_supplicant*.conf* /etc/hostapd*.conf*"
+for FILE in $(ls $PATTERN 2>/dev/null)
+do
+  chown kurad:kurad $FILE
+done
+
 # execute patch_sysctl.sh from installer install folder
 chmod 700 ${INSTALL_DIR}/kura/install/patch_sysctl.sh
 ${INSTALL_DIR}/kura/install/patch_sysctl.sh ${INSTALL_DIR}/kura/install/sysctl.kura.conf /etc/sysctl.conf

--- a/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
@@ -99,6 +99,13 @@ fi
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#assigning possible .conf files ownership to kurad
+PATTERN="/etc/dhcpd*.conf* /etc/resolv.conf* /etc/wpa_supplicant*.conf* /etc/hostapd*.conf*"
+for FILE in $(ls $PATTERN 2>/dev/null)
+do
+  chown kurad:kurad $FILE
+done
+
 # execute patch_sysctl.sh from installer install folder
 chmod 700 ${INSTALL_DIR}/kura/install/patch_sysctl.sh
 ${INSTALL_DIR}/kura/install/patch_sysctl.sh ${INSTALL_DIR}/kura/install/sysctl.kura.conf /etc/sysctl.conf


### PR DESCRIPTION
* Reassigned ownership of configuration in /etc folder to kurad user.

* Reassigned ownership of configuration in /etc folder to kurad user. Closes #3391
