### PR TITLE
Fixed wrong version

### DIFF
--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag.dbus/META-INF/MANIFEST.MF
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag.dbus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.kura.example.ble.tisensortag.dbus
 Bundle-SymbolicName: org.eclipse.kura.example.ble.tisensortag.dbus;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
 Import-Package: org.eclipse.kura;version="[1.0,2.0)",

--- a/kura/examples/org.eclipse.kura.example.ble.tisensortag.dbus/pom.xml
+++ b/kura/examples/org.eclipse.kura.example.ble.tisensortag.dbus/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.kura.example.ble.tisensortag.dbus</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 	<properties>


### PR DESCRIPTION
Fixed ble.tisensortag.dbus version setting it to 1.1.0-SNAPSHOT

Signed-off-by: Maiero <matteo.maiero@eurotech.com>

