### PR TITLE
Deprecated SafeProcess and related classes

### DIFF
--- a/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Export-Package: org.eclipse.kura.core.data;version="1.1.0",
  org.eclipse.kura.core.linux.executor;version="1.0.0",
  org.eclipse.kura.core.linux.util;version="1.2.0",
  org.eclipse.kura.core.ssl;version="1.0.0",
- org.eclipse.kura.core.util;version="1.2.0"
+ org.eclipse.kura.core.util;version="1.3.0";x-internal:=true
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.crypto,

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/util/LinuxProcessUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/util/LinuxProcessUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -34,6 +34,11 @@ import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated since {@link org.eclipse.kura.core.util} version 1.3 in favor of
+ *             {@link org.eclipse.kura.executor.CommandExecutorService}
+ */
+@Deprecated
 public class LinuxProcessUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(LinuxProcessUtil.class);

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/util/ProcessStats.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/util/ProcessStats.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,10 @@ import java.io.OutputStream;
 
 import org.eclipse.kura.core.util.SafeProcess;
 
+/**
+ * @deprecated since {@link org.eclipse.kura.core.util} version 1.3
+ */
+@Deprecated
 public class ProcessStats {
 
     private final SafeProcess process;

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/util/ProcessUtil.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/util/ProcessUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,11 @@ import java.util.concurrent.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated since {@link org.eclipse.kura.core.util} version 1.3 in favor of
+ *             {@link org.eclipse.kura.executor.CommandExecutorService}
+ */
+@Deprecated
 public class ProcessUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(ProcessUtil.class);

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/util/SafeProcess.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/util/SafeProcess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,11 @@ import java.util.concurrent.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated since {@link org.eclipse.kura.core.util} version 1.3 in favor of
+ *             {@link org.eclipse.kura.executor.CommandExecutorService}
+ */
+@Deprecated
 public class SafeProcess {
 
     private static final Logger logger = LoggerFactory.getLogger(SafeProcess.class);


### PR DESCRIPTION
This PR deprecates the following classes:

- `SafeProcess`
- `ProcessUtil`
- `LinuxProcessUtil`
- `ProcessStats`

They are replaced by the `CommandExecutorService`.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>