### PR TITLE
Used safer regex to match the beginning of the version string

### DIFF
--- a/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
+++ b/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
@@ -1260,9 +1260,9 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
         for (int i = 0; i < split.length; i++) {
             String s = split[i];
 
+            // version is never at the beginning
             if (i > 0 && i < matchIndex) {
-                // version is never at the beginning
-                if (s.matches("\\d+.(\\w+(.)?)+")) {
+                if (s.matches("^(\\d+.)")) {
                     version += s;
                     matchIndex = i;
                 } else {

--- a/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
+++ b/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.StringJoiner;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
@@ -1253,31 +1254,33 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
      */
     private String[] getApkNameAndVersion(String fullName) {
         String[] split = fullName.split("-");
-        String name = "";
-        String version = "";
+        StringBuilder name = new StringBuilder();
+        StringBuilder version = new StringBuilder();
         int matchIndex = 1000;
+        Pattern pattern = Pattern.compile("^([0-9]+.?)");
 
         for (int i = 0; i < split.length; i++) {
             String s = split[i];
 
             // version is never at the beginning
             if (i > 0 && i < matchIndex) {
-                if (s.matches("^(\\d+.)")) {
-                    version += s;
+                if (pattern.matcher(s).lookingAt()) {
+                    version.append(s);
                     matchIndex = i;
                 } else {
-                    name += "-" + s;
+                    name.append("-");
+                    name.append(s);
                 }
             }
+            
+            // everything else after match is version
             if (i > matchIndex) {
-                // everything else after match is version
-                version += "-" + s;
+                version.append("-");
+                version.append(s);
             }
         }
-        // assuming the first part belongs to the name
-        name = split[0] + name;
 
-        return new String[] { name, version };
+        return new String[] { split[0] + name.toString(), version.toString() };
     }
 
     private CommandStatus execute(String[] commandLine) {

--- a/kura/test/org.eclipse.kura.core.system.test/src/test/java/org/eclipse/kura/core/system/SystemServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.system.test/src/test/java/org/eclipse/kura/core/system/SystemServiceTest.java
@@ -305,7 +305,7 @@ public class SystemServiceTest {
         Command apkCommand = new Command(new String[] { "apk", "list", "-I", "|", "awk", "'{ print $1 }'" });
         apkCommand.setExecuteInAShell(true);
         CommandStatus apkSuccessfulStatus = new CommandStatus(apkCommand, new LinuxExitStatus(0));
-        apkSuccessfulStatus.setOutputStream(writeToOutputStream("dos2unix-7.4.1-r0"));
+        apkSuccessfulStatus.setOutputStream(writeToOutputStream("dos2unix-7.4.1-r0\nkmod-26-r0"));
         when(cesMock.execute(apkCommand)).thenReturn(apkSuccessfulStatus);
 
         SystemServiceImpl systemService = new SystemServiceImpl();
@@ -313,7 +313,7 @@ public class SystemServiceTest {
 
         List<SystemResourceInfo> packages = systemService.getSystemPackages();
         assertFalse(packages.isEmpty());
-        assertEquals(5, packages.size());
+        assertEquals(6, packages.size());
         assertEquals("package1", packages.get(0).getName());
         assertEquals("1.0.0", packages.get(0).getVersion());
         assertEquals(SystemResourceType.DEB, packages.get(0).getType());
@@ -327,6 +327,8 @@ public class SystemServiceTest {
         assertEquals(SystemResourceType.APK, packages.get(4).getType());
         assertEquals("dos2unix", packages.get(4).getName());
         assertEquals("7.4.1-r0", packages.get(4).getVersion());
+        assertEquals("kmod", packages.get(5).getName());
+        assertEquals("26-r0", packages.get(5).getVersion());
     }
 
     @Test(expected = KuraProcessExecutionErrorException.class)


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. The previously used regex was vulnerable to polynomial runtime due to backtracking and could lead to denial of service.

**Related Issue:** N/A.

**Description of the solution adopted:** Instead of matching the whole version as a combination of digits, dots, and words  it is matched just the beginning of it.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
