### PR TITLE
Add multiuser support for UI log view

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -78,7 +78,7 @@ public class LogTabUi extends Composite {
     CheckBox showMoreInfoCheckbox;
 
     private static final int CACHE_SIZE_LIMIT = 5000;
-    private final List<GwtLogEntry> logs = new LinkedList<>();
+    private final LinkedList<GwtLogEntry> logs = new LinkedList<>();
     private boolean hasLogProvider = false;
     private boolean autoFollow = true;
 
@@ -118,13 +118,12 @@ public class LogTabUi extends Composite {
         this.showMoreInfoCheckbox.addClickHandler(click -> displayLogs());
 
         LogPollService.subscribe(entries -> {
-            LogTabUi.this.logs.addAll(entries);
-
-            if (LogTabUi.this.logs.size() > CACHE_SIZE_LIMIT) {
-                List<GwtLogEntry> newEntries = LogTabUi.this.logs.subList(CACHE_SIZE_LIMIT, LogTabUi.this.logs.size());
-                LogTabUi.this.logs.clear();
-                LogTabUi.this.logs.addAll(newEntries);
+            if (LogTabUi.this.logs.size() + entries.size() > CACHE_SIZE_LIMIT) {
+                for (int i = 0; i < entries.size(); i++) {
+                    LogTabUi.this.logs.removeFirst();
+                }
             }
+            LogTabUi.this.logs.addAll(entries);
 
             displayLogs();
         });

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -119,6 +119,13 @@ public class LogTabUi extends Composite {
 
         LogPollService.subscribe(entries -> {
             LogTabUi.this.logs.addAll(entries);
+
+            if (LogTabUi.this.logs.size() > CACHE_SIZE_LIMIT) {
+                List<GwtLogEntry> newEntries = LogTabUi.this.logs.subList(CACHE_SIZE_LIMIT, LogTabUi.this.logs.size());
+                LogTabUi.this.logs.clear();
+                LogTabUi.this.logs.addAll(newEntries);
+            }
+
             displayLogs();
         });
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -77,6 +77,7 @@ public class LogTabUi extends Composite {
     @UiField
     CheckBox showMoreInfoCheckbox;
 
+    private static final int CACHE_SIZE_LIMIT = 5000;
     private final List<GwtLogEntry> logs = new LinkedList<>();
     private boolean hasLogProvider = false;
     private boolean autoFollow = true;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/LogPollService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/LogPollService.java
@@ -44,6 +44,8 @@ public class LogPollService {
     private final Logger logger = Logger.getLogger("LogPollService");
     private int rpcCount = 0;
 
+    private int lastReadEntryId = 0;
+
     private LogPollService() {
         ((ServiceDefTarget) this.gwtLogService).setRpcRequestBuilder(new TimeoutRequestBuilder());
     }
@@ -86,7 +88,7 @@ public class LogPollService {
 
             @Override
             public void run() {
-                instance.gwtLogService.readLogs(instance.eventCallback);
+                instance.gwtLogService.readLogs(instance.lastReadEntryId, instance.eventCallback);
             }
         };
         instance.resendTimer.schedule(timeout);
@@ -126,6 +128,8 @@ public class LogPollService {
                 for (LogListener listener : LogPollService.instance.listeners) {
                     listener.onLogsReceived(result);
                 }
+
+                LogPollService.instance.lastReadEntryId = result.get(result.size() - 1).getId();
 
                 stopResendTimer();
             } else {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtLogServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtLogServiceImpl.java
@@ -47,8 +47,8 @@ public class GwtLogServiceImpl extends OsgiRemoteServiceServlet implements GwtLo
     }
 
     @Override
-    public List<GwtLogEntry> readLogs() throws GwtKuraException {
-        return cache.getLogs();
+    public List<GwtLogEntry> readLogs(int fromId) throws GwtKuraException {
+        return cache.getLogs(fromId);
     }
 
     private void loadLogProviders() {
@@ -96,21 +96,26 @@ public class GwtLogServiceImpl extends OsgiRemoteServiceServlet implements GwtLo
 
         private static final List<GwtLogEntry> cache = new LinkedList<>();
         private static final int MAX_CACHE_SIZE = 1000;
+        private static int nextEntryId = 0;
 
         public void add(GwtLogEntry newEntry) {
             synchronized (cache) {
                 if (cache.size() >= MAX_CACHE_SIZE) {
                     cache.remove(0);
                 }
+                newEntry.setId(nextEntryId++);
                 cache.add(newEntry);
             }
         }
 
-        public List<GwtLogEntry> getLogs() {
-            List<GwtLogEntry> result = new ArrayList<>();
+        public List<GwtLogEntry> getLogs(int fromId) {
+            List<GwtLogEntry> result = new LinkedList<>();
             synchronized (cache) {
-                result.addAll(cache);
-                cache.clear();
+                cache.forEach(entry -> {
+                    if (entry.getId() > fromId) {
+                        result.add(entry);
+                    }
+                });
             }
             return result;
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtLogServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtLogServiceImpl.java
@@ -126,6 +126,8 @@ public class GwtLogServiceImpl extends OsgiRemoteServiceServlet implements GwtLo
          */
         private static void manageIdIntOverflow() {
             if (nextEntryId >= Integer.MAX_VALUE) {
+                logger.info("ID overflow for cached UI log entries. Reindexing.");
+
                 for (int i = 0; i < cache.size(); i++) {
                     cache.get(i).setId(i);
                 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtLogServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtLogServiceImpl.java
@@ -94,14 +94,14 @@ public class GwtLogServiceImpl extends OsgiRemoteServiceServlet implements GwtLo
 
     private static final class LogEntriesCache {
 
-        private static final List<GwtLogEntry> cache = new LinkedList<>();
+        private static final LinkedList<GwtLogEntry> cache = new LinkedList<>();
         private static final int MAX_CACHE_SIZE = 1000;
         private static int nextEntryId = 0;
 
         public void add(GwtLogEntry newEntry) {
             synchronized (cache) {
                 if (cache.size() >= MAX_CACHE_SIZE) {
-                    cache.remove(0);
+                    cache.removeFirst();
                 }
                 manageIdIntOverflow();
                 newEntry.setId(nextEntryId++);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtLogServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtLogServiceImpl.java
@@ -103,6 +103,7 @@ public class GwtLogServiceImpl extends OsgiRemoteServiceServlet implements GwtLo
                 if (cache.size() >= MAX_CACHE_SIZE) {
                     cache.remove(0);
                 }
+                manageIdIntOverflow();
                 newEntry.setId(nextEntryId++);
                 cache.add(newEntry);
             }
@@ -118,6 +119,18 @@ public class GwtLogServiceImpl extends OsgiRemoteServiceServlet implements GwtLo
                 });
             }
             return result;
+        }
+
+        /*
+         * Very unlikely to happen, but if it will then entries are reindexed
+         */
+        private static void manageIdIntOverflow() {
+            if (nextEntryId >= Integer.MAX_VALUE) {
+                for (int i = 0; i < cache.size(); i++) {
+                    cache.get(i).setId(i);
+                }
+                nextEntryId = cache.size();
+            }
         }
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtLogEntry.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtLogEntry.java
@@ -18,6 +18,7 @@ import java.util.Date;
 public class GwtLogEntry extends KuraBaseModel implements Serializable {
 
     private static final long serialVersionUID = 8526545631929936271L;
+    private int id;
 
     public enum LogEntryKeys {
 
@@ -42,8 +43,16 @@ public class GwtLogEntry extends KuraBaseModel implements Serializable {
         }
     }
 
+    public void setId(int id) {
+        this.id = id;
+    }
+
     public void setSourceLogProviderPid(String sourceLogProviderPid) {
         super.set(LogEntryKeys.SOURCE_LOGPROVIDER_PID.getKey(), sourceLogProviderPid);
+    }
+
+    public int getId() {
+        return this.id;
     }
 
     public String getSourceLogProviderPid() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtLogService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtLogService.java
@@ -29,6 +29,6 @@ public interface GwtLogService extends RemoteService {
 
     public List<String> initLogProviders(GwtXSRFToken xsrfToken) throws GwtKuraException;
 
-    public List<GwtLogEntry> readLogs() throws GwtKuraException;
+    public List<GwtLogEntry> readLogs(int fromId) throws GwtKuraException;
 
 }


### PR DESCRIPTION
Brief description of the PR. This PR adds a mechanism to support multiple clients accessing the same log cache stored on the server.

**Related Issue:** N/A.

**Description of the solution adopted:** Each `GwtLogEntry` is decorated with an ID generated by the server so that successive entries have increasing IDs. The client stores the last ID read and now asks the server to retrieve only the new ones.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
