### PR TITLE
Updated manage_kura_users script

### DIFF
--- a/kura/distrib/src/main/resources/common/manage_kura_users.sh
+++ b/kura/distrib/src/main/resources/common/manage_kura_users.sh
@@ -37,7 +37,7 @@ function create_users {
 		if [ ! -f /etc/polkit-1/localauthority/50-local.d/51-org.freedesktop.systemd1.pkla ]; then
 		    echo "[No password prompt for kurad user]
 Identity=unix-user:kurad
-Action=org.freedesktop.systemd1.manage-units
+Action=org.freedesktop.systemd1.*
 ResultInactive=no
 ResultActive=no
 ResultAny=yes" > /etc/polkit-1/localauthority/50-local.d/51-org.freedesktop.systemd1.pkla
@@ -52,12 +52,20 @@ ResultAny=yes" > /etc/polkit-1/localauthority/50-local.d/51-org.freedesktop.syst
         action.lookup(\"unit\") == \"bluetooth.service\")) {
         return polkit.Result.YES;
     }
+    if (action.id == \"org.freedesktop.systemd1.manage-unit-files\" &&
+        subject.user == \"kurad\") {
+        return polkit.Result.YES;
+    }
 });" > /usr/share/polkit-1/rules.d/kura.rules
 			else
 			    echo "polkit.addRule(function(action, subject) {
     if (action.id == \"org.freedesktop.systemd1.manage-units\" &&
         subject.user == \"kurad\" &&
         action.lookup(\"unit\") == \"bluetooth.service\") {
+        return polkit.Result.YES;
+    }
+    if (action.id == \"org.freedesktop.systemd1.manage-unit-files\" &&
+        subject.user == \"kurad\") {
         return polkit.Result.YES;
     }
 });" > /usr/share/polkit-1/rules.d/kura.rules


### PR DESCRIPTION
Updated `manage_kura_users.sh` script.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** The script that create and configure permissions for kura related users is updated to grant the permission for enabling/disabling systemd units.

Signed-off-by: Merlino <pierantonio.merlino@eurotech.com>