### PR TITLE
Fixed typo in kura_install.sh  Ubuntu 20.04.3 Raspberry Pi 3/4

### DIFF
--- a/kura/distrib/src/main/resources/raspberry-pi-3-4-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-3-4-ubuntu-20/kura_install.sh
@@ -146,7 +146,7 @@ ln -s /etc/apparmor.d/usr.sbin.dhcpd /etc/apparmor.d/disable/
 apparmor_parser -R /etc/apparmor.d/usr.sbin.dhcpd
 
 #disable dhcpd named profile
-ln -s /etc/apparmor.d/usr.sbin.named/etc/apparmor.d/disable/
+ln -s /etc/apparmor.d/usr.sbin.named /etc/apparmor.d/disable/
 apparmor_parser -R /etc/apparmor.d/usr.sbin.named
 
 #assigning possible .conf files ownership to kurad


### PR DESCRIPTION
Fixed a little typo when named service apparmor profile  was disabled.