### PR TITLE
Fixed FirewallConfigurationService deactivation method

### DIFF
--- a/kura/org.eclipse.kura.net.admin/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.net.admin/META-INF/MANIFEST.MF
@@ -48,7 +48,7 @@ Import-Package: javax.microedition.io,
  org.osgi.service.io;version="1.0.0",
  org.osgi.service.useradmin;version="1.0.0",
  org.osgi.util.tracker;version="1.5.1",
- org.slf4j;version="1.6.4"
+ org.slf4j;version="1.7.25"
 Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -50,7 +50,6 @@ import org.eclipse.kura.net.firewall.FirewallOpenPortConfigIP;
 import org.eclipse.kura.net.firewall.FirewallOpenPortConfigIP4;
 import org.eclipse.kura.net.firewall.FirewallPortForwardConfigIP;
 import org.eclipse.kura.net.firewall.FirewallPortForwardConfigIP4;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.event.EventAdmin;
 import org.slf4j.Logger;
@@ -61,7 +60,6 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
     private static final Logger logger = LoggerFactory.getLogger(FirewallConfigurationServiceImpl.class);
 
     private EventAdmin eventAdmin;
-    private ServiceRegistration<?> serviceRegistration;
     private LinuxFirewall firewall;
     private CommandExecutorService executorService;
 
@@ -86,15 +84,17 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
     }
 
     protected void activate(ComponentContext componentContext, Map<String, Object> properties) {
-        logger.debug("activate()");
+        logger.info("Activating FirewallConfigurationService...");
 
         this.firewall = getLinuxFirewall();
         updated(properties);
+
+        logger.info("Activating FirewallConfigurationService... Done.");
     }
 
     protected void deactivate(ComponentContext componentContext) {
-        logger.debug("deactivate()");
-        this.serviceRegistration.unregister();
+        logger.info("Deactivating FirewallConfigurationService...");
+        logger.info("Deactivating FirewallConfigurationService... Done.");
     }
 
     public synchronized void updated(Map<String, Object> properties) {


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. The `ServiceRegistration` was never initialised and, in fact, never used. So, a NPE was given during the deactivation. Updated also the `slf4j` version for fixing the `InstanceAlreadyExistsException` exception at startup for this particular bundle.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
