### PR TITLE
Fixed typos in firewall.init

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-centos-7/firewall.init
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7/firewall.init
@@ -99,11 +99,11 @@ if [ -f $iptables_config_file ]; then
 	iptables-restore < $iptables_config_file
 fi
 
-create_filter_chains()
-create_nat_chains()
-create_mangle_chains()
-configure_policies()
-configure_ip_forwarding()
+create_filter_chains
+create_nat_chains
+create_mangle_chains
+configure_policies
+configure_ip_forwarding
 
 # source a custom firewall script
 if [ -f /etc/init.d/firewall_cust ]; then

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/firewall.init
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/firewall.init
@@ -99,11 +99,11 @@ if [ -f $iptables_config_file ]; then
 	iptables-restore < $iptables_config_file
 fi
 
-create_filter_chains()
-create_nat_chains()
-create_mangle_chains()
-configure_policies()
-configure_ip_forwarding()
+create_filter_chains
+create_nat_chains
+create_mangle_chains
+configure_policies
+configure_ip_forwarding
 
 # source a custom firewall script
 if [ -f /etc/init.d/firewall_cust ]; then

--- a/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/firewall.init
@@ -99,11 +99,11 @@ if [ -f $iptables_config_file ]; then
 	iptables-restore < $iptables_config_file
 fi
 
-create_filter_chains()
-create_nat_chains()
-create_mangle_chains()
-configure_policies()
-configure_ip_forwarding()
+create_filter_chains
+create_nat_chains
+create_mangle_chains
+configure_policies
+configure_ip_forwarding
 
 # source a custom firewall script
 if [ -f /etc/init.d/firewall_cust ]; then


### PR DESCRIPTION
This PR removes useless parenthesis from the `firewall.init` script.
 
Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>
