### PR TITLE
Changed ownership and permission for named files

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
@@ -97,6 +97,8 @@ cp ${INSTALL_DIR}/kura/install/usr.sbin.named /etc/apparmor.d/
 if [ ! -f "/etc/bind/rndc.key" ] ; then
     rndc-confgen -r /dev/urandom -a
 fi
+chown bind:bind /etc/bind/rndc.key
+chmod 600 /etc/bind/rndc.key
 
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf

--- a/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
@@ -94,7 +94,9 @@ cp ${INSTALL_DIR}/kura/install/usr.sbin.named /etc/apparmor.d/
 if [ ! -f "/etc/bind/rndc.key" ] ; then
 	rndc-confgen -r /dev/urandom -a
 fi
-
+chown bind:bind /etc/bind/rndc.key
+chmod 600 /etc/bind/rndc.key
+        
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura


### PR DESCRIPTION
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>

This PR fixes the following error in the named logs:

```
named[16289]: open: /etc/bind/rndc.key: permission denied
```

