### PR TITLE
Disabled side-class loading from H2DB

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -388,6 +388,7 @@ if [ -z "$KURA_RUNNING" ] ; then
         -Djdk.dio.registry=${DIR}/framework/jdk.dio.properties \
         -Djdk.tls.trustNameService=true \
         -Dosgi.console=5002 \
+		-Dh2.allowedClasses=org.h2.* \
         -Declipse.consoleLog=true >> /var/log/kura-console.log 2>> /var/log/kura-console.log \
         -jar ${DIR}/plugins/org.eclipse.equinox.launcher_${org.eclipse.equinox.launcher.version}.jar \
         -configuration /tmp/.kura/configuration &


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Added a system property at startup to only allow classes from `org.h2` to be used by H2DB. This should prevent some vulnerabilities.

**Related Issue:** N/A.

**Description of the solution adopted:** As now, an intruder can load own custom class and execute its code in a process with H2 Console. For example, the following queries shouldn't be executable:
```
CREATE ALIAS SET_PROPERTY FOR "java.lang.System.setProperty";
CALL SET_PROPERTY('abc', '1');
CREATE ALIAS GET_PROPERTY FOR "java.lang.System.getProperty";
CALL GET_PROPERTY('abc');
```
This PR disables side-class loading at kura startup for H2. For further reference see https://github.com/h2database/h2database/security/advisories/GHSA-h376-j262-vhq6 and https://jfrog.com/blog/the-jndi-strikes-back-unauthenticated-rce-in-h2-database-console/. This fix should mitigate CVE-2021-42392 and CVE-2021-23463.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
