### PR TITLE
Updated snapshot0 profiles to have default filesystem log providers

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/snapshot_0.xml
@@ -783,4 +783,36 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="filesystem-kura-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-7</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="filesystem-kura-audit-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura-audit.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-audit-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-8</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/snapshot_0.xml
@@ -369,4 +369,36 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="filesystem-kura-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-7</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="filesystem-kura-audit-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura-audit.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-audit-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-8</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
@@ -559,4 +559,36 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="filesystem-kura-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-7</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="filesystem-kura-audit-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura-audit.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-audit-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-8</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/snapshot_0.xml
@@ -344,4 +344,36 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="filesystem-kura-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-7</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="filesystem-kura-audit-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura-audit.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-audit-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-8</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/raspberry-pi-2/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/snapshot_0.xml
@@ -684,4 +684,36 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="filesystem-kura-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-7</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="filesystem-kura-audit-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura-audit.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-audit-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-8</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/raspberry-pi-3-4-ubuntu-20-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-3-4-ubuntu-20-nn/snapshot_0.xml
@@ -344,4 +344,36 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="filesystem-kura-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-7</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="filesystem-kura-audit-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura-audit.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-audit-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-8</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/raspberry-pi-3-4-ubuntu-20/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-3-4-ubuntu-20/snapshot_0.xml
@@ -684,4 +684,36 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="filesystem-kura-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-7</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="filesystem-kura-audit-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura-audit.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-audit-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-8</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/snapshot_0.xml
@@ -369,4 +369,36 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="filesystem-kura-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-7</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
+    <esf:configuration pid="filesystem-kura-audit-log">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="logFilePath" type="String">
+                <esf:value>/var/log/kura-audit.log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>filesystem-kura-audit-log</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.log.filesystem.provider.FilesystemLogProvider-1636726365743-8</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. This PR adds two default filesystem log providers that start on startup. For each profile, two default configurations are provided:
- **filesystem-kura-log** which reads entries from the file `/var/log/kura.log`
- **filesystem-kura-audit-log** which reads entries from the file `/var/log/kura-audit.log`

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
