### PR TITLE
Backport Fix UI security section (#3408)

### DIFF
--- a/kura/org.eclipse.kura.http.server.manager/OSGI-INF/metatype/org.eclipse.kura.http.server.manager.HttpService.xml
+++ b/kura/org.eclipse.kura.http.server.manager/OSGI-INF/metatype/org.eclipse.kura.http.server.manager.HttpService.xml
@@ -56,14 +56,14 @@
             default="(kura.service.pid=changeme)"
             description="Specifies, as an OSGi target filter, the pid of the KeystoreService used to manage the HTTPS Keystore.">
         </AD>
-
+      
         <AD id="https.revocation.check.enabled"
             name="Revocation Check Enabled"
             type="Boolean"
             cardinality="0"
             required="false"
             default="false"
-            description="If enabled, the revocation status of client certificates will be ckeched during TLS handshake. If a revoked certificate is detected, handshake will fail. The revocation status will be checked using OCSP, CRLDP or the CRLs cached by the attached KeystoreService instance, depending on the value of the Revocation Check Mode parameter. If not enabled, revocation ckeck will not be performed."/>
+            description="If enabled, the revocation status of client certificates will be checked during TLS handshake. If a revoked certificate is detected, the following handshake will fail. The revocation status will be checked using OCSP, CRLDP, or the CRLs cached by the attached KeystoreService instance, depending on the value of the Revocation Check Mode parameter. If not enabled, the revocation check will not be performed."/>
 
         <AD id="ssl.revocation.mode"
             name="Revocation Check Mode"
@@ -83,8 +83,7 @@
             cardinality="0"
             required="false"
             default="false"
-            description="Specifies whether the revocation soft fail is enabled or not. If it is enabled and the gateway is not able verify the revocation status of a client certificate (for example due to a connectivity problem), the certificate will be rejected. This parameter is ignored if Revocation Check Enabled is set to false."/>
-
+            description="Specifies whether the revocation soft fail is enabled or not. If it is enabled and the gateway is not able to verify the revocation status of a client certificate (for example due to a connectivity problem), the certificate will be rejected. This parameter is ignored if Revocation Check Enabled is set to false."/>
     </OCD>
 
     <Designate pid="org.eclipse.kura.http.server.manager.HttpService">

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AlertDialog.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AlertDialog.java
@@ -4,9 +4,9 @@
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -179,8 +179,6 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
     @UiField
     Panel sidenavOverlay;
     @UiField
-    Label serviceDescription;
-    @UiField
     Button logoutButton;
     @UiField
     Button headerLogoutButton;
@@ -822,7 +820,6 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
 
     private void setHeader(final String title, final String subTitle) {
         this.contentPanelHeader.setText(title);
-        this.serviceDescription.setText(subTitle != null ? subTitle : "");
     }
 
     public void render(GwtConfigComponent item) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -113,6 +113,10 @@
 		white-space:
 		pre-wrap;
 		}
+        
+        .panel-footer {
+        margin-left: 5vh;
+        }
 	</ui:style>
 
 	<b:Container fluid="true">
@@ -268,9 +272,6 @@
 										addStyleNames="content-panel">
 										<b:PanelHeader ui:field="contentPanelHeader"
 											addStyleNames="{style.content-panel-header}" />
-										<b:Row>
-											<g:Label ui:field="serviceDescription" />
-										</b:Row>
 										<b:PanelBody ui:field="contentPanelBody"
 											addStyleNames="{style.content-panel-body}">
 										</b:PanelBody>
@@ -287,7 +288,7 @@
 						size="MD_12">
 						<b:Row>
 							<b:Panel>
-								<b:PanelFooter>
+								<b:PanelFooter addStyleNames="{style.panel-footer}">
 									<b:Row>
 										<b:Column size="MD_6,XS_6">
 											<b.html:Paragraph alignment="LEFT">

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/NewPasswordInput.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/NewPasswordInput.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui;
 
-import org.eclipse.kura.web.client.util.PasswordStrengthValidators;
+import org.eclipse.kura.web.client.ui.validator.PasswordStrengthValidators;
 import org.eclipse.kura.web.shared.model.GwtConsoleUserOptions;
 import org.gwtbootstrap3.client.ui.Input;
 import org.gwtbootstrap3.client.ui.form.validator.Validator;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/RestrictedComponentServiceUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/RestrictedComponentServiceUi.ui.xml
@@ -22,7 +22,13 @@
 
     <ui:with field="msgs" type="org.eclipse.kura.web.client.messages.Messages"></ui:with>
 
+    
     <b:Container fluid="true">
+        <b:Column size="MD12">
+            <b:Row>
+                <b.html:Br />
+            </b:Row>
+        </b:Column>
         <b:Column size="MD12">
             <b:Row>
                 <g:HTMLPanel>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -60,6 +60,7 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
+import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 
 public class ServicesUi extends AbstractServicesUi {
@@ -86,6 +87,8 @@ public class ServicesUi extends AbstractServicesUi {
     FormGroup validatedGroup;
     Modal modal;
 
+    @UiField
+    Label serviceDescription;
     @UiField
     Button apply;
     @UiField
@@ -132,6 +135,8 @@ public class ServicesUi extends AbstractServicesUi {
         this.originalConfig = addedItem;
         restoreConfiguration(this.originalConfig);
         this.fields.clear();
+
+        this.serviceDescription.setText(addedItem.getComponentDescription());
 
         this.apply.setText(MSGS.apply());
         this.apply.addClickHandler(event -> apply());
@@ -184,10 +189,10 @@ public class ServicesUi extends AbstractServicesUi {
         if (isDirty()) {
             // Modal
             this.modal = new Modal();
-            modal.setClosable(false);
-            modal.setFade(true);
-            modal.setDataKeyboard(true);
-            modal.setDataBackdrop(ModalBackdrop.STATIC);
+            this.modal.setClosable(false);
+            this.modal.setFade(true);
+            this.modal.setDataKeyboard(true);
+            this.modal.setDataBackdrop(ModalBackdrop.STATIC);
 
             ModalHeader header = new ModalHeader();
             header.setTitle(MSGS.confirm());
@@ -219,7 +224,7 @@ public class ServicesUi extends AbstractServicesUi {
 
                     @Override
                     public void run() {
-                        listener.ifPresent(Listener::onConfigurationChanged);
+                        ServicesUi.this.listener.ifPresent(Listener::onConfigurationChanged);
                     }
                 };
 
@@ -325,20 +330,20 @@ public class ServicesUi extends AbstractServicesUi {
 
                 final List<String> messages;
 
-                if (validator.isPresent()) {
-                    final List<ValidationResult> result = validator.get().validate(this.configurableComponent);
+                if (this.validator.isPresent()) {
+                    final List<ValidationResult> result = this.validator.get().validate(this.configurableComponent);
                     messages = result.stream().map(ValidationResult::getMessage).collect(Collectors.toList());
 
                     if (result.stream().anyMatch(r -> r instanceof ServicesUi.Error)) {
-                        alertDialog.show(MSGS.error(), MSGS.formWithErrorsOrIncomplete(), AlertDialog.Severity.ERROR,
-                                null, messages.toArray(new String[messages.size()]));
+                        this.alertDialog.show(MSGS.error(), MSGS.formWithErrorsOrIncomplete(),
+                                AlertDialog.Severity.ERROR, null, messages.toArray(new String[messages.size()]));
                         return;
                     }
                 } else {
                     messages = Collections.emptyList();
                 }
 
-                alertDialog.show(MSGS.confirm(),
+                this.alertDialog.show(MSGS.confirm(),
                         MSGS.deviceConfigConfirmation(this.configurableComponent.getComponentName()),
                         AlertDialog.Severity.INFO, ok -> {
                             if (ok) {
@@ -355,7 +360,8 @@ public class ServicesUi extends AbstractServicesUi {
                                                                         ? caught.getLocalizedMessage()
                                                                         : caught.getClass().getName(),
                                                                 caught);
-                                                        onApply.ifPresent(action -> action.accept(Optional.of(caught)));
+                                                        ServicesUi.this.onApply.ifPresent(
+                                                                action -> action.accept(Optional.of(caught)));
                                                     }
 
                                                     @Override
@@ -367,7 +373,8 @@ public class ServicesUi extends AbstractServicesUi {
                                                         ServicesUi.this.originalConfig = ServicesUi.this.configurableComponent;
                                                         context.defer(2000, () -> ServicesUi.this.listener
                                                                 .ifPresent(Listener::onConfigurationChanged));
-                                                        onApply.ifPresent(action -> action.accept(Optional.empty()));
+                                                        ServicesUi.this.onApply
+                                                                .ifPresent(action -> action.accept(Optional.empty()));
                                                     }
                                                 })))));
                             }
@@ -376,7 +383,7 @@ public class ServicesUi extends AbstractServicesUi {
 
         } else {
             errorLogger.log(Level.SEVERE, "Device configuration error!");
-            alertDialog.show(MSGS.warning(), MSGS.formWithErrorsOrIncomplete(), AlertDialog.Severity.ERROR,
+            this.alertDialog.show(MSGS.warning(), MSGS.formWithErrorsOrIncomplete(), AlertDialog.Severity.ERROR,
                     (ConfirmListener) null);
         }
     }
@@ -429,8 +436,9 @@ public class ServicesUi extends AbstractServicesUi {
             this.message = message;
         }
 
+        @Override
         public String getMessage() {
-            return message;
+            return this.message;
         }
     }
 
@@ -442,8 +450,9 @@ public class ServicesUi extends AbstractServicesUi {
             this.message = message;
         }
 
+        @Override
         public String getMessage() {
-            return message;
+            return this.message;
         }
     }
 
@@ -467,13 +476,13 @@ public class ServicesUi extends AbstractServicesUi {
         @Override
         public void updateComponentConfiguration(GwtXSRFToken token, GwtConfigComponent component,
                 AsyncCallback<Void> callback) {
-            gwtComponentService.updateComponentConfiguration(token, component, callback);
+            this.gwtComponentService.updateComponentConfiguration(token, component, callback);
 
         }
 
         @Override
         public void deleteFactoryConfiguration(GwtXSRFToken token, String pid, AsyncCallback<Void> callback) {
-            gwtComponentService.deleteFactoryConfiguration(token, pid, true, callback);
+            this.gwtComponentService.deleteFactoryConfiguration(token, pid, true, callback);
         }
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/ServicesUi.ui.xml
@@ -2,16 +2,16 @@
 
 <!--
 
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
-  
+    Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
- 
-	SPDX-License-Identifier: EPL-2.0
-	
-	Contributors:
-	 Eurotech
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
 
 -->
 
@@ -50,6 +50,10 @@
     </ui:style>
 
     <b:Container fluid="true">
+        <b:Row>
+            <b.html:Br />
+            <g:Label ui:field="serviceDescription" />
+        </b:Row>
         <b:Row b:id="confirmDialog">
             <b:Panel>
                 <b:ButtonGroup size="SMALL">

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
 import org.eclipse.kura.web.client.ui.NewPasswordInput;
-import org.eclipse.kura.web.client.ui.RegexValidator;
+import org.eclipse.kura.web.client.ui.validator.RegexValidator;
 import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.client.util.HelpButton;
 import org.eclipse.kura.web.client.util.MessageUtils;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.ui.xml
@@ -8,10 +8,10 @@
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
  
-	SPDX-License-Identifier: EPL-2.0
-	
-	Contributors:
-	 Eurotech
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+    Eurotech
 
 -->
 
@@ -20,23 +20,31 @@
     xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt"
     xmlns:kura="urn:import:org.eclipse.kura.web.client.ui">
 
+    <ui:with field="msgs" type="org.eclipse.kura.web.client.messages.Messages" />
+
     <ui:style>
     .important {
-    	font-weight: bold;
+        font-weight: bold;
     }
-    
+
     .modal-scroll-panel {
-    	max-height: 70vh;
+        max-height: 70vh;
     }
     </ui:style>
 
     <b:Container fluid="true">
         <b:Column size="MD_12">
             <b:Row>
+                <b.html:Paragraph alignment="LEFT">
+                    <b.html:Br  />
+                    <g:HTML HTML="{msgs.securityCertificateListWarning}" />
+                </b.html:Paragraph>
+            </b:Row>
+            <b:Row>
                 <b:Panel>
                     <b:NavPills justified="true">
                         <b:ButtonGroup size="SMALL">
-                        	<b:Button ui:field="add" addStyleNames="fa fa-plus"></b:Button>
+                            <b:Button ui:field="add" addStyleNames="fa fa-plus"></b:Button>
                             <b:Button ui:field="uninstall" addStyleNames="fa fa-minus" enabled="false"></b:Button>
                             <b:Button ui:field="refresh" addStyleNames="fa fa-refresh"></b:Button>
                         </b:ButtonGroup>
@@ -50,17 +58,20 @@
                     ui:field="certificatesGrid" />
             </b:Row>
             <b:Modal title="Add Certificate" fade="true" dataBackdrop="STATIC" dataKeyboard="true" b:id="certAddModal" ui:field="certAddModal" closable="false">
-  				<b:ModalBody b:id="certAddModalBody">
-  				    <g:ScrollPanel ui:field="certAddModalBody" addStyleNames="{style.modal-scroll-panel}"/>
-  				</b:ModalBody>
-  				<b:ModalFooter>
-  					<b:Button dataDismiss="MODAL" b:id="closeModalButton" ui:field="closeModalButton">Close</b:Button>
-  					<b:Button type="PRIMARY" b:id="nextStepButton" ui:field="nextStepButton">Do something</b:Button>
-  				</b:ModalFooter>
-  			</b:Modal>
+                <b:ModalBody b:id="certAddModalBody">
+                    <g:ScrollPanel ui:field="certAddModalBody" addStyleNames="{style.modal-scroll-panel}"/>
+                </b:ModalBody>
+                <b:ModalFooter>
+                    <b:Button dataDismiss="MODAL" b:id="applyModalButton" ui:field="applyModalButton">Apply</b:Button>
+                    <b:Button dataDismiss="MODAL" b:id="resetModalButton" ui:field="resetModalButton">Reset</b:Button>
+                    <b:Button dataDismiss="MODAL" b:id="closeModalButton" ui:field="closeModalButton">Close</b:Button>
+
+                    <b:Button type="PRIMARY" b:id="nextStepButton" ui:field="nextStepButton">Do something</b:Button>
+                </b:ModalFooter>
+            </b:Modal>
         </b:Column>
         <b:PanelFooter ui:field="tablePanelFooter">
         </b:PanelFooter>
         <kura:AlertDialog ui:field="alertDialog"/>
     </b:Container>
-</ui:UiBinder> 
+</ui:UiBinder>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/KeyPairTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/KeyPairTabUi.ui.xml
@@ -34,22 +34,14 @@
     .small-text {
     	font-size: 0.90em;
     }
+    
+    #storageAlias {
+    	text-transform: lowercase;
+    }
     </ui:style>
 
     <b:Container fluid="true">
         <b:Column size="MD_12">
-            <b:Row>
-                <b:Panel>
-                    <b:NavPills justified="true">
-                        <b:ButtonGroup size="SMALL">
-                            <b:Button ui:field="apply"
-                                addStyleNames="fa fa-check"></b:Button>
-                            <b:Button ui:field="reset"
-                                addStyleNames="fa fa-times"></b:Button>
-                        </b:ButtonGroup>
-                    </b:NavPills>
-                </b:Panel>
-            </b:Row>
             <b:Row>
                 <g:HTMLPanel ui:field="description">
                 </g:HTMLPanel>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/ThreatManagerTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/ThreatManagerTabUi.java
@@ -22,7 +22,6 @@ import org.eclipse.kura.web.client.ui.AbstractServicesUi;
 import org.eclipse.kura.web.client.ui.AlertDialog;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
 import org.eclipse.kura.web.client.ui.Tab;
-import org.eclipse.kura.web.client.ui.cloudconnection.CloudConnectionsUi;
 import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.client.util.FilterBuilder;
 import org.eclipse.kura.web.client.util.request.RequestQueue;
@@ -53,7 +52,7 @@ public class ThreatManagerTabUi extends AbstractServicesUi implements Tab {
     interface IdsTabUiUiBinder extends UiBinder<Widget, ThreatManagerTabUi> {
     }
 
-    private static final Logger logger = Logger.getLogger(CloudConnectionsUi.class.getSimpleName());
+    private static final Logger logger = Logger.getLogger(ThreatManagerTabUi.class.getSimpleName());
     private static final Messages MSGS = GWT.create(Messages.class);
 
     private final GwtSecurityTokenServiceAsync gwtXSRFService = GWT.create(GwtSecurityTokenService.class);
@@ -103,7 +102,7 @@ public class ThreatManagerTabUi extends AbstractServicesUi implements Tab {
 
         this.apply.setEnabled(false);
         this.reset.setEnabled(false);
-        
+
         logger.info("ready to init modal");
 
         initNotificationModal();
@@ -137,7 +136,7 @@ public class ThreatManagerTabUi extends AbstractServicesUi implements Tab {
         if (isDirty()) {
             this.notificationModalBody.clear();
             this.notificationModalBody
-            .add(new Span(MSGS.deviceConfigConfirmation(this.configurableComponent.getComponentName())));
+                    .add(new Span(MSGS.deviceConfigConfirmation(this.configurableComponent.getComponentName())));
             this.notificationModal.show();
             this.cancelButton.setFocus(true);
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
@@ -20,7 +20,7 @@ import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
 import org.eclipse.kura.web.client.ui.Picker;
 import org.eclipse.kura.web.client.ui.drivers.assets.BooleanInputCell;
-import org.eclipse.kura.web.client.util.PasswordStrengthValidators;
+import org.eclipse.kura.web.client.ui.validator.PasswordStrengthValidators;
 import org.eclipse.kura.web.shared.model.GwtUserConfig;
 import org.eclipse.kura.web.shared.model.GwtUserData;
 import org.gwtbootstrap3.client.ui.Button;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/NotEmptyValidator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/NotEmptyValidator.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.client.ui.validator;
+
+import java.util.function.Predicate;
+
+public class NotEmptyValidator extends PredicateValidator {
+
+    private static final Predicate<String> notEmptyPredicat = value -> value != null && !value.isEmpty();
+
+    public NotEmptyValidator(String message) {
+        super(notEmptyPredicat, message);
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.HIGHEST;
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/NotInListValidator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/NotInListValidator.java
@@ -1,20 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
-package org.eclipse.kura.web.client.ui;
+package org.eclipse.kura.web.client.ui.validator;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
 
 import org.gwtbootstrap3.client.ui.form.error.BasicEditorError;
 import org.gwtbootstrap3.client.ui.form.validator.Validator;
@@ -22,13 +21,13 @@ import org.gwtbootstrap3.client.ui.form.validator.Validator;
 import com.google.gwt.editor.client.Editor;
 import com.google.gwt.editor.client.EditorError;
 
-public class PredicateValidator implements Validator<String> {
+public class NotInListValidator<T> implements Validator<T> {
 
-    private final Predicate<String> predicate;
+    private final List<T> values;
     private final String message;
 
-    public PredicateValidator(final Predicate<String> predicate, final String message) {
-        this.predicate = predicate;
+    public NotInListValidator(final List<T> values, final String message) {
+        this.values = values;
         this.message = message;
     }
 
@@ -38,10 +37,10 @@ public class PredicateValidator implements Validator<String> {
     }
 
     @Override
-    public List<EditorError> validate(final Editor<String> editor, final String value) {
-
-        return this.predicate.test(value) ? Collections.emptyList()
-                : Collections.singletonList(new BasicEditorError(editor, value, this.message));
+    public List<EditorError> validate(final Editor<T> editor, final T value) {
+        return this.values.contains(value)
+                ? Collections.singletonList(new BasicEditorError(editor, value, this.message))
+                : Collections.emptyList();
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/PEMValidator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/PEMValidator.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.client.ui.validator;
+
+public class PEMValidator extends RegexValidator {
+
+    private static final String PEM_REGEX = "^-{3,}BEGIN CERTIFICATE-{3,}[\\W\\w]*?-{3,}END CERTIFICATE-{3,}$";
+
+    public PEMValidator(String message) {
+        super(PEM_REGEX, message);
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/PKCS8Validator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/PKCS8Validator.java
@@ -1,21 +1,22 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
-package org.eclipse.kura.web.client.ui;
+package org.eclipse.kura.web.client.ui.validator;
 
-public class RegexValidator extends PredicateValidator {
+public class PKCS8Validator extends RegexValidator {
 
-    public RegexValidator(final String pattern, final String message) {
-        super(v -> v.matches(pattern), message);
+    private static final String PKCS8 = "^-{3,}BEGIN \\w+ PRIVATE KEY-{3,}[\\W\\w]*?-{3,}END \\w+ PRIVATE KEY-{3,}$";
+
+    public PKCS8Validator(String message) {
+        super(PKCS8, message);
     }
-
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/PasswordStrengthValidators.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/PasswordStrengthValidators.java
@@ -10,14 +10,12 @@
  * Contributors:
  *  Eurotech
  *******************************************************************************/
-package org.eclipse.kura.web.client.util;
+package org.eclipse.kura.web.client.ui.validator;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.kura.web.client.messages.Messages;
-import org.eclipse.kura.web.client.ui.PredicateValidator;
-import org.eclipse.kura.web.client.ui.RegexValidator;
 import org.eclipse.kura.web.shared.model.GwtConsoleUserOptions;
 import org.gwtbootstrap3.client.ui.form.validator.Validator;
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/PredicateValidator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/PredicateValidator.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.client.ui.validator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.gwtbootstrap3.client.ui.form.error.BasicEditorError;
+import org.gwtbootstrap3.client.ui.form.validator.Validator;
+
+import com.google.gwt.editor.client.Editor;
+import com.google.gwt.editor.client.EditorError;
+
+public class PredicateValidator implements Validator<String> {
+
+    private final Predicate<String> predicate;
+    private final String message;
+
+    public PredicateValidator(final Predicate<String> predicate, final String message) {
+        this.predicate = predicate;
+        this.message = message;
+    }
+
+    @Override
+    public int getPriority() {
+        return Priority.MEDIUM;
+    }
+
+    @Override
+    public List<EditorError> validate(final Editor<String> editor, final String value) {
+
+        return this.predicate.test(value) ? Collections.emptyList()
+                : Collections.singletonList(new BasicEditorError(editor, value, this.message));
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/RegexValidator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/RegexValidator.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.client.ui.validator;
+
+public class RegexValidator extends PredicateValidator {
+
+    public RegexValidator(final String pattern, final String message) {
+        super(v -> v.matches(pattern), message);
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/StringLengthValidator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/StringLengthValidator.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.client.ui.validator;
+
+import java.util.function.Predicate;
+
+public class StringLengthValidator extends PredicateValidator {
+
+    public StringLengthValidator(int maxSize, String message) {
+        super(createStringLimits(0, maxSize), message);
+    }
+
+    public StringLengthValidator(int minSize, int maxSize, String message) {
+        super(createStringLimits(minSize, maxSize), message);
+    }
+
+    private static Predicate<String> createStringLimits(int minSize, int maxSize) {
+        return value -> value.length() >= minSize && value.length() <= maxSize;
+    }
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/StringNotInListValidator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/StringNotInListValidator.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.client.ui.validator;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.gwt.editor.client.Editor;
+import com.google.gwt.editor.client.EditorError;
+
+public class StringNotInListValidator extends NotInListValidator<String> {
+
+    public StringNotInListValidator(List<String> values, String message) {
+        super(values.stream().map(String::trim).collect(Collectors.toList()), message);
+    }
+
+    @Override
+    public List<EditorError> validate(Editor<String> editor, String value) {
+        return super.validate(editor, value.trim());
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -144,6 +144,7 @@ fileDownloadSuccess=File was successfully downloaded
 fileDownloadFailure=File download failed
 
 securityIntro=Review and update the available security settings.
+securityCertificateListWarning=Review and update the available certificate list.<br />For some keystore types, a device reboot might be required after a certificate update to make the change effective.<br />For certain services like SSL and Web UI, the corresponding service will automatically restart after a keystore change.
 securityUninstallCertificate=Are you sure you want to remove the certificate {0}? Removing a certificate might have unexpected effects on the stability of the framework. If in doubt answer "No".
 securityAllAuthMethodsDisabled=All authentication methods are disabled. Web UI access will be disabled if changes are applied
 securityAllConnectorsDisabled=All HTTP connectors are disabled. Web UI access will be disabled if changes are applied.
@@ -273,6 +274,8 @@ settingsReloadStartupFingerprintDescription=Allows to change the startup command
 
 
 certificateAlias=Alias
+certificateAliasUsed=Certificate Alias already used.
+certificateAliasMaxLength=Alias must be at most {0} characters
 certificateKeystoreName=Keystore Service Name
 certificateKind=Type
 certificateValidityStart=Valid from


### PR DESCRIPTION
* Closes #3262

* Closes #3261, #3260, #3259

* Closes #3192

* Closes #3194

* Closes #3174

* Closes #3165

* Improvements in regex espressions.

* Closes #3162

* Closes #3158
Also fix a bug in aliases list generation.

* Closes #3155

* Code Review Fixes

* Fixed indentation

* Fixed formatting

Signed-off-by: Maiero <matteo.maiero@eurotech.com>

* Removed description duplication. Added spacing between panel header and description. Re-sorted button in certificate modal. Apply and Close buttons  are hidden again.

* Added missing file.

* Updated securityCertificateListWarning

* Updated securityCertificateListWarning

* Typos fixed. Now alias name are trimmed in uniqueness verification.

* Several fixes.

* Added Certificate Alias Max Size (128 Characters).
Moved all validators in a new package (org.eclipse.kura.web.client.ui.validator)

* Fixed formatting

Signed-off-by: Maiero <matteo.maiero@eurotech.com>

* Reverted button position as before.

* Fixed some typos.

Co-authored-by: Maiero <matteo.maiero@eurotech.com>

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
