### PR TITLE
[Backport] Removed keystore custom password in kura.properties

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-centos-7-nn/kura.properties
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7-nn/kura.properties
@@ -60,13 +60,6 @@ kura.legacy.bluetooth.beacon.scan=false
 
 
 ## -----------------------------------------------------------------------------
-## Java SSL Key Store Settings
-## -----------------------------------------------------------------------------
-kura.ssl.keyStorePassword=changeit
-kura.https.keyStorePassword=changeit
-
-
-## -----------------------------------------------------------------------------
 ##  Remote Configuration Properties
 ## -----------------------------------------------------------------------------
 console.device.management.service.ignore=org.eclipse.kura.net.admin.NetworkConfigurationService,org.eclipse.kura.net.admin.FirewallConfigurationService

--- a/kura/distrib/src/main/resources/intel-up2-centos-7/kura.properties
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7/kura.properties
@@ -60,13 +60,6 @@ kura.legacy.bluetooth.beacon.scan=false
 
 
 ## -----------------------------------------------------------------------------
-## Java Key Store Settings
-## -----------------------------------------------------------------------------
-kura.ssl.keyStorePassword=changeit
-kura.https.keyStorePassword=changeit
-
-
-## -----------------------------------------------------------------------------
 ##  Remote Configuration Properties
 ## -----------------------------------------------------------------------------
 console.device.management.service.ignore=org.eclipse.kura.net.admin.NetworkConfigurationService,org.eclipse.kura.net.admin.FirewallConfigurationService

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura.properties
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura.properties
@@ -59,13 +59,6 @@ kura.legacy.bluetooth.beacon.scan=false
 
 
 ## -----------------------------------------------------------------------------
-## Java Key Store Settings
-## -----------------------------------------------------------------------------
-kura.ssl.keyStorePassword=changeit
-kura.https.keyStorePassword=changeit
-
-
-## -----------------------------------------------------------------------------
 ##  Remote Configuration Properties
 ## -----------------------------------------------------------------------------
 console.device.management.service.ignore=org.eclipse.kura.net.admin.NetworkConfigurationService,org.eclipse.kura.net.admin.FirewallConfigurationService

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura.properties
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura.properties
@@ -60,13 +60,6 @@ kura.legacy.bluetooth.beacon.scan=false
 
 
 ## -----------------------------------------------------------------------------
-## Java SSL Key Store Settings
-## -----------------------------------------------------------------------------
-kura.ssl.keyStorePassword=changeit
-kura.https.keyStorePassword=changeit
-
-
-## -----------------------------------------------------------------------------
 ##  Remote Configuration Properties
 ## -----------------------------------------------------------------------------
 console.device.management.service.ignore=org.eclipse.kura.net.admin.NetworkConfigurationService

--- a/kura/distrib/src/main/resources/raspberry-pi-2/kura.properties
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/kura.properties
@@ -60,13 +60,6 @@ kura.legacy.bluetooth.beacon.scan=false
 
 
 ## -----------------------------------------------------------------------------
-## Java SSL Key Store Settings
-## -----------------------------------------------------------------------------
-kura.ssl.keyStorePassword=changeit
-kura.https.keyStorePassword=changeit
-
-
-## -----------------------------------------------------------------------------
 ##  Remote Configuration Properties
 ## -----------------------------------------------------------------------------
 console.device.management.service.ignore=org.eclipse.kura.net.admin.NetworkConfigurationService,org.eclipse.kura.net.admin.FirewallConfigurationService

--- a/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura.properties
+++ b/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura.properties
@@ -59,13 +59,6 @@ kura.legacy.bluetooth.beacon.scan=false
 
 
 ## -----------------------------------------------------------------------------
-## Java SSL Key Store Settings
-## -----------------------------------------------------------------------------
-kura.ssl.keyStorePassword=changeit
-kura.https.keyStorePassword=changeit
-
-
-## -----------------------------------------------------------------------------
 ##  Remote Configuration Properties
 ## -----------------------------------------------------------------------------
 console.device.management.service.ignore=org.eclipse.kura.net.admin.NetworkConfigurationService,org.eclipse.kura.net.admin.FirewallConfigurationService

--- a/kura/emulator/org.eclipse.kura.emulator/src/main/resources/kura.properties
+++ b/kura/emulator/org.eclipse.kura.emulator/src/main/resources/kura.properties
@@ -64,7 +64,7 @@ file.upload.in.memory.size.threshold=10240
 file.upload.size.max=-1
 file.command.zip.max.size=100
 file.command.zip.max.number=1024
-kura.https.keyStorePassword=changeit
+
 
 
 ## -----------------------------------------------------------------------------


### PR DESCRIPTION
This way of defining password is not supported anymore.

Signed-off-by: Maiero <matteo.maiero@eurotech.com>
