### PR TITLE
Now SslContext cache is cleaned when KeystoreService in SSLManager is…

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
@@ -99,6 +99,8 @@ public class SslManagerServiceImpl implements SslManagerService, ConfigurableCom
         this.keystoreService = keystoreService;
         this.keystoreServicePid = Optional.of((String) properties.get(ConfigurationService.KURA_SERVICE_PID));
 
+        this.clearSslContexCache();
+
         if (this.sslServiceListeners != null) {
             // Notify listeners that service has been updated
             this.sslServiceListeners.onConfigurationUpdated();
@@ -107,6 +109,14 @@ public class SslManagerServiceImpl implements SslManagerService, ConfigurableCom
 
     public void unsetKeystoreService(KeystoreService keystoreService) {
         if (this.keystoreService == keystoreService) {
+
+            this.clearSslContexCache();
+
+            if (this.sslServiceListeners != null) {
+                // Notify listeners that service has been updated
+                this.sslServiceListeners.onConfigurationUpdated();
+            }
+
             this.keystoreService = null;
             this.keystoreServicePid = Optional.empty();
         }
@@ -537,7 +547,14 @@ public class SslManagerServiceImpl implements SslManagerService, ConfigurableCom
         final KeystoreChangedEvent keystoreChangedEvent = (KeystoreChangedEvent) event;
 
         if (this.keystoreServicePid.equals(Optional.of(keystoreChangedEvent.getSenderPid()))) {
+            this.clearSslContexCache();
             this.sslServiceListeners.onConfigurationUpdated();
+        }
+    }
+
+    private void clearSslContexCache() {
+        if (sslContexts != null) {
+            this.sslContexts.clear();
         }
     }
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
@@ -110,15 +110,15 @@ public class SslManagerServiceImpl implements SslManagerService, ConfigurableCom
     public void unsetKeystoreService(KeystoreService keystoreService) {
         if (this.keystoreService == keystoreService) {
 
+            this.keystoreService = null;
+            this.keystoreServicePid = Optional.empty();
+
             this.clearSslContexCache();
 
             if (this.sslServiceListeners != null) {
                 // Notify listeners that service has been updated
                 this.sslServiceListeners.onConfigurationUpdated();
             }
-
-            this.keystoreService = null;
-            this.keystoreServicePid = Optional.empty();
         }
     }
 


### PR DESCRIPTION
 Now SslContext cache is cleaned when KeystoreService in SSLManager is updated.

This close #3605 