### PR TITLE
Fix GATT characteristic name when parsing to match enum

### DIFF
--- a/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeGattCharacteristicImpl.java
+++ b/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeGattCharacteristicImpl.java
@@ -168,7 +168,7 @@ public class BluetoothLeGattCharacteristicImpl implements BluetoothLeGattCharact
     public List<BluetoothLeGattCharacteristicProperties> getProperties() {
         List<BluetoothLeGattCharacteristicProperties> properties = new ArrayList<>();
         for (String flag : this.characteristic.getFlags()) {
-            properties.add(BluetoothLeGattCharacteristicProperties.valueOf(flag.toUpperCase()));
+            properties.add(BluetoothLeGattCharacteristicProperties.valueOf(flag.toUpperCase().replace('-', '_')));
         }
         return properties;
     }


### PR DESCRIPTION
Signed-off-by: Andrej Krota <andrej.krota@gmail.com>

Replace - with _ when reading GATT characteristic name

**Related Issue:** This PR fixes/closes #3624 

