### PR TITLE
Added check for TI SensorTag version in legacy example

### DIFF
--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/TiSensorTag.java
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag/src/main/java/org/eclipse/kura/example/ble/tisensortag/TiSensorTag.java
@@ -148,7 +148,7 @@ public class TiSensorTag implements BluetoothLeNotificationListener {
         this.cc2650 = cc2650;
     }
 
-    public String getFirmareRevision() {
+    public String getFirmwareRevision() {
         return this.firmwareRevision;
     }
 

--- a/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.test/src/test/java/org/eclipse/kura/example/ble/tisensortag/TiSensorTagTest.java
+++ b/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.test/src/test/java/org/eclipse/kura/example/ble/tisensortag/TiSensorTagTest.java
@@ -96,7 +96,7 @@ public class TiSensorTagTest {
         TiSensorTag tag = builder.build(true);
 
         assertFalse(tag.isCC2650());
-        assertEquals("1.4", tag.getFirmareRevision());
+        assertEquals("1.4", tag.getFirmwareRevision());
     }
 
     @Test
@@ -109,7 +109,7 @@ public class TiSensorTagTest {
         TiSensorTag tag = builder.build(true);
 
         assertTrue(tag.isCC2650());
-        assertEquals("1.40", tag.getFirmareRevision());
+        assertEquals("1.40", tag.getFirmwareRevision());
         assertTrue(tag.isConnected());
     }
 
@@ -127,7 +127,7 @@ public class TiSensorTagTest {
 
         tag.setFirmwareRevision();
 
-        assertNull(tag.getFirmareRevision());
+        assertNull(tag.getFirmwareRevision());
     }
 
     @Test
@@ -242,8 +242,7 @@ public class TiSensorTagTest {
         TiSensorTagNotificationListener listener = mock(TiSensorTagNotificationListener.class);
 
         TiSensorTagBuilder builder = testWrite(true, TiSensorTagGatt.HANDLE_TEMP_SENSOR_NOTIFICATION_2650, "01:00",
-                "enableTemperatureNotifications",
-                listener);
+                "enableTemperatureNotifications", listener);
 
         TiSensorTag tag = builder.getTag();
 


### PR DESCRIPTION
Since the TI SensorTag firmware version above 1.2 is not supported in the legacy example, this PR adds a check for it during connection.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>
