### PR TITLE
Fixed footer left margin on small screens

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -113,10 +113,6 @@
 		white-space:
 		pre-wrap;
 		}
-		
-        .panel-footer {
-        margin-left: 20vh;
-        }
 	</ui:style>
 
 	<b:Container fluid="true">
@@ -289,7 +285,7 @@
 						size="MD_12">
 						<b:Row>
 							<b:Panel>
-								<b:PanelFooter addStyleNames="{style.panel-footer}">
+								<b:PanelFooter addStyleNames="panel-footer">
 									<b:Row>
 										<b:Column size="MD_6,XS_6">
 											<b.html:Paragraph alignment="LEFT">

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -442,17 +442,19 @@ Sidenav START
 	.no-sidenav .sidenav {
 		display: none;
 	}
-	
-	.no-sidenav .footer {
-		left: 0 !important;
+
+	/*
+	.no-sidenav .panel-footer {
+		margin-left: 0;
 	}
+	*/
 	
 	.main-container:not(.no-sidenav) .no-sidenav-logo {
 		display: none;
 	}
 	
-	.footer {
-		left: 16.66666667%;
+	.main-container:not(.no-sidenav) .panel-footer {
+		margin-left: 16.66666667%;
 	}
 	
 	.sidenav-overlay {
@@ -495,6 +497,10 @@ Sidenav START
 	
 	.no-sidenav-logo {
 		display: none;
+	}
+	
+	.panel-footer {
+		margin-left: 0;
 	}
 }
 

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -442,12 +442,6 @@ Sidenav START
 	.no-sidenav .sidenav {
 		display: none;
 	}
-
-	/*
-	.no-sidenav .panel-footer {
-		margin-left: 0;
-	}
-	*/
 	
 	.main-container:not(.no-sidenav) .no-sidenav-logo {
 		display: none;


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. This PR fixes the left margin for the footer when sidenav is not shown.

**Related Issue:** N/A.

**Description of the solution adopted:** Fixed Denali's CSS and removed the custom style rule in EntryClassUi.ui.xml that was overriding others.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
