### PR TITLE
Fixed error on invalid char length

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/ValidationUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/ValidationUtil.java
@@ -160,7 +160,7 @@ public final class ValidationUtil {
     private static void validateChar(final String value, final GwtConfigParameter param,
             final ValidationErrorConsumer consumer) {
         if (value.length() > 1) {
-            consumer.addError(MessageUtils.get(Integer.toString(value.length()), value));
+            consumer.addError(MessageUtils.get(INVALID_VALUE, value));
         }
         if (param.getMin() != null && param.getMin().charAt(0) > value.charAt(0)) {
             consumer.addError(MessageUtils.get(CONFIG_MIN_VALUE, param.getMin().charAt(0)));


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Added error message on invalid char length validation.

**Related Issue:** N/A.

**Description of the solution adopted:** The validator checked the length of the given input on char fields, but it didn't produce a meaningful error message. With this PR, an "invalid value" error is shown.

**Screenshots:** Now, an invalid value error is shown.

![solution](https://user-images.githubusercontent.com/39562568/127118124-a2d78b01-9be0-406b-a048-2a3a9bc143d6.png)

**Any side note on the changes made:** N/A.
