### PR TITLE
Added UI support for JSON snapshot format

### DIFF
--- a/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/rest/configuration/api/CreateFactoryComponentConfigurationsRequest.java
+++ b/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/rest/configuration/api/CreateFactoryComponentConfigurationsRequest.java
@@ -19,7 +19,7 @@ import org.eclipse.kura.internal.rest.configuration.FailureHandler;
 public class CreateFactoryComponentConfigurationsRequest implements Validable {
 
     private final List<FactoryComponentConfigurationDTO> configs;
-    private final boolean takeSnapshot;
+    private final Boolean takeSnapshot;
 
     public CreateFactoryComponentConfigurationsRequest(List<FactoryComponentConfigurationDTO> configs,
             boolean takeSnapshot) {
@@ -32,7 +32,7 @@ public class CreateFactoryComponentConfigurationsRequest implements Validable {
     }
 
     public boolean isTakeSnapshot() {
-        return takeSnapshot;
+        return this.takeSnapshot == null || this.takeSnapshot;
     }
 
     @Override

--- a/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/rest/configuration/api/DTOUtil.java
+++ b/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/rest/configuration/api/DTOUtil.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.rest.configuration.api;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.kura.configuration.ComponentConfiguration;
+import org.eclipse.kura.configuration.Password;
+import org.eclipse.kura.configuration.metatype.OCD;
+import org.eclipse.kura.crypto.CryptoService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DTOUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(DTOUtil.class);
+
+    private DTOUtil() {
+    }
+
+    public static ComponentConfigurationDTO toComponentConfigurationDTO(final ComponentConfiguration config,
+            final CryptoService cryptoService, final boolean decryptPasswords) {
+
+        return new ComponentConfigurationDTO(config.getPid(), ocdToDto(config.getDefinition()),
+                configurationPropertiesToDtos(config.getConfigurationProperties(), cryptoService, decryptPasswords));
+    }
+
+    public static ComponentConfigurationList toComponentConfigurationList(final List<ComponentConfiguration> configs,
+            final CryptoService cryptoService, final boolean decryptPasswords) {
+        final List<ComponentConfigurationDTO> result = configs.stream()
+                .map(c -> toComponentConfigurationDTO(c, cryptoService, decryptPasswords)).collect(Collectors.toList());
+
+        return new ComponentConfigurationList(result);
+    }
+
+    public static Map<String, Object> dtosToConfigurationProperties(final Map<String, PropertyDTO> properties) {
+        if (properties == null) {
+            return null;
+        }
+
+        final Map<String, Object> result = new HashMap<>(properties.size());
+
+        for (final Entry<String, PropertyDTO> e : properties.entrySet()) {
+
+            if (e.getValue().getValue() == null) {
+                result.put(e.getKey(), null);
+            } else {
+                final Object propertyValue = e.getValue().toConfigurationProperty()
+                        .orElseThrow(() -> new IllegalArgumentException(
+                                "Invalid property value for " + e.getKey() + " " + e.getValue()));
+
+                result.put(e.getKey(), propertyValue);
+            }
+        }
+
+        return result;
+    }
+
+    public static OcdDTO ocdToDto(final OCD ocd) {
+        if (ocd == null) {
+            return null;
+        } else {
+            return new OcdDTO(ocd);
+        }
+    }
+
+    public static Map<String, PropertyDTO> configurationPropertiesToDtos(Map<String, Object> properties,
+            final CryptoService cryptoService, final boolean decryptPasswords) {
+        if (properties == null) {
+            return null;
+        }
+
+        final Map<String, PropertyDTO> result = new HashMap<>();
+
+        for (final Entry<String, Object> entry : properties.entrySet()) {
+
+            final Optional<Object> value;
+
+            if (entry.getValue() == null) {
+                continue;
+            }
+
+            if (decryptPasswords) {
+                value = decryptPassword(entry.getValue(), cryptoService);
+            } else {
+                value = Optional.ofNullable(entry.getValue());
+            }
+
+            final Optional<PropertyDTO> propertyDTO = value.flatMap(PropertyDTO::fromConfigurationProperty);
+
+            if (!propertyDTO.isPresent()) {
+                logger.warn("ignoring invalid configiration property for {}: {}", entry.getKey(), entry.getValue());
+            } else {
+                result.put(entry.getKey(), propertyDTO.get());
+            }
+        }
+
+        return result;
+    }
+
+    public static Optional<Object> decryptPassword(final Object property, final CryptoService cryptoService) {
+        try {
+            final Object result;
+
+            if (property instanceof Password) {
+                result = new Password(cryptoService.decryptAes(((Password) property).getPassword()));
+            } else if (property instanceof Password[]) {
+                final Password[] asPasswords = (Password[]) property;
+                final Password[] resultPasswords = new Password[asPasswords.length];
+
+                for (int i = 0; i < asPasswords.length; i++) {
+                    resultPasswords[i] = new Password(cryptoService.decryptAes(asPasswords[i].getPassword()));
+                }
+
+                result = resultPasswords;
+            } else {
+                result = property;
+            }
+
+            return Optional.ofNullable(result);
+        } catch (final Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/rest/configuration/api/DeleteFactoryComponentRequest.java
+++ b/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/rest/configuration/api/DeleteFactoryComponentRequest.java
@@ -19,7 +19,7 @@ import org.eclipse.kura.internal.rest.configuration.FailureHandler;
 public class DeleteFactoryComponentRequest implements Validable {
 
     private final Set<String> pids;
-    private final boolean takeSnapshot;
+    private final Boolean takeSnapshot;
 
     public DeleteFactoryComponentRequest(Set<String> pids, boolean takeSnapshot) {
         this.pids = pids;
@@ -31,7 +31,7 @@ public class DeleteFactoryComponentRequest implements Validable {
     }
 
     public boolean isTakeSnapshot() {
-        return takeSnapshot;
+        return this.takeSnapshot == null || this.takeSnapshot;
     }
 
     @Override

--- a/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/rest/configuration/api/UpdateComponentConfigurationRequest.java
+++ b/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/rest/configuration/api/UpdateComponentConfigurationRequest.java
@@ -21,7 +21,7 @@ import org.eclipse.kura.internal.rest.configuration.FailureHandler;
 public class UpdateComponentConfigurationRequest implements Validable {
 
     private final List<ComponentConfigurationDTO> configs;
-    private boolean takeSnapshot = true;
+    private Boolean takeSnapshot;
 
     public UpdateComponentConfigurationRequest(List<ComponentConfigurationDTO> componentConfigurations,
             boolean takeSnapshot) {
@@ -34,7 +34,7 @@ public class UpdateComponentConfigurationRequest implements Validable {
     }
 
     public boolean isTakeSnapshot() {
-        return this.takeSnapshot;
+        return this.takeSnapshot == null || this.takeSnapshot;
     }
 
     @Override

--- a/kura/org.eclipse.kura.web2/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.web2/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Import-Package: com.eclipsesource.json;version="0.9.5",
+ com.google.gson;version="2.7.0",
  javax.crypto,
  javax.crypto.spec,
  javax.security.auth,
@@ -64,6 +65,7 @@ Import-Package: com.eclipsesource.json;version="0.9.5",
  org.eclipse.kura.net.modem;version="[2.1,3.0)",
  org.eclipse.kura.net.wifi;version="[2.2,3.0)",
  org.eclipse.kura.position;version="[1.0,2.0)",
+ org.eclipse.kura.rest.configuration.api;version="[1.0,2.0)",
  org.eclipse.kura.security;version="[1.0,2.0)",
  org.eclipse.kura.security.keystore;version="1.0.0",
  org.eclipse.kura.security.tamper.detection;version="[1.0,2.0)",

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotDownloadModal.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotDownloadModal.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.web.client.ui.settings;
+
+import org.gwtbootstrap3.client.ui.Button;
+import org.gwtbootstrap3.client.ui.ListBox;
+import org.gwtbootstrap3.client.ui.Modal;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.Widget;
+
+public class SnapshotDownloadModal extends Composite {
+
+    private static SnapshotDownloadModalUiBinder uiBinder = GWT.create(SnapshotDownloadModalUiBinder.class);
+
+    interface SnapshotDownloadModalUiBinder extends UiBinder<Widget, SnapshotDownloadModal> {
+    }
+
+    @UiField
+    Modal modal;
+    @UiField
+    ListBox formatList;
+    @UiField
+    Button download;
+
+    private Listener listener = format -> {
+    };
+
+    public SnapshotDownloadModal() {
+        initWidget(uiBinder.createAndBindUi(this));
+
+        this.download.addClickHandler(e -> {
+            this.modal.hide();
+            this.listener.onDonwload(this.formatList.getSelectedValue());
+        });
+    }
+
+    public void show(final Listener listener) {
+        this.listener = listener;
+        this.modal.show();
+    }
+
+    public interface Listener {
+
+        public void onDonwload(String format);
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotDownloadModal.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotDownloadModal.ui.xml
@@ -1,0 +1,45 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+
+<!--
+    
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+  
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+ 
+	SPDX-License-Identifier: EPL-2.0
+	
+	Contributors:
+     Eurotech
+     
+-->
+
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+    xmlns:b="urn:import:org.gwtbootstrap3.client.ui" xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
+    xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt"
+    xmlns:settings="urn:import:org.eclipse.kura.web.client.ui.settings">
+
+    <ui:with field="msgs" type="org.eclipse.kura.web.client.messages.Messages" />
+
+    <b:Modal closable="false" fade="true" dataBackdrop="STATIC" ui:field="modal" title="{msgs.deviceSnapshotDownloadModalTitle}">
+            <b:ModalBody>
+                <g:FormPanel>
+                    <b:FieldSet>
+                        <b:FormGroup>
+                            <b.html:Paragraph text="{msgs.deviceSnapshotDownloadModalLabel}" />
+                            <b:ListBox b:id="formatList" ui:field="formatList">
+					          <g:item>XML</g:item>
+					          <g:item>JSON</g:item>
+					        </b:ListBox>
+                        </b:FormGroup>
+                    </b:FieldSet>
+                </g:FormPanel>
+            </b:ModalBody>
+            <b:ModalFooter>
+                <b:Button addStyleNames="fa" type="PRIMARY" dataDismiss="MODAL" text="{msgs.cancelButton}" />
+                <b:Button addStyleNames="fa" type="PRIMARY" ui:field="download" text="{msgs.download}" />
+            </b:ModalFooter>
+        </b:Modal>
+
+</ui:UiBinder> 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotsTabUi.java
@@ -99,6 +99,9 @@ public class SnapshotsTabUi extends Composite implements Tab {
     Hidden xsrfTokenField;
 
     @UiField
+    SnapshotDownloadModal downloadModal;
+
+    @UiField
     CellTable<GwtSnapshot> snapshotsGrid = new CellTable<>();
 
     GwtSnapshot selected;
@@ -230,7 +233,7 @@ public class SnapshotsTabUi extends Composite implements Tab {
 
     private void initUploadModalHandlers() {
         this.uploadUpload.setEnabled(false);
-        this.filePath.getElement().setAttribute("accept", ".xml");
+        this.filePath.getElement().setAttribute("accept", ".xml,.json");
         this.filePath.addChangeHandler(event -> {
             String fileName = this.filePath.getFilename();
             boolean uploadEnabled = false;
@@ -350,9 +353,13 @@ public class SnapshotsTabUi extends Composite implements Tab {
         final StringBuilder sbUrl = new StringBuilder();
 
         Long snapshot = this.selected.getSnapshotId();
-        sbUrl.append("/device_snapshots?snapshotId=").append(snapshot);
 
-        DownloadHelper.instance().startDownload(token, sbUrl.toString());
+        downloadModal.show(format -> {
+            sbUrl.append("/device_snapshots?snapshotId=").append(snapshot).append("&format=").append(format);
+
+            DownloadHelper.instance().startDownload(token, sbUrl.toString());
+        });
+
     }
 
     private void uploadAndApply() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotsTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/settings/SnapshotsTabUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,8 @@
 
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
     xmlns:b="urn:import:org.gwtbootstrap3.client.ui" xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html"
-    xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt">
+    xmlns:g="urn:import:com.google.gwt.user.client.ui" xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt"
+    xmlns:settings="urn:import:org.eclipse.kura.web.client.ui.settings">
 
     <ui:style>
     .important {
@@ -72,6 +73,8 @@
                         </b:Container>
                 </b:ModalBody>
             </b:Modal>
+            
+            <settings:SnapshotDownloadModal ui:field="downloadModal" />
         </b:Column>
     </b:Container>
 </ui:UiBinder> 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,7 @@ import org.eclipse.kura.web.client.configuration.HasConfiguration;
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.AlertDialog;
 import org.eclipse.kura.web.client.ui.AlertDialog.ConfirmListener;
+import org.eclipse.kura.web.client.ui.settings.SnapshotDownloadModal;
 import org.eclipse.kura.web.client.ui.wires.composer.BlinkEffect;
 import org.eclipse.kura.web.client.ui.wires.composer.DropEvent;
 import org.eclipse.kura.web.client.ui.wires.composer.PortNames;
@@ -128,6 +129,9 @@ public class WiresPanelUi extends Composite
     @UiField
     NavPills wireEmitterReceiverMenu;
 
+    @UiField
+    SnapshotDownloadModal snapshotDownloadModal;
+
     interface WiresPanelUiUiBinder extends UiBinder<Widget, WiresPanelUi> {
     }
 
@@ -190,7 +194,7 @@ public class WiresPanelUi extends Composite
                         AlertDialog.Severity.ALERT, (ConfirmListener) null);
                 return;
             }
-            WiresRPC.downloadWiresSnapshot();
+            snapshotDownloadModal.show(WiresRPC::downloadWiresSnapshot);
         });
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresPanelUi.ui.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <!--
 
-    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,7 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
     xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html" xmlns:g="urn:import:com.google.gwt.user.client.ui"
     xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt" xmlns:kura="urn:import:org.eclipse.kura.web.client.ui"
-    xmlns:wires="urn:import:org.eclipse.kura.web.client.ui.wires">
+    xmlns:wires="urn:import:org.eclipse.kura.web.client.ui.wires" xmlns:settings="urn:import:org.eclipse.kura.web.client.ui.settings">
 
     <ui:with field="msgs" type="org.eclipse.kura.web.client.messages.Messages"></ui:with>
 
@@ -155,5 +155,6 @@
 
         <wires:WiresDialogs ui:field="dialogs"/>
         <kura:AlertDialog ui:field="confirmDialog" b:id="wires-confirm-dialog"/>
+        <settings:SnapshotDownloadModal ui:field="snapshotDownloadModal" />
     </b:Container>
 </ui:UiBinder>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresRPC.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/wires/WiresRPC.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -219,7 +219,7 @@ public final class WiresRPC {
         });
     }
 
-    public static void downloadWiresSnapshot() {
+    public static void downloadWiresSnapshot(final String format) {
         EntryClassUi.showWaitModal();
         gwtXSRFService.generateSecurityToken(new AsyncCallback<GwtXSRFToken>() {
 
@@ -232,7 +232,7 @@ public final class WiresRPC {
             @Override
             public void onSuccess(GwtXSRFToken token) {
                 EntryClassUi.hideWaitModal();
-                DownloadHelper.instance().startDownload(token, "/wiresSnapshot");
+                DownloadHelper.instance().startDownload(token, "/wiresSnapshot?format=" + format);
             }
         });
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
@@ -518,9 +518,17 @@ public class FileServlet extends AuditServlet {
 
         final List<ComponentConfiguration> configImpls;
 
-        if ("application/xml".equals(fileItem.getContentType())) {
+        String fileName = fileItem.getName();
+
+        if (fileName != null) {
+            fileName = fileName.toLowerCase();
+        } else {
+            fileName = "";
+        }
+
+        if (fileName.endsWith("xml")) {
             configImpls = parseXmlSnapshot(fileItemString);
-        } else if ("application/json".equals(fileItem.getContentType())) {
+        } else if (fileName.endsWith("json")) {
             configImpls = parseJsonSnapshot(fileItemString);
         } else {
             throw new ServletException("Unsupported content type");

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/WiresSnapshotServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/WiresSnapshotServlet.java
@@ -13,7 +13,6 @@
 package org.eclipse.kura.web.server.servlet;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +38,7 @@ import org.eclipse.kura.crypto.CryptoService;
 import org.eclipse.kura.marshalling.Marshaller;
 import org.eclipse.kura.web.server.GwtWireGraphServiceImpl;
 import org.eclipse.kura.web.server.KuraRemoteServiceServlet;
+import org.eclipse.kura.web.server.util.GwtServerUtil;
 import org.eclipse.kura.web.server.util.ServiceLocator;
 import org.eclipse.kura.web.shared.GwtKuraException;
 import org.eclipse.kura.web.shared.model.GwtXSRFToken;
@@ -55,6 +55,9 @@ public class WiresSnapshotServlet extends AuditServlet {
 
     private static final String WIRE_GRAPH_SERVICE_PID = "org.eclipse.kura.wire.graph.WireGraphService";
     private static final String WIRE_ASSET_FACTORY_PID = "org.eclipse.kura.wire.WireAsset";
+
+    private static final String JSON_FORMAT = "json";
+    private static final String XML_FORMAT = "xml";
 
     private static final long serialVersionUID = -7483037360719617846L;
     private static final Logger logger = LoggerFactory.getLogger(WiresSnapshotServlet.class);
@@ -141,21 +144,7 @@ public class WiresSnapshotServlet extends AuditServlet {
                 return null;
             });
 
-            final XmlComponentConfigurations xmlConfigs = new XmlComponentConfigurations();
-            xmlConfigs.setConfigurations(result);
-
-            final String marshalled = toSnapshot(xmlConfigs);
-
-            final String snapshotName = "graph_snapshot_" + System.currentTimeMillis() + ".xml";
-
-            response.setCharacterEncoding("UTF-8");
-            response.setContentType("application/xml");
-            response.setHeader("Content-Disposition", "attachment; filename=" + snapshotName);
-            response.setHeader("Cache-Control", "no-transform, max-age=0");
-
-            try (PrintWriter writer = response.getWriter()) {
-                writer.write(marshalled);
-            }
+            GwtServerUtil.writeSnapshot(request, response, result, "graph_snapshot_" + System.currentTimeMillis());
 
         } catch (Exception e) {
             logger.warn("Failed to download snapshot", e);

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -288,6 +288,8 @@ deviceSnapshotId=Snapshot Id
 deviceSnapshotCreatedOn=Created On
 deviceSnapshotsNone=No Snapshots Available
 deviceSnapshotRollbackConfirm=Are you sure you want to rollback to a previous configuration? During the rollback operation, the device will disconnect and reconnect. If a timeout is encountered during the reload of the device configuration, please refresh it manually. 
+deviceSnapshotDownloadModalTitle=Download snapshot
+deviceSnapshotDownloadModalLabel=Select the format to be used for the downloaded snapshot
 
 netIntro=Select a Network Interface and configure it. DHCP Server and NAT can be configured only for interfaces enabled for LAN usage. When applying your changes, your connection to the gateway may be lost depending on your network configuration changes.  
 netInterfaceName=Interface Name


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

* Adds a new dialog that is shown in the Settings -> Snapshots and in the Wires UI that is shown when a snapshot download is requested, it allows to choose between the existing XML format and the new CONF-V2 JSON format.
* Snapshots downloaded in JSON format can be applied using the web ui in Settings -> Snapshots like XML snapshots, or using `CONF-V2/PUT/configurableComponents/configurations/_update`.
* Changed CONF-V2 methods to use `true` as default value for the `takeSnapshot` parameter if not specified