### PR TITLE
Hidden threat manager tab on no-network profiles

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/SecurityPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/SecurityPanelUi.java
@@ -213,6 +213,12 @@ public class SecurityPanelUi extends Composite {
         } else if (this.tamperDetection.isActive()) {
             this.tamperDetectionPanel.refresh();
         }
+
+        if (!this.session.isNetAdminAvailable()) {
+            this.threatManager.setVisible(false);
+            this.threatManagerPanel.setVisible(false);
+            this.threatManager.removeFromParent();
+        }
     }
 
     public void setSession(GwtSession currentSession) {


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. The threat manager tab is not providing useful information on a NN device.

**Related Issue:** N/A.

**Description of the solution adopted:** UI elements related to the threat manager tab are hidden and the tab itself is removed from its parent.

**Screenshots:** Before this PR, on a NN device the network threat manager was shown as:

![empty-network-threat-manager](https://user-images.githubusercontent.com/39562568/130601025-cc959884-1ae1-4ab7-b28d-242b0bdf31d5.png)


**Any side note on the changes made:** N/A.
