### PR TITLE
Fixed help section width in modem tab

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -786,22 +786,6 @@ Help panel START
 Help panel END
 ***********************/
 
-/**********************
-Modem Help Fix START
-***********************/
-
-#modem-help {
-	max-width: 20%;
-}
-
-#modem-help * {
-	max-width 100%;
-}
-
-/**********************
-Modem Help Fix END
-***********************/
-
 /** Most GWT widgets already have a style name defined */
 .gwt-DialogBox {
 	width: 400px;


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Fixed help section width in modem tab.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:**

Before:
<img width="1653" alt="network-help-width-problem" src="https://user-images.githubusercontent.com/39562568/126762127-ee80e0f0-4cf6-4aa7-8e70-ef7dc59f10b0.png">

After:
![network-help-width-solution](https://user-images.githubusercontent.com/39562568/126762275-0fa5e554-3ac2-45a0-bc74-82f8c61ba310.png)


**Any side note on the changes made:** N/A.
