### PR TITLE
Allowed network admin to perform a findDeviceConfiguration request

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtDeviceService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtDeviceService.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.kura.web.server.Audit;
 import org.eclipse.kura.web.server.RequiredPermissions;
+import org.eclipse.kura.web.server.RequiredPermissions.Mode;
 import org.eclipse.kura.web.shared.GwtKuraException;
 import org.eclipse.kura.web.shared.KuraPermission;
 import org.eclipse.kura.web.shared.model.GwtGroupedNVPair;
@@ -28,6 +29,7 @@ import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 @RequiredPermissions(KuraPermission.DEVICE)
 public interface GwtDeviceService extends RemoteService {
 
+    @RequiredPermissions(mode = Mode.ANY, value = { KuraPermission.DEVICE, KuraPermission.NETWORK_ADMIN })
     public List<GwtGroupedNVPair> findDeviceConfiguration(GwtXSRFToken xsrfToken) throws GwtKuraException;
 
     public List<GwtGroupedNVPair> findBundles(GwtXSRFToken xsrfToken) throws GwtKuraException;


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Allowed network admin to perform a findDeviceConfiguration request.

**Related Issue:** N/A.

**Description of the solution adopted:** Before this PR, a user with just the "kura.network.admin" permission could not see the "Network" tab since it requires "findDeviceConfiguration" method from the GwtDeviceService, which in turn requires the "kura.device" permission.

**Screenshots:** Permission error.

![screen](https://user-images.githubusercontent.com/39562568/131319435-bfe5a0b5-e385-48e3-8b4b-39b4cccbf735.png)


**Any side note on the changes made:** N/A.
