### PR TITLE
Reviewed refresh logic in firewall tabs.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/NatTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/NatTabUi.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -158,9 +158,8 @@ public class NatTabUi extends Composite implements Tab, ButtonBar.Listener {
 
     public NatTabUi() {
         initWidget(uiBinder.createAndBindUi(this));
-        this.selectionModel.addSelectionChangeHandler(event -> {
-            NatTabUi.this.buttonBar.setEditDeleteButtonsDirty(NatTabUi.this.selectionModel.getSelectedObject() != null);
-        });
+        this.selectionModel.addSelectionChangeHandler(event -> NatTabUi.this.buttonBar
+                .setEditDeleteButtonsDirty(NatTabUi.this.selectionModel.getSelectedObject() != null));
         this.natGrid.setSelectionModel(this.selectionModel);
 
         initTable();
@@ -184,7 +183,7 @@ public class NatTabUi extends Composite implements Tab, ButtonBar.Listener {
     @Override
     public void refresh() {
         EntryClassUi.showWaitModal();
-        this.natDataProvider.getList().clear();
+        clear();
         this.gwtXSRFService.generateSecurityToken(new AsyncCallback<GwtXSRFToken>() {
 
             @Override
@@ -209,13 +208,10 @@ public class NatTabUi extends Composite implements Tab, ButtonBar.Listener {
                             @Override
                             public void onSuccess(List<GwtFirewallNatEntry> result) {
                                 for (GwtFirewallNatEntry pair : result) {
-                                    NatTabUi.this.natDataProvider.getList().remove(pair);
                                     NatTabUi.this.natDataProvider.getList().add(pair);
                                 }
-                                setVisibility();
                                 refreshTable();
-                                NatTabUi.this.buttonBar.setApplyResetButtonsDirty(false);
-                                NatTabUi.this.buttonBar.setEditDeleteButtonsDirty(false);
+                                setVisibility();
                                 EntryClassUi.hideWaitModal();
                             }
                         });
@@ -345,6 +341,7 @@ public class NatTabUi extends Composite implements Tab, ButtonBar.Listener {
         this.natGrid.setVisibleRange(0, size);
         this.natDataProvider.flush();
         this.natGrid.redraw();
+        this.selectionModel.setSelected(this.selectionModel.getSelectedObject(), false);
     }
 
     @Override
@@ -616,7 +613,8 @@ public class NatTabUi extends Composite implements Tab, ButtonBar.Listener {
                 List<EditorError> result = new ArrayList<>();
                 if (!NatTabUi.this.source.getText().trim().isEmpty()
                         && !NatTabUi.this.source.getText().trim().matches(FieldType.NETWORK.getRegex())) {
-                    result.add(new BasicEditorError(NatTabUi.this.source, value, MSGS.firewallNatFormSourceNetworkErrorMessage()));
+                    result.add(new BasicEditorError(NatTabUi.this.source, value,
+                            MSGS.firewallNatFormSourceNetworkErrorMessage()));
                 }
                 return result;
             }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/OpenPortsTabUi.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -192,7 +192,7 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
     @Override
     public void refresh() {
         EntryClassUi.showWaitModal();
-        this.openPortsDataProvider.getList().clear();
+        clear();
         this.notification.setVisible(false);
         this.gwtXSRFService.generateSecurityToken(new AsyncCallback<GwtXSRFToken>() {
 
@@ -218,14 +218,10 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
                             @Override
                             public void onSuccess(List<GwtFirewallOpenPortEntry> result) {
                                 for (GwtFirewallOpenPortEntry pair : result) {
-                                    // Avoid duplicates
-                                    OpenPortsTabUi.this.openPortsDataProvider.getList().remove(pair);
                                     OpenPortsTabUi.this.openPortsDataProvider.getList().add(pair);
                                 }
                                 refreshTable();
                                 setVisibility();
-                                OpenPortsTabUi.this.buttonBar.setApplyResetButtonsDirty(false);
-                                OpenPortsTabUi.this.buttonBar.setEditDeleteButtonsDirty(false);
                                 EntryClassUi.hideWaitModal();
                             }
                         });
@@ -371,6 +367,7 @@ public class OpenPortsTabUi extends Composite implements Tab, ButtonBar.Listener
         this.openPortsGrid.setVisibleRange(0, size);
         this.openPortsDataProvider.flush();
         this.openPortsGrid.redraw();
+        this.selectionModel.setSelected(this.selectionModel.getSelectedObject(), false);
     }
 
     @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/PortForwardingTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/PortForwardingTabUi.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -187,10 +187,8 @@ public class PortForwardingTabUi extends Composite implements Tab, ButtonBar.Lis
 
     public PortForwardingTabUi() {
         initWidget(uiBinder.createAndBindUi(this));
-        this.selectionModel.addSelectionChangeHandler(event -> {
-            PortForwardingTabUi.this.buttonBar
-                    .setEditDeleteButtonsDirty(PortForwardingTabUi.this.selectionModel.getSelectedObject() != null);
-        });
+        this.selectionModel.addSelectionChangeHandler(event -> PortForwardingTabUi.this.buttonBar
+                .setEditDeleteButtonsDirty(PortForwardingTabUi.this.selectionModel.getSelectedObject() != null));
         this.portForwardGrid.setSelectionModel(this.selectionModel);
 
         this.buttonBar.setListener(this);
@@ -216,7 +214,7 @@ public class PortForwardingTabUi extends Composite implements Tab, ButtonBar.Lis
     @Override
     public void refresh() {
         EntryClassUi.showWaitModal();
-        this.portForwardDataProvider.getList().clear();
+        clear();
         this.notification.setVisible(false);
 
         this.gwtXSRFService.generateSecurityToken(new AsyncCallback<GwtXSRFToken>() {
@@ -243,14 +241,10 @@ public class PortForwardingTabUi extends Composite implements Tab, ButtonBar.Lis
                             @Override
                             public void onSuccess(List<GwtFirewallPortForwardEntry> result) {
                                 for (GwtFirewallPortForwardEntry pair : result) {
-                                    // Avoid duplicates
-                                    PortForwardingTabUi.this.portForwardDataProvider.getList().remove(pair);
                                     PortForwardingTabUi.this.portForwardDataProvider.getList().add(pair);
                                 }
                                 setVisibility();
                                 refreshTable();
-                                PortForwardingTabUi.this.buttonBar.setApplyResetButtonsDirty(false);
-                                PortForwardingTabUi.this.buttonBar.setEditDeleteButtonsDirty(false);
                                 EntryClassUi.hideWaitModal();
                             }
                         });
@@ -436,6 +430,7 @@ public class PortForwardingTabUi extends Composite implements Tab, ButtonBar.Lis
         this.portForwardGrid.setVisibleRange(0, size);
         this.portForwardDataProvider.flush();
         this.portForwardGrid.redraw();
+        this.selectionModel.setSelected(this.selectionModel.getSelectedObject(), false);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes #3738

**Description of the solution adopted:** Reviewed the refresh approach across all the firewall tabs.

**Screenshots:** N/A

**Any side note on the changes made:** N/A

@marcellorinaldo Can you please have a check of this PR?
@mstankovic Is it possible to have a run of QA tests?
