### PR TITLE
Added LogProvider interface in logs API

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/log/LogProvider.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/log/LogProvider.java
@@ -10,19 +10,34 @@
  * Contributors:
  *  Eurotech
  ******************************************************************************/
-
 package org.eclipse.kura.log;
 
+import org.eclipse.kura.log.listener.LogListener;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * The LogReader interface is implemented by all the services responsible to read logs from the system, filesystem or
- * processes running on the system.
+ * The LogProvider interface is implemented by all the services responsible to notify {@link LogListener}.
  *
  * @noextend This class is not intended to be extended by clients.
  * @since 1.0
  */
 @ProviderType
-public interface LogReader extends LogProvider {
+public interface LogProvider {
+
+    /**
+     * Registers a {@link LogListener} that will be notified of new log events
+     * 
+     * @param listener
+     *            a {@link LogListener}
+     */
+    public void registerLogListener(LogListener listener);
+
+    /**
+     * Unregisters a {@link LogListener} from the list of log events listeners
+     * 
+     * @param listener
+     *            the {@link LogListener} to unregister
+     */
+    public void unregisterLogListener(LogListener listener);
 
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/log/listener/LogListener.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/log/listener/LogListener.java
@@ -13,16 +13,16 @@
 package org.eclipse.kura.log.listener;
 
 import org.eclipse.kura.log.LogEntry;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
- * Listener interface to be implemented by applications that needs to be notified of events in the {@link LogReader}
+ * Listener interface to be implemented by applications that need to be notified of events in the {@link LogProvider}.
  *
  * @noextend This class is not intended to be extended by clients.
  * @since 1.0
  */
-@ProviderType
-public interface LogReaderListener {
+@ConsumerType
+public interface LogListener {
 
     /**
      * Notifies the listener that a new log entry has been received.


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Added a `LogProvider` interface and renamed `LogReaderListener` to `LogListener`.

**Related Issue:** N/A.

**Description of the solution adopted:** `LogReader` now extends `LogProvider` to better separate the roles of retrieving the logs (`LogReader`) and publish them to the listeners (`LogProvider`).

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
