### PR TITLE
Added waiting modal when downloading logs using cookies

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.kura.web.Console;
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
+import org.eclipse.kura.web.client.util.DownloadHelper;
 import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.client.util.LogPollService;
 import org.eclipse.kura.web.shared.model.GwtLogEntry;
@@ -39,6 +40,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Cookies;
+import com.google.gwt.user.client.Random;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -89,15 +91,20 @@ public class LogTabUi extends Composite {
     private boolean hasLogProvider = false;
     private boolean autoFollow = true;
 
+    private final String nonce = Integer.toString(Random.nextInt());
+
     private static final int DOWNLOAD_COMPLETE_WAIT_TIMEOUT = 5000;
-    private static final Timer waitDownloadCompleted = new Timer() {
+    private Timer waitDownloadCompleted = new Timer() {
 
         // safety parameter, 9 = 45secs
         private short retryLimit = 9;
+        private String cookieName;
 
         @Override
         public void run() {
-            if (Cookies.getCookie("LogsDownload") != null) {
+            cookieName = "LogsDownload-" + LogTabUi.this.nonce;
+
+            if (Cookies.getCookie(cookieName) != null) {
                 hideModalAndStop();
             }
 
@@ -112,7 +119,8 @@ public class LogTabUi extends Composite {
 
         private void hideModalAndStop() {
             EntryClassUi.hideWaitModal();
-            Cookies.removeCookie("LogsDownload", "/");
+            Cookies.removeCookie(cookieName, "/");
+            this.retryLimit = 9;
             this.cancel();
         }
 
@@ -134,11 +142,12 @@ public class LogTabUi extends Composite {
 
                     @Override
                     public void onSuccess(GwtXSRFToken token) {
-                        LogTabUi.this.logForm.submit();
+                        final StringBuilder sbUrl = new StringBuilder();
+                        sbUrl.append("/log?nonce=").append(LogTabUi.this.nonce);
+                        DownloadHelper.instance().startDownload(token, sbUrl.toString());
 
                         EntryClassUi.showWaitModal();
-                        Cookies.removeCookie("LogsDownload", "/");
-                        LogTabUi.waitDownloadCompleted.schedule(DOWNLOAD_COMPLETE_WAIT_TIMEOUT);
+                        LogTabUi.this.waitDownloadCompleted.schedule(DOWNLOAD_COMPLETE_WAIT_TIMEOUT);
                     }
                 }));
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.eclipse.kura.web.Console;
 import org.eclipse.kura.web.client.messages.Messages;
+import org.eclipse.kura.web.client.ui.EntryClassUi;
 import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.client.util.LogPollService;
 import org.eclipse.kura.web.shared.model.GwtLogEntry;
@@ -32,10 +33,13 @@ import org.gwtbootstrap3.client.ui.FormLabel;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.Row;
+import org.gwtbootstrap3.client.ui.Form;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.Cookies;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
@@ -62,7 +66,7 @@ public class LogTabUi extends Composite {
     @UiField
     Button execute;
     @UiField
-    FormPanel logForm;
+    Form logForm;
     @UiField
     FormLabel logLabel;
     @UiField
@@ -85,6 +89,35 @@ public class LogTabUi extends Composite {
     private boolean hasLogProvider = false;
     private boolean autoFollow = true;
 
+    private static final int DOWNLOAD_COMPLETE_WAIT_TIMEOUT = 5000;
+    private static final Timer waitDownloadCompleted = new Timer() {
+
+        // safety parameter, 9 = 45secs
+        private short retryLimit = 9;
+
+        @Override
+        public void run() {
+            if (Cookies.getCookie("LogsDownload") != null) {
+                hideModalAndStop();
+            }
+
+            // eventually regain access to the UI
+            if (this.retryLimit <= 0) {
+                hideModalAndStop();
+            }
+
+            this.retryLimit--;
+            this.schedule(DOWNLOAD_COMPLETE_WAIT_TIMEOUT);
+        }
+
+        private void hideModalAndStop() {
+            EntryClassUi.hideWaitModal();
+            Cookies.removeCookie("LogsDownload", "/");
+            this.cancel();
+        }
+
+    };
+
     public LogTabUi() {
         initWidget(uiBinder.createAndBindUi(this));
 
@@ -102,6 +135,10 @@ public class LogTabUi extends Composite {
                     @Override
                     public void onSuccess(GwtXSRFToken token) {
                         LogTabUi.this.logForm.submit();
+
+                        EntryClassUi.showWaitModal();
+                        Cookies.removeCookie("LogsDownload", "/");
+                        LogTabUi.waitDownloadCompleted.schedule(DOWNLOAD_COMPLETE_WAIT_TIMEOUT);
                     }
                 }));
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.ui.xml
@@ -56,14 +56,14 @@
 	        </b:Row>
 	        
 	        <b:Row addStyleNames="panel-footer">
-	            <gwt:FormPanel ui:field="logForm">
+	            <b:Form ui:field="logForm">
 	                <b:FieldSet>
 	                    <b:ButtonGroup pull="LEFT">
 	                    	<b:Button ui:field="execute" addStyleNames="fa fa-download">Download</b:Button>
 	                    	<b:FormLabel ui:field="logLabel" addStyleNames="{style.download-label-text}" />
 	                    </b:ButtonGroup>
 	                </b:FieldSet>
-	            </gwt:FormPanel>
+	            </b:Form>
 	        </b:Row>
         
         </b:Column>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/LogServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/LogServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -31,6 +31,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -117,6 +118,10 @@ public class LogServlet extends AuditServlet {
         try {
             byte[] zip = zipFiles(fileList);
             ServletOutputStream sos = httpServletResponse.getOutputStream();
+
+            Cookie downloadedCookie = new Cookie("LogsDownload", "finished");
+            downloadedCookie.setPath("/");
+            httpServletResponse.addCookie(downloadedCookie);
             httpServletResponse.setContentType("application/zip");
             httpServletResponse.setHeader("Content-Disposition", "attachment; filename=\"Kura_Logs.zip\"");
 


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Brief description of the PR. Added rotating cog modal when downloading system logs from "Device" section.

**Related Issue:** N/A.

**Description of the solution adopted:**
There is no possibility to detect the completion of form submission after `LogTabUi.this.logForm.submit();`. There is a `addHandlerOnSubmissionComplete` method but it is not working because of GWT. In `LogServlet.java` we can build the `httpServletResponse`, so cookies are added to the response to signal the end of the process simulating `addHandlerOnSubmissionComplete`.

In `LogTabUi.java` a `Timer` verifies the presence of the cookie and hides the modal. The timer repeats the check every 5000ms. For safety, if after 9 attempts (that correspond to 45secs) the cookie is not detected, the timer stops and the modal is hidden.

To allow multiple interactions from different sessions, a random number called `nonce` is generated in the client `LogTabUi.java`. That number is added to the request and will be used by the servlet as a suffix for the cookie name. The client can then verify if the cookie is related to his request. There might be very rare nonce collisions.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
