### PR TITLE
Fixed system packages parsing on APK package manager

### DIFF
--- a/kura/test/org.eclipse.kura.core.system.test/src/test/java/org/eclipse/kura/core/system/SystemServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.system.test/src/test/java/org/eclipse/kura/core/system/SystemServiceTest.java
@@ -286,7 +286,7 @@ public class SystemServiceTest {
     }
 
     @Test
-    public void testgGetSystemPackages() throws IOException, KuraProcessExecutionErrorException {
+    public void testGetSystemPackages() throws IOException, KuraProcessExecutionErrorException {
         CommandExecutorService cesMock = mock(CommandExecutorService.class);
 
         Command dpkgCommand = new Command(new String[] { "dpkg-query", "-W" });
@@ -325,7 +325,8 @@ public class SystemServiceTest {
         assertEquals("package4", packages.get(3).getName());
         assertEquals(SystemResourceType.RPM, packages.get(3).getType());
         assertEquals(SystemResourceType.APK, packages.get(4).getType());
-        assertEquals("dos2unix-7.4.1-r0", packages.get(4).getName());
+        assertEquals("dos2unix", packages.get(4).getName());
+        assertEquals("7.4.1-r0", packages.get(4).getVersion());
     }
 
     @Test(expected = KuraProcessExecutionErrorException.class)


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Fixed package name parsing when retrieving packages list with a APK package manager.

**Related Issue:** N/A.

**Description of the solution adopted:** With APK package manager, the name and version of a software were not separated with a sequence of spaces but with "-". For example, "dos2unix-7.4.1-r0". The regex is complex because it may happen that the package name itself contains "-" as well as numbers.

**Screenshots:** Before.

![screen1](https://user-images.githubusercontent.com/39562568/131627727-304630e6-adb2-4e36-8701-1b0d97f7098e.png)

After.

![Screenshot 2021-09-01 at 09 10 08](https://user-images.githubusercontent.com/39562568/131627867-d9c96e9d-a608-4388-8216-a74fa79eb0b4.png)

**Any side note on the changes made:** N/A.
