### PR TITLE
Added support for PEMKeyPair object in KeystoreService

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/KeystoreRemoteService.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/KeystoreRemoteService.java
@@ -108,8 +108,11 @@ public class KeystoreRemoteService {
         PrivateKey privkey = null;
         if (object instanceof org.bouncycastle.asn1.pkcs.PrivateKeyInfo) {
             privkey = converter.getPrivateKey((org.bouncycastle.asn1.pkcs.PrivateKeyInfo) object);
+        } else if (object instanceof org.bouncycastle.openssl.PEMKeyPair) {
+            privkey = converter.getKeyPair((org.bouncycastle.openssl.PEMKeyPair) object).getPrivate();
+        } else {
+            throw new IOException("PrivateKey not recognized.");
         }
-
         return new PrivateKeyEntry(privkey, certs);
     }
 


### PR DESCRIPTION
This PR adds the support for PEMKeyPair object in KeystoreService.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** Some key pair causes a NPE when uploaded in Kura. This because the private  key is parsed as a PEMKeyPair object instead of a PrivateKeyInfo. This PR adds the support for the PEMKeyPair class and shows a more meaningful message on the screen when the key pair is not recognized.

**Screenshots:** When the wrong key pair is uploaded on ESF, this is the error shown on screen:

<img width="840" alt="Screen Shot 2021-09-01 at 5 40 42 PM" src="https://user-images.githubusercontent.com/2919570/131796749-94f815c9-e5fb-44b4-a805-a7ce6b915116.png">

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>