### PR TITLE
Add log UI new window button

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -77,7 +77,7 @@ public class LogTabUi extends Composite {
     @UiField
     CheckBox showMoreInfoCheckbox;
 
-    private static final int CACHE_SIZE_LIMIT = 5000;
+    private static final int CACHE_SIZE_LIMIT = 1500;
     private final LinkedList<GwtLogEntry> logs = new LinkedList<>();
     private boolean hasLogProvider = false;
     private boolean autoFollow = true;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -36,6 +36,7 @@ import org.gwtbootstrap3.client.ui.Row;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FormPanel;
@@ -76,6 +77,8 @@ public class LogTabUi extends Composite {
     CheckBox showStackTraceCheckbox;
     @UiField
     CheckBox showMoreInfoCheckbox;
+    @UiField
+    Button openNewWindow;
 
     private static final int CACHE_SIZE_LIMIT = 1500;
     private final LinkedList<GwtLogEntry> logs = new LinkedList<>();
@@ -126,6 +129,10 @@ public class LogTabUi extends Composite {
             LogTabUi.this.logs.addAll(entries);
 
             displayLogs();
+        });
+
+        this.openNewWindow.addClickHandler(handler -> {
+            Window.open(Window.Location.getHref(), "_blank", "");
         });
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.ui.xml
@@ -27,34 +27,46 @@
     	margin: 5px;
     }
     .log-area {
-    	width: 95%;
+    	width: 100%;
+    }
+    .open-window-btn {
+    	float: right;
     }
     </ui:style>
     <b:Container fluid="true" addStyleNames="log-panel">
+    
+    	<b:Column size="MD_12">
         
-        <b:Row>
-	        <b:Panel b:id="deviceLogsPanel" ui:field="deviceLogsPanel">
-	        	<b:Row b:id="controlsRow" ui:field="controlsRow">
-	        		<b:ListBox b:id="logProviderListBox" ui:field="logProviderListBox"/>
-	        		<b:CheckBox b:id="showStackTraceCheckbox" ui:field="showStackTraceCheckbox">Show errors stacktrace</b:CheckBox>
-	        		<b:CheckBox b:id="showMoreInfoCheckbox" ui:field="showMoreInfoCheckbox">Show additional info</b:CheckBox>
-	        	</b:Row>
-	        	<b:Row>
-	          		<g:TextArea ui:field="logTextArea" addStyleNames="{style.log-area}"/>
-	            </b:Row>
-	        </b:Panel>
-        </b:Row>
+	        <b:Row>
+		        <b:Panel b:id="deviceLogsPanel" ui:field="deviceLogsPanel">		        	
+		        	<b:Row b:id="controlsRow" ui:field="controlsRow">
+		        		<b:Column size="XS_10 SM_10 MD_11">
+			        		<b:ListBox b:id="logProviderListBox" ui:field="logProviderListBox"/>
+			        		<b:CheckBox b:id="showStackTraceCheckbox" ui:field="showStackTraceCheckbox">Show errors stacktrace</b:CheckBox>
+			        		<b:CheckBox b:id="showMoreInfoCheckbox" ui:field="showMoreInfoCheckbox">Show additional info</b:CheckBox>
+		        		</b:Column>
+		        		<b:Column size="XS_2 SM_2 MD_1">
+			            	<b:Button ui:field="openNewWindow" addStyleNames="fa {style.open-window-btn}">New window</b:Button>
+			            </b:Column>
+		        	</b:Row>
+		        	<b:Row>
+	          			<g:TextArea ui:field="logTextArea" addStyleNames="{style.log-area}"/>
+		            </b:Row>
+		        </b:Panel>
+	        </b:Row>
+	        
+	        <b:Row addStyleNames="panel-footer">
+	            <gwt:FormPanel ui:field="logForm">
+	                <b:FieldSet>
+	                    <b:ButtonGroup pull="LEFT">
+	                    	<b:Button ui:field="execute" addStyleNames="fa fa-download">Download</b:Button>
+	                    	<b:FormLabel ui:field="logLabel" addStyleNames="{style.download-label-text}" />
+	                    </b:ButtonGroup>
+	                </b:FieldSet>
+	            </gwt:FormPanel>
+	        </b:Row>
         
-        <b:Row addStyleNames="panel-footer">
-            <gwt:FormPanel ui:field="logForm">
-                <b:FieldSet>
-                    <b:ButtonGroup pull="LEFT">
-                    	<b:Button ui:field="execute" addStyleNames="fa fa-download">Download</b:Button>
-                    	<b:FormLabel ui:field="logLabel" addStyleNames="{style.download-label-text}" />
-                    </b:ButtonGroup>
-                </b:FieldSet>
-            </gwt:FormPanel>
-        </b:Row>
+        </b:Column>
         
     </b:Container>
 </ui:UiBinder> 


### PR DESCRIPTION
Brief description of the PR. Added a new button in the "Device Logs" section to open a new Window in browser.

**Related Issue:** N/A.

**Description of the solution adopted:** This button can be handy when trying to debug some functionalities, having in separate windows the logs in real-time and the Kura UI. The button allows to open a new browser window and login with the current user with just one click.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.