### PR TITLE
Allow suppressing the start of the bluetooth daemon

### DIFF
--- a/kura/org.eclipse.kura.ble.provider/OSGI-INF/bluetoothLe.xml
+++ b/kura/org.eclipse.kura.ble.provider/OSGI-INF/bluetoothLe.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+   Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
 	
 	Contributors:
 	 Eurotech
+	 Red Hat, Inc
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" modified="updated" name="org.eclipse.kura.bluetooth.le.BluetoothLeService">
@@ -20,4 +21,5 @@
    </service>
    <property name="service.pid" value="org.eclipse.kura.bluetooth.le.BluetoothLeService"/>
    <reference bind="setExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static" unbind="unsetExecutorService"/>
+   <reference bind="setSystemService" cardinality="1..1" interface="org.eclipse.kura.system.SystemService" name="SystemService" policy="static" unbind="unsetSystemService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImpl.java
+++ b/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImpl.java
@@ -46,7 +46,7 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
 
     protected void activate(ComponentContext context) {
         logger.info("Activating Bluetooth Le Service...");
-        if (!startBluetoothUbuntuSnap() && !startBluetoothSystemd() && !startBluetoothInitd()) {
+        if (!startBluetoothSuppressed() && !startBluetoothUbuntuSnap() && !startBluetoothSystemd() && !startBluetoothInitd()) {
             startBluetoothDaemon();
         }
         try {
@@ -108,6 +108,11 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
         } else {
             return false;
         }
+    }
+
+    private boolean startBluetoothSuppressed() {
+        // Allow to disable the bluetooth service start, e.g. when running inside a container
+        return Boolean.getBoolean("kura.ble.suppressBluetoothDaemonStart");
     }
 
     private boolean execute(String commandLine) {

--- a/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImpl.java
+++ b/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.kura.bluetooth.le.BluetoothLeAdapter;
 import org.eclipse.kura.bluetooth.le.BluetoothLeService;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.system.SystemService;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.osgi.service.component.ComponentContext;
 
@@ -33,6 +34,7 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
 
     private DeviceManager deviceManager;
     private CommandExecutorService executorService;
+    private SystemService systemService;
 
     public void setExecutorService(CommandExecutorService executorService) {
         this.executorService = executorService;
@@ -41,6 +43,16 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
     public void unsetExecutorService(CommandExecutorService executorService) {
         if (this.executorService == executorService) {
             this.executorService = null;
+        }
+    }
+
+    public void setSystemService(SystemService systemService) {
+        this.systemService = systemService;
+    }
+
+    public void unsetSystemService(SystemService systemService) {
+        if (this.systemService != systemService) {
+            this.systemService = null;
         }
     }
 
@@ -112,7 +124,8 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
 
     private boolean startBluetoothSuppressed() {
         // Allow to disable the bluetooth service start, e.g. when running inside a container
-        return Boolean.getBoolean("kura.ble.suppressBluetoothDaemonStart");
+        String value = this.systemService.getProperties().getProperty("kura.ble.suppressBluetoothDaemonStart");
+        return Boolean.parseBoolean(value);
     }
 
     private boolean execute(String commandLine) {

--- a/kura/test/org.eclipse.kura.internal.ble.test/src/test/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.internal.ble.test/src/test/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImplTest.java
@@ -20,11 +20,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.executor.CommandStatus;
+import org.eclipse.kura.system.SystemService;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -54,6 +56,12 @@ public class BluetoothLeServiceImplTest {
         };
     }
 
+    protected SystemService mockSystemService() {
+        SystemService systemMock = mock(SystemService.class);
+        when(systemMock.getProperties()).thenReturn(new Properties());
+        return systemMock;
+    }
+
     @Test
     public void activateSystemdTest() {
         CommandExecutorService executorMock = mock(CommandExecutorService.class);
@@ -61,6 +69,7 @@ public class BluetoothLeServiceImplTest {
         CommandStatus status = new CommandStatus(command, new LinuxExitStatus(0));
         when(executorMock.execute(command)).thenReturn(status);
         bluetoothLeService.setExecutorService(executorMock);
+        bluetoothLeService.setSystemService(mockSystemService());
         bluetoothLeService.activate(null);
 
         verify(executorMock, times(1)).execute(command);
@@ -76,6 +85,7 @@ public class BluetoothLeServiceImplTest {
         CommandStatus statusSysV = new CommandStatus(commandSysV, new LinuxExitStatus(0));
         when(executorMock.execute(commandSysV)).thenReturn(statusSysV);
         bluetoothLeService.setExecutorService(executorMock);
+        bluetoothLeService.setSystemService(mockSystemService());
         bluetoothLeService.activate(null);
 
         verify(executorMock, times(1)).execute(commandSystemd);
@@ -95,6 +105,7 @@ public class BluetoothLeServiceImplTest {
         CommandStatus statusBTService = new CommandStatus(commandBTService, new LinuxExitStatus(0));
         when(executorMock.execute(commandBTService)).thenReturn(statusBTService);
         bluetoothLeService.setExecutorService(executorMock);
+        bluetoothLeService.setSystemService(mockSystemService());
         bluetoothLeService.activate(null);
 
         verify(executorMock, times(1)).execute(commandSystemd);
@@ -109,6 +120,7 @@ public class BluetoothLeServiceImplTest {
         CommandStatus status = new CommandStatus(command, new LinuxExitStatus(0));
         when(executorMock.execute(command)).thenReturn(status);
         bluetoothLeService.setExecutorService(executorMock);
+        bluetoothLeService.setSystemService(mockSystemService());
         bluetoothLeService.activate(null);
         assertEquals("AA:BB:CC:DD:EE:FF", bluetoothLeService.getAdapter("hci0").getAddress());
     }
@@ -120,6 +132,7 @@ public class BluetoothLeServiceImplTest {
         CommandStatus status = new CommandStatus(command, new LinuxExitStatus(0));
         when(executorMock.execute(command)).thenReturn(status);
         bluetoothLeService.setExecutorService(executorMock);
+        bluetoothLeService.setSystemService(mockSystemService());
         bluetoothLeService.activate(null);
         assertEquals("AA:BB:CC:DD:EE:FF", bluetoothLeService.getAdapters().get(0).getAddress());
     }


### PR DESCRIPTION
This change allows suppressing the start of the bluetooth daemon.

This functionality already exists in the context of snap packages. However, this PR makes this a more generic functionality, allowing container to use this too.