### PR TITLE
Added support for clock library error report management

### DIFF
--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/JavaNtpClockSyncProvider.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/JavaNtpClockSyncProvider.java
@@ -48,9 +48,9 @@ public class JavaNtpClockSyncProvider extends AbstractNtpClockSyncProvider {
             TimeInfo info = ntpClient.getTime(ntpHostAddr, this.ntpPort);
             this.lastSync = new Date();
             info.computeDetails();
+            info.getComments().forEach(comment -> logger.debug("Clock sync compute comment: {}", comment));
             List<String> computeErrors = info.getComments().stream().filter(comment -> comment.contains("Error:"))
                     .collect(Collectors.toList());
-            computeErrors.forEach(error -> logger.debug("Clock sync compute error: {}", error));
             Long delayValue = info.getDelay();
             if (delayValue != null && delayValue.longValue() < 1000 && computeErrors.isEmpty()) {
                 this.listener.onClockUpdate(info.getOffset());

--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/JavaNtpClockSyncProvider.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/JavaNtpClockSyncProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,8 @@ package org.eclipse.kura.linux.clock;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.net.ntp.NTPUDPClient;
 import org.apache.commons.net.ntp.TimeInfo;
@@ -42,23 +44,25 @@ public class JavaNtpClockSyncProvider extends AbstractNtpClockSyncProvider {
         ntpClient.setDefaultTimeout(this.ntpTimeout);
         try {
             ntpClient.open();
-            try {
-                InetAddress ntpHostAddr = InetAddress.getByName(this.ntpHost);
-                TimeInfo info = ntpClient.getTime(ntpHostAddr, this.ntpPort);
-                this.lastSync = new Date();
-                info.computeDetails();
-                Long delayValue = info.getDelay();
-                if (delayValue != null && delayValue.longValue() < 1000) {
-                    this.listener.onClockUpdate(info.getOffset());
-                    ret = true;
-                } else {
-                    logger.error("Incorrect delay value({}), clock will not be updated", info.getDelay());
-                }
-            } catch (IOException e) {
-                logger.warn(
-                        "Error while synchronizing System Clock with NTP host {}. Please verify network connectivity ...",
-                        this.ntpHost);
+            InetAddress ntpHostAddr = InetAddress.getByName(this.ntpHost);
+            TimeInfo info = ntpClient.getTime(ntpHostAddr, this.ntpPort);
+            this.lastSync = new Date();
+            info.computeDetails();
+            List<String> computeErrors = info.getComments().stream().filter(comment -> comment.contains("Error:"))
+                    .collect(Collectors.toList());
+            computeErrors.forEach(error -> logger.debug("Clock sync compute error: {}", error));
+            Long delayValue = info.getDelay();
+            if (delayValue != null && delayValue.longValue() < 1000 && computeErrors.isEmpty()) {
+                this.listener.onClockUpdate(info.getOffset());
+                ret = true;
+            } else {
+                logger.error("Incorrect clock sync. Delay value({}), clock will not be updated", info.getDelay());
             }
+
+        } catch (IOException e) {
+            logger.warn(
+                    "Error while synchronizing System Clock with NTP host {}. Please verify network connectivity ...",
+                    this.ntpHost);
         } catch (Exception e) {
             throw new KuraException(KuraErrorCode.CONNECTION_FAILED, e);
         } finally {


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

Brief description of the PR. This PR enriches the existing java NTP clock management introducing a check to verify if the library reports anomalies in the clock sync. Error conditions noticed by the library are now identified and reported to the end user. And if an error is now happening in the parsing of the NTP data, the process will fail, causing the resina job to continue its process.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** See description

**Screenshots:** N/A

**Any side note on the changes made:** N/A
