### PR TITLE
Close streams in BT legacy code

### DIFF
--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
@@ -220,11 +220,13 @@ public class BluetoothProcess {
         closeQuietly(this.errorStream);
         closeQuietly(this.readOutputStream);
         closeQuietly(this.readErrorStream);
+        closeQuietly(this.inputStream);
+        closeQuietly(this.writeInputStream);
         if (this.futureInputGobbler != null) {
-            logger.info("Is futureInputGobbler closed? " + this.futureInputGobbler.cancel(true));
+            this.futureInputGobbler.cancel(true);
         }
         if (this.futureErrorGobbler != null) {
-            logger.info("Is futureErrorGobbler closed? " + this.futureErrorGobbler.cancel(true));
+            this.futureErrorGobbler.cancel(true);
         }
     }
 

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
@@ -504,7 +504,7 @@ public class BluetoothUtil {
         killCommand.add(HCITOOL);
         killCommand.add("-i");
         killCommand.add(interfaceName);
-        Arrays.asList(params).stream().forEach(s -> killCommand.add(s));
+        Arrays.asList(params).stream().forEach(killCommand::add);
         return executorService.kill(killCommand.toArray(new String[0]), LinuxSignal.SIGINT);
     }
 

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
When the legacy sensorTag example is used, a set of threads are used for scanning. Unfortunately, these are not properly closed when the scan is stopped.
After some investigation, it seems that the streams used for reading/writing on the stdout/stdin are not closed in the BluetoothProcess class. This PR fixes this behavior.
