### PR TITLE
[Backport] Disable hwclock update with chrony. (#3503)

### DIFF
--- a/kura/org.eclipse.kura.linux.clock/OSGI-INF/metatype/org.eclipse.kura.clock.ClockService.xml
+++ b/kura/org.eclipse.kura.linux.clock/OSGI-INF/metatype/org.eclipse.kura.clock.ClockService.xml
@@ -108,14 +108,14 @@
             cardinality="0" 
             required="true"
             default="/dev/rtc0" 
-            description="The RTC File Name. It defaults to /dev/rtc0."/>
+            description="The RTC File Name. It defaults to /dev/rtc0. This option is not used if chrony-advanced option is selected in clock.provider."/>
             
         <AD id="chrony.advanced.config"
             name="Chrony Configuration"
             type="String"
             cardinality="0"
             required="false"
-            description="chrony configuration file.|TextArea" />
+            description="Chrony configuration file.|TextArea" />
             
     </OCD>
     <Designate pid="org.eclipse.kura.clock.ClockService">

--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ChronyClockSyncProvider.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ChronyClockSyncProvider.java
@@ -199,7 +199,7 @@ public class ChronyClockSyncProvider implements ClockSyncProvider {
                     this.lastSyncValue = new Date(
                             TimeUnit.MILLISECONDS.convert(journalEntry.getTime(), TimeUnit.MICROSECONDS));
 
-                    this.listener.onClockUpdate(parseOffset(journalEntry.getMessage()));
+                    this.listener.onClockUpdate(0, false);
                 }
             } else {
                 logger.debug("No new clock stepping event");
@@ -209,13 +209,6 @@ public class ChronyClockSyncProvider implements ClockSyncProvider {
                     journalClockUpdateRead.getErrorStream());
         }
 
-    }
-
-    private long parseOffset(String message) {
-        String secondsString = message.split(" ")[5];
-        Float microseconds = Float.valueOf(secondsString) * 1_000_000;
-
-        return TimeUnit.SECONDS.convert(microseconds.longValue(), TimeUnit.MICROSECONDS);
     }
 
     @Override
@@ -268,22 +261,15 @@ public class ChronyClockSyncProvider implements ClockSyncProvider {
 
         @SerializedName("__REALTIME_TIMESTAMP")
         private final long time;
-        @SerializedName("MESSAGE")
-        private final String message;
 
         @SuppressWarnings("unused")
-        public JournalChronyEntry(long time, String message) {
+        public JournalChronyEntry(long time) {
             super();
             this.time = time;
-            this.message = message;
         }
 
         public long getTime() {
             return this.time;
-        }
-
-        public String getMessage() {
-            return this.message;
         }
 
     }

--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ClockServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ClockServiceImpl.java
@@ -198,13 +198,13 @@ public class ClockServiceImpl implements ConfigurableComponent, ClockService, Cl
      * Called by the current ClockSyncProvider after each Clock synchronization
      */
     @Override
-    public void onClockUpdate(long offset) {
+    public void onClockUpdate(long offset, boolean changeSystemClock) {
 
         logger.info("Clock update. Offset: {}", offset);
 
         // set system clock if necessary
         boolean bClockUpToDate = false;
-        if (offset != 0) {
+        if (offset != 0 && changeSystemClock) {
             long time = System.currentTimeMillis() + offset;
             Command command = new Command(new String[] { "date", "-s", "@" + Long.toString(time / 1000) });
             command.setTimeout(60);
@@ -229,7 +229,7 @@ public class ClockServiceImpl implements ConfigurableComponent, ClockService, Cl
 
         String path = (String) this.properties.getOrDefault(PROP_RTC_FILENAME, "/dev/rtc0");
 
-        if (updateHwClock) {
+        if (updateHwClock && changeSystemClock) {
             Command command = new Command(new String[] { "hwclock", "--utc", "--systohc", "-f", path });
             command.setTimeout(60);
             CommandStatus status = this.executorService.execute(command);

--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ClockSyncListener.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ClockSyncListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,5 +14,5 @@ package org.eclipse.kura.linux.clock;
 
 public interface ClockSyncListener {
 
-    public void onClockUpdate(long offset);
+    public void onClockUpdate(long offset, boolean changeSystemClock);
 }

--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/JavaNtpClockSyncProvider.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/JavaNtpClockSyncProvider.java
@@ -53,12 +53,11 @@ public class JavaNtpClockSyncProvider extends AbstractNtpClockSyncProvider {
                     .collect(Collectors.toList());
             Long delayValue = info.getDelay();
             if (delayValue != null && delayValue.longValue() < 1000 && computeErrors.isEmpty()) {
-                this.listener.onClockUpdate(info.getOffset());
+                this.listener.onClockUpdate(info.getOffset(), true);
                 ret = true;
             } else {
                 logger.error("Incorrect clock sync. Delay value({}), clock will not be updated", info.getDelay());
             }
-
         } catch (IOException e) {
             logger.warn(
                     "Error while synchronizing System Clock with NTP host {}. Please verify network connectivity ...",

--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/NtpdClockSyncProvider.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/NtpdClockSyncProvider.java
@@ -53,7 +53,7 @@ public class NtpdClockSyncProvider extends AbstractNtpClockSyncProvider {
 
                 // Call update method with 0 offset to ensure the clock event gets fired and the HW clock
                 // is updated if desired.
-                this.listener.onClockUpdate(0);
+                this.listener.onClockUpdate(0, true);
                 ret = true;
             } else {
                 logger.warn(

--- a/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/ChronyClockSyncProviderTest.java
+++ b/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/ChronyClockSyncProviderTest.java
@@ -64,7 +64,7 @@ public class ChronyClockSyncProviderTest {
         ChronyClockSyncProvider ntsClockSyncProvider = new ChronyClockSyncProvider(commandExecutorMock,
                 cryptoServiceMock);
         AtomicBoolean invoked = new AtomicBoolean(false);
-        ClockSyncListener listener = offset -> {
+        ClockSyncListener listener = (offset, update) -> {
             assertEquals(0, offset);
 
             invoked.set(true);

--- a/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/ClockServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/ClockServiceImplTest.java
@@ -185,7 +185,7 @@ public class ClockServiceImplTest {
         ClockServiceImpl svc = new ClockServiceImpl() {
 
             @Override
-            public void onClockUpdate(long offset) {
+            public void onClockUpdate(long offset, boolean update) {
                 synchronized (lock) {
                     lock.notifyAll();
                 }
@@ -230,7 +230,7 @@ public class ClockServiceImplTest {
         properties.put("clock.set.hwclock", false);
         TestUtil.setFieldValue(svc, "properties", properties);
 
-        svc.onClockUpdate(0); // 0 offset => don't perform sys clock update
+        svc.onClockUpdate(0, false); // 0 offset => don't perform sys clock update
 
         verify(eaMock, times(1)).postEvent(isA(ClockEvent.class));
     }
@@ -256,7 +256,7 @@ public class ClockServiceImplTest {
         properties.put("clock.set.hwclock", true);
         TestUtil.setFieldValue(svc, "properties", properties);
 
-        svc.onClockUpdate(1);
+        svc.onClockUpdate(1, true);
 
         verify(eaMock, times(1)).postEvent(isA(ClockEvent.class)); // sys clock updated successfully
     }
@@ -279,7 +279,7 @@ public class ClockServiceImplTest {
         properties.put("clock.set.hwclock", true);
         TestUtil.setFieldValue(svc, "properties", properties);
 
-        svc.onClockUpdate(1);
+        svc.onClockUpdate(1, true);
 
         verify(eaMock, times(0)).postEvent(isA(ClockEvent.class)); // sys clock not updated
     }
@@ -302,7 +302,7 @@ public class ClockServiceImplTest {
         properties.put("clock.set.hwclock", true);
         TestUtil.setFieldValue(svc, "properties", properties);
 
-        svc.onClockUpdate(1);
+        svc.onClockUpdate(1, true);
 
         verify(eaMock, times(1)).postEvent(isA(ClockEvent.class)); // sys clock updated successfully
     }

--- a/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/NtpdClockSyncProviderTest.java
+++ b/kura/test/org.eclipse.kura.linux.clock.test/src/test/java/org/eclipse/kura/linux/clock/NtpdClockSyncProviderTest.java
@@ -43,7 +43,7 @@ public class NtpdClockSyncProviderTest {
         ClockSyncListener listener = new ClockSyncListener() {
 
             @Override
-            public void onClockUpdate(long offset) {
+            public void onClockUpdate(long offset, boolean update) {
                 assertEquals(0, offset);
 
                 invoked.set(true);
@@ -69,7 +69,7 @@ public class NtpdClockSyncProviderTest {
         ClockSyncListener listener = new ClockSyncListener() {
 
             @Override
-            public void onClockUpdate(long offset) {
+            public void onClockUpdate(long offset, boolean update) {
                 invoked.set(true);
             }
         };


### PR DESCRIPTION
* Now onClockUpdate accepts a parameter to handle hardware clock update.

* Added note in rtc metatype description

Signed-off-by: Maiero <matteo.maiero@eurotech.com>

Co-authored-by: Maiero <matteo.maiero@eurotech.com>

