### PR TITLE
When running into a timeout, report an error

### DIFF
--- a/kura/distrib/src/main/sh/extract.sh
+++ b/kura/distrib/src/main/sh/extract.sh
@@ -57,6 +57,7 @@ function run_kura_install {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The installation process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done
@@ -71,6 +72,7 @@ function run_kura_install {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The installation process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done
@@ -92,6 +94,7 @@ function run_do_restore {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The restore process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done
@@ -106,6 +109,7 @@ function run_do_restore {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The restore process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done

--- a/kura/distrib/src/main/sh/extract_nn.sh
+++ b/kura/distrib/src/main/sh/extract_nn.sh
@@ -38,6 +38,7 @@ function run_kura_install {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The installation process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done
@@ -52,6 +53,7 @@ function run_kura_install {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The installation process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done

--- a/kura/distrib/src/main/sh/extract_upgrade.sh
+++ b/kura/distrib/src/main/sh/extract_upgrade.sh
@@ -90,6 +90,7 @@ function run_kura_upgrade {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The installation process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done
@@ -104,6 +105,7 @@ function run_kura_upgrade {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The installation process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done
@@ -124,6 +126,7 @@ function run_cleanup {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The installation process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done
@@ -138,6 +141,7 @@ function run_cleanup {
             if [ "$DELTA" -ge "$TIMEOUT_TIME" ]; then
                 echo "The installation process is not responding. It'll be stopped."
                 kill -9 $PID >> /dev/null 2>&1
+                exit 2
             fi
             sleep $REFRESH_TIME
         done


### PR DESCRIPTION
When the installer fails with a timeout, it still reports "success" to the caller.

Now, the installer scripts returns "2", which indicates an error.