### PR TITLE
Prevent ip_forward from being set to 0

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/LinuxFirewall.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/LinuxFirewall.java
@@ -361,6 +361,7 @@ public class LinuxFirewall {
     }
 
     private void applyRules() throws KuraException {
+        this.iptables.applyRules();
         if (this.portForwardRules != null && !this.portForwardRules.isEmpty()
                 || this.autoNatRules != null && !this.autoNatRules.isEmpty()
                 || this.natRules != null && !this.natRules.isEmpty()) {
@@ -371,7 +372,6 @@ public class LinuxFirewall {
                 throw new KuraIOException(e, "Failed to enable ip forwarding");
             }
         }
-        this.iptables.applyRules();
     }
 
     public void enable() throws KuraException {


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. With this PR, the LinuxFirewall is only able to enable ip_forwarding and no more able to disable it.

**Related Issue:** This PR fixes/closes #3546.

**Description of the solution adopted:** Before this PR, the ip_forward variable could be set to 0 by Kura. As explained in the linked issue, this could cause problems to external applications that expect the variable to be set to 1. Now, Kura is never setting ip_forward to 0 but can set it to 1 if necessary (for example, if the user defines NAT or forwarding rules).

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
