### PR TITLE
Fix Identities tab uncleared dirty status

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -981,6 +981,9 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
             this.wiresBinder.clearDirtyState();
             this.wiresBinder.unload();
         }
+        if (this.users.isVisible()) {
+            this.usersBinder.setDirty(false);
+        }
     }
 
     GwtConfigComponent getSelected() {


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. After having modified some values in the Identities tab, if the changes are not applied then a warning is shown as usual. If we decide to discard the changes, then the warning is shown when entering in every section. This PR fixes this erratic behavior, the modal is not shown anymore if changes are discarded.

**Related Issue:** N/A.

**Description of the solution adopted:** Reset of the dirty status to false if the users tab is visible.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
