### PR TITLE
[Backport] Refactoring flooding protection configurator

### DIFF
--- a/kura/org.eclipse.kura.net.admin/OSGI-INF/firewallConfigurationService.xml
+++ b/kura/org.eclipse.kura.net.admin/OSGI-INF/firewallConfigurationService.xml
@@ -28,5 +28,4 @@
    </service>
    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
    <reference bind="setExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static" unbind="unsetExecutorService"/>
-   <reference bind="setFloodingProtectionConfigurationService" cardinality="0..1" interface="org.eclipse.kura.security.FloodingProtectionConfigurationService" name="FloodingProtectionConfigurationService" policy="static" unbind="unsetFloodingProtectionConfigurationService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationService.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
 package org.eclipse.kura.net.admin;
 
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.net.FirewallConfiguration;
@@ -61,5 +62,13 @@ public interface FirewallConfigurationService {
      * @throws KuraException
      */
     public void setFirewallNatConfiguration(List<FirewallNatConfig> natConfigs) throws KuraException;
+
+    /**
+     * Adds flooding protection rules to the firewall configuration.
+     * 
+     * @param floodingRules
+     *            Set of rules specified as Strings to protect against flooding attacks
+     */
+    public void addFloodingProtectionRules(Set<String> floodingRules);
 
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -17,8 +17,7 @@ import static org.osgi.framework.Constants.SERVICE_PID;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.Hashtable;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -51,19 +50,13 @@ import org.eclipse.kura.net.firewall.FirewallOpenPortConfigIP;
 import org.eclipse.kura.net.firewall.FirewallOpenPortConfigIP4;
 import org.eclipse.kura.net.firewall.FirewallPortForwardConfigIP;
 import org.eclipse.kura.net.firewall.FirewallPortForwardConfigIP4;
-import org.eclipse.kura.security.FloodingProtectionConfigurationChangeEvent;
-import org.eclipse.kura.security.FloodingProtectionConfigurationService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
-import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
-import org.osgi.service.event.EventConstants;
-import org.osgi.service.event.EventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FirewallConfigurationServiceImpl
-        implements FirewallConfigurationService, SelfConfiguringComponent, EventHandler {
+public class FirewallConfigurationServiceImpl implements FirewallConfigurationService, SelfConfiguringComponent {
 
     private static final Logger logger = LoggerFactory.getLogger(FirewallConfigurationServiceImpl.class);
 
@@ -71,7 +64,6 @@ public class FirewallConfigurationServiceImpl
     private ServiceRegistration<?> serviceRegistration;
     private LinuxFirewall firewall;
     private CommandExecutorService executorService;
-    private FloodingProtectionConfigurationService floodingConfiguration;
 
     public void setEventAdmin(EventAdmin eventAdmin) {
         this.eventAdmin = eventAdmin;
@@ -93,29 +85,10 @@ public class FirewallConfigurationServiceImpl
         }
     }
 
-    public void setFloodingProtectionConfigurationService(
-            FloodingProtectionConfigurationService floodingConfiguration) {
-        this.floodingConfiguration = floodingConfiguration;
-    }
-
-    public void unsetFloodingProtectionConfigurationService(
-            FloodingProtectionConfigurationService floodingConfiguration) {
-        if (this.floodingConfiguration == floodingConfiguration) {
-            this.floodingConfiguration = null;
-        }
-    }
-
     protected void activate(ComponentContext componentContext, Map<String, Object> properties) {
         logger.debug("activate()");
 
         this.firewall = getLinuxFirewall();
-
-        Dictionary<String, Object> props = new Hashtable<>();
-        String[] eventTopics = { FloodingProtectionConfigurationChangeEvent.FP_EVENT_CONFIG_CHANGE_TOPIC };
-        props.put(EventConstants.EVENT_TOPIC, eventTopics);
-        this.serviceRegistration = componentContext.getBundleContext().registerService(EventHandler.class.getName(),
-                this, props);
-
         updated(properties);
     }
 
@@ -146,8 +119,6 @@ public class FirewallConfigurationServiceImpl
         } catch (KuraException e) {
             logger.error("Failed to set Firewall NAT Configuration", e);
         }
-
-        setFloodingProtectionConfiguration();
 
         // raise the event because there was a change
         this.eventAdmin.postEvent(new FirewallConfigurationChangeEvent(properties));
@@ -332,14 +303,6 @@ public class FirewallConfigurationServiceImpl
         addNatRules(natRules);
     }
 
-    @Override
-    public void handleEvent(Event event) {
-        logger.debug("Received event: {}", event.getTopic());
-        if (event.getTopic().equals(FloodingProtectionConfigurationChangeEvent.FP_EVENT_CONFIG_CHANGE_TOPIC)) {
-            setFloodingProtectionConfiguration();
-        }
-    }
-
     protected void addLocalRules(ArrayList<LocalRule> localRules) throws KuraException {
         this.firewall.addLocalRules(localRules);
     }
@@ -434,15 +397,12 @@ public class FirewallConfigurationServiceImpl
         return new NetworkPair(IPAddress.parseHostAddress("0.0.0.0"), (short) 0);
     }
 
-    private void setFloodingProtectionConfiguration() {
-        if (this.floodingConfiguration != null) {
-            try {
-                this.firewall.setAdditionalRules(this.floodingConfiguration.getFloodingProtectionFilterRules(),
-                        this.floodingConfiguration.getFloodingProtectionNatRules(),
-                        this.floodingConfiguration.getFloodingProtectionMangleRules());
-            } catch (KuraException e) {
-                logger.error("Failed to set Firewall Flooding Protection Configuration", e);
-            }
+    @Override
+    public void addFloodingProtectionRules(Set<String> floodingRules) {
+        try {
+            this.firewall.setAdditionalRules(new HashSet<>(), new HashSet<>(), floodingRules);
+        } catch (KuraException e) {
+            logger.error("Failed to set Firewall Flooding Protection Configuration", e);
         }
     }
 }

--- a/kura/org.eclipse.kura.network.threat.manager/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.network.threat.manager/META-INF/MANIFEST.MF
@@ -18,4 +18,5 @@ Import-Package: javax.ws.rs;version="2.0.1",
  org.osgi.framework;version="1.10.0",
  org.osgi.service.component;version="1.4.0",
  org.osgi.service.event;version="1.4.0",
- org.slf4j;version="1.7.25"
+ org.slf4j;version="1.7.25",
+ org.eclipse.kura.net.admin;version="[1.4.0,2.0)"

--- a/kura/org.eclipse.kura.network.threat.manager/OSGI-INF/flooding_configuration_service.xml
+++ b/kura/org.eclipse.kura.network.threat.manager/OSGI-INF/flooding_configuration_service.xml
@@ -23,5 +23,5 @@
       <provide interface="org.eclipse.kura.security.FloodingProtectionConfigurationService"/>
    </service>
    <property name="kura.ui.service.hide" type="Boolean" value="true"/>
-   <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
+   <reference bind="setFirewallConfigurationService" unbind="unsetFirewallConfigurationService" cardinality="1..1" interface="org.eclipse.kura.net.admin.FirewallConfigurationService" name="FirewallConfigurationService" policy="static"/> 
 </scr:component>

--- a/kura/org.eclipse.kura.network.threat.manager/pom.xml
+++ b/kura/org.eclipse.kura.network.threat.manager/pom.xml
@@ -30,5 +30,6 @@
 
 	<properties>
 		<kura.basedir>${project.basedir}/..</kura.basedir>
+		<sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test/*/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 </project>

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
@@ -24,11 +24,13 @@ import static org.mockito.Mockito.when;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Map.Entry;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
@@ -42,6 +44,7 @@ import org.eclipse.kura.net.IP4Address;
 import org.eclipse.kura.net.IPAddress;
 import org.eclipse.kura.net.NetProtocol;
 import org.eclipse.kura.net.NetworkPair;
+import org.eclipse.kura.net.admin.event.FirewallConfigurationChangeEvent;
 import org.eclipse.kura.net.firewall.FirewallAutoNatConfig;
 import org.eclipse.kura.net.firewall.FirewallNatConfig;
 import org.eclipse.kura.net.firewall.FirewallOpenPortConfigIP;
@@ -507,6 +510,55 @@ public class FirewallConfigurationServiceImplTest {
 
         svc.setFirewallOpenPortConfiguration(firewallConfiguration);
 
+    }
+    
+    @Test
+    public void addFloodingProtectionRulesTest() {
+        final LinuxFirewall mockFirewall = mock(LinuxFirewall.class);
+        
+        FirewallConfigurationServiceImpl svc = new FirewallConfigurationServiceImpl() {
+            
+            @Override
+            protected LinuxFirewall getLinuxFirewall() {
+                return mockFirewall;
+            }
+            
+            @Override
+            public synchronized void updated(Map<String, Object> properties) {
+                // don't care about the properties in this test
+                // update is not called when adding flooding protection rules,
+                // it is called just during activate
+            }
+        };
+        
+        ComponentContext mockContext = mock(ComponentContext.class);
+        svc.activate(mockContext, new HashMap<String, Object>());
+        
+        String[] floodingRules = {
+                "-A prerouting-kura -m conntrack --ctstate INVALID -j DROP",
+                "-A prerouting-kura -p tcp ! --syn -m conntrack --ctstate NEW -j DROP",
+                "-A prerouting-kura -p tcp -m conntrack --ctstate NEW -m tcpmss ! --mss 536:65535 -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags FIN,SYN FIN,SYN -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags SYN,RST SYN,RST -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags FIN,RST FIN,RST -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags FIN,ACK FIN -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags ACK,URG URG -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags ACK,FIN FIN -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags ACK,PSH PSH -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags ALL ALL -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags ALL NONE -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags ALL FIN,PSH,URG -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags ALL SYN,FIN,PSH,URG -j DROP",
+                "-A prerouting-kura -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP",
+                "-A prerouting-kura -p icmp -j DROP", "-A prerouting-kura -f -j DROP" };
+        
+        svc.addFloodingProtectionRules(new HashSet<>(Arrays.asList(floodingRules)));
+        
+        try {
+            verify(mockFirewall, times(1)).setAdditionalRules(anyObject(), anyObject(), anyObject());
+        } catch(KuraException e) {
+            assert(false);
+        }
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Updated tests

Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Cleaned up test class and unnecessary logs

Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Added Sonar coverage report path to pom.xml

Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Restricted net-admin version and used annotation in test to mark expected exception

Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Removed EventHandler and simplified addFloodingProtectionRules method

Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Fixed addFloodingProtectionRulesTest errors caused by merge

Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Squashed commits

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
