### PR TITLE
Fixed NPE H2DbWireRecordStore and removed unnecessary OSGi reference

### DIFF
--- a/kura/org.eclipse.kura.core/OSGI-INF/h2dbserver.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/h2dbserver.xml
@@ -15,7 +15,6 @@
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" immediate="true" modified="updated" name="org.eclipse.kura.core.db.H2DbServer">
    <implementation class="org.eclipse.kura.core.db.H2DbServer"/>
-   <reference bind="setConfigurationService" cardinality="1..1" interface="org.eclipse.kura.configuration.ConfigurationService" name="ConfigurationService" policy="static" unbind="unsetConfigurationService"/>
    <property name="service.pid" type="String" value="org.eclipse.kura.core.db.H2DbServer"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
@@ -102,7 +102,9 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
     public synchronized void bindDbService(H2DbService dbService) {
         this.dbService = dbService;
         this.dbHelper = H2DbServiceHelper.of(dbService);
-        reconcileDB(this.wireRecordStoreOptions.getTableName());
+        if (nonNull(this.dbService) && nonNull(this.wireRecordStoreOptions)) {
+            reconcileDB(this.wireRecordStoreOptions.getTableName());
+        }
     }
 
     public synchronized void unbindDbService(H2DbService dbService) {


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Removed OSGi dangling reference and added null checks in dbstore bind method.

**Related Issue:** N/A.

**Description of the solution adopted:** Removed a dangling OSGi reference in the H2DbServer component: the configuration service is not required in that component. Added a nullity check in the bindDbService of the H2DbWireRecordStore that caused NPE on first launch.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
