### PR TITLE
Deprecated old bluetooth classes

### DIFF
--- a/kura/org.eclipse.kura.linux.bluetooth/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.linux.bluetooth/META-INF/MANIFEST.MF
@@ -15,5 +15,5 @@ Import-Package: org.apache.commons.io;version="2.4.0",
  org.slf4j;version="1.6.4"
 Service-Component: OSGI-INF/bluetooth.xml
 Bundle-ActivationPolicy: lazy
-Export-Package: org.eclipse.kura.linux.bluetooth.le.beacon,
- org.eclipse.kura.linux.bluetooth.util
+Export-Package: org.eclipse.kura.linux.bluetooth.le.beacon;version="1.0.600",
+ org.eclipse.kura.linux.bluetooth.util;version="1.0.600"

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BTSnoopParser.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BTSnoopParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,7 +19,10 @@ import org.apache.commons.io.IOUtils;
 
 /**
  * Parses a btsnoop stream into btsnoop records
+ * 
+ * @deprecated since {@link org.eclipse.kura.linux.bluetooth.le.beacon} version 1.0.600
  */
+@Deprecated
 public class BTSnoopParser {
 
     private InputStream is;

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BluetoothAdvertisingData.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BluetoothAdvertisingData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kura.linux.bluetooth.le.beacon;
 
+/**
+ * @deprecated since {@link org.eclipse.kura.linux.bluetooth.util} version 1.0.600
+ */
+@Deprecated
 public class BluetoothAdvertisingData {
 
     private static final String PKT_BYTES_NUMBER = "1e";

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BluetoothConfigurationProcessListener.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/le/beacon/BluetoothConfigurationProcessListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,10 @@ import org.eclipse.kura.linux.bluetooth.util.BluetoothProcessListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated since {@link org.eclipse.kura.linux.bluetooth.le.beacon} version 1.0.600
+ */
+@Deprecated
 public class BluetoothConfigurationProcessListener implements BluetoothProcessListener {
 
     private static final Logger logger = LoggerFactory.getLogger(BluetoothConfigurationProcessListener.class);

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BTSnoopListener.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BTSnoopListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,10 @@ package org.eclipse.kura.linux.bluetooth.util;
 
 /**
  * For listening to btsnoop streams
+ * 
+ * @deprecated since {@link org.eclipse.kura.linux.bluetooth.util} version 1.0.600
  */
+@Deprecated
 public interface BTSnoopListener {
 
     /**

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcess.java
@@ -35,6 +35,10 @@ import org.eclipse.kura.linux.bluetooth.le.beacon.BTSnoopParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated since {@link org.eclipse.kura.linux.bluetooth.util} version 1.0.600
+ */
+@Deprecated
 public class BluetoothProcess {
 
     private static final String END_OF_STREAM_MESSAGE = "End of stream!";

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcessListener.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothProcessListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kura.linux.bluetooth.util;
 
+/**
+ * @deprecated since {@link org.eclipse.kura.linux.bluetooth.util} version 1.0.600
+ */
+@Deprecated
 public interface BluetoothProcessListener {
 
     public void processInputStream(String string);

--- a/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
+++ b/kura/org.eclipse.kura.linux.bluetooth/src/main/java/org/eclipse/kura/linux/bluetooth/util/BluetoothUtil.java
@@ -42,6 +42,10 @@ import org.eclipse.kura.executor.Signal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated since {@link org.eclipse.kura.linux.bluetooth.util} version 1.0.600
+ */
+@Deprecated
 public class BluetoothUtil {
 
     private static final String ERROR_EXECUTING_COMMAND_MESSAGE = "Error executing command: {}";


### PR DESCRIPTION
This PR deprecates the following classes:

- org.eclipse.kura.linux.bluetooth.le.beacon.BluetoothAdvertisingData
- org.eclipse.kura.linux.bluetooth.le.beacon.BluetoothConfigurationProcessListener
- org.eclipse.kura.linux.bluetooth.le.beacon.BTSnoopParser
- org.eclipse.kura.linux.bluetooth.util.BluetoothProcess
- org.eclipse.kura.linux.bluetooth.util.BluetoothProcessListener
- org.eclipse.kura.linux.bluetooth.util.BluetoothUtil
- org.eclipse.kura.linux.bluetooth.util.BTSnoopListener

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>
