### PR TITLE
Added scale factor parameter in BaseAsset

### DIFF
--- a/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/AssetConstants.java
+++ b/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/AssetConstants.java
@@ -43,7 +43,10 @@ public enum AssetConstants {
     TYPE(CHANNEL_DEFAULT_PROPERTY_PREFIX.value() + "type"),
 
     /** Value type Property to be used in the configuration. */
-    VALUE_TYPE(CHANNEL_DEFAULT_PROPERTY_PREFIX.value() + "value.type");
+    VALUE_TYPE(CHANNEL_DEFAULT_PROPERTY_PREFIX.value() + "value.type"),
+
+    /** Scale factor Property to be used in the configuration. */
+    FACTOR(CHANNEL_DEFAULT_PROPERTY_PREFIX.value() + "factor");
 
     /** The value. */
     private String value;

--- a/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/BaseChannelDescriptor.java
+++ b/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/BaseChannelDescriptor.java
@@ -17,6 +17,7 @@ package org.eclipse.kura.asset.provider;
 import static org.eclipse.kura.asset.provider.AssetConstants.NAME;
 import static org.eclipse.kura.asset.provider.AssetConstants.TYPE;
 import static org.eclipse.kura.asset.provider.AssetConstants.VALUE_TYPE;
+import static org.eclipse.kura.asset.provider.AssetConstants.FACTOR;
 
 import java.util.List;
 
@@ -39,6 +40,7 @@ import org.eclipse.kura.util.collection.CollectionUtil;
  * <li>name</li> denotes the name of the channel
  * <li>type</li>
  * <li>value.type</li>
+ * <li>factor</li> scale factor for the numeric values
  * </ul>
  *
  * The <b><i>type</i></b> would be one of the following:
@@ -129,6 +131,17 @@ public class BaseChannelDescriptor implements ChannelDescriptor {
         addOptions(valueType, DataType.values());
 
         this.defaultElements.add(valueType);
+
+        final Tad factor = new Tad();
+        factor.setId(AssetConstants.FACTOR.value());
+        factor.setName(AssetConstants.FACTOR.value().substring(1));
+        factor.setType(Tscalar.DOUBLE);
+        factor.setDefault("1.0");
+        factor.setDescription("Scale factor for the numeric values read and written");
+        factor.setCardinality(0);
+        factor.setRequired(true);
+
+        this.defaultElements.add(factor);
     }
 
     /** {@inheritDoc} */

--- a/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/BaseChannelDescriptor.java
+++ b/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/BaseChannelDescriptor.java
@@ -133,8 +133,8 @@ public class BaseChannelDescriptor implements ChannelDescriptor {
         this.defaultElements.add(valueType);
 
         final Tad factor = new Tad();
-        factor.setId(AssetConstants.FACTOR.value());
-        factor.setName(AssetConstants.FACTOR.value().substring(1));
+        factor.setId(FACTOR.value());
+        factor.setName(FACTOR.value().substring(1));
         factor.setType(Tscalar.DOUBLE);
         factor.setDefault("1.0");
         factor.setDescription("Scale factor for the numeric values read and written");


### PR DESCRIPTION
Added scale factor parameters in BaseAsset

**Related Issue:** This PR fixes/closes #2312

**Description of the solution adopted:** Added a scale factor for the numeric variables so that the compatible drivers include by default support to scale the value.