### PR TITLE
Removed string trims in input and password validation

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/AbstractServicesUi.java
@@ -407,7 +407,7 @@ public abstract class AbstractServicesUi extends Composite {
             public List<EditorError> validate(Editor editor, Object value) {
 
                 List<EditorError> result = new ArrayList<>();
-                if ((input.getText() == null || "".equals(input.getText().trim())) && param.isRequired()) {
+                if ((input.getText() == null || "".equals(input.getText())) && param.isRequired()) {
                     // null in required field
                     result.add(new BasicEditorError(input, input.getText(), MSGS.formRequiredParameter()));
                     AbstractServicesUi.this.valid.put(param.getId(), false);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/ValidationUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/ValidationUtil.java
@@ -54,9 +54,7 @@ public final class ValidationUtil {
             }
         }
 
-        String trimmedValue = value.trim();
-
-        if (param.isRequired() && trimmedValue.isEmpty()) {
+        if (param.isRequired() && value.isEmpty()) {
             consumer.addError(MSGS.formRequiredParameter());
             return;
         }
@@ -64,31 +62,31 @@ public final class ValidationUtil {
         try {
             switch (param.getType()) {
             case BOOLEAN:
-                validateBoolean(trimmedValue, param, consumer);
+                validateBoolean(value, param, consumer);
                 break;
             case CHAR:
-                validateChar(trimmedValue, param, consumer);
+                validateChar(value, param, consumer);
                 break;
             case STRING:
-                validateString(trimmedValue, param, consumer);
+                validateString(value, param, consumer);
                 break;
             case FLOAT:
-                validateFloat(trimmedValue, param, consumer);
+                validateFloat(value, param, consumer);
                 break;
             case INTEGER:
-                validateInteger(trimmedValue, param, consumer);
+                validateInteger(value, param, consumer);
                 break;
             case SHORT:
-                validateShort(trimmedValue, param, consumer);
+                validateShort(value, param, consumer);
                 break;
             case BYTE:
-                validateByte(trimmedValue, param, consumer);
+                validateByte(value, param, consumer);
                 break;
             case LONG:
-                validateLong(trimmedValue, param, consumer);
+                validateLong(value, param, consumer);
                 break;
             case DOUBLE:
-                validateDouble(trimmedValue, param, consumer);
+                validateDouble(value, param, consumer);
                 break;
             case PASSWORD:
                 break;
@@ -97,7 +95,7 @@ public final class ValidationUtil {
                 break;
             }
         } catch (NumberFormatException e) {
-            consumer.addError(MessageUtils.get(INVALID_VALUE, trimmedValue));
+            consumer.addError(MessageUtils.get(INVALID_VALUE, value));
         }
 
     }


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Removed string trim before validation.

**Related Issue:** N/A.

**Description of the solution adopted:** Trimming the value before validation was not safe in certain conditions. An error is now shown if a user inserts spaces before and after the values.
Removed trim also when checking if password is empty: a password consisting of only whitespaces is no more identified as an empty one.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
