### PR TITLE
Enabled "Apply" button in identities UI when changing from password enabled to disabled

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
@@ -136,6 +136,9 @@ public class UserConfigUi extends Composite {
         this.passwordDisabled.addChangeHandler(e -> {
             this.userData.setPasswordAuthEnabled(false);
             this.userData.setNewPassword(Optional.empty());
+            if (this.hasPassword) {
+                this.listener.onUserDataChanged(this.userData);
+            }
             updatePasswordWidgetState();
         });
 


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Enabled "Apply" button in identities UI when changing from password enabled to disabled. Previously, if an identity configuration was modified by disabling the password, the "Apply" button won't be enabled.
In order to enable it the user had to alter another configuration parameter (e.g. assigning and removing a permission).

**Related Issue:** N/A.

**Description of the solution adopted:** Change listener is triggered when switching from password enabled to disabled.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
