### PR TITLE
h2db impl service now provides org.eclipse.kura.db.BaseDbService inte…

### DIFF
--- a/kura/org.eclipse.kura.core/OSGI-INF/h2db.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/h2db.xml
@@ -17,6 +17,7 @@
    <implementation class="org.eclipse.kura.core.db.H2DbServiceImpl"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
+      <provide interface="org.eclipse.kura.db.BaseDbService"/>
       <provide interface="org.eclipse.kura.db.H2DbService"/>
    </service>
    <property name="service.pid" value="org.eclipse.kura.core.db.H2DbService"/>


### PR DESCRIPTION
…rface

Signed-off-by: Maiero <matteo.maiero@eurotech.com>

This PR changes the list of services provided by the h2db service implementation to not expose it only as provider of org.eclipse.kura.db.H2DbService but also of org.eclipse.kura.db.BaseDbService

**Related Issue:** This PR fixes/closes #3395 

**Description of the solution adopted:** N/A

**Screenshots:** N/A

**Any side note on the changes made:** N/A
