### PR TITLE
Fixed 0.0.0.0 address in firewall configuration

### DIFF
--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/FirewallConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/FirewallConfiguration.java
@@ -13,6 +13,7 @@
 package org.eclipse.kura.core.net;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,145 +64,171 @@ public class FirewallConfiguration {
 
     public FirewallConfiguration(Map<String, Object> properties) {
         this();
-        String str = null;
-        String[] astr = null;
-        if (properties.containsKey(OPEN_PORTS_PROP_NAME)) {
-            str = (String) properties.get(OPEN_PORTS_PROP_NAME);
-            if (!str.isEmpty()) {
-                astr = str.split(";");
-                for (String sop : astr) {
-                    try {
-                        String[] sa = sop.split(",");
-                        if (sa.length == 8 && "#".equals(sa[7])) {
-                            NetProtocol protocol = NetProtocol.valueOf(sa[1]);
-                            String permittedNetwork = sa[2];
-                            short permittedNetworkMask = 0;
-                            if (!permittedNetwork.isEmpty()) {
-                                permittedNetwork = sa[2].split("/")[0];
-                                permittedNetworkMask = Short.parseShort(sa[2].split("/")[1]);
-                            }
-                            String permittedIface = null;
-                            if (!sa[3].isEmpty()) {
-                                permittedIface = sa[3];
-                            }
-                            String unpermittedIface = null;
-                            if (!sa[4].isEmpty()) {
-                                unpermittedIface = sa[4];
-                            }
-                            String permittedMAC = null;
-                            if (!sa[5].isEmpty()) {
-                                permittedMAC = sa[5];
-                            }
-                            String sourcePortRange = null;
-                            if (!sa[6].isEmpty()) {
-                                sourcePortRange = sa[6];
-                            }
-                            int port = 0;
-                            String portRange = null;
-                            FirewallOpenPortConfigIP<? extends IPAddress> openPortEntry = null;
-                            if (sa[0].indexOf(':') > 0) {
-                                portRange = sa[0];
-                                openPortEntry = new FirewallOpenPortConfigIP4(portRange, protocol,
-                                        new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork),
-                                                permittedNetworkMask),
-                                        permittedIface, unpermittedIface, permittedMAC, sourcePortRange);
-                            } else {
-                                port = Integer.parseInt(sa[0]);
-                                openPortEntry = new FirewallOpenPortConfigIP4(port, protocol,
-                                        new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork),
-                                                permittedNetworkMask),
-                                        permittedIface, unpermittedIface, permittedMAC, sourcePortRange);
-                            }
-                            this.openPortConfigs.add(openPortEntry);
-                        }
-                    } catch (Exception e) {
-                        logger.error("Failed to parse Open Port Entry - {}", e);
-                    }
-                }
-            }
-        }
-        if (properties.containsKey(PORT_FORWARDING_PROP_NAME)) {
-            str = (String) properties.get(PORT_FORWARDING_PROP_NAME);
-            if (!str.isEmpty()) {
-                astr = str.split(";");
-                for (String sop : astr) {
-                    try {
-                        String[] sa = sop.split(",");
-                        if (sa.length == 11 && "#".equals(sa[10])) {
-                            String inboundIface = null;
-                            if (!sa[0].isEmpty()) {
-                                inboundIface = sa[0];
-                            }
-                            String outboundIface = null;
-                            if (!sa[1].isEmpty()) {
-                                outboundIface = sa[1];
-                            }
-                            IP4Address address = (IP4Address) IPAddress.parseHostAddress(sa[2]);
-                            NetProtocol protocol = NetProtocol.valueOf(sa[3]);
-                            int inPort = Integer.parseInt(sa[4]);
-                            int outPort = Integer.parseInt(sa[5]);
-                            boolean masquerade = Boolean.parseBoolean(sa[6]);
-                            String permittedNetwork = null;
-                            short permittedNetworkMask = 0;
-                            if (!sa[7].isEmpty()) {
-                                permittedNetwork = sa[7].split("/")[0];
-                                permittedNetworkMask = Short.parseShort(sa[7].split("/")[1]);
-                            }
-                            String permittedMAC = null;
-                            if (!sa[8].isEmpty()) {
-                                permittedMAC = sa[8];
-                            }
-                            String sourcePortRange = null;
-                            if (!sa[9].isEmpty()) {
-                                sourcePortRange = sa[9];
-                            }
-                            FirewallPortForwardConfigIP<? extends IPAddress> portForwardEntry = new FirewallPortForwardConfigIP4(
-                                    inboundIface, outboundIface, address, protocol, inPort, outPort, masquerade,
-                                    new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork),
-                                            permittedNetworkMask),
-                                    permittedMAC, sourcePortRange);
-                            this.portForwardConfigs.add(portForwardEntry);
-                        }
-                    } catch (Exception e) {
-                        logger.error("Failed to parse Port Forward Entry - {}", e);
-                    }
-                }
-            }
-        }
+        parseOpenPortRules(properties);
+        parsePortForwardingRules(properties);
+        parseNatRules(properties);
+    }
+
+    private void parseNatRules(Map<String, Object> properties) {
+        String str;
+        String[] astr;
         if (properties.containsKey(NAT_PROP_NAME)) {
             str = (String) properties.get(NAT_PROP_NAME);
             if (!str.isEmpty()) {
                 astr = str.split(";");
-                for (String sop : astr) {
-                    String[] sa = sop.split(",");
-                    if (sa.length == 7 && "#".equals(sa[6])) {
-                        String srcIface = null;
-                        if (!sa[0].isEmpty()) {
-                            srcIface = sa[0];
-                        }
-                        String dstIface = null;
-                        if (!sa[1].isEmpty()) {
-                            dstIface = sa[1];
-                        }
-                        String protocol = null;
-                        if (!sa[2].isEmpty()) {
-                            protocol = sa[2];
-                        }
-                        String src = null;
-                        if (!sa[3].isEmpty()) {
-                            src = sa[3];
-                        }
-                        String dst = null;
-                        if (!sa[4].isEmpty()) {
-                            dst = sa[4];
-                        }
-                        boolean masquerade = Boolean.parseBoolean(sa[5]);
-                        FirewallNatConfig natEntry = new FirewallNatConfig(srcIface, dstIface, protocol, src, dst,
-                                masquerade, RuleType.IP_FORWARDING);
-                        this.natConfigs.add(natEntry);
-                    }
-                }
+                Arrays.asList(astr).forEach(this::parseNatRule);
             }
+        }
+    }
+
+    private void parseNatRule(String sop) {
+        String[] sa = sop.split(",");
+        if (sa.length == 7 && "#".equals(sa[6])) {
+            String srcIface = null;
+            if (!sa[0].isEmpty()) {
+                srcIface = sa[0];
+            }
+            String dstIface = null;
+            if (!sa[1].isEmpty()) {
+                dstIface = sa[1];
+            }
+            String protocol = null;
+            if (!sa[2].isEmpty()) {
+                protocol = sa[2];
+            }
+            String src = null;
+            if (!sa[3].isEmpty()) {
+                src = sa[3];
+            }
+            String dst = null;
+            if (!sa[4].isEmpty()) {
+                dst = sa[4];
+            }
+            boolean masquerade = Boolean.parseBoolean(sa[5]);
+            FirewallNatConfig natEntry = new FirewallNatConfig(srcIface, dstIface, protocol, src, dst, masquerade,
+                    RuleType.IP_FORWARDING);
+            this.natConfigs.add(natEntry);
+        }
+    }
+
+    private void parsePortForwardingRules(Map<String, Object> properties) {
+        String str;
+        String[] astr;
+        if (properties.containsKey(PORT_FORWARDING_PROP_NAME)) {
+            str = (String) properties.get(PORT_FORWARDING_PROP_NAME);
+            if (!str.isEmpty()) {
+                astr = str.split(";");
+                Arrays.asList(astr).forEach(this::parsePortForwardingRule);
+            }
+        }
+    }
+
+    private void parsePortForwardingRule(String sop) {
+        try {
+            String[] sa = sop.split(",");
+            if (sa.length == 11 && "#".equals(sa[10])) {
+                String inboundIface = null;
+                if (!sa[0].isEmpty()) {
+                    inboundIface = sa[0];
+                }
+                String outboundIface = null;
+                if (!sa[1].isEmpty()) {
+                    outboundIface = sa[1];
+                }
+                IP4Address address = (IP4Address) IPAddress.parseHostAddress(sa[2]);
+                NetProtocol protocol = NetProtocol.valueOf(sa[3]);
+                int inPort = Integer.parseInt(sa[4]);
+                int outPort = Integer.parseInt(sa[5]);
+                boolean masquerade = Boolean.parseBoolean(sa[6]);
+                String permittedNetwork = null;
+                short permittedNetworkMask = 0;
+                if (!sa[7].isEmpty()) {
+                    permittedNetwork = sa[7].split("/")[0];
+                    permittedNetworkMask = Short.parseShort(sa[7].split("/")[1]);
+                } else {
+                    permittedNetwork = "0.0.0.0";
+                }
+                String permittedMAC = null;
+                if (!sa[8].isEmpty()) {
+                    permittedMAC = sa[8];
+                }
+                String sourcePortRange = null;
+                if (!sa[9].isEmpty()) {
+                    sourcePortRange = sa[9];
+                }
+                FirewallPortForwardConfigIP<? extends IPAddress> portForwardEntry = new FirewallPortForwardConfigIP4(
+                        inboundIface, outboundIface, address, protocol, inPort, outPort, masquerade,
+                        new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork),
+                                permittedNetworkMask),
+                        permittedMAC, sourcePortRange);
+                this.portForwardConfigs.add(portForwardEntry);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to parse Port Forward Entry", e);
+        }
+    }
+
+    private void parseOpenPortRules(Map<String, Object> properties) {
+        String str;
+        String[] astr;
+        if (properties.containsKey(OPEN_PORTS_PROP_NAME)) {
+            str = (String) properties.get(OPEN_PORTS_PROP_NAME);
+            if (!str.isEmpty()) {
+                astr = str.split(";");
+                Arrays.asList(astr).forEach(this::parseOpenPortRule);
+            }
+        }
+    }
+
+    private void parseOpenPortRule(String sop) {
+        try {
+            String[] sa = sop.split(",");
+            if (sa.length == 8 && "#".equals(sa[7])) {
+                NetProtocol protocol = NetProtocol.valueOf(sa[1]);
+                String permittedNetwork = null;
+                short permittedNetworkMask = 0;
+                if (!sa[2].isEmpty()) {
+                    permittedNetwork = sa[2].split("/")[0];
+                    permittedNetworkMask = Short.parseShort(sa[2].split("/")[1]);
+                } else {
+                    permittedNetwork = "0.0.0.0";
+                }
+                String permittedIface = null;
+                if (!sa[3].isEmpty()) {
+                    permittedIface = sa[3];
+                }
+                String unpermittedIface = null;
+                if (!sa[4].isEmpty()) {
+                    unpermittedIface = sa[4];
+                }
+                String permittedMAC = null;
+                if (!sa[5].isEmpty()) {
+                    permittedMAC = sa[5];
+                }
+                String sourcePortRange = null;
+                if (!sa[6].isEmpty()) {
+                    sourcePortRange = sa[6];
+                }
+                int port = 0;
+                String portRange = null;
+                FirewallOpenPortConfigIP<? extends IPAddress> openPortEntry = null;
+                if (sa[0].contains(":")) {
+                    portRange = sa[0];
+                    openPortEntry = new FirewallOpenPortConfigIP4(portRange, protocol,
+                            new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork),
+                                    permittedNetworkMask),
+                            permittedIface, unpermittedIface, permittedMAC, sourcePortRange);
+                } else {
+                    port = Integer.parseInt(sa[0]);
+                    openPortEntry = new FirewallOpenPortConfigIP4(port, protocol,
+                            new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork),
+                                    permittedNetworkMask),
+                            permittedIface, unpermittedIface, permittedMAC, sourcePortRange);
+                }
+                this.openPortConfigs.add(openPortEntry);
+            }
+        } catch (Exception e) {
+            logger.error("Failed to parse Open Port Entry", e);
         }
     }
 
@@ -262,7 +289,7 @@ public class FirewallConfiguration {
 
     private String formOpenPortConfigPropValue() {
         StringBuilder sb = new StringBuilder();
-        for (FirewallOpenPortConfigIP<? extends IPAddress> openPortConfig : this.openPortConfigs) {
+        this.openPortConfigs.forEach(openPortConfig -> {
             String port = openPortConfig.getPortRange();
             if (port == null) {
                 port = Integer.toString(openPortConfig.getPort());
@@ -292,7 +319,7 @@ public class FirewallConfiguration {
                 sb.append(openPortConfig.getSourcePortRange());
             }
             sb.append(",#;");
-        }
+        });
         int ind = sb.lastIndexOf(";");
         if (ind > 0) {
             sb.deleteCharAt(ind);
@@ -302,7 +329,7 @@ public class FirewallConfiguration {
 
     private String formPortForwardConfigPropValue() {
         StringBuilder sb = new StringBuilder();
-        for (FirewallPortForwardConfigIP<? extends IPAddress> portForwardConfig : this.portForwardConfigs) {
+        this.portForwardConfigs.forEach(portForwardConfig -> {
             if (portForwardConfig.getInboundInterface() != null) {
                 sb.append(portForwardConfig.getInboundInterface());
             }
@@ -334,7 +361,7 @@ public class FirewallConfiguration {
                 sb.append(portForwardConfig.getSourcePortRange());
             }
             sb.append(",#;");
-        }
+        });
         int ind = sb.lastIndexOf(";");
         if (ind > 0) {
             sb.deleteCharAt(ind);

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/FirewallConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/FirewallConfiguration.java
@@ -12,6 +12,7 @@
  ******************************************************************************/
 package org.eclipse.kura.core.net;
 
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -184,52 +185,53 @@ public class FirewallConfiguration {
         try {
             String[] sa = sop.split(",");
             if (sa.length == 8 && "#".equals(sa[7])) {
-                NetProtocol protocol = NetProtocol.valueOf(sa[1]);
-                String permittedNetwork = null;
-                short permittedNetworkMask = 0;
-                if (!sa[2].isEmpty()) {
-                    permittedNetwork = sa[2].split("/")[0];
-                    permittedNetworkMask = Short.parseShort(sa[2].split("/")[1]);
-                } else {
-                    permittedNetwork = "0.0.0.0";
-                }
-                String permittedIface = null;
-                if (!sa[3].isEmpty()) {
-                    permittedIface = sa[3];
-                }
-                String unpermittedIface = null;
-                if (!sa[4].isEmpty()) {
-                    unpermittedIface = sa[4];
-                }
-                String permittedMAC = null;
-                if (!sa[5].isEmpty()) {
-                    permittedMAC = sa[5];
-                }
-                String sourcePortRange = null;
-                if (!sa[6].isEmpty()) {
-                    sourcePortRange = sa[6];
-                }
-                int port = 0;
-                String portRange = null;
-                FirewallOpenPortConfigIP<? extends IPAddress> openPortEntry = null;
-                if (sa[0].contains(":")) {
-                    portRange = sa[0];
-                    openPortEntry = new FirewallOpenPortConfigIP4(portRange, protocol,
-                            new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork),
-                                    permittedNetworkMask),
-                            permittedIface, unpermittedIface, permittedMAC, sourcePortRange);
-                } else {
-                    port = Integer.parseInt(sa[0]);
-                    openPortEntry = new FirewallOpenPortConfigIP4(port, protocol,
-                            new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork),
-                                    permittedNetworkMask),
-                            permittedIface, unpermittedIface, permittedMAC, sourcePortRange);
-                }
-                this.openPortConfigs.add(openPortEntry);
+                this.openPortConfigs.add(buildOpenPortConfigIP(sa));
             }
         } catch (Exception e) {
             logger.error("Failed to parse Open Port Entry", e);
         }
+    }
+
+    private FirewallOpenPortConfigIP<? extends IPAddress> buildOpenPortConfigIP(String[] sa)
+            throws UnknownHostException {
+        FirewallOpenPortConfigIP<? extends IPAddress> openPortEntry = null;
+        NetProtocol protocol = NetProtocol.valueOf(sa[1]);
+        String permittedNetwork = "0.0.0.0";
+        short permittedNetworkMask = 0;
+        if (!sa[2].isEmpty()) {
+            permittedNetwork = sa[2].split("/")[0];
+            permittedNetworkMask = Short.parseShort(sa[2].split("/")[1]);
+        }
+        String permittedIface = null;
+        if (!sa[3].isEmpty()) {
+            permittedIface = sa[3];
+        }
+        String unpermittedIface = null;
+        if (!sa[4].isEmpty()) {
+            unpermittedIface = sa[4];
+        }
+        String permittedMAC = null;
+        if (!sa[5].isEmpty()) {
+            permittedMAC = sa[5];
+        }
+        String sourcePortRange = null;
+        if (!sa[6].isEmpty()) {
+            sourcePortRange = sa[6];
+        }
+        int port = 0;
+        String portRange = null;
+        if (sa[0].contains(":")) {
+            portRange = sa[0];
+            openPortEntry = new FirewallOpenPortConfigIP4(portRange, protocol,
+                    new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork), permittedNetworkMask),
+                    permittedIface, unpermittedIface, permittedMAC, sourcePortRange);
+        } else {
+            port = Integer.parseInt(sa[0]);
+            openPortEntry = new FirewallOpenPortConfigIP4(port, protocol,
+                    new NetworkPair<>((IP4Address) IPAddress.parseHostAddress(permittedNetwork), permittedNetworkMask),
+                    permittedIface, unpermittedIface, permittedMAC, sourcePortRange);
+        }
+        return openPortEntry;
     }
 
     public void addConfig(NetConfig netConfig) {

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/FirewallConfigurationTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/FirewallConfigurationTest.java
@@ -83,7 +83,7 @@ public class FirewallConfigurationTest {
             assertEquals(expected1, conf.getOpenPortConfigs().get(0));
 
             FirewallOpenPortConfigIP4 expected2 = new FirewallOpenPortConfigIP4("42:100", NetProtocol.udp,
-                    new NetworkPair<IP4Address>((IP4Address) IP4Address.parseHostAddress("127.0.0.1"), (short) 0), null,
+                    new NetworkPair<IP4Address>((IP4Address) IP4Address.parseHostAddress("0.0.0.0"), (short) 0), null,
                     null, null, null);
             assertEquals(expected2, conf.getOpenPortConfigs().get(1));
         } catch (UnknownHostException e) {
@@ -154,7 +154,7 @@ public class FirewallConfigurationTest {
 
             FirewallPortForwardConfigIP4 expected2 = new FirewallPortForwardConfigIP4(null, null,
                     (IP4Address) IP4Address.parseHostAddress("127.0.0.1"), NetProtocol.tcp, 0, 0, false,
-                    new NetworkPair<IP4Address>((IP4Address) IP4Address.parseHostAddress("127.0.0.1"), (short) 0), null,
+                    new NetworkPair<IP4Address>((IP4Address) IP4Address.parseHostAddress("0.0.0.0"), (short) 0), null,
                     null);
             assertEquals(expected2, conf.getPortForwardConfigs().get(1));
         } catch (UnknownHostException e) {


### PR DESCRIPTION
According to the [official documentation](https://docs.oracle.com/javase/8/docs/api/java/net/InetAddress.html#getByName-java.lang.String-), `java.net.InetAddress.getByName` returns the localhost (127.0.0.1) address if the passed parameter is empty. When the `FirewallConfigurationService` generates a `FirewallConfiguration` object from the properties, the rules where the permitted network was not set generates a localhost address instead the meta-address 0.0.0.0.

This PR add a check for empty addresses before creating the configuration.
Moreover, a refactor is done for the `FirewallConfiguration` class.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>
