### PR TITLE
Enable receive timeout for modem serial communication

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/hspa/HspaModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/hspa/HspaModem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ import org.eclipse.kura.linux.net.modem.UsbModemDriver;
 import org.eclipse.kura.net.NetConfig;
 import org.eclipse.kura.net.admin.modem.HspaCellularModem;
 import org.eclipse.kura.net.admin.modem.telit.he910.TelitHe910;
+import org.eclipse.kura.net.admin.util.SerialUtil;
 import org.eclipse.kura.net.modem.ModemDevice;
 import org.eclipse.kura.net.modem.ModemPdpContext;
 import org.eclipse.kura.net.modem.ModemPdpContextType;
@@ -457,19 +458,10 @@ public class HspaModem implements HspaCellularModem {
 
     protected CommConnection openSerialPort(String port) throws KuraException {
 
-        CommConnection connection = null;
         if (this.connectionFactory != null) {
-            String uri = new CommURI.Builder(port).withBaudRate(115200).withDataBits(8).withStopBits(1).withParity(0)
-                    .withTimeout(2000).build().toString();
-
-            try {
-                connection = (CommConnection) this.connectionFactory.createConnection(uri, 1, false);
-            } catch (Exception e) {
-                logger.debug("Exception creating connection: " + e);
-                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e, "Connection Failed");
-            }
+            return SerialUtil.openSerialPort(this.connectionFactory, port);
         }
-        return connection;
+        return null;
     }
 
     @Override

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/sierra/mc87xx/SierraMc87xx.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/sierra/mc87xx/SierraMc87xx.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,7 @@ import org.eclipse.kura.linux.net.modem.SupportedUsbModemsInfo;
 import org.eclipse.kura.net.NetConfig;
 import org.eclipse.kura.net.admin.modem.HspaCellularModem;
 import org.eclipse.kura.net.admin.modem.telit.he910.TelitHe910;
+import org.eclipse.kura.net.admin.util.SerialUtil;
 import org.eclipse.kura.net.modem.ModemDevice;
 import org.eclipse.kura.net.modem.ModemPdpContext;
 import org.eclipse.kura.net.modem.ModemPdpContextType;
@@ -558,19 +559,10 @@ public class SierraMc87xx implements HspaCellularModem {
 
     private CommConnection openSerialPort(String port) throws KuraException {
 
-        CommConnection connection = null;
         if (this.connectionFactory != null) {
-            String uri = new CommURI.Builder(port).withBaudRate(115200).withDataBits(8).withStopBits(1).withParity(0)
-                    .withTimeout(2000).build().toString();
-
-            try {
-                connection = (CommConnection) this.connectionFactory.createConnection(uri, 1, false);
-            } catch (Exception e) {
-                logger.debug("Exception creating connection: {}", e);
-                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
-            }
+            return SerialUtil.openSerialPort(this.connectionFactory, port);
         }
-        return connection;
+        return null;
     }
 
     private void closeSerialPort(CommConnection connection) throws KuraException {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/sierra/usb598/SierraUsb598.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/sierra/usb598/SierraUsb598.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -36,6 +36,8 @@ import org.eclipse.kura.net.admin.modem.EvdoCellularModem;
 import org.eclipse.kura.net.admin.modem.sierra.CnS;
 import org.eclipse.kura.net.admin.modem.sierra.CnsAppIDs;
 import org.eclipse.kura.net.admin.modem.sierra.CnsOpTypes;
+import org.eclipse.kura.net.admin.util.SerialUtil;
+import org.eclipse.kura.net.modem.CellularModem.SerialPortType;
 import org.eclipse.kura.net.modem.ModemCdmaServiceProvider;
 import org.eclipse.kura.net.modem.ModemDevice;
 import org.eclipse.kura.net.modem.ModemPdpContext;
@@ -565,19 +567,10 @@ public class SierraUsb598 implements EvdoCellularModem {
 
     private CommConnection openSerialPort(String port) throws KuraException {
 
-        CommConnection connection = null;
         if (this.connectionFactory != null) {
-            String uri = new CommURI.Builder(port).withBaudRate(115200).withDataBits(8).withStopBits(1).withParity(0)
-                    .withTimeout(2000).build().toString();
-
-            try {
-                connection = (CommConnection) this.connectionFactory.createConnection(uri, 1, false);
-            } catch (Exception e) {
-                logger.debug("Exception creating connection: {}", e);
-                throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
-            }
+            return SerialUtil.openSerialPort(this.connectionFactory, port);
         }
-        return connection;
+        return null;
     }
 
     private void closeSerialPort(CommConnection connection) throws KuraException {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/telit/generic/TelitModem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,7 @@ import org.eclipse.kura.linux.net.modem.SupportedUsbModemsInfo;
 import org.eclipse.kura.linux.net.modem.UsbModemDriver;
 import org.eclipse.kura.net.NetConfig;
 import org.eclipse.kura.net.admin.modem.telit.he910.TelitHe910;
+import org.eclipse.kura.net.admin.util.SerialUtil;
 import org.eclipse.kura.net.modem.CellularModem.SerialPortType;
 import org.eclipse.kura.net.modem.ModemDevice;
 import org.eclipse.kura.usb.UsbModemDevice;
@@ -627,19 +628,10 @@ public abstract class TelitModem {
 
     protected CommConnection openSerialPort(String port) throws KuraException {
 
-        CommConnection connection = null;
         if (this.connectionFactory != null) {
-            String uri = new CommURI.Builder(port).withBaudRate(115200).withDataBits(8).withStopBits(1).withParity(0)
-                    .withTimeout(2000).build().toString();
-
-            try {
-                connection = (CommConnection) this.connectionFactory.createConnection(uri, 1, false);
-            } catch (Exception e) {
-                logger.debug("Exception creating connection: " + e);
-                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e, "Connection Failed");
-            }
+            return SerialUtil.openSerialPort(this.connectionFactory, port);
         }
-        return connection;
+        return null;
     }
 
     protected void closeSerialPort(CommConnection connection) throws KuraException {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/util/SerialUtil.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/util/SerialUtil.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ * Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.util;
+
+import java.util.OptionalInt;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.comm.CommConnection;
+import org.eclipse.kura.comm.CommURI;
+import org.eclipse.kura.system.SystemService;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.io.ConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class SerialUtil {
+
+    private static final String RECEIVE_TIMEOUT_PROP_NAME = "net.admin.modem.receive.timeout.ms";
+    private static final Logger logger = LoggerFactory.getLogger(SerialUtil.class);
+    private static final String DEFAULT_RECEIVE_TIMEOUT = "5000";
+    private static OptionalInt receiveTimeout;
+
+    private SerialUtil() {
+    }
+
+    public static synchronized OptionalInt getReceiveTimeout() {
+        if (receiveTimeout == null) {
+            receiveTimeout = getReceiveTimeoutInternal();
+        }
+
+        return receiveTimeout;
+    }
+
+    public static CommConnection openSerialPort(final ConnectionFactory factory, final String port)
+            throws KuraException {
+
+        CommConnection connection = null;
+
+        final OptionalInt currentReceiveTimeout = SerialUtil.getReceiveTimeout();
+
+        CommURI.Builder builder = new CommURI.Builder(port).withBaudRate(115200).withDataBits(8).withStopBits(1)
+                .withParity(0).withOpenTimeout(2000);
+
+        if (currentReceiveTimeout.isPresent()) {
+            logger.debug("Setting receive timeout to {} ms", currentReceiveTimeout.getAsInt());
+
+            builder = builder.withReceiveTimeout(currentReceiveTimeout.getAsInt());
+        }
+
+        final String uri = builder.build().toString();
+
+        try {
+            connection = (CommConnection) factory.createConnection(uri, 1, false);
+        } catch (Exception e) {
+            logger.debug("Exception creating connection", e);
+            throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e, "Connection Failed");
+        }
+
+        return connection;
+    }
+
+    private static OptionalInt getReceiveTimeoutInternal() {
+        final BundleContext bundleContext = FrameworkUtil.getBundle(SerialUtil.class).getBundleContext();
+
+        final ServiceReference<SystemService> systemServiceRef = bundleContext.getServiceReference(SystemService.class);
+
+        OptionalInt result = OptionalInt.empty();
+
+        if (systemServiceRef == null) {
+            return result;
+        }
+
+        SystemService systemService = null;
+
+        try {
+            systemService = bundleContext.getService(systemServiceRef);
+
+            final String raw = systemService.getProperties().getProperty(RECEIVE_TIMEOUT_PROP_NAME,
+                    DEFAULT_RECEIVE_TIMEOUT);
+
+            final int parsed = Integer.parseInt(raw);
+
+            if (parsed > 0) {
+                result = OptionalInt.of(parsed);
+            } else {
+                result = OptionalInt.empty();
+            }
+
+        } catch (final Exception e) {
+            result = OptionalInt.empty();
+        } finally {
+            if (systemService != null) {
+                bundleContext.ungetService(systemServiceRef);
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

Enables serial receive timeout for communication with modems. The receive timeout is set to 5 seconds by default and can be customized using the newly introduced `net.admin.modem.receive.timeout.ms` property in `kura.properties`.
Given the current implementation of modem communication that relies heavily on the `InputStream.available()` method, the timeout should never trigger, but this PR enables it as a safety measure to avoid potential reads without a timeout.
The behavior of the previous implementation can be recovered by setting the`net.admin.modem.receive.timeout.ms` property to a value lesser or equal than zero.