### PR TITLE
Network configuration clean up

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/snapshot_0.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+
+    Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
+
+-->
 <esf:configurations xmlns:ocd="http://www.osgi.org/xmlns/metatype/v1.2.0" xmlns:esf="http://eurotech.com/esf/2.0">
     <esf:configuration pid="org.eclipse.kura.net.admin.FirewallConfigurationService">
 	<esf:properties>
@@ -15,17 +29,8 @@
     </esf:configuration>
     <esf:configuration pid="org.eclipse.kura.net.admin.NetworkConfigurationService">
         <esf:properties>
-        <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.winsServers" type="String">
-                <esf:value/>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.mac" type="String">
-                <esf:value>00:00:00:00:00:00</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.ip4.prefix" type="Short">
                 <esf:value>24</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.domains" type="String">
-                <esf:value/>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.dhcpServer4.maxLeaseTime" type="Integer">
                 <esf:value>7200</esf:value>
@@ -33,14 +38,8 @@
             <esf:property array="false" encrypted="false" name="net.interfaces" type="String">
                 <esf:value>wlp4s0,enp3s0,lo,enp2s0</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.virtual" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.lo.config.ip4.status" type="String">
                 <esf:value>netIPv4StatusEnabledLAN</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.loopback" type="Boolean">
-                <esf:value>false</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.ip4.address" type="String">
                 <esf:value>172.16.1.1</esf:value>
@@ -51,14 +50,8 @@
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.infra.pingAccessPoint" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.virtual" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.dhcpServer4.defaultLeaseTime" type="Integer">
                 <esf:value>7200</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.up" type="Boolean">
-                <esf:value>true</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.ip4.address" type="String">
                 <esf:value>172.16.0.1</esf:value>
@@ -84,23 +77,8 @@
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.ip4.gateway" type="String">
                 <esf:value/>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.driver" type="String">
-                <esf:value> r8169</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.virtual" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.ignoreSSID" type="Boolean">
                 <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.ptp" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.domains" type="String">
-                <esf:value/>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.driver.version" type="String">
-                <esf:value> 2.3LK-NAPI</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp3s0.config.ip4.dnsServers" type="String">
                 <esf:value/>
@@ -108,23 +86,11 @@
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.dhcpClient4.enabled" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.config.name" type="String">
-                <esf:value>lo</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.ptp" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.infra.ssid" type="String">
                 <esf:value/>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.loopback" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.dhcpServer4.passDns" type="Boolean">
                 <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.infra.channel" type="String">
-                <esf:value>1 2 3 4 5 6 7 8 9 10 11 12 13</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp3s0.config.nat.enabled" type="Boolean">
                 <esf:value>true</esf:value>
@@ -132,41 +98,17 @@
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.ip4.gateway" type="String">
                 <esf:value>127.0.0.1</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.config.autoconnect" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.dhcpClient4.enabled" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.driver.version" type="String">
-                <esf:value> 2.3LK-NAPI</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.firmware.version" type="String">
-                <esf:value> rtl8168g-2_0.0.1 02/06/13</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.up" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.ptp" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.driver.version" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="true" name="net.interface.wlp4s0.config.wifi.infra.passphrase" type="Password">
                 <esf:value/>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.mac" type="String">
-                <esf:value>00:07:32:49:AC:A2</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.nat.enabled" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.infra.securityType" type="String">
                 <esf:value>SECURITY_NONE</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.wifi.bitrate" type="Long">
-                <esf:value>0</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.bgscan" type="String">
                 <esf:value/>
@@ -183,17 +125,8 @@
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.infra.ignoreSSID" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.ip4.address" type="String">
-                <esf:value>127.0.0.1</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.lo.config.ip4.prefix" type="Short">
                 <esf:value>-1</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.autoconnect" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.hardwareMode" type="String">
-                <esf:value>g</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.dhcpServer4.enabled" type="Boolean">
                 <esf:value>true</esf:value>
@@ -204,50 +137,20 @@
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.driver" type="String">
                 <esf:value>nl80211</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.ptp" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.config.domains" type="String">
-                <esf:value/>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.eth.link.up" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.dhcpServer4.prefix" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.infra.broadcast" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.autoconnect" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.lo.config.dhcpClient4.enabled" type="Boolean">
                 <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.name" type="String">
-                <esf:value>enp2s0</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.mode" type="String">
                 <esf:value>MASTER</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.ip4.dnsServers" type="String">
-                <esf:value>127.0.0.53</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.winsServers" type="String">
-                <esf:value/>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.dhcpServer4.maxLeaseTime" type="Integer">
                 <esf:value>7200</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.virtual" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.config.mtu" type="Integer">
-                <esf:value>1500</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.firmware.version" type="String">
-                <esf:value> rtl8168g-2_0.0.1 02/06/13</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.dhcpServer4.rangeStart" type="String">
                 <esf:value>172.16.1.100</esf:value>
@@ -255,44 +158,11 @@
             <esf:property array="false" encrypted="false" name="net.interface.lo.config.ip4.dnsServers" type="String">
                 <esf:value/>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.ip4.netmask" type="String">
-                <esf:value>255.0.0.0</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.dhcpServer4.rangeEnd" type="String">
                 <esf:value>172.16.0.110</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.config.name" type="String">
-                <esf:value>enp3s0</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.mac" type="String">
-                <esf:value>E0:94:67:5B:0D:BF</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.pairwiseCiphers" type="String">
                 <esf:value>CCMP</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.eth.link.up" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.state" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.ip4.dnsServers" type="String">
-                <esf:value/>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.ip4.netmask" type="String">
-                <esf:value>255.255.255.0</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.config.state" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.ip4.broadcast" type="String">
-                <esf:value>172.16.0.255</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.broadcast" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.wifi.capabilities" type="String">
-                <esf:value>CIPHER_TKIP CIPHER_CCMP WPA RSN </esf:value>
             </esf:property>
             <esf:property array="false" encrypted="true" name="net.interface.wlp4s0.config.wifi.master.passphrase" type="Password">
                 <esf:value>dGVzdEtFWVM=</esf:value>
@@ -300,41 +170,11 @@
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.securityType" type="String">
                 <esf:value>SECURITY_WPA2</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.driver" type="String">
-                <esf:value> iwlwifi</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.ip4.prefix" type="Short">
-                <esf:value>8</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp3s0.config.dhcpClient4.enabled" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.loopback" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.mac" type="String">
-                <esf:value>00:07:32:49:AC:A3</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.config.state" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.state" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.ip4.prefix" type="Short">
                 <esf:value>24</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.ip4.broadcast" type="String">
-                <esf:value>127.0.0.1</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.mtu" type="Integer">
-                <esf:value>1500</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.loopback" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.mtu" type="Integer">
-                <esf:value>1500</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.ip4.gateway" type="String">
                 <esf:value/>
@@ -351,23 +191,11 @@
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.dhcpServer4.prefix" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.driver" type="String">
-                <esf:value> r8169</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.lo.type" type="String">
                 <esf:value>LOOPBACK</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.pingAccessPoint" type="Boolean">
                 <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.config.mtu" type="Integer">
-                <esf:value>65536</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.driver" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.name" type="String">
-                <esf:value>wlp4s0</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.lo.config.ip4.address" type="String">
                 <esf:value/>
@@ -381,32 +209,11 @@
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.dhcpServer4.rangeEnd" type="String">
                 <esf:value>172.16.1.110</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.firmware.version" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.firmware.version" type="String">
-                <esf:value> 29.1044073957.0</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.channel" type="String">
                 <esf:value>1</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.config.winsServers" type="String">
-                <esf:value/>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.type" type="String">
                 <esf:value>ETHERNET</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.up" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.driver.version" type="String">
-                <esf:value> 4.18.0-17-generic</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.infra.hardwareMode" type="String">
-                <esf:value/>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.up" type="Boolean">
-                <esf:value>true</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.ip4.status" type="String">
                 <esf:value>netIPv4StatusEnabledLAN</esf:value>
@@ -417,13 +224,7 @@
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.wifi.master.radioMode" type="String">
                 <esf:value>RADIO_MODE_80211g</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.ip4.prefix" type="Short">
-                <esf:value>24</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp4s0.config.dhcpServer4.passDns" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.lo.config.autoconnect" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
         </esf:properties>

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
-    Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -32,19 +32,7 @@
             <esf:property name="net.interface.eth0.config.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.ip4.dnsServers" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.passDns" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.driver" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.driver.version" array="false" encrypted="false" type="String">
-                <esf:value>unkown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.virtual" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.type" array="false" encrypted="false" type="String">
@@ -53,74 +41,20 @@
             <esf:property name="net.interface.lo.type" array="false" encrypted="false" type="String">
                 <esf:value>LOOPBACK</esf:value>
             </esf:property>
-            <esf:property name="net.interface.lo.virtual" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ptp" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property name="net.interface.lo.config.ip4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>8</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.winsServers" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.mtu" array="false" encrypted="false" type="Integer">
-                <esf:value>16436</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ip4.broadcast" array="false" encrypted="false" type="String">
-                <esf:value>255.0.0.0</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledWAN</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.config.name" array="false" encrypted="false" type="String">
-                <esf:value>eth0</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.eth.link.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.config.mtu" array="false" encrypted="false" type="Integer">
-                <esf:value>1500</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.devicePath" array="false" encrypted="false" type="String">
-                <esf:value>1.1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.ip4.broadcast" array="false" encrypted="false" type="String">
-                <esf:value>255.255.255.0</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.vendor.id" array="false" encrypted="false" type="String">
-                <esf:value>0424</esf:value>
             </esf:property>
             <esf:property name="net.interfaces" array="false" encrypted="false" type="String">
                 <esf:value>lo,eth0</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.ip4.address" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.domains" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ip4.address" array="false" encrypted="false" type="String">
-                <esf:value>127.0.0.1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.autoconnect" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.mac" array="false" encrypted="false" type="String">
-                <esf:value>00:00:00:00:00:00</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.loopback" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.maxLeaseTime" array="false" encrypted="false" type="Integer">
                 <esf:value>7200</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.product.id" array="false" encrypted="false" type="String">
-                <esf:value>ec00</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.rangeStart" array="false" encrypted="false" type="String">
                 <esf:value>172.16.0.100</esf:value>
@@ -128,32 +62,8 @@
             <esf:property name="net.interface.eth0.config.dhcpServer4.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property name="net.interface.lo.firmware.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ip4.dnsServers" array="false" encrypted="false" type="String">
-                <esf:value>127.0.0.1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.name" array="false" encrypted="false" type="String">
-                <esf:value>lo</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.mac" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.driver.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.state" array="false" encrypted="false" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.defaultLeaseTime" array="false" encrypted="false" type="Integer">
                 <esf:value>7200</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.driver" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.ptp" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
             </esf:property>
             <esf:property name="modified.interface.names" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
@@ -167,15 +77,6 @@
             <esf:property name="net.interface.eth0.config.dhcpServer4.rangeEnd" array="false" encrypted="false" type="String">
                 <esf:value>172.16.0.110</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.config.state" array="false" encrypted="false" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.busNumber" array="false" encrypted="false" type="String">
-                <esf:value>1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
             <esf:property name="net.interface.lo.config.dhcpClient4.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
@@ -184,23 +85,9 @@
             </esf:property>
             <esf:property name="net.interface.lo.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledLAN</esf:value>
-            </esf:property>s
-            <esf:property name="net.interface.eth0.config.autoconnect" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.usb.product.name" array="false" encrypted="false"/>
             <esf:property name="net.interface.lo.config.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.vendor.name" array="false" encrypted="false"/>
-            <esf:property name="net.interface.eth0.loopback" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.firmware.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
             </esf:property>
         </esf:properties>
     </esf:configuration>

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/snapshot_0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
-    Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -29,13 +29,7 @@
     </esf:configuration>
     <esf:configuration pid="org.eclipse.kura.net.admin.NetworkConfigurationService">
         <esf:properties>
-            <esf:property name="net.interface.wlan0.config.wifi.master.broadcast" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.ip4.dnsServers" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.passDns" array="false" encrypted="false" type="Boolean">
@@ -44,44 +38,14 @@
             <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>testKEYS</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.driver" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.autoconnect" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.driver.version" array="false" encrypted="false" type="String">
-                <esf:value>unkown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.virtual" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.infra.mode" array="false" encrypted="false" type="String">
                 <esf:value>INFRA</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.wifi.bitrate" array="false" encrypted="false" type="Long">
-                <esf:value>0</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.channel" array="false" encrypted="false" type="String">
-                <esf:value>1 2 3 4 5 6 7 8 9 10 11</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.type" array="false" encrypted="false" type="String">
                 <esf:value>ETHERNET</esf:value>
             </esf:property>
             <esf:property name="net.interface.lo.type" array="false" encrypted="false" type="String">
                 <esf:value>LOOPBACK</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.virtual" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.virtual" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ptp" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.master.hardwareMode" array="false" encrypted="false" type="String">
-                <esf:value>g</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.master.securityType" array="false" encrypted="false" type="String">
                 <esf:value>SECURITY_WPA2</esf:value>
@@ -92,32 +56,8 @@
             <esf:property name="net.interface.lo.config.ip4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>8</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.firmware.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.winsServers" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.mtu" array="false" encrypted="false" type="Integer">
-                <esf:value>16436</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ip4.broadcast" array="false" encrypted="false" type="String">
-                <esf:value>255.0.0.0</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledWAN</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.loopback" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.config.name" array="false" encrypted="false" type="String">
-                <esf:value>eth0</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.wifi.capabilities" array="false" encrypted="false" type="String">
-                <esf:value>CIPHER_TKIP CIPHER_CCMP WPA RSN </esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.broadcast" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.dhcpServer4.passDns" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
@@ -125,29 +65,8 @@
             <esf:property name="net.interface.wlan0.config.nat.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.eth.link.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.ptp" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.winsServers" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.config.mtu" array="false" encrypted="false" type="Integer">
-                <esf:value>1500</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.devicePath" array="false" encrypted="false" type="String">
-                <esf:value>1.1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.ip4.broadcast" array="false" encrypted="false" type="String">
-                <esf:value>255.255.255.0</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.dhcpServer4.rangeStart" array="false" encrypted="false" type="String">
                 <esf:value>172.16.1.100</esf:value>
@@ -164,12 +83,6 @@
             <esf:property name="net.interface.wlan0.config.wifi.master.driver" array="false" encrypted="false" type="String">
                 <esf:value>nl80211</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.mac" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.vendor.id" array="false" encrypted="false" type="String">
-                <esf:value>0424</esf:value>
-            </esf:property>
             <esf:property name="net.interfaces" array="false" encrypted="false" type="String">
                 <esf:value>lo,wlan0,eth0</esf:value>
             </esf:property>
@@ -179,23 +92,8 @@
             <esf:property name="net.interface.wlan0.config.ip4.address" array="false" encrypted="false" type="String">
                 <esf:value>172.16.1.1</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.ip4.address" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.domains" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
             <esf:property name="net.interface.lo.ip4.address" array="false" encrypted="false" type="String">
                 <esf:value>127.0.0.1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.autoconnect" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.mac" array="false" encrypted="false" type="String">
-                <esf:value>00:00:00:00:00:00</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.loopback" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.maxLeaseTime" array="false" encrypted="false" type="Integer">
                 <esf:value>7200</esf:value>
@@ -203,50 +101,14 @@
             <esf:property name="net.interface.wlan0.config.ip4.gateway" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.usb.product.id" array="false" encrypted="false" type="String">
-                <esf:value>ec00</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.rangeStart" array="false" encrypted="false" type="String">
                 <esf:value>172.16.0.100</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.state" array="false" encrypted="false" type="String">
-                <esf:value>DISCONNECTED</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.firmware.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ip4.dnsServers" array="false" encrypted="false" type="String">
-                <esf:value>127.0.0.1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.name" array="false" encrypted="false" type="String">
-                <esf:value>lo</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.mac" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.name" array="false" encrypted="false" type="String">
-                <esf:value>wlan0</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.driver.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.state" array="false" encrypted="false" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.defaultLeaseTime" array="false" encrypted="false" type="Integer">
                 <esf:value>7200</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.driver" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.ptp" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="modified.interface.names" array="false" encrypted="false" type="String">
-                <esf:value>wlan0</esf:value>
             </esf:property>
             <esf:property name="net.interface.lo.config.ip4.address" array="false" encrypted="false" type="String">
                 <esf:value>127.0.0.1</esf:value>
@@ -260,17 +122,8 @@
             <esf:property name="net.interface.eth0.config.dhcpServer4.rangeEnd" array="false" encrypted="false" type="String">
                 <esf:value>172.16.0.110</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.config.state" array="false" encrypted="false" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.busNumber" array="false" encrypted="false" type="String">
-                <esf:value>1</esf:value>
-            </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.mode" array="false" encrypted="false" type="String">
                 <esf:value>MASTER</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.driver" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.master.radioMode" array="false" encrypted="false" type="String">
                 <esf:value>RADIO_MODE_80211g</esf:value>
@@ -278,14 +131,8 @@
             <esf:property name="net.interface.wlan0.config.dhcpServer4.rangeEnd" array="false" encrypted="false" type="String">
                 <esf:value>172.16.1.110</esf:value>
             </esf:property>
-            <esf:property name="net.interface.lo.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
             <esf:property name="net.interface.lo.config.dhcpClient4.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.mtu" array="false" encrypted="false" type="Integer">
-                <esf:value>1500</esf:value>
             </esf:property>
             <esf:property name="net.interface.lo.config.ip4.gateway" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
@@ -299,10 +146,6 @@
             <esf:property name="net.interface.wlan0.config.wifi.master.ssid" array="false" encrypted="false" type="String">
                 <esf:value>kura_gateway_raspberry_pi</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.config.autoconnect" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.product.name" array="false" encrypted="false"/>
             <esf:property name="net.interface.wlan0.config.dhcpServer4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
@@ -311,10 +154,6 @@
             </esf:property>
             <esf:property name="net.interface.lo.config.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.vendor.name" array="false" encrypted="false"/>
-            <esf:property name="net.interface.eth0.loopback" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
@@ -325,16 +164,10 @@
             <esf:property name="net.interface.wlan0.config.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.domains" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
             <esf:property name="net.interface.wlan0.config.dhcpClient4.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.infra.ssid" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.hardwareMode" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.dhcpServer4.defaultLeaseTime" array="false" encrypted="false" type="Integer">
@@ -342,15 +175,6 @@
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledLAN</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.firmware.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.driver.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
             </esf:property>
         </esf:properties>
     </esf:configuration>

--- a/kura/distrib/src/main/resources/raspberry-pi/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi/snapshot_0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 
-    Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -29,13 +29,7 @@
     </esf:configuration>
     <esf:configuration pid="org.eclipse.kura.net.admin.NetworkConfigurationService">
         <esf:properties>
-            <esf:property name="net.interface.wlan0.config.wifi.master.broadcast" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.ip4.dnsServers" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.passDns" array="false" encrypted="false" type="Boolean">
@@ -44,44 +38,14 @@
             <esf:property name="net.interface.wlan0.config.wifi.master.passphrase" array="false" encrypted="false" type="Password">
                 <esf:value>testKEYS</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.driver" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.autoconnect" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.driver.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.virtual" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.infra.mode" array="false" encrypted="false" type="String">
                 <esf:value>INFRA</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.wifi.bitrate" array="false" encrypted="false" type="Long">
-                <esf:value>0</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.channel" array="false" encrypted="false" type="String">
-                <esf:value>1 2 3 4 5 6 7 8 9 10 11</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.type" array="false" encrypted="false" type="String">
                 <esf:value>ETHERNET</esf:value>
             </esf:property>
             <esf:property name="net.interface.lo.type" array="false" encrypted="false" type="String">
                 <esf:value>LOOPBACK</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.virtual" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.virtual" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ptp" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.master.hardwareMode" array="false" encrypted="false" type="String">
-                <esf:value>g</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.master.securityType" array="false" encrypted="false" type="String">
                 <esf:value>SECURITY_WPA2</esf:value>
@@ -92,29 +56,8 @@
             <esf:property name="net.interface.lo.config.ip4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>8</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.firmware.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.winsServers" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.mtu" array="false" encrypted="false" type="Integer">
-                <esf:value>16436</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ip4.broadcast" array="false" encrypted="false" type="String">
-                <esf:value>255.0.0.0</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledWAN</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.loopback" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.config.name" array="false" encrypted="false" type="String">
-                <esf:value>eth0</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.wifi.capabilities" array="false" encrypted="false" type="String">
-                <esf:value>CIPHER_TKIP CIPHER_CCMP WPA RSN </esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.infra.broadcast" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
@@ -125,29 +68,11 @@
             <esf:property name="net.interface.wlan0.config.nat.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.eth.link.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.ptp" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.winsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.config.mtu" array="false" encrypted="false" type="Integer">
-                <esf:value>1500</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.devicePath" array="false" encrypted="false" type="String">
-                <esf:value>1.1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.ip4.broadcast" array="false" encrypted="false" type="String">
-                <esf:value>255.255.255.0</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.dhcpServer4.rangeStart" array="false" encrypted="false" type="String">
                 <esf:value>172.16.1.100</esf:value>
@@ -164,12 +89,6 @@
             <esf:property name="net.interface.wlan0.config.wifi.master.driver" array="false" encrypted="false" type="String">
                 <esf:value>nl80211</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.mac" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.vendor.id" array="false" encrypted="false" type="String">
-                <esf:value>0424</esf:value>
-            </esf:property>
             <esf:property name="net.interfaces" array="false" encrypted="false" type="String">
                 <esf:value>lo,wlan0,eth0</esf:value>
             </esf:property>
@@ -179,32 +98,11 @@
             <esf:property name="net.interface.wlan0.config.ip4.address" array="false" encrypted="false" type="String">
                 <esf:value>172.16.1.1</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.ip4.address" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.domains" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ip4.address" array="false" encrypted="false" type="String">
-                <esf:value>127.0.0.1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.autoconnect" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.mac" array="false" encrypted="false" type="String">
-                <esf:value>00:00:00:00:00:00</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.loopback" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.maxLeaseTime" array="false" encrypted="false" type="Integer">
                 <esf:value>7200</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.gateway" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.product.id" array="false" encrypted="false" type="String">
-                <esf:value>ec00</esf:value>
             </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.rangeStart" array="false" encrypted="false" type="String">
                 <esf:value>172.16.0.100</esf:value>
@@ -212,41 +110,8 @@
             <esf:property name="net.interface.eth0.config.dhcpServer4.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.state" array="false" encrypted="false" type="String">
-                <esf:value>DISCONNECTED</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.firmware.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.ip4.dnsServers" array="false" encrypted="false" type="String">
-                <esf:value>127.0.0.1</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.name" array="false" encrypted="false" type="String">
-                <esf:value>lo</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.mac" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.name" array="false" encrypted="false" type="String">
-                <esf:value>wlan0</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.driver.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.config.state" array="false" encrypted="false" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.defaultLeaseTime" array="false" encrypted="false" type="Integer">
                 <esf:value>7200</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.lo.driver" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.ptp" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="modified.interface.names" array="false" encrypted="false" type="String">
-                <esf:value>wlan0</esf:value>
             </esf:property>
             <esf:property name="net.interface.lo.config.ip4.address" array="false" encrypted="false" type="String">
                 <esf:value>127.0.0.1</esf:value>
@@ -260,17 +125,8 @@
             <esf:property name="net.interface.eth0.config.dhcpServer4.rangeEnd" array="false" encrypted="false" type="String">
                 <esf:value>172.16.0.110</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.config.state" array="false" encrypted="false" type="String">
-                <esf:value>ACTIVATED</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.busNumber" array="false" encrypted="false" type="String">
-                <esf:value>1</esf:value>
-            </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.mode" array="false" encrypted="false" type="String">
                 <esf:value>MASTER</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.driver" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.master.radioMode" array="false" encrypted="false" type="String">
                 <esf:value>RADIO_MODE_80211g</esf:value>
@@ -278,14 +134,8 @@
             <esf:property name="net.interface.wlan0.config.dhcpServer4.rangeEnd" array="false" encrypted="false" type="String">
                 <esf:value>172.16.1.110</esf:value>
             </esf:property>
-            <esf:property name="net.interface.lo.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
             <esf:property name="net.interface.lo.config.dhcpClient4.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.mtu" array="false" encrypted="false" type="Integer">
-                <esf:value>1500</esf:value>
             </esf:property>
             <esf:property name="net.interface.lo.config.ip4.gateway" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
@@ -299,10 +149,6 @@
             <esf:property name="net.interface.wlan0.config.wifi.master.ssid" array="false" encrypted="false" type="String">
                 <esf:value>kura_gateway_raspberry_pi</esf:value>
             </esf:property>
-            <esf:property name="net.interface.eth0.config.autoconnect" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.product.name" array="false" encrypted="false"/>
             <esf:property name="net.interface.wlan0.config.dhcpServer4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
@@ -311,10 +157,6 @@
             </esf:property>
             <esf:property name="net.interface.lo.config.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.usb.vendor.name" array="false" encrypted="false"/>
-            <esf:property name="net.interface.eth0.loopback" array="false" encrypted="false" type="Boolean">
-                <esf:value>false</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
@@ -325,16 +167,10 @@
             <esf:property name="net.interface.wlan0.config.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
-            <esf:property name="net.interface.wlan0.config.domains" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
             <esf:property name="net.interface.wlan0.config.dhcpClient4.enabled" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.infra.ssid" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.config.wifi.infra.hardwareMode" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>
             </esf:property>
             <esf:property name="net.interface.wlan0.config.dhcpServer4.defaultLeaseTime" array="false" encrypted="false" type="Integer">
@@ -342,15 +178,6 @@
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledLAN</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.firmware.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.eth0.up" array="false" encrypted="false" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property name="net.interface.wlan0.driver.version" array="false" encrypted="false" type="String">
-                <esf:value>unknown</esf:value>
             </esf:property>
         </esf:properties>
     </esf:configuration>

--- a/kura/emulator/org.eclipse.kura.emulator.net/src/main/java/org/eclipse/kura/emulator/net/EmulatedNetworkServiceImpl.java
+++ b/kura/emulator/org.eclipse.kura.emulator.net/src/main/java/org/eclipse/kura/emulator/net/EmulatedNetworkServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
@@ -353,7 +354,12 @@ public class EmulatedNetworkServiceImpl implements NetworkService {
     }
 
     @Override
-    public String getModemPppInterfaceName(String usbPath) throws KuraException {
+    public String getModemPppInterfaceName(String usbPath) {
         return null;
+    }
+
+    @Override
+    public Optional<ModemDevice> getModemDevice(String usbPath) {
+        return Optional.empty();
     }
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/NetInterfaceState.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/NetInterfaceState.java
@@ -16,6 +16,7 @@ package org.eclipse.kura.net;
  * The current state of the a NetworkInterface.
  */
 public enum NetInterfaceState {
+
     /** The device is in an unknown state. */
     UNKNOWN(0),
     /** The device is recognized but not managed by NetworkManager. */

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/NetworkService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/NetworkService.java
@@ -34,12 +34,18 @@ public interface NetworkService {
 
     /**
      * Returns the overall state of the networking subsystem
+     * 
+     * @deprecated since 2.3
      */
+    @Deprecated
     public NetworkState getState() throws KuraException;
 
     /**
      * Returns the state of a specific network interface
+     * 
+     * @deprecated since 2.3
      */
+    @Deprecated
     public NetInterfaceState getState(String interfaceName) throws KuraException;
 
     /**

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/NetworkService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/NetworkService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/NetworkService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/NetworkService.java
@@ -13,6 +13,7 @@
 package org.eclipse.kura.net;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.net.modem.ModemDevice;
@@ -110,5 +111,17 @@ public interface NetworkService {
      * 
      * @since 2.3
      */
-    public String getModemPppInterfaceName(String usbPath) throws KuraException;
+    public String getModemPppInterfaceName(String usbPath);
+
+    /**
+     * Given a usb path, look up the associated modem device
+     * 
+     * @param usbPath
+     *            a string representing the usb port (i.e. 1-2.3)
+     * @return the {@link ModemDevice} attached to the specified usb port
+     * @throws KuraException
+     * 
+     * @since 2.3
+     */
+    public Optional<ModemDevice> getModemDevice(String usbPath);
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/dhcp/DhcpServerConfigIP.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/dhcp/DhcpServerConfigIP.java
@@ -321,16 +321,15 @@ public abstract class DhcpServerConfigIP<T extends IPAddress> implements DhcpSer
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("Enabled? ").append(this.enabled).append(" :: ");
-        sb.append("Prefix: ").append(this.prefix).append(" :: ");
-        sb.append("PassDNS? ").append(this.passDns).append("\n");
+        sb.append("# enabled? ").append(this.enabled).append("\n");
+        sb.append("# prefix: ").append(this.prefix).append("\n");
+        sb.append("# pass DNS? ").append(this.passDns).append("\n\n");
 
-        sb.append(
-                "\t\tsubnet " + this.subnet.getHostAddress() + " netmask " + this.subnetMask.getHostAddress() + " {\n");
+        sb.append("subnet " + this.subnet.getHostAddress() + " netmask " + this.subnetMask.getHostAddress() + " {\n");
 
         // DNS servers
         if (this.passDns && this.dnsServers != null && !this.dnsServers.isEmpty()) {
-            sb.append("\t\t\toption domain-name-servers ");
+            sb.append("    option domain-name-servers ");
             for (int i = 0; i < this.dnsServers.size(); i++) {
                 if (this.dnsServers.get(i) != null) {
                     sb.append(this.dnsServers.get(i).getHostAddress());
@@ -345,28 +344,28 @@ public abstract class DhcpServerConfigIP<T extends IPAddress> implements DhcpSer
         }
         // interface
         if (this.interfaceName != null) {
-            sb.append("\t\t\tinterface " + this.interfaceName + ";\n");
+            sb.append("    interface " + this.interfaceName + ";\n");
         }
         // router address
         if (this.routerAddress != null) {
-            sb.append("\t\t\toption routers " + this.routerAddress.getHostAddress() + ";\n");
+            sb.append("    option routers " + this.routerAddress.getHostAddress() + ";\n");
         }
         // if DNS should not be forwarded, add the following lines
         if (!this.passDns) {
-            sb.append("\t\t\tddns-update-style none;\n");
-            sb.append("\t\t\tddns-updates off;\n");
+            sb.append("    ddns-update-style none;\n");
+            sb.append("    ddns-updates off;\n");
         }
         // Lease times
-        sb.append("\t\t\tdefault-lease-time " + this.defaultLeaseTime + ";\n");
+        sb.append("    default-lease-time " + this.defaultLeaseTime + ";\n");
         if (this.maximumLeaseTime > -1) {
-            sb.append("\t\t\tmax-lease-time " + this.maximumLeaseTime + ";\n");
+            sb.append("    max-lease-time " + this.maximumLeaseTime + ";\n");
         }
 
         // Add the pool and range
-        sb.append("\t\t\tpool {\n");
-        sb.append("\t\t\t\trange " + this.rangeStart.getHostAddress() + " " + this.rangeEnd.getHostAddress() + ";\n");
-        sb.append("\t\t\t}\n");
-        sb.append("\t\t}\n");
+        sb.append("    pool {\n");
+        sb.append("        range " + this.rangeStart.getHostAddress() + " " + this.rangeEnd.getHostAddress() + ";\n");
+        sb.append("    }\n");
+        sb.append("}\n");
 
         return sb.toString();
     }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/dhcp/DhcpServerConfigIP.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/dhcp/DhcpServerConfigIP.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -321,15 +321,16 @@ public abstract class DhcpServerConfigIP<T extends IPAddress> implements DhcpSer
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("# enabled? ").append(this.enabled).append("\n");
-        sb.append("# prefix: ").append(this.prefix).append("\n");
-        sb.append("# pass DNS? ").append(this.passDns).append("\n\n");
+        sb.append("Enabled? ").append(this.enabled).append(" :: ");
+        sb.append("Prefix: ").append(this.prefix).append(" :: ");
+        sb.append("PassDNS? ").append(this.passDns).append("\n");
 
-        sb.append("subnet " + this.subnet.getHostAddress() + " netmask " + this.subnetMask.getHostAddress() + " {\n");
+        sb.append(
+                "\t\tsubnet " + this.subnet.getHostAddress() + " netmask " + this.subnetMask.getHostAddress() + " {\n");
 
         // DNS servers
         if (this.passDns && this.dnsServers != null && !this.dnsServers.isEmpty()) {
-            sb.append("    option domain-name-servers ");
+            sb.append("\t\t\toption domain-name-servers ");
             for (int i = 0; i < this.dnsServers.size(); i++) {
                 if (this.dnsServers.get(i) != null) {
                     sb.append(this.dnsServers.get(i).getHostAddress());
@@ -344,28 +345,28 @@ public abstract class DhcpServerConfigIP<T extends IPAddress> implements DhcpSer
         }
         // interface
         if (this.interfaceName != null) {
-            sb.append("    interface " + this.interfaceName + ";\n");
+            sb.append("\t\t\tinterface " + this.interfaceName + ";\n");
         }
         // router address
         if (this.routerAddress != null) {
-            sb.append("    option routers " + this.routerAddress.getHostAddress() + ";\n");
+            sb.append("\t\t\toption routers " + this.routerAddress.getHostAddress() + ";\n");
         }
         // if DNS should not be forwarded, add the following lines
         if (!this.passDns) {
-            sb.append("    ddns-update-style none;\n");
-            sb.append("    ddns-updates off;\n");
+            sb.append("\t\t\tddns-update-style none;\n");
+            sb.append("\t\t\tddns-updates off;\n");
         }
         // Lease times
-        sb.append("    default-lease-time " + this.defaultLeaseTime + ";\n");
+        sb.append("\t\t\tdefault-lease-time " + this.defaultLeaseTime + ";\n");
         if (this.maximumLeaseTime > -1) {
-            sb.append("    max-lease-time " + this.maximumLeaseTime + ";\n");
+            sb.append("\t\t\tmax-lease-time " + this.maximumLeaseTime + ";\n");
         }
 
         // Add the pool and range
-        sb.append("    pool {\n");
-        sb.append("        range " + this.rangeStart.getHostAddress() + " " + this.rangeEnd.getHostAddress() + ";\n");
-        sb.append("    }\n");
-        sb.append("}\n");
+        sb.append("\t\t\tpool {\n");
+        sb.append("\t\t\t\trange " + this.rangeStart.getHostAddress() + " " + this.rangeEnd.getHostAddress() + ";\n");
+        sb.append("\t\t\t}\n");
+        sb.append("\t\t}\n");
 
         return sb.toString();
     }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiConfig.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiConfig.java
@@ -174,8 +174,10 @@ public class WifiConfig implements NetConfig {
     }
 
     public void setPasskey(String key) {
-        Password psswd = new Password(key);
-        this.passkey = psswd;
+        if (key != null) {
+            Password psswd = new Password(key);
+            this.passkey = psswd;
+        }
     }
 
     public String getHardwareMode() {

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiConfig.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiConfig.java
@@ -98,6 +98,24 @@ public class WifiConfig implements NetConfig {
         this.wifiCountryCode = null;
     }
 
+    /**
+     * @since 2.3
+     * 
+     * @param mode
+     *            for the configuration as {@link WifiMode}
+     * @param ssid
+     *            of the the wifi interface
+     * @param channels
+     *            supported by the wifi interface
+     * @param security
+     *            mode of the interface as {@link WifiSecurity}
+     * @param passkey
+     *            for the wifi interface
+     * @param hwMode
+     *            the hardware mode
+     * @param bgscan
+     *            the background scan
+     */
     public WifiConfig(WifiMode mode, String ssid, int[] channels, WifiSecurity security, String passkey, String hwMode,
             WifiBgscan bgscan) {
         super();

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiConfig.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -55,9 +55,6 @@ public class WifiConfig implements NetConfig {
     /** Radio mode **/
     private WifiRadioMode radioMode;
 
-    /** Whether or not to broadcast the SSID **/
-    private boolean broadcast;
-
     /** Background scan **/
     private WifiBgscan bgscan;
 
@@ -80,7 +77,12 @@ public class WifiConfig implements NetConfig {
         super();
     }
 
+    /**
+     * @deprecated since 2.3. Use {@link WifiConfig(WifiMode mode, String ssid, int[] channels, WifiSecurity security,
+     *             String passkey, String hwMode, WifiBgscan bgscan)}
+     */
     @SuppressWarnings("checkstyle:parameterNumber")
+    @Deprecated
     public WifiConfig(WifiMode mode, String ssid, int[] channels, WifiSecurity security, String passkey, String hwMode,
             boolean broadcast, WifiBgscan bgscan) {
         super();
@@ -91,7 +93,21 @@ public class WifiConfig implements NetConfig {
         this.security = security;
         this.passkey = new Password(passkey);
         this.hwMode = hwMode;
-        this.broadcast = broadcast;
+        this.bgscan = bgscan;
+        this.channelFrequencies = null;
+        this.wifiCountryCode = null;
+    }
+
+    public WifiConfig(WifiMode mode, String ssid, int[] channels, WifiSecurity security, String passkey, String hwMode,
+            WifiBgscan bgscan) {
+        super();
+
+        this.mode = mode;
+        this.ssid = ssid;
+        this.channels = channels;
+        this.security = security;
+        this.passkey = new Password(passkey);
+        this.hwMode = hwMode;
         this.bgscan = bgscan;
         this.channelFrequencies = null;
         this.wifiCountryCode = null;
@@ -178,12 +194,20 @@ public class WifiConfig implements NetConfig {
         this.radioMode = radioMode;
     }
 
+    /**
+     * @deprecated since 2.3
+     */
+    @Deprecated
     public boolean getBroadcast() {
-        return this.broadcast;
+        return false;
     }
 
+    /**
+     * @deprecated since 2.3
+     */
+    @Deprecated
     public void setBroadcast(boolean broadcast) {
-        this.broadcast = broadcast;
+        // Do nothing...
     }
 
     public WifiBgscan getBgscan() {
@@ -282,7 +306,6 @@ public class WifiConfig implements NetConfig {
         result = prime * result + (this.passkey == null ? 0 : this.passkey.hashCode());
         result = prime * result + (this.hwMode == null ? 0 : this.hwMode.hashCode());
         result = prime * result + (this.radioMode == null ? 0 : this.radioMode.hashCode());
-        result = prime * result + (this.broadcast ? 1021 : 1031);
 
         result = prime * result + (this.pairwiseCiphers == null ? 0 : WifiCiphers.getCode(this.pairwiseCiphers));
 
@@ -353,9 +376,6 @@ public class WifiConfig implements NetConfig {
         if (!compare(this.bgscan, other.bgscan)) {
             return false;
         }
-        if (this.broadcast != other.broadcast) {
-            return false;
-        }
         if (this.pingAccessPoint != other.pingAccessPoint()) {
             return false;
         }
@@ -371,7 +391,7 @@ public class WifiConfig implements NetConfig {
 
     @Override
     public boolean isValid() {
-        return this.mode != null ? true : false;
+        return this.mode != null;
     }
 
     @Override
@@ -417,7 +437,6 @@ public class WifiConfig implements NetConfig {
         if (this.radioMode != null) {
             sb.append("radioMode: ").append(this.radioMode).append(" :: ");
         }
-        sb.append("broadcast: ").append(this.broadcast).append(" :: ");
         if (this.bgscan != null) {
             sb.append("bgscan: ").append(this.bgscan).append(" :: ");
         }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiConfig.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/wifi/WifiConfig.java
@@ -85,17 +85,7 @@ public class WifiConfig implements NetConfig {
     @Deprecated
     public WifiConfig(WifiMode mode, String ssid, int[] channels, WifiSecurity security, String passkey, String hwMode,
             boolean broadcast, WifiBgscan bgscan) {
-        super();
-
-        this.mode = mode;
-        this.ssid = ssid;
-        this.channels = channels;
-        this.security = security;
-        this.passkey = new Password(passkey);
-        this.hwMode = hwMode;
-        this.bgscan = bgscan;
-        this.channelFrequencies = null;
-        this.wifiCountryCode = null;
+        this(mode, ssid, channels, security, passkey, hwMode, bgscan);
     }
 
     /**

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -108,7 +108,7 @@ public class NetworkConfiguration {
     private static final Boolean DEFAULT_DIVERSITY_ENABLED_VALUE = false;
     private static final Boolean DEFAULT_ENABLED_VALUE = false;
     private static final Integer DEFAULT_PROFILE_ID_VALUE = 0;
-    private static final Integer DEFAULT_PPP_NUMBER_VALUE = 0;
+    // private static final Integer DEFAULT_PPP_NUMBER_VALUE = 0;
     private static final Integer DEFAULT_DATA_COMPRESSION_VALUE = 0;
     private static final Integer DEFAULT_HEADER_COMPRESSION_VALUE = 0;
 
@@ -1064,7 +1064,7 @@ public class NetworkConfiguration {
         modemConfig.setPassword(getPassword(prefix, properties));
         modemConfig.setPdpType(getPdpType(prefix, properties));
         modemConfig.setProfileID(getProfileId(prefix, properties));
-        modemConfig.setPppNumber(getPppNumber(prefix, properties));
+        // modemConfig.setPppNumber(getPppNumber(prefix, properties));
         modemConfig.setPersist(isPersist(prefix, properties));
         modemConfig.setMaxFail(getMaximumFailures(prefix, properties));
         modemConfig.setResetTimeout(getResetTimeout(prefix, properties));
@@ -1146,11 +1146,11 @@ public class NetworkConfiguration {
         return value != null ? (Integer) value : DEFAULT_PROFILE_ID_VALUE;
     }
 
-    private static int getPppNumber(String prefix, Map<String, Object> properties) {
-        String key = prefix + PPP_NUM;
-        Object value = properties.getOrDefault(key, DEFAULT_PPP_NUMBER_VALUE);
-        return value != null ? (Integer) value : DEFAULT_PPP_NUMBER_VALUE;
-    }
+    // private static int getPppNumber(String prefix, Map<String, Object> properties) {
+    // String key = prefix + PPP_NUM;
+    // Object value = properties.getOrDefault(key, DEFAULT_PPP_NUMBER_VALUE);
+    // return value != null ? (Integer) value : DEFAULT_PPP_NUMBER_VALUE;
+    // }
 
     private static PdpType getPdpType(String prefix, Map<String, Object> properties) {
         String key = prefix + "pdpType";
@@ -2044,7 +2044,8 @@ public class NetworkConfiguration {
                 logger.trace("Adding modem netconfig");
 
                 ModemConfig modemConfig = getModemConfig(netIfConfigPrefix, props);
-                ((ModemInterfaceConfigImpl) netInterfaceConfig).setPppNum(modemConfig.getPppNumber());
+                modemConfig.setPppNumber(((ModemInterfaceConfigImpl) netInterfaceConfig).getPppNum());
+                // ((ModemInterfaceConfigImpl) netInterfaceConfig).setPppNum(modemConfig.getPppNumber());
                 netConfigs.add(modemConfig);
             }
         }

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -549,7 +549,7 @@ public class NetworkConfiguration {
 
             // add the properties of the interface
             newNetworkProperties.put(netIfReadOnlyPrefix + "type", netInterfaceConfig.getType().toString());
-            newNetworkProperties.put(netIfPrefix + AUTOCONNECT, netInterfaceConfig.isAutoConnect());
+            // newNetworkProperties.put(netIfPrefix + AUTOCONNECT, netInterfaceConfig.isAutoConnect());
             newNetworkProperties.put(netIfPrefix + "mtu", netInterfaceConfig.getMTU());
 
             netInterfaceConfig.getNetInterfaceAddresses().forEach(nia -> {
@@ -1108,7 +1108,7 @@ public class NetworkConfiguration {
     private static void addNetConfigIP4Properties(NetConfigIP4 nc, String netIfConfigPrefix,
             Map<String, Object> properties) {
 
-        properties.put(netIfConfigPrefix + AUTOCONNECT, nc.isAutoConnect());
+        // properties.put(netIfConfigPrefix + AUTOCONNECT, nc.isAutoConnect());
         properties.put(netIfConfigPrefix + "ip4.status", nc.getStatus().toString());
 
         StringBuilder sbDnsAddresses = new StringBuilder();
@@ -1317,14 +1317,14 @@ public class NetworkConfiguration {
         String netIfPrefix = sbPrefix.append("config.").toString();
         String netIfConfigPrefix = sbPrefix.toString();
 
-        // Auto connect
-        boolean autoConnect = false;
-        String autoConnectKey = netIfPrefix + AUTOCONNECT;
-        if (props.containsKey(autoConnectKey)) {
-            autoConnect = (Boolean) props.get(autoConnectKey);
-            logger.trace("got autoConnect: {}", autoConnect);
-            netInterfaceConfig.setAutoConnect(autoConnect);
-        }
+        // // Auto connect
+        // boolean autoConnect = false;
+        // String autoConnectKey = netIfPrefix + AUTOCONNECT;
+        // if (props.containsKey(autoConnectKey)) {
+        // autoConnect = (Boolean) props.get(autoConnectKey);
+        // logger.trace("got autoConnect: {}", autoConnect);
+        // netInterfaceConfig.setAutoConnect(autoConnect);
+        // }
 
         // USB
         String vendorId = (String) props.get(netIfReadOnlyPrefix + "usb.vendor.id");
@@ -1435,7 +1435,8 @@ public class NetworkConfiguration {
             NetConfigIP4 netConfigIP4;
             boolean dhcpEnabled = isDhcpClient4Enabled(props, interfaceName);
 
-            netConfigIP4 = new NetConfigIP4(NetInterfaceStatus.valueOf(configStatus4), autoConnect);
+            NetInterfaceStatus status4 = NetInterfaceStatus.valueOf(configStatus4);
+            netConfigIP4 = new NetConfigIP4(status4, getAutoConnectProperty(status4));
             netConfigs.add(netConfigIP4);
 
             if (dhcpEnabled) {
@@ -1673,7 +1674,8 @@ public class NetworkConfiguration {
 
             if (!dhcp6Enabled) {
                 // ip6
-                netConfigIP6 = new NetConfigIP6(NetInterfaceStatus.valueOf(configStatus6), autoConnect, dhcp6Enabled);
+                NetInterfaceStatus status6 = NetInterfaceStatus.valueOf(configStatus6);
+                netConfigIP6 = new NetConfigIP6(status6, getAutoConnectProperty(status6), dhcp6Enabled);
                 netConfigs.add(netConfigIP6);
 
                 String configIp6 = NET_INTERFACE + interfaceName + ".config.ip6.address";
@@ -1758,5 +1760,18 @@ public class NetworkConfiguration {
             logger.trace("DHCP 4 enabled? {}", dhcpEnabled);
         }
         return dhcpEnabled;
+    }
+
+    private boolean getAutoConnectProperty(NetInterfaceStatus status) {
+        boolean autoconnect = false;
+        if (status.equals(NetInterfaceStatus.netIPv4StatusEnabledLAN)
+                || status.equals(NetInterfaceStatus.netIPv4StatusEnabledWAN)
+                || status.equals(NetInterfaceStatus.netIPv4StatusL2Only)
+                || status.equals(NetInterfaceStatus.netIPv6StatusEnabledLAN)
+                || status.equals(NetInterfaceStatus.netIPv6StatusEnabledWAN)
+                || status.equals(NetInterfaceStatus.netIPv6StatusL2Only)) {
+            autoconnect = true;
+        }
+        return autoconnect;
     }
 }

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -549,8 +549,6 @@ public class NetworkConfiguration {
 
             // add the properties of the interface
             newNetworkProperties.put(netIfReadOnlyPrefix + "type", netInterfaceConfig.getType().toString());
-            // newNetworkProperties.put(netIfPrefix + AUTOCONNECT, netInterfaceConfig.isAutoConnect());
-            // newNetworkProperties.put(netIfPrefix + "mtu", netInterfaceConfig.getMTU());
 
             netInterfaceConfig.getNetInterfaceAddresses().forEach(nia -> {
                 if (nia != null) {
@@ -609,15 +607,9 @@ public class NetworkConfiguration {
     private void addModemConnectionProperty(Map<String, Object> newNetworkProperties, String netIfConfigPrefix,
             NetInterfaceAddressConfig nia) {
         // Modem interface address
-        if (nia instanceof ModemInterfaceAddress) {
-            // if (((ModemInterfaceAddress) nia).getConnectionType() != null) {
-            // newNetworkProperties.put(netIfConfigPrefix + "connection.type",
-            // ((ModemInterfaceAddress) nia).getConnectionType().toString());
-            // }
-            if (((ModemInterfaceAddress) nia).getConnectionStatus() != null) {
-                newNetworkProperties.put(netIfConfigPrefix + "connection.status",
-                        ((ModemInterfaceAddress) nia).getConnectionStatus().toString());
-            }
+        if (nia instanceof ModemInterfaceAddress && ((ModemInterfaceAddress) nia).getConnectionStatus() != null) {
+            newNetworkProperties.put(netIfConfigPrefix + "connection.status",
+                    ((ModemInterfaceAddress) nia).getConnectionStatus().toString());
         }
     }
 
@@ -689,12 +681,6 @@ public class NetworkConfiguration {
         } else {
             properties.put(prefix + PASSPHRASE, new Password(""));
         }
-        // if (wifiConfig.getHardwareMode() != null) {
-        // properties.put(prefix + HARDWARE_MODE, wifiConfig.getHardwareMode());
-        // } else {
-        // properties.put(prefix + HARDWARE_MODE, "");
-        // }
-        // properties.put(prefix + BROADCAST, Boolean.valueOf(wifiConfig.getBroadcast()));
         if (wifiConfig.getRadioMode() != null) {
             properties.put(prefix + ".radioMode", wifiConfig.getRadioMode().toString());
         }
@@ -892,9 +878,7 @@ public class NetworkConfiguration {
         properties.put(prefix + "apn", modemConfig.getApn());
         properties.put(prefix + "authType",
                 modemConfig.getAuthType() != null ? modemConfig.getAuthType().toString() : "");
-        // properties.put(prefix + "dataCompression", modemConfig.getDataCompression());
         properties.put(prefix + "dialString", modemConfig.getDialString());
-        // properties.put(prefix + "headerCompression", modemConfig.getHeaderCompression());
         properties.put(prefix + "ipAddress",
                 modemConfig.getIpAddress() != null ? modemConfig.getIpAddress().toString() : "");
         properties.put(prefix + "password", modemConfig.getPasswordAsPassword());
@@ -906,7 +890,6 @@ public class NetworkConfiguration {
         properties.put(prefix + "resetTimeout", modemConfig.getResetTimeout());
         properties.put(prefix + "lcpEchoInterval", modemConfig.getLcpEchoInterval());
         properties.put(prefix + "lcpEchoFailure", modemConfig.getLcpEchoFailure());
-        // properties.put(prefix + "profileId", modemConfig.getProfileID());
         properties.put(prefix + "username", modemConfig.getUsername());
         properties.put(prefix + "enabled", modemConfig.isEnabled());
         properties.put(prefix + "gpsEnabled", modemConfig.isGpsEnabled());
@@ -1108,7 +1091,6 @@ public class NetworkConfiguration {
     private static void addNetConfigIP4Properties(NetConfigIP4 nc, String netIfConfigPrefix,
             Map<String, Object> properties) {
 
-        // properties.put(netIfConfigPrefix + AUTOCONNECT, nc.isAutoConnect());
         properties.put(netIfConfigPrefix + "ip4.status", nc.getStatus().toString());
 
         StringBuilder sbDnsAddresses = new StringBuilder();
@@ -1140,28 +1122,6 @@ public class NetworkConfiguration {
             } else {
                 properties.put(netIfConfigPrefix + "ip4.gateway", "");
             }
-
-            // StringBuilder sbWinsAddresses = new StringBuilder();
-            // if (nc.getWinsServers() != null) {
-            // for (IP4Address ip : nc.getWinsServers()) {
-            // if (sbWinsAddresses.length() != 0) {
-            // sbWinsAddresses.append(",");
-            // }
-            // sbWinsAddresses.append(ip.getHostAddress());
-            // }
-            // }
-            // properties.put(netIfConfigPrefix + "winsServers", sbWinsAddresses.toString());
-
-            // StringBuilder sbDomains = new StringBuilder();
-            // if (nc.getDomains() != null) {
-            // for (String domain : nc.getDomains()) {
-            // if (sbDomains.length() != 0) {
-            // sbDomains.append(",");
-            // }
-            // sbDomains.append(domain);
-            // }
-            // }
-            // properties.put(netIfConfigPrefix + "domains", sbDomains.toString());
         }
     }
 
@@ -1186,15 +1146,6 @@ public class NetworkConfiguration {
                 sbDnsAddresses.append(ip.getHostAddress());
             }
             properties.put(netIfConfigPrefix + "ip6.dnsServers", sbDnsAddresses.toString());
-
-            // StringBuilder sbDomains = new StringBuilder();
-            // for (String domain : nc.getDomains()) {
-            // if (sbDomains.length() != 0) {
-            // sbDomains.append(",");
-            // }
-            // sbDomains.append(domain);
-            // }
-            // properties.put(netIfConfigPrefix + "domains", sbDomains.toString());
         }
     }
 
@@ -1316,15 +1267,6 @@ public class NetworkConfiguration {
 
         String netIfPrefix = sbPrefix.append("config.").toString();
         String netIfConfigPrefix = sbPrefix.toString();
-
-        // // Auto connect
-        // boolean autoConnect = false;
-        // String autoConnectKey = netIfPrefix + AUTOCONNECT;
-        // if (props.containsKey(autoConnectKey)) {
-        // autoConnect = (Boolean) props.get(autoConnectKey);
-        // logger.trace("got autoConnect: {}", autoConnect);
-        // netInterfaceConfig.setAutoConnect(autoConnect);
-        // }
 
         // USB
         String vendorId = (String) props.get(netIfReadOnlyPrefix + "usb.vendor.id");

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -694,7 +694,7 @@ public class NetworkConfiguration {
         } else {
             properties.put(prefix + HARDWARE_MODE, "");
         }
-        properties.put(prefix + BROADCAST, Boolean.valueOf(wifiConfig.getBroadcast()));
+        // properties.put(prefix + BROADCAST, Boolean.valueOf(wifiConfig.getBroadcast()));
         if (wifiConfig.getRadioMode() != null) {
             properties.put(prefix + ".radioMode", wifiConfig.getRadioMode().toString());
         }

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -689,11 +689,11 @@ public class NetworkConfiguration {
         } else {
             properties.put(prefix + PASSPHRASE, new Password(""));
         }
-        if (wifiConfig.getHardwareMode() != null) {
-            properties.put(prefix + HARDWARE_MODE, wifiConfig.getHardwareMode());
-        } else {
-            properties.put(prefix + HARDWARE_MODE, "");
-        }
+        // if (wifiConfig.getHardwareMode() != null) {
+        // properties.put(prefix + HARDWARE_MODE, wifiConfig.getHardwareMode());
+        // } else {
+        // properties.put(prefix + HARDWARE_MODE, "");
+        // }
         // properties.put(prefix + BROADCAST, Boolean.valueOf(wifiConfig.getBroadcast()));
         if (wifiConfig.getRadioMode() != null) {
             properties.put(prefix + ".radioMode", wifiConfig.getRadioMode().toString());
@@ -1141,16 +1141,16 @@ public class NetworkConfiguration {
                 properties.put(netIfConfigPrefix + "ip4.gateway", "");
             }
 
-            StringBuilder sbWinsAddresses = new StringBuilder();
-            if (nc.getWinsServers() != null) {
-                for (IP4Address ip : nc.getWinsServers()) {
-                    if (sbWinsAddresses.length() != 0) {
-                        sbWinsAddresses.append(",");
-                    }
-                    sbWinsAddresses.append(ip.getHostAddress());
-                }
-            }
-            properties.put(netIfConfigPrefix + "winsServers", sbWinsAddresses.toString());
+            // StringBuilder sbWinsAddresses = new StringBuilder();
+            // if (nc.getWinsServers() != null) {
+            // for (IP4Address ip : nc.getWinsServers()) {
+            // if (sbWinsAddresses.length() != 0) {
+            // sbWinsAddresses.append(",");
+            // }
+            // sbWinsAddresses.append(ip.getHostAddress());
+            // }
+            // }
+            // properties.put(netIfConfigPrefix + "winsServers", sbWinsAddresses.toString());
 
             StringBuilder sbDomains = new StringBuilder();
             if (nc.getDomains() != null) {

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -1152,16 +1152,16 @@ public class NetworkConfiguration {
             // }
             // properties.put(netIfConfigPrefix + "winsServers", sbWinsAddresses.toString());
 
-            StringBuilder sbDomains = new StringBuilder();
-            if (nc.getDomains() != null) {
-                for (String domain : nc.getDomains()) {
-                    if (sbDomains.length() != 0) {
-                        sbDomains.append(",");
-                    }
-                    sbDomains.append(domain);
-                }
-            }
-            properties.put(netIfConfigPrefix + "domains", sbDomains.toString());
+            // StringBuilder sbDomains = new StringBuilder();
+            // if (nc.getDomains() != null) {
+            // for (String domain : nc.getDomains()) {
+            // if (sbDomains.length() != 0) {
+            // sbDomains.append(",");
+            // }
+            // sbDomains.append(domain);
+            // }
+            // }
+            // properties.put(netIfConfigPrefix + "domains", sbDomains.toString());
         }
     }
 
@@ -1187,14 +1187,14 @@ public class NetworkConfiguration {
             }
             properties.put(netIfConfigPrefix + "ip6.dnsServers", sbDnsAddresses.toString());
 
-            StringBuilder sbDomains = new StringBuilder();
-            for (String domain : nc.getDomains()) {
-                if (sbDomains.length() != 0) {
-                    sbDomains.append(",");
-                }
-                sbDomains.append(domain);
-            }
-            properties.put(netIfConfigPrefix + "domains", sbDomains.toString());
+            // StringBuilder sbDomains = new StringBuilder();
+            // for (String domain : nc.getDomains()) {
+            // if (sbDomains.length() != 0) {
+            // sbDomains.append(",");
+            // }
+            // sbDomains.append(domain);
+            // }
+            // properties.put(netIfConfigPrefix + "domains", sbDomains.toString());
         }
     }
 

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -79,7 +79,6 @@ public class NetworkConfiguration {
     private static final String HARDWARE_MODE = ".hardwareMode";
     private static final String PASSPHRASE = ".passphrase";
     private static final String SECURITY_TYPE = ".securityType";
-    private static final String PPP_NUM = "pppNum";
     private static final String AUTOCONNECT = "autoconnect";
     private static final String NET_INTERFACE = "net.interface.";
     private static final String NET_INTERFACES = "net.interfaces";
@@ -315,7 +314,6 @@ public class NetworkConfiguration {
         sb.append(" :: Data Compression: " + ((ModemConfig) netConfig).getDataCompression());
         sb.append(" :: Dial String: " + ((ModemConfig) netConfig).getDialString());
         sb.append(" :: Header Compression: " + ((ModemConfig) netConfig).getHeaderCompression());
-        sb.append(" :: Password: " + ((ModemConfig) netConfig).getPasswordAsPassword().toString());
         sb.append(" :: PPP number: " + ((ModemConfig) netConfig).getPppNumber());
         sb.append(" :: Profile ID: " + ((ModemConfig) netConfig).getProfileID());
         sb.append(" :: Username: " + ((ModemConfig) netConfig).getUsername());
@@ -425,7 +423,7 @@ public class NetworkConfiguration {
     }
 
     protected void appendDhcpServerConfig(StringBuilder sb, NetConfig netConfig) {
-        sb.append("\n\tDhcpServerConfig :: ");
+        sb.append("\n\tDhcpServerConfig :: \n");
         sb.append(((DhcpServerConfig) netConfig).toString());
     }
 
@@ -589,16 +587,13 @@ public class NetworkConfiguration {
                         addModemConfigProperties((ModemConfig) netConfig, netIfConfigPrefix, newNetworkProperties);
                     } else if (netConfig instanceof NetConfigIP4) {
                         logger.trace("adding netconfig NetConfigIP4 for {}", netInterfaceConfig.getName());
-                        addNetConfigIP4Properties((NetConfigIP4) netConfig, netIfConfigPrefix,
-                                newNetworkProperties);
+                        addNetConfigIP4Properties((NetConfigIP4) netConfig, netIfConfigPrefix, newNetworkProperties);
                     } else if (netConfig instanceof NetConfigIP6) {
                         logger.trace("adding netconfig NetConfigIP6 for {}", netInterfaceConfig.getName());
-                        addNetConfigIP6Properties((NetConfigIP6) netConfig, netIfConfigPrefix,
-                                newNetworkProperties);
+                        addNetConfigIP6Properties((NetConfigIP6) netConfig, netIfConfigPrefix, newNetworkProperties);
                     } else if (netConfig instanceof DhcpServerConfig4) {
                         logger.trace("adding netconfig DhcpServerConfig4 for {}", netInterfaceConfig.getName());
-                        addDhcpServerConfig4((DhcpServerConfig4) netConfig, netIfConfigPrefix,
-                                newNetworkProperties);
+                        addDhcpServerConfig4((DhcpServerConfig4) netConfig, netIfConfigPrefix, newNetworkProperties);
                     } else if (netConfig instanceof FirewallAutoNatConfig) {
                         logger.trace("adding netconfig FirewallNatConfig for {}", netInterfaceConfig.getName());
                         addFirewallNatConfig(netIfConfigPrefix, newNetworkProperties);
@@ -901,7 +896,6 @@ public class NetworkConfiguration {
                 modemConfig.getIpAddress() != null ? modemConfig.getIpAddress().toString() : "");
         properties.put(prefix + "password", modemConfig.getPasswordAsPassword());
         properties.put(prefix + "pdpType", modemConfig.getPdpType() != null ? modemConfig.getPdpType().toString() : "");
-        properties.put(prefix + PPP_NUM, modemConfig.getPppNumber());
         properties.put(prefix + "persist", modemConfig.isPersist());
         properties.put(prefix + "maxFail", modemConfig.getMaxFail());
         properties.put(prefix + "idle", modemConfig.getIdle());

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -322,6 +322,8 @@ public class NetworkConfiguration {
         sb.append(" :: Auth Type: " + ((ModemConfig) netConfig).getAuthType());
         sb.append(" :: IP Address: " + ((ModemConfig) netConfig).getIpAddress());
         sb.append(" :: PDP Type: " + ((ModemConfig) netConfig).getPdpType());
+        sb.append(" :: Gps enabled: " + ((ModemConfig) netConfig).isGpsEnabled());
+        sb.append(" :: Antenna diversity enabled: " + ((ModemConfig) netConfig).isDiversityEnabled());
     }
 
     protected void appendWifiConfig(StringBuilder sb, NetConfig netConfig) {

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -61,6 +61,8 @@ import org.eclipse.kura.net.wifi.WifiMode;
 import org.eclipse.kura.net.wifi.WifiRadioMode;
 import org.eclipse.kura.net.wifi.WifiSecurity;
 import org.eclipse.kura.system.SystemService;
+import org.eclipse.kura.usb.UsbDevice;
+import org.eclipse.kura.usb.UsbNetDevice;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
@@ -1309,6 +1311,7 @@ public class NetworkConfiguration {
         // build the prefixes for all the properties associated with this interface
         StringBuilder sbPrefix = new StringBuilder();
         sbPrefix.append(NET_INTERFACE).append(interfaceName).append(".");
+        String netIfReadOnlyPrefix = sbPrefix.toString();
 
         String netIfPrefix = sbPrefix.append("config.").toString();
         String netIfConfigPrefix = sbPrefix.toString();
@@ -1320,6 +1323,21 @@ public class NetworkConfiguration {
             autoConnect = (Boolean) props.get(autoConnectKey);
             logger.trace("got autoConnect: {}", autoConnect);
             netInterfaceConfig.setAutoConnect(autoConnect);
+        }
+
+        // USB
+        String vendorId = (String) props.get(netIfReadOnlyPrefix + "usb.vendor.id");
+        String vendorName = (String) props.get(netIfReadOnlyPrefix + "usb.vendor.name");
+        String productId = (String) props.get(netIfReadOnlyPrefix + "usb.product.id");
+        String productName = (String) props.get(netIfReadOnlyPrefix + "usb.product.name");
+        String usbBusNumber = (String) props.get(netIfReadOnlyPrefix + "usb.busNumber");
+        String usbDevicePath = (String) props.get(netIfReadOnlyPrefix + "usb.devicePath");
+
+        if (vendorId != null && productId != null) {
+            UsbDevice usbDevice = new UsbNetDevice(vendorId, productId, vendorName, productName, usbBusNumber,
+                    usbDevicePath, interfaceName);
+            logger.trace("adding usbDevice: {}, port: {}", usbDevice, usbDevice.getUsbPort());
+            netInterfaceConfig.setUsbDevice(usbDevice);
         }
 
         // Status

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -549,7 +549,6 @@ public class NetworkConfiguration {
 
             // add the properties of the interface
             newNetworkProperties.put(netIfReadOnlyPrefix + "type", netInterfaceConfig.getType().toString());
-            newNetworkProperties.put(netIfPrefix + "name", netInterfaceConfig.getName());
             newNetworkProperties.put(netIfPrefix + AUTOCONNECT, netInterfaceConfig.isAutoConnect());
             newNetworkProperties.put(netIfPrefix + "mtu", netInterfaceConfig.getMTU());
 

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -77,7 +77,6 @@ public class NetworkConfiguration {
     private static final String ADDRESS = " :: Address: ";
     private static final String GOT_MESSAGE = "got {}: {}";
     private static final String BGSCAN = ".bgscan";
-    private static final String BROADCAST = ".broadcast";
     private static final String HARDWARE_MODE = ".hardwareMode";
     private static final String PASSPHRASE = ".passphrase";
     private static final String SECURITY_TYPE = ".securityType";

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -610,10 +610,10 @@ public class NetworkConfiguration {
             NetInterfaceAddressConfig nia) {
         // Modem interface address
         if (nia instanceof ModemInterfaceAddress) {
-            if (((ModemInterfaceAddress) nia).getConnectionType() != null) {
-                newNetworkProperties.put(netIfConfigPrefix + "connection.type",
-                        ((ModemInterfaceAddress) nia).getConnectionType().toString());
-            }
+            // if (((ModemInterfaceAddress) nia).getConnectionType() != null) {
+            // newNetworkProperties.put(netIfConfigPrefix + "connection.type",
+            // ((ModemInterfaceAddress) nia).getConnectionType().toString());
+            // }
             if (((ModemInterfaceAddress) nia).getConnectionStatus() != null) {
                 newNetworkProperties.put(netIfConfigPrefix + "connection.status",
                         ((ModemInterfaceAddress) nia).getConnectionStatus().toString());

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -892,9 +892,9 @@ public class NetworkConfiguration {
         properties.put(prefix + "apn", modemConfig.getApn());
         properties.put(prefix + "authType",
                 modemConfig.getAuthType() != null ? modemConfig.getAuthType().toString() : "");
-        properties.put(prefix + "dataCompression", modemConfig.getDataCompression());
+        // properties.put(prefix + "dataCompression", modemConfig.getDataCompression());
         properties.put(prefix + "dialString", modemConfig.getDialString());
-        properties.put(prefix + "headerCompression", modemConfig.getHeaderCompression());
+        // properties.put(prefix + "headerCompression", modemConfig.getHeaderCompression());
         properties.put(prefix + "ipAddress",
                 modemConfig.getIpAddress() != null ? modemConfig.getIpAddress().toString() : "");
         properties.put(prefix + "password", modemConfig.getPasswordAsPassword());
@@ -906,7 +906,7 @@ public class NetworkConfiguration {
         properties.put(prefix + "resetTimeout", modemConfig.getResetTimeout());
         properties.put(prefix + "lcpEchoInterval", modemConfig.getLcpEchoInterval());
         properties.put(prefix + "lcpEchoFailure", modemConfig.getLcpEchoFailure());
-        properties.put(prefix + "profileId", modemConfig.getProfileID());
+        // properties.put(prefix + "profileId", modemConfig.getProfileID());
         properties.put(prefix + "username", modemConfig.getUsername());
         properties.put(prefix + "enabled", modemConfig.isEnabled());
         properties.put(prefix + "gpsEnabled", modemConfig.isGpsEnabled());

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -81,7 +81,6 @@ public class NetworkConfiguration {
     private static final String HARDWARE_MODE = ".hardwareMode";
     private static final String PASSPHRASE = ".passphrase";
     private static final String SECURITY_TYPE = ".securityType";
-    private static final String AUTOCONNECT = "autoconnect";
     private static final String NET_INTERFACE = "net.interface.";
     private static final String NET_INTERFACES = "net.interfaces";
 

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -330,7 +330,6 @@ public class NetworkConfiguration {
 
         sb.append(" :: SSID: " + ((WifiConfig) netConfig).getSSID());
         sb.append(" :: BgScan: " + ((WifiConfig) netConfig).getBgscan());
-        sb.append(" :: Broadcast: " + ((WifiConfig) netConfig).getBroadcast());
         int[] channels = ((WifiConfig) netConfig).getChannels();
         if (channels != null && channels.length > 0) {
             sb.append(" :: Channels: ");
@@ -840,14 +839,6 @@ public class NetworkConfiguration {
 
             wifiConfig.setPingAccessPoint(pingAccessPoint);
         }
-
-        // broadcast
-        key = prefix + BROADCAST;
-        Boolean broadcast = (Boolean) properties.get(key);
-        if (broadcast != null) {
-            wifiConfig.setBroadcast(broadcast);
-        }
-        logger.trace("hwMode is {}", hwMode);
 
         // radio mode
         key = prefix + ".radioMode";

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -550,7 +550,7 @@ public class NetworkConfiguration {
             // add the properties of the interface
             newNetworkProperties.put(netIfReadOnlyPrefix + "type", netInterfaceConfig.getType().toString());
             // newNetworkProperties.put(netIfPrefix + AUTOCONNECT, netInterfaceConfig.isAutoConnect());
-            newNetworkProperties.put(netIfPrefix + "mtu", netInterfaceConfig.getMTU());
+            // newNetworkProperties.put(netIfPrefix + "mtu", netInterfaceConfig.getMTU());
 
             netInterfaceConfig.getNetInterfaceAddresses().forEach(nia -> {
                 if (nia != null) {

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -521,7 +521,7 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
             wifiInterface.setCapabilities(this.linuxNetworkUtil.getWifiCapabilities(interfaceName));
         } catch (final Exception e) {
             logger.warn("failed to get capabilities for {}", interfaceName);
-            logger.debug("excepton", e);
+            logger.debug("exception", e);
             wifiInterface.setCapabilities(EnumSet.noneOf(Capability.class));
         }
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
@@ -295,39 +295,12 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
 
     @Override
     public NetworkState getState() throws KuraException {
-        // see if we have global access by trying to ping - maybe there is a better way?
-        if (this.linuxNetworkUtil.canPing("8.8.8.8", 1) || this.linuxNetworkUtil.canPing("8.8.4.4", 1)) {
-            return NetworkState.CONNECTED_GLOBAL;
-        }
-
-        // if we have a link we at least of network local access
-        List<NetInterface<? extends NetInterfaceAddress>> netInterfaces = getNetworkInterfaces();
-        for (NetInterface<? extends NetInterfaceAddress> netInterface : netInterfaces) {
-            if (netInterface.getType() == NetInterfaceType.ETHERNET
-                    && ((EthernetInterfaceImpl<? extends NetInterfaceAddress>) netInterface).isLinkUp()) {
-                return NetworkState.CONNECTED_SITE;
-            }
-        }
-
-        @SuppressWarnings("checkstyle:lineLength")
-        LoopbackInterfaceImpl<? extends NetInterfaceAddress> netInterface = (LoopbackInterfaceImpl<? extends NetInterfaceAddress>) getNetworkInterface(
-                "lo");
-        if (netInterface.isUp()) {
-            return NetworkState.CONNECTED_LOCAL;
-        }
-
         return NetworkState.UNKNOWN;
     }
 
     @Override
     public NetInterfaceState getState(String interfaceName) throws KuraException {
-        NetInterface<? extends NetInterfaceAddress> netInterface = getNetworkInterface(interfaceName);
-        if (netInterface == null) {
-            logger.error("There is no status available for network interface {}", interfaceName);
-            return NetInterfaceState.UNKNOWN;
-        } else {
-            return netInterface.getState();
-        }
+        return NetInterfaceState.UNKNOWN;
     }
 
     @Override

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
@@ -963,8 +963,17 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
     }
 
     @Override
-    public String getModemPppInterfaceName(String usbPath) throws KuraException {
+    public String getModemPppInterfaceName(String usbPath) {
         return generatePppName(this.validUsbModemsPppNumbers.get(usbPath));
+    }
+
+    @Override
+    public Optional<ModemDevice> getModemDevice(String usbPath) {
+        Optional<ModemDevice> modem = Optional.empty();
+        if (this.validUsbModemsPppNumbers.containsKey(usbPath)) {
+            modem = Optional.of(this.detectedUsbModems.get(usbPath));
+        }
+        return modem;
     }
 
     private boolean isVirtual(String interfaceName) {

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -296,10 +296,7 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
     @Override
     public NetworkState getState() throws KuraException {
         // see if we have global access by trying to ping - maybe there is a better way?
-        if (this.linuxNetworkUtil.canPing("8.8.8.8", 1)) {
-            return NetworkState.CONNECTED_GLOBAL;
-        }
-        if (this.linuxNetworkUtil.canPing("8.8.4.4", 1)) {
+        if (this.linuxNetworkUtil.canPing("8.8.8.8", 1) || this.linuxNetworkUtil.canPing("8.8.4.4", 1)) {
             return NetworkState.CONNECTED_GLOBAL;
         }
 
@@ -595,32 +592,24 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
     }
 
     private boolean validateDeviceAddedEvent(Event event) {
-        if (event.getProperty(UsbDeviceEvent.USB_EVENT_VENDOR_ID_PROPERTY) == null) {
-            return false;
-        }
-        if (event.getProperty(UsbDeviceEvent.USB_EVENT_PRODUCT_ID_PROPERTY) == null) {
-            return false;
-        }
-        if (event.getProperty(UsbDeviceEvent.USB_EVENT_USB_PORT_PROPERTY) == null) {
-            return false;
-        }
-        if (event.getProperty(UsbDeviceEvent.USB_EVENT_PRODUCT_NAME_PROPERTY) == null) {
+        if (event.getProperty(UsbDeviceEvent.USB_EVENT_VENDOR_ID_PROPERTY) == null
+                || event.getProperty(UsbDeviceEvent.USB_EVENT_PRODUCT_ID_PROPERTY) == null
+                || event.getProperty(UsbDeviceEvent.USB_EVENT_USB_PORT_PROPERTY) == null
+                || event.getProperty(UsbDeviceEvent.USB_EVENT_PRODUCT_NAME_PROPERTY) == null) {
             return false;
         }
         if (event.getProperty(UsbDeviceEvent.USB_EVENT_RESOURCE_PROPERTY) == null
                 || ((String) event.getProperty(UsbDeviceEvent.USB_EVENT_RESOURCE_PROPERTY)).startsWith("usb")) {
             return false;
         }
-        return (event.getProperty(UsbDeviceEvent.USB_EVENT_DEVICE_TYPE_PROPERTY) != null
+        return event.getProperty(UsbDeviceEvent.USB_EVENT_DEVICE_TYPE_PROPERTY) != null
                 && !((UsbDeviceType) event.getProperty(UsbDeviceEvent.USB_EVENT_DEVICE_TYPE_PROPERTY))
-                        .equals(UsbDeviceType.USB_NET_DEVICE));
+                        .equals(UsbDeviceType.USB_NET_DEVICE);
     }
 
     private boolean validateDeviceRemovedEvent(Event event) {
-        if (event.getProperty(UsbDeviceEvent.USB_EVENT_VENDOR_ID_PROPERTY) == null) {
-            return false;
-        }
-        if (event.getProperty(UsbDeviceEvent.USB_EVENT_PRODUCT_ID_PROPERTY) == null) {
+        if (event.getProperty(UsbDeviceEvent.USB_EVENT_VENDOR_ID_PROPERTY) == null
+                || event.getProperty(UsbDeviceEvent.USB_EVENT_PRODUCT_ID_PROPERTY) == null) {
             return false;
         }
         return event.getProperty(UsbDeviceEvent.USB_EVENT_USB_PORT_PROPERTY) != null;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationService.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,8 +19,15 @@ public interface NetworkConfigurationService {
 
     public static final String PID = "org.eclipse.kura.net.admin.NetworkConfigurationService";
 
+    /*
+     * Sets the network configuration and write it into the system.
+     */
     public void setNetworkConfiguration(NetworkConfiguration networkConfiguration) throws KuraException;
 
+    /*
+     * Returns the current network configuration with actual and desired properties.
+     * i.e. the current ip address as read from the system and the ip address that should be applied.
+     */
     public NetworkConfiguration getNetworkConfiguration() throws KuraException;
 
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -302,6 +302,8 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
 
     @Override
     public synchronized ComponentConfiguration getConfiguration() throws KuraException {
+        // This method returns the network configuration properties without the current values.
+        // i.e. the ip address that should be applied to the system, but not the actual one.
         logger.debug("getConfiguration()");
         return new ComponentConfigurationImpl(PID, getDefinition(),
                 getNetworkConfiguration().getConfigurationProperties());

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
@@ -54,6 +54,7 @@ import org.eclipse.kura.net.admin.event.NetworkConfigurationChangeEvent;
 import org.eclipse.kura.net.admin.modem.SupportedUsbModemsFactoryInfo;
 import org.eclipse.kura.net.admin.visitor.linux.LinuxWriteVisitor;
 import org.eclipse.kura.net.modem.CellularModem;
+import org.eclipse.kura.net.modem.ModemDevice;
 import org.eclipse.kura.net.modem.ModemManagerService;
 import org.eclipse.kura.usb.UsbModemDevice;
 import org.eclipse.kura.usb.UsbNetDevice;
@@ -227,7 +228,8 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
 
                     setInterfaceType(modifiedProps, interfaceName, type);
                     if (NetInterfaceType.MODEM.equals(type)) {
-                        setPppNumber(modifiedProps, interfaceName);
+                        setModemPppNumber(modifiedProps, interfaceName);
+                        setModemUsbDeviceProperties(modifiedProps, interfaceName);
                     }
                 }
 
@@ -249,7 +251,7 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
         }
     }
 
-    protected void setPppNumber(Map<String, Object> modifiedProps, String interfaceName) throws KuraException {
+    protected void setModemPppNumber(Map<String, Object> modifiedProps, String interfaceName) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX).append(interfaceName).append(".config.pppNum");
         Integer pppNum = Integer.valueOf(this.networkService.getModemPppInterfaceName(interfaceName).substring(3));
@@ -260,6 +262,20 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX).append(interfaceName).append(".type");
         modifiedProps.put(sb.toString(), type.toString());
+    }
+
+    protected void setModemUsbDeviceProperties(Map<String, Object> modifiedProps, String interfaceName) {
+        Optional<ModemDevice> modemOptional = this.networkService.getModemDevice(interfaceName);
+        if (modemOptional.isPresent() && modemOptional.get() instanceof UsbModemDevice) {
+            String prefix = PREFIX + interfaceName + ".";
+            UsbModemDevice usbModemDevice = (UsbModemDevice) modemOptional.get();
+            modifiedProps.put(prefix + "usb.vendor.id", usbModemDevice.getVendorId());
+            modifiedProps.put(prefix + "usb.vendor.name", usbModemDevice.getManufacturerName());
+            modifiedProps.put(prefix + "usb.product.id", usbModemDevice.getProductId());
+            modifiedProps.put(prefix + "usb.product.name", usbModemDevice.getProductName());
+            modifiedProps.put(prefix + "usb.busNumber", usbModemDevice.getUsbBusNumber());
+            modifiedProps.put(prefix + "usb.devicePath", usbModemDevice.getUsbDevicePath());
+        }
     }
 
     private boolean isEncrypted(String password) {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/EthernetMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/EthernetMonitorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -232,7 +232,6 @@ public class EthernetMonitorServiceImpl implements EthernetMonitorService, Event
 
                     if (isConfigChanged(newNiacs, curNiacs)) {
                         logger.info("Found a new Ethernet network configuration for {}", interfaceName);
-
                         if (!((AbstractNetInterface<?>) newInterfaceConfig).isInterfaceManaged()) {
                             logger.info(
                                     "The {} interface is configured not to be managed by Kura and will not be monitored.",
@@ -247,7 +246,7 @@ public class EthernetMonitorServiceImpl implements EthernetMonitorService, Event
                         this.networkConfiguration.put(interfaceName, newInterfaceConfig);
                         currentInterfaceConfig = newInterfaceConfig;
 
-                        // Post a status change event - not to be confusd with the Config Change that I am consuming
+                        // Post a status change event - not to be confused with the Config Change that I am consuming
                         postStatusChangeEvent = true;
                     }
 
@@ -391,6 +390,9 @@ public class EthernetMonitorServiceImpl implements EthernetMonitorService, Event
                 // post event if there were any changes
                 if (postStatusChangeEvent) {
                     logger.debug("Posting NetworkStatusChangeEvent for {}: {}", interfaceName, currentInterfaceState);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug(this.netConfigService.getNetworkConfiguration().toString());
+                    }
                     this.eventAdmin.postEvent(new NetworkStatusChangeEvent(interfaceName, currentInterfaceState, null));
                     this.interfaceState.put(interfaceName, currentInterfaceState);
                 }

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
@@ -101,7 +101,6 @@ public class NetworkConfigurationTest {
         Map<String, Object> properties = new HashMap<>();
         properties.put("net.interfaces", interfaces);
         properties.put("net.interface.if1.type", "ETHERNET");
-        properties.put("net.interface.if1.state", NetInterfaceState.DISCONNECTED);
 
         NetworkConfiguration config = new NetworkConfiguration(properties);
 
@@ -118,7 +117,6 @@ public class NetworkConfigurationTest {
         interfaceAddresses.add(addressConfig);
 
         EthernetInterfaceConfigImpl interfaceConfig = new EthernetInterfaceConfigImpl("if1");
-        interfaceConfig.setState(NetInterfaceState.DISCONNECTED);
         interfaceConfig.setNetInterfaceAddresses(interfaceAddresses);
 
         assertEquals(interfaceConfig, config.getNetInterfaceConfigs().get(0));
@@ -131,7 +129,6 @@ public class NetworkConfigurationTest {
         Map<String, Object> properties = new HashMap<>();
         properties.put("net.interfaces", "if1,if2");
         properties.put("net.interface.if1.type", "ETHERNET");
-        properties.put("net.interface.if1.state", NetInterfaceState.DISCONNECTED);
 
         NetworkConfiguration config = new NetworkConfiguration(properties);
 
@@ -148,7 +145,6 @@ public class NetworkConfigurationTest {
         interfaceAddresses.add(addressConfig);
 
         EthernetInterfaceConfigImpl interfaceConfig = new EthernetInterfaceConfigImpl("if1");
-        interfaceConfig.setState(NetInterfaceState.DISCONNECTED);
         interfaceConfig.setNetInterfaceAddresses(interfaceAddresses);
 
         assertEquals(interfaceConfig, config.getNetInterfaceConfigs().get(0));
@@ -659,7 +655,7 @@ public class NetworkConfigurationTest {
                 + " :: Driver: null :: Driver Version: null :: Firmware Version: null :: MTU: 0 :: State: null"
                 + " :: Type: WIFI :: Usb Device: null :: Prefix: 0\n	WifiConfig  :: SSID: null :: BgScan: null"
                 + " :: Broadcast: false :: Group Ciphers: null :: Hardware Mode: null :: Mode: null"
-                + " :: Pairwise Ciphers: null :: Passkey: null :: Security: null";
+                + " :: Pairwise Ciphers: null :: Security: null";
 
         assertEquals(expected, config.toString());
     }
@@ -687,7 +683,7 @@ public class NetworkConfigurationTest {
         String expected = "\nname: if1 :: Loopback? false :: Point to Point? false :: Up? false :: Virtual? false"
                 + " :: Driver: null :: Driver Version: null :: Firmware Version: null :: MTU: 0 :: State: null :: Type: WIFI"
                 + " :: Usb Device: null :: Prefix: 0\n	WifiConfig  :: SSID: null :: BgScan: null :: Broadcast: false"
-                + " :: Group Ciphers: null :: Hardware Mode: null :: Mode: null :: Pairwise Ciphers: null :: Passkey: null"
+                + " :: Group Ciphers: null :: Hardware Mode: null :: Mode: null :: Pairwise Ciphers: null"
                 + " :: Security: null";
 
         assertEquals(expected, config.toString());
@@ -717,7 +713,7 @@ public class NetworkConfigurationTest {
                 + " :: Driver: null :: Driver Version: null :: Firmware Version: null :: MTU: 0 :: State: null :: Type: WIFI"
                 + " :: Usb Device: null :: Prefix: 0\n	WifiConfig  :: SSID: null :: BgScan: null :: Broadcast: false"
                 + " :: Channels: 1,2 :: Group Ciphers: null :: Hardware Mode: null :: Mode: null :: Pairwise Ciphers: null"
-                + " :: Passkey: null :: Security: null";
+                + " :: Security: null";
 
         assertEquals(expected, config.toString());
     }
@@ -755,7 +751,7 @@ public class NetworkConfigurationTest {
         String expected = "\nname: if1 :: Loopback? false :: Point to Point? false :: Up? false :: Virtual? false"
                 + " :: Driver: null :: Driver Version: null :: Firmware Version: null :: MTU: 0 :: State: null"
                 + " :: Type: MODEM :: Usb Device: null :: Prefix: 0\n	ModemConfig  :: APN: apn :: Data Compression: 0"
-                + " :: Dial String: dialString :: Header Compression: 0 :: Password: password :: PPP number: 0"
+                + " :: Dial String: dialString :: Header Compression: 0 :: PPP number: 0"
                 + " :: Profile ID: 0 :: Username: username :: Auth Type: AUTO :: IP Address: 10.0.0.2 :: PDP Type: PPP";
 
         assertEquals(expected, config.toString());
@@ -798,7 +794,12 @@ public class NetworkConfigurationTest {
 
         String expected = "\nname: if1 :: Loopback? false :: Point to Point? false :: Up? false :: Virtual? false"
                 + " :: Driver: null :: Driver Version: null :: Firmware Version: null :: MTU: 0 :: State: null"
-                + " :: Type: ETHERNET :: Usb Device: null :: Prefix: 0\n	DhcpServerConfig \n	FirewallAutoNatConfig "
+                + " :: Type: ETHERNET :: Usb Device: null :: Prefix: 0\n	DhcpServerConfig :: \n# enabled? true\n"
+                + "# prefix: 24\n" + "# pass DNS? false\n" + "\n" + "subnet 192.168.1.0 netmask 255.255.255.0 {\n"
+                + "    interface eth0;\n" + "    option routers 192.168.1.1;\n" + "    ddns-update-style none;\n"
+                + "    ddns-updates off;\n" + "    default-lease-time 7200;\n" + "    max-lease-time 7200;\n"
+                + "    pool {\n" + "        range 192.168.1.100 192.168.1.254;\n" + "    }\n"
+                + "}\n\n	FirewallAutoNatConfig "
                 + "\n	NULL NETCONFIG PRESENT?!?\n	UNKNOWN CONFIG TYPE???: org.eclipse.kura.core.net.MockConfig";
 
         assertEquals(expected, config.toString());
@@ -912,19 +913,10 @@ public class NetworkConfigurationTest {
 
         Map<String, Object> expected = new HashMap<>();
         expected.put("net.interfaces", "if1");
-        expected.put("net.interface.if1.mac", "N/A");
-        expected.put("net.interface.if1.loopback", false);
-        expected.put("net.interface.if1.ptp", false);
-        expected.put("net.interface.if1.up", false);
-        expected.put("net.interface.if1.virtual", false);
         expected.put("net.interface.if1.type", "ETHERNET");
-        expected.put("net.interface.if1.driver", null);
-        expected.put("net.interface.if1.driver.version", null);
-        expected.put("net.interface.if1.firmware.version", null);
         expected.put("net.interface.if1.config.name", "if1");
         expected.put("net.interface.if1.config.autoconnect", false);
         expected.put("net.interface.if1.config.mtu", 0);
-        expected.put("net.interface.if1.eth.link.up", false);
 
         assertMapEquals(expected, properties);
     }
@@ -1092,7 +1084,6 @@ public class NetworkConfigurationTest {
         NetworkConfiguration config = new NetworkConfiguration();
 
         EthernetInterfaceConfigImpl netInterfaceConfig1 = new EthernetInterfaceConfigImpl("if1");
-        netInterfaceConfig1.setState(NetInterfaceState.ACTIVATED);
         netInterfaceConfig1.setUsbDevice(new UsbBlockDevice("vendorId", "productId", "vendorName", "productName",
                 "usbBusNumber", "usbDevicePath", "deviceNode"));
         config.addNetInterfaceConfig(netInterfaceConfig1);
@@ -1140,46 +1131,13 @@ public class NetworkConfigurationTest {
         HashMap<String, Object> expected = new HashMap<>();
         expected.put("net.interface.if1.type", "ETHERNET");
         expected.put("net.interface.if1.config.name", "if1");
-        expected.put("net.interface.if1.config.state", "ACTIVATED");
         expected.put("net.interface.if1.config.autoconnect", netInterfaceConfig1.isAutoConnect());
         expected.put("net.interface.if1.config.mtu", netInterfaceConfig1.getMTU());
-        expected.put("net.interface.if1.driver", netInterfaceConfig1.getDriver());
-        expected.put("net.interface.if1.driver.version", netInterfaceConfig1.getDriverVersion());
-        expected.put("net.interface.if1.firmware.version", netInterfaceConfig1.getFirmwareVersion());
-        expected.put("net.interface.if1.mac",
-                NetUtil.hardwareAddressToString(netInterfaceConfig1.getHardwareAddress()));
-        expected.put("net.interface.if1.loopback", netInterfaceConfig1.isLoopback());
-        expected.put("net.interface.if1.ptp", netInterfaceConfig1.isPointToPoint());
-        expected.put("net.interface.if1.up", netInterfaceConfig1.isUp());
-        expected.put("net.interface.if1.virtual", netInterfaceConfig1.isVirtual());
-        expected.put("net.interface.if1.usb.vendor.id", "vendorId");
-        expected.put("net.interface.if1.usb.vendor.name", "vendorName");
-        expected.put("net.interface.if1.usb.product.id", "productId");
-        expected.put("net.interface.if1.usb.product.name", "productName");
-        expected.put("net.interface.if1.usb.busNumber", "usbBusNumber");
-        expected.put("net.interface.if1.usb.devicePath", "usbDevicePath");
-        expected.put("net.interface.if1.eth.link.up", netInterfaceConfig1.isLinkUp());
 
         expected.put("net.interface.if2.type", "ETHERNET");
         expected.put("net.interface.if2.config.name", "if2");
         expected.put("net.interface.if2.config.autoconnect", netInterfaceConfig2.isAutoConnect());
         expected.put("net.interface.if2.config.mtu", netInterfaceConfig2.getMTU());
-        expected.put("net.interface.if2.driver", netInterfaceConfig2.getDriver());
-        expected.put("net.interface.if2.driver.version", netInterfaceConfig2.getDriverVersion());
-        expected.put("net.interface.if2.firmware.version", netInterfaceConfig2.getFirmwareVersion());
-        expected.put("net.interface.if2.mac",
-                NetUtil.hardwareAddressToString(netInterfaceConfig2.getHardwareAddress()));
-        expected.put("net.interface.if2.loopback", netInterfaceConfig2.isLoopback());
-        expected.put("net.interface.if2.ptp", netInterfaceConfig2.isPointToPoint());
-        expected.put("net.interface.if2.up", netInterfaceConfig2.isUp());
-        expected.put("net.interface.if2.virtual", netInterfaceConfig2.isVirtual());
-        expected.put("net.interface.if2.eth.link.up", netInterfaceConfig2.isLinkUp());
-        expected.put("net.interface.if2.ip4.address", "10.0.0.10");
-        expected.put("net.interface.if2.ip4.broadcast", "10.0.0.255");
-        expected.put("net.interface.if2.ip4.gateway", "10.0.0.1");
-        expected.put("net.interface.if2.ip4.netmask", "255.255.255.0");
-        expected.put("net.interface.if2.ip4.prefix", (short) 24);
-        expected.put("net.interface.if2.ip4.dnsServers", "10.0.1.1,10.0.1.2");
         expected.put("net.interface.if2.config.autoconnect", true);
         expected.put("net.interface.if2.config.ip4.status", "netIPv4StatusEnabledLAN");
         expected.put("net.interface.if2.config.ip4.dnsServers", "");
@@ -1244,47 +1202,17 @@ public class NetworkConfigurationTest {
         expected.put("net.interface.if1.config.name", "if1");
         expected.put("net.interface.if1.config.autoconnect", netInterfaceConfig1.isAutoConnect());
         expected.put("net.interface.if1.config.mtu", netInterfaceConfig1.getMTU());
-        expected.put("net.interface.if1.driver", netInterfaceConfig1.getDriver());
-        expected.put("net.interface.if1.driver.version", netInterfaceConfig1.getDriverVersion());
-        expected.put("net.interface.if1.firmware.version", netInterfaceConfig1.getFirmwareVersion());
-        expected.put("net.interface.if1.mac",
-                NetUtil.hardwareAddressToString(netInterfaceConfig1.getHardwareAddress()));
-        expected.put("net.interface.if1.loopback", netInterfaceConfig1.isLoopback());
-        expected.put("net.interface.if1.ptp", netInterfaceConfig1.isPointToPoint());
-        expected.put("net.interface.if1.up", netInterfaceConfig1.isUp());
-        expected.put("net.interface.if1.virtual", netInterfaceConfig1.isVirtual());
 
         expected.put("net.interface.if2.type", "WIFI");
         expected.put("net.interface.if2.config.name", "if2");
         expected.put("net.interface.if2.config.autoconnect", netInterfaceConfig2.isAutoConnect());
         expected.put("net.interface.if2.config.mtu", netInterfaceConfig2.getMTU());
-        expected.put("net.interface.if2.driver", netInterfaceConfig2.getDriver());
-        expected.put("net.interface.if2.driver.version", netInterfaceConfig2.getDriverVersion());
-        expected.put("net.interface.if2.firmware.version", netInterfaceConfig2.getFirmwareVersion());
-        expected.put("net.interface.if2.mac",
-                NetUtil.hardwareAddressToString(netInterfaceConfig2.getHardwareAddress()));
-        expected.put("net.interface.if2.loopback", netInterfaceConfig2.isLoopback());
-        expected.put("net.interface.if2.ptp", netInterfaceConfig2.isPointToPoint());
-        expected.put("net.interface.if2.up", netInterfaceConfig2.isUp());
-        expected.put("net.interface.if2.virtual", netInterfaceConfig2.isVirtual());
-        expected.put("net.interface.if2.wifi.capabilities", "");
 
         expected.put("net.interface.if3.type", "WIFI");
         expected.put("net.interface.if3.config.name", "if3");
         expected.put("net.interface.if3.config.autoconnect", netInterfaceConfig3.isAutoConnect());
         expected.put("net.interface.if3.config.mtu", netInterfaceConfig3.getMTU());
-        expected.put("net.interface.if3.driver", netInterfaceConfig3.getDriver());
-        expected.put("net.interface.if3.driver.version", netInterfaceConfig3.getDriverVersion());
-        expected.put("net.interface.if3.firmware.version", netInterfaceConfig3.getFirmwareVersion());
-        expected.put("net.interface.if3.mac",
-                NetUtil.hardwareAddressToString(netInterfaceConfig3.getHardwareAddress()));
-        expected.put("net.interface.if3.loopback", netInterfaceConfig3.isLoopback());
-        expected.put("net.interface.if3.ptp", netInterfaceConfig3.isPointToPoint());
-        expected.put("net.interface.if3.up", netInterfaceConfig3.isUp());
-        expected.put("net.interface.if3.virtual", netInterfaceConfig3.isVirtual());
-        expected.put("net.interface.if3.wifi.capabilities", "CIPHER_TKIP CIPHER_CCMP ");
-        expected.put("net.interface.if3.wifi.bitrate", (long) 42);
-        expected.put("net.interface.if3.wifi.mode", null);
+        expected.put("net.interface.if3.config.wifi.mode", "ADHOC");
         expected.put("net.interface.if3.config.wifi.adhoc.ssid", "ssid");
         expected.put("net.interface.if3.config.wifi.adhoc.driver", "driver");
         expected.put("net.interface.if3.config.wifi.adhoc.mode", "ADHOC");
@@ -1330,7 +1258,6 @@ public class NetworkConfigurationTest {
         interfaceAddresses.add(interfaceAddressConfig1);
         ModemInterfaceAddressConfigImpl interfaceAddressConfig2 = new ModemInterfaceAddressConfigImpl();
         interfaceAddressConfig2.setConnectionType(ModemConnectionType.PPP);
-        interfaceAddressConfig2.setConnectionStatus(ModemConnectionStatus.CONNECTED);
         ArrayList<NetConfig> netConfigs = new ArrayList<>();
         ModemConfig netConfig = new ModemConfig();
         netConfig.setApn("apn");
@@ -1368,49 +1295,12 @@ public class NetworkConfigurationTest {
         expected.put("net.interface.if1.config.name", "if1");
         expected.put("net.interface.if1.config.autoconnect", netInterfaceConfig1.isAutoConnect());
         expected.put("net.interface.if1.config.mtu", netInterfaceConfig1.getMTU());
-        expected.put("net.interface.if1.driver", netInterfaceConfig1.getDriver());
-        expected.put("net.interface.if1.driver.version", netInterfaceConfig1.getDriverVersion());
-        expected.put("net.interface.if1.firmware.version", netInterfaceConfig1.getFirmwareVersion());
-        expected.put("net.interface.if1.mac",
-                NetUtil.hardwareAddressToString(netInterfaceConfig1.getHardwareAddress()));
-        expected.put("net.interface.if1.loopback", netInterfaceConfig1.isLoopback());
-        expected.put("net.interface.if1.ptp", netInterfaceConfig1.isPointToPoint());
-        expected.put("net.interface.if1.up", netInterfaceConfig1.isUp());
-        expected.put("net.interface.if1.virtual", netInterfaceConfig1.isVirtual());
-        expected.put("net.interface.if1.manufacturer", netInterfaceConfig1.getManufacturer());
-        expected.put("net.interface.if1.model", netInterfaceConfig1.getModel());
-        expected.put("net.interface.if1.revisionId", "");
-        expected.put("net.interface.if1.serialNum", netInterfaceConfig1.getSerialNumber());
-        expected.put("net.interface.if1.technologyTypes", "");
-        expected.put("net.interface.if1.config.identifier", netInterfaceConfig1.getModemIdentifier());
-        expected.put("net.interface.if1.config.powerMode", "UNKNOWN");
-        expected.put("net.interface.if1.config.pppNum", netInterfaceConfig1.getPppNum());
-        expected.put("net.interface.if1.config.poweredOn", netInterfaceConfig1.isPoweredOn());
 
         expected.put("net.interface.if2.type", "MODEM");
         expected.put("net.interface.if2.config.name", "if2");
         expected.put("net.interface.if2.config.autoconnect", netInterfaceConfig2.isAutoConnect());
         expected.put("net.interface.if2.config.mtu", netInterfaceConfig2.getMTU());
-        expected.put("net.interface.if2.driver", netInterfaceConfig2.getDriver());
-        expected.put("net.interface.if2.driver.version", netInterfaceConfig2.getDriverVersion());
-        expected.put("net.interface.if2.firmware.version", netInterfaceConfig2.getFirmwareVersion());
-        expected.put("net.interface.if2.mac",
-                NetUtil.hardwareAddressToString(netInterfaceConfig2.getHardwareAddress()));
-        expected.put("net.interface.if2.loopback", netInterfaceConfig2.isLoopback());
-        expected.put("net.interface.if2.ptp", netInterfaceConfig2.isPointToPoint());
-        expected.put("net.interface.if2.up", netInterfaceConfig2.isUp());
-        expected.put("net.interface.if2.virtual", netInterfaceConfig2.isVirtual());
-        expected.put("net.interface.if2.manufacturer", netInterfaceConfig2.getManufacturer());
-        expected.put("net.interface.if2.model", netInterfaceConfig2.getModel());
-        expected.put("net.interface.if2.revisionId", "rev1,rev2");
-        expected.put("net.interface.if2.serialNum", netInterfaceConfig2.getSerialNumber());
-        expected.put("net.interface.if2.technologyTypes", "CDMA,EVDO");
-        expected.put("net.interface.if2.config.identifier", netInterfaceConfig2.getModemIdentifier());
-        expected.put("net.interface.if2.config.powerMode", "LOW_POWER");
-        expected.put("net.interface.if2.config.pppNum", netInterfaceConfig2.getPppNum());
-        expected.put("net.interface.if2.config.poweredOn", netInterfaceConfig2.isPoweredOn());
         expected.put("net.interface.if2.config.connection.type", "PPP");
-        expected.put("net.interface.if2.config.connection.status", "CONNECTED");
         expected.put("net.interface.if2.config.apn", "apn");
         expected.put("net.interface.if2.config.authType", "");
         expected.put("net.interface.if2.config.dataCompression", 42);
@@ -1419,7 +1309,6 @@ public class NetworkConfigurationTest {
         expected.put("net.interface.if2.config.ipAddress", "");
         expected.put("net.interface.if2.config.password", new Password("password"));
         expected.put("net.interface.if2.config.pdpType", "");
-        expected.put("net.interface.if2.config.pppNum", 123);
         expected.put("net.interface.if2.config.persist", true);
         expected.put("net.interface.if2.config.maxFail", 10);
         expected.put("net.interface.if2.config.idle", 20);
@@ -1747,7 +1636,6 @@ public class NetworkConfigurationTest {
         expected.put("prefix.ipAddress", "");
         expected.put("prefix.password", new Password("password"));
         expected.put("prefix.pdpType", "");
-        expected.put("prefix.pppNum", 123);
         expected.put("prefix.persist", true);
         expected.put("prefix.maxFail", 10);
         expected.put("prefix.idle", 20);
@@ -1805,7 +1693,6 @@ public class NetworkConfigurationTest {
         expected.put("prefix.ipAddress", "10.0.0.1");
         expected.put("prefix.password", new Password("password"));
         expected.put("prefix.pdpType", "IP");
-        expected.put("prefix.pppNum", 123);
         expected.put("prefix.persist", true);
         expected.put("prefix.maxFail", 10);
         expected.put("prefix.idle", 20);
@@ -2234,7 +2121,6 @@ public class NetworkConfigurationTest {
         loopbackInterfaceAddressConfigs.add(addressConfig);
         loopbackInterfaceConfig.setNetInterfaceAddresses(loopbackInterfaceAddressConfigs);
         loopbackInterfaceConfig.setAutoConnect(true);
-        loopbackInterfaceConfig.setState(NetInterfaceState.DISCONNECTED);
 
         HashMap<String, NetInterfaceConfig<? extends NetInterfaceAddressConfig>> expected = new HashMap<>();
         expected.put(interfaceName, loopbackInterfaceConfig);
@@ -2283,7 +2169,6 @@ public class NetworkConfigurationTest {
         wifiInterfaceAddressConfigs.add(addressConfig);
         wifiInterfaceConfig.setNetInterfaceAddresses(wifiInterfaceAddressConfigs);
         wifiInterfaceConfig.setAutoConnect(true);
-        wifiInterfaceConfig.setState(NetInterfaceState.DISCONNECTED);
 
         HashMap<String, NetInterfaceConfig<? extends NetInterfaceAddressConfig>> expected = new HashMap<>();
         expected.put(interfaceName, wifiInterfaceConfig);
@@ -2332,12 +2217,10 @@ public class NetworkConfigurationTest {
 
         HashMap<String, Object> properties = new HashMap<>();
         properties.put("net.interface.if1.type", "ETHERNET");
-        properties.put("net.interface.if1.state", NetInterfaceState.DISCONNECTED);
 
         TestUtil.invokePrivate(config, "populateNetInterfaceConfiguration", netInterfaceConfig, properties);
 
         EthernetInterfaceConfigImpl expected = new EthernetInterfaceConfigImpl("if1");
-        expected.setState(NetInterfaceState.DISCONNECTED);
 
         assertEquals(expected, netInterfaceConfig);
     }
@@ -2359,12 +2242,10 @@ public class NetworkConfigurationTest {
         properties.put("net.interface.if1.config.wifi.mode", "ADHOC");
         properties.put("net.interface.if1.config.wifi.master.passphrase", "password");
         properties.put("net.interface.if1.config.wifi.infra.passphrase", "password");
-        properties.put("net.interface.if1.state", NetInterfaceState.DISCONNECTED);
 
         TestUtil.invokePrivate(config, "populateNetInterfaceConfiguration", netInterfaceConfig, properties);
 
         WifiInterfaceConfigImpl expected = new WifiInterfaceConfigImpl("if1");
-        expected.setState(NetInterfaceState.DISCONNECTED);
         expected.setAutoConnect(true);
         expected.setUp(false);
         expected.setCapabilities(EnumSet.of(Capability.CIPHER_CCMP, Capability.CIPHER_TKIP));

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
@@ -752,7 +752,8 @@ public class NetworkConfigurationTest {
                 + " :: Driver: null :: Driver Version: null :: Firmware Version: null :: MTU: 0 :: State: null"
                 + " :: Type: MODEM :: Usb Device: null :: Prefix: 0\n	ModemConfig  :: APN: apn :: Data Compression: 0"
                 + " :: Dial String: dialString :: Header Compression: 0 :: PPP number: 0"
-                + " :: Profile ID: 0 :: Username: username :: Auth Type: AUTO :: IP Address: 10.0.0.2 :: PDP Type: PPP";
+                + " :: Profile ID: 0 :: Username: username :: Auth Type: AUTO :: IP Address: 10.0.0.2 :: PDP Type: PPP"
+                + " :: Gps enabled: false :: Antenna diversity enabled: false";
 
         assertEquals(expected, config.toString());
     }

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
@@ -915,9 +915,6 @@ public class NetworkConfigurationTest {
         Map<String, Object> expected = new HashMap<>();
         expected.put("net.interfaces", "if1");
         expected.put("net.interface.if1.type", "ETHERNET");
-        expected.put("net.interface.if1.config.name", "if1");
-        expected.put("net.interface.if1.config.autoconnect", false);
-        expected.put("net.interface.if1.config.mtu", 0);
 
         assertMapEquals(expected, properties);
     }
@@ -1131,15 +1128,8 @@ public class NetworkConfigurationTest {
 
         HashMap<String, Object> expected = new HashMap<>();
         expected.put("net.interface.if1.type", "ETHERNET");
-        expected.put("net.interface.if1.config.name", "if1");
-        expected.put("net.interface.if1.config.autoconnect", netInterfaceConfig1.isAutoConnect());
-        expected.put("net.interface.if1.config.mtu", netInterfaceConfig1.getMTU());
 
         expected.put("net.interface.if2.type", "ETHERNET");
-        expected.put("net.interface.if2.config.name", "if2");
-        expected.put("net.interface.if2.config.autoconnect", netInterfaceConfig2.isAutoConnect());
-        expected.put("net.interface.if2.config.mtu", netInterfaceConfig2.getMTU());
-        expected.put("net.interface.if2.config.autoconnect", true);
         expected.put("net.interface.if2.config.ip4.status", "netIPv4StatusEnabledLAN");
         expected.put("net.interface.if2.config.ip4.dnsServers", "");
         expected.put("net.interface.if2.config.dhcpClient4.enabled", true);
@@ -1189,7 +1179,6 @@ public class NetworkConfigurationTest {
         netConfig.setMode(WifiMode.ADHOC);
         netConfig.setSSID("ssid");
         netConfig.setDriver("driver");
-        netConfig.setBroadcast(false);
         netConfig.setPingAccessPoint(false);
         netConfig.setIgnoreSSID(false);
         netConfigs.add(netConfig);
@@ -1200,19 +1189,10 @@ public class NetworkConfigurationTest {
 
         HashMap<String, Object> expected = new HashMap<>();
         expected.put("net.interface.if1.type", "WIFI");
-        expected.put("net.interface.if1.config.name", "if1");
-        expected.put("net.interface.if1.config.autoconnect", netInterfaceConfig1.isAutoConnect());
-        expected.put("net.interface.if1.config.mtu", netInterfaceConfig1.getMTU());
 
         expected.put("net.interface.if2.type", "WIFI");
-        expected.put("net.interface.if2.config.name", "if2");
-        expected.put("net.interface.if2.config.autoconnect", netInterfaceConfig2.isAutoConnect());
-        expected.put("net.interface.if2.config.mtu", netInterfaceConfig2.getMTU());
 
         expected.put("net.interface.if3.type", "WIFI");
-        expected.put("net.interface.if3.config.name", "if3");
-        expected.put("net.interface.if3.config.autoconnect", netInterfaceConfig3.isAutoConnect());
-        expected.put("net.interface.if3.config.mtu", netInterfaceConfig3.getMTU());
         expected.put("net.interface.if3.config.wifi.mode", "ADHOC");
         expected.put("net.interface.if3.config.wifi.adhoc.ssid", "ssid");
         expected.put("net.interface.if3.config.wifi.adhoc.driver", "driver");
@@ -1220,8 +1200,6 @@ public class NetworkConfigurationTest {
         expected.put("net.interface.if3.config.wifi.adhoc.securityType", "NONE");
         expected.put("net.interface.if3.config.wifi.adhoc.channel", "");
         expected.put("net.interface.if3.config.wifi.adhoc.passphrase", new Password(""));
-        expected.put("net.interface.if3.config.wifi.adhoc.hardwareMode", "");
-        expected.put("net.interface.if3.config.wifi.adhoc.broadcast", false);
         expected.put("net.interface.if3.config.wifi.adhoc.bgscan", "");
         expected.put("net.interface.if3.config.wifi.adhoc.pingAccessPoint", false);
         expected.put("net.interface.if3.config.wifi.adhoc.ignoreSSID", false);
@@ -1293,20 +1271,11 @@ public class NetworkConfigurationTest {
 
         HashMap<String, Object> expected = new HashMap<>();
         expected.put("net.interface.if1.type", "MODEM");
-        expected.put("net.interface.if1.config.name", "if1");
-        expected.put("net.interface.if1.config.autoconnect", netInterfaceConfig1.isAutoConnect());
-        expected.put("net.interface.if1.config.mtu", netInterfaceConfig1.getMTU());
 
         expected.put("net.interface.if2.type", "MODEM");
-        expected.put("net.interface.if2.config.name", "if2");
-        expected.put("net.interface.if2.config.autoconnect", netInterfaceConfig2.isAutoConnect());
-        expected.put("net.interface.if2.config.mtu", netInterfaceConfig2.getMTU());
-        expected.put("net.interface.if2.config.connection.type", "PPP");
         expected.put("net.interface.if2.config.apn", "apn");
         expected.put("net.interface.if2.config.authType", "");
-        expected.put("net.interface.if2.config.dataCompression", 42);
         expected.put("net.interface.if2.config.dialString", "dialString");
-        expected.put("net.interface.if2.config.headerCompression", 100);
         expected.put("net.interface.if2.config.ipAddress", "");
         expected.put("net.interface.if2.config.password", new Password("password"));
         expected.put("net.interface.if2.config.pdpType", "");
@@ -1317,7 +1286,6 @@ public class NetworkConfigurationTest {
         expected.put("net.interface.if2.config.resetTimeout", 30);
         expected.put("net.interface.if2.config.lcpEchoInterval", 40);
         expected.put("net.interface.if2.config.lcpEchoFailure", 50);
-        expected.put("net.interface.if2.config.profileId", 60);
         expected.put("net.interface.if2.config.username", "username");
         expected.put("net.interface.if2.config.enabled", true);
         expected.put("net.interface.if2.config.gpsEnabled", true);
@@ -1354,7 +1322,6 @@ public class NetworkConfigurationTest {
         wifiConfig.setMode(WifiMode.ADHOC);
         wifiConfig.setSSID("ssid");
         wifiConfig.setDriver("driver");
-        wifiConfig.setBroadcast(false);
         wifiConfig.setPingAccessPoint(false);
         wifiConfig.setIgnoreSSID(false);
 
@@ -1367,8 +1334,6 @@ public class NetworkConfigurationTest {
         expected.put("prefix.wifi.adhoc.securityType", "NONE");
         expected.put("prefix.wifi.adhoc.channel", "");
         expected.put("prefix.wifi.adhoc.passphrase", new Password(""));
-        expected.put("prefix.wifi.adhoc.hardwareMode", "");
-        expected.put("prefix.wifi.adhoc.broadcast", (Boolean) false);
         expected.put("prefix.wifi.adhoc.bgscan", "");
         expected.put("prefix.wifi.adhoc.pingAccessPoint", (Boolean) false);
         expected.put("prefix.wifi.adhoc.ignoreSSID", (Boolean) false);
@@ -1390,7 +1355,6 @@ public class NetworkConfigurationTest {
         wifiConfig.setSecurity(WifiSecurity.GROUP_CCMP);
         wifiConfig.setPasskey("password");
         wifiConfig.setHardwareMode("HW mode");
-        wifiConfig.setBroadcast(true);
         wifiConfig.setRadioMode(WifiRadioMode.RADIO_MODE_80211a);
         wifiConfig.setBgscan(new WifiBgscan(WifiBgscanModule.LEARN, 1, 2, 3));
         wifiConfig.setPairwiseCiphers(WifiCiphers.CCMP);
@@ -1407,8 +1371,6 @@ public class NetworkConfigurationTest {
         expected.put("prefix.wifi.adhoc.securityType", "GROUP_CCMP");
         expected.put("prefix.wifi.adhoc.channel", "1 2 3");
         expected.put("prefix.wifi.adhoc.passphrase", new Password("password"));
-        expected.put("prefix.wifi.adhoc.hardwareMode", "HW mode");
-        expected.put("prefix.wifi.adhoc.broadcast", (Boolean) true);
         expected.put("prefix.wifi.adhoc.radioMode", "RADIO_MODE_80211a");
         expected.put("prefix.wifi.adhoc.bgscan", "learn:1:2:3");
         expected.put("prefix.wifi.adhoc.pairwiseCiphers", "CCMP");
@@ -1631,9 +1593,7 @@ public class NetworkConfigurationTest {
         HashMap<String, Object> expected = new HashMap<>();
         expected.put("prefix.apn", "apn");
         expected.put("prefix.authType", "");
-        expected.put("prefix.dataCompression", 42);
         expected.put("prefix.dialString", "dialString");
-        expected.put("prefix.headerCompression", 100);
         expected.put("prefix.ipAddress", "");
         expected.put("prefix.password", new Password("password"));
         expected.put("prefix.pdpType", "");
@@ -1644,7 +1604,6 @@ public class NetworkConfigurationTest {
         expected.put("prefix.resetTimeout", 30);
         expected.put("prefix.lcpEchoInterval", 40);
         expected.put("prefix.lcpEchoFailure", 50);
-        expected.put("prefix.profileId", 60);
         expected.put("prefix.username", "username");
         expected.put("prefix.enabled", true);
         expected.put("prefix.gpsEnabled", true);
@@ -1688,9 +1647,7 @@ public class NetworkConfigurationTest {
         HashMap<String, Object> expected = new HashMap<>();
         expected.put("prefix.apn", "apn");
         expected.put("prefix.authType", "AUTO");
-        expected.put("prefix.dataCompression", 42);
         expected.put("prefix.dialString", "dialString");
-        expected.put("prefix.headerCompression", 100);
         expected.put("prefix.ipAddress", "10.0.0.1");
         expected.put("prefix.password", new Password("password"));
         expected.put("prefix.pdpType", "IP");
@@ -1701,7 +1658,6 @@ public class NetworkConfigurationTest {
         expected.put("prefix.resetTimeout", 30);
         expected.put("prefix.lcpEchoInterval", 40);
         expected.put("prefix.lcpEchoFailure", 50);
-        expected.put("prefix.profileId", 60);
         expected.put("prefix.username", "username");
         expected.put("prefix.enabled", true);
         expected.put("prefix.gpsEnabled", true);
@@ -1945,7 +1901,6 @@ public class NetworkConfigurationTest {
 
         String prefix = "prefix.";
         HashMap<String, Object> expected = new HashMap<>();
-        expected.put("prefix.autoconnect", true);
         expected.put("prefix.ip4.status", "netIPv4StatusEnabledLAN");
         expected.put("prefix.ip4.dnsServers", "10.0.0.1,10.0.0.2");
         expected.put("prefix.dhcpClient4.enabled", true);
@@ -1976,15 +1931,12 @@ public class NetworkConfigurationTest {
 
         String prefix = "prefix.";
         HashMap<String, Object> expected = new HashMap<>();
-        expected.put("prefix.autoconnect", true);
         expected.put("prefix.ip4.status", "netIPv4StatusEnabledLAN");
         expected.put("prefix.ip4.dnsServers", "");
         expected.put("prefix.dhcpClient4.enabled", false);
         expected.put("prefix.ip4.address", "10.0.0.1");
         expected.put("prefix.ip4.prefix", (short) 24);
         expected.put("prefix.ip4.gateway", "10.0.0.2");
-        expected.put("prefix.winsServers", "10.0.1.1,10.0.1.2");
-        expected.put("prefix.domains", "domain1,domain2");
 
         HashMap<String, Object> properties = new HashMap<>();
 
@@ -2032,7 +1984,6 @@ public class NetworkConfigurationTest {
         expected.put("prefix.dhcpClient6.enabled", false);
         expected.put("prefix.address", "2001:db8:0:0:0:ff00:42:8329");
         expected.put("prefix.ip6.dnsServers", "2001:db8:0:0:0:ff00:42:1000,2001:db8:0:0:0:ff00:42:1001");
-        expected.put("prefix.domains", "domain1,domain2");
 
         HashMap<String, Object> properties = new HashMap<>();
 
@@ -2109,19 +2060,18 @@ public class NetworkConfigurationTest {
         NetInterfaceType type = NetInterfaceType.LOOPBACK;
         HashMap<String, Object> properties = new HashMap<>();
         properties.put("net.interface.if1.type", "LOOPBACK");
-        properties.put("net.interface.if1.config.autoconnect", true);
         properties.put("net.interface.if1.state", NetInterfaceState.DISCONNECTED);
 
         LoopbackInterfaceConfigImpl loopbackInterfaceConfig = new LoopbackInterfaceConfigImpl(interfaceName);
         List<NetInterfaceAddressConfig> loopbackInterfaceAddressConfigs = new ArrayList<>();
         NetInterfaceAddressConfigImpl addressConfig = new NetInterfaceAddressConfigImpl();
         List<NetConfig> netConfigs = new ArrayList<>();
-        netConfigs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, true));
-        netConfigs.add(new NetConfigIP6(NetInterfaceStatus.netIPv6StatusDisabled, true));
+        netConfigs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+        netConfigs.add(new NetConfigIP6(NetInterfaceStatus.netIPv6StatusDisabled, false));
         addressConfig.setNetConfigs(netConfigs);
         loopbackInterfaceAddressConfigs.add(addressConfig);
         loopbackInterfaceConfig.setNetInterfaceAddresses(loopbackInterfaceAddressConfigs);
-        loopbackInterfaceConfig.setAutoConnect(true);
+        loopbackInterfaceConfig.setAutoConnect(false);
 
         HashMap<String, NetInterfaceConfig<? extends NetInterfaceAddressConfig>> expected = new HashMap<>();
         expected.put(interfaceName, loopbackInterfaceConfig);
@@ -2140,7 +2090,6 @@ public class NetworkConfigurationTest {
         NetInterfaceType type = NetInterfaceType.WIFI;
         HashMap<String, Object> properties = new HashMap<>();
         properties.put("net.interface.if1.type", "WIFI");
-        properties.put("net.interface.if1.config.autoconnect", true);
         properties.put("net.interface.if1.state", NetInterfaceState.DISCONNECTED);
 
         properties.put("net.interface.if1.config.wifi.master.ssid", "ssid");
@@ -2153,23 +2102,23 @@ public class NetworkConfigurationTest {
         List<WifiInterfaceAddressConfig> wifiInterfaceAddressConfigs = new ArrayList<>();
         WifiInterfaceAddressConfigImpl addressConfig = new WifiInterfaceAddressConfigImpl();
         List<NetConfig> netConfigs = new ArrayList<>();
-        netConfigs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, true));
-        netConfigs.add(new NetConfigIP6(NetInterfaceStatus.netIPv6StatusDisabled, true));
+        netConfigs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+        netConfigs.add(new NetConfigIP6(NetInterfaceStatus.netIPv6StatusDisabled, false));
 
         WifiConfig wifiConfig1 = new WifiConfig(WifiMode.MASTER, "ssid", null, WifiSecurity.NONE, "passphrase", "",
-                false, null);
+                null);
         wifiConfig1.setDriver("");
         netConfigs.add(wifiConfig1);
 
         WifiConfig wifiConfig2 = new WifiConfig(WifiMode.INFRA, "ssid", null, WifiSecurity.NONE, "passphrase", "",
-                false, new WifiBgscan(""));
+                new WifiBgscan(""));
         wifiConfig2.setDriver("");
         netConfigs.add(wifiConfig2);
 
         addressConfig.setNetConfigs(netConfigs);
         wifiInterfaceAddressConfigs.add(addressConfig);
         wifiInterfaceConfig.setNetInterfaceAddresses(wifiInterfaceAddressConfigs);
-        wifiInterfaceConfig.setAutoConnect(true);
+        wifiInterfaceConfig.setAutoConnect(false);
 
         HashMap<String, NetInterfaceConfig<? extends NetInterfaceAddressConfig>> expected = new HashMap<>();
         expected.put(interfaceName, wifiInterfaceConfig);
@@ -2238,7 +2187,6 @@ public class NetworkConfigurationTest {
         HashMap<String, Object> properties = new HashMap<>();
         properties.put("net.interface.if1.type", "WIFI");
         properties.put("net.interface.if1.up", false);
-        properties.put("net.interface.if1.config.autoconnect", true);
         properties.put("net.interface.if1.wifi.capabilities", "CIPHER_CCMP CIPHER_TKIP");
         properties.put("net.interface.if1.config.wifi.mode", "ADHOC");
         properties.put("net.interface.if1.config.wifi.master.passphrase", "password");
@@ -2247,7 +2195,7 @@ public class NetworkConfigurationTest {
         TestUtil.invokePrivate(config, "populateNetInterfaceConfiguration", netInterfaceConfig, properties);
 
         WifiInterfaceConfigImpl expected = new WifiInterfaceConfigImpl("if1");
-        expected.setAutoConnect(true);
+        expected.setAutoConnect(false);
         expected.setUp(false);
         expected.setCapabilities(EnumSet.of(Capability.CIPHER_CCMP, Capability.CIPHER_TKIP));
 
@@ -2257,8 +2205,8 @@ public class NetworkConfigurationTest {
 
         List<NetConfig> netConfigs = new ArrayList<>();
 
-        netConfigs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, true));
-        netConfigs.add(new NetConfigIP6(NetInterfaceStatus.netIPv6StatusDisabled, true));
+        netConfigs.add(new NetConfigIP4(NetInterfaceStatus.netIPv4StatusDisabled, false));
+        netConfigs.add(new NetConfigIP6(NetInterfaceStatus.netIPv6StatusDisabled, false));
 
         WifiConfig netConfig1 = new WifiConfig();
         netConfig1.setMode(WifiMode.MASTER);

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
@@ -654,7 +654,7 @@ public class NetworkConfigurationTest {
         String expected = "\nname: if1 :: Loopback? false :: Point to Point? false :: Up? false :: Virtual? false"
                 + " :: Driver: null :: Driver Version: null :: Firmware Version: null :: MTU: 0 :: State: null"
                 + " :: Type: WIFI :: Usb Device: null :: Prefix: 0\n	WifiConfig  :: SSID: null :: BgScan: null"
-                + " :: Broadcast: false :: Group Ciphers: null :: Hardware Mode: null :: Mode: null"
+                + " :: Group Ciphers: null :: Hardware Mode: null :: Mode: null"
                 + " :: Pairwise Ciphers: null :: Security: null";
 
         assertEquals(expected, config.toString());
@@ -682,7 +682,7 @@ public class NetworkConfigurationTest {
 
         String expected = "\nname: if1 :: Loopback? false :: Point to Point? false :: Up? false :: Virtual? false"
                 + " :: Driver: null :: Driver Version: null :: Firmware Version: null :: MTU: 0 :: State: null :: Type: WIFI"
-                + " :: Usb Device: null :: Prefix: 0\n	WifiConfig  :: SSID: null :: BgScan: null :: Broadcast: false"
+                + " :: Usb Device: null :: Prefix: 0\n	WifiConfig  :: SSID: null :: BgScan: null"
                 + " :: Group Ciphers: null :: Hardware Mode: null :: Mode: null :: Pairwise Ciphers: null"
                 + " :: Security: null";
 
@@ -711,7 +711,7 @@ public class NetworkConfigurationTest {
 
         String expected = "\nname: if1 :: Loopback? false :: Point to Point? false :: Up? false :: Virtual? false"
                 + " :: Driver: null :: Driver Version: null :: Firmware Version: null :: MTU: 0 :: State: null :: Type: WIFI"
-                + " :: Usb Device: null :: Prefix: 0\n	WifiConfig  :: SSID: null :: BgScan: null :: Broadcast: false"
+                + " :: Usb Device: null :: Prefix: 0\n	WifiConfig  :: SSID: null :: BgScan: null"
                 + " :: Channels: 1,2 :: Group Ciphers: null :: Hardware Mode: null :: Mode: null :: Pairwise Ciphers: null"
                 + " :: Security: null";
 

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/NetworkServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/NetworkServiceImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -49,42 +49,8 @@ public class NetworkServiceImplTest {
     private List<NetInterface<? extends NetInterfaceAddress>> networkInterfaces;
 
     @Test
-    public void shouldBeGlobalConnected() throws KuraException {
-        givenNetworkService();
-        givenCanPingGlobal();
-
-        whenGetState();
-
-        thenStateIsGlobalConnected();
-    }
-
-    @Test
-    public void shouldBeSiteConnected() throws KuraException {
-        givenNetworkService();
-        givenCannotPingGlobal();
-        givenEthernetInterface("eth0", true, true);
-
-        whenGetState();
-
-        thenStateIsSiteConnected();
-    }
-
-    @Test
-    public void shouldBeLocalConnected() throws KuraException {
-        givenNetworkService();
-        givenCannotPingGlobal();
-        givenLoopbackInterface(true);
-
-        whenGetState();
-
-        thenStateIsLocalConnected();
-    }
-
-    @Test
     public void shouldBeUnknownConnected() throws KuraException {
         givenNetworkService();
-        givenCannotPingGlobal();
-        givenLoopbackInterface(false);
 
         whenGetState();
 
@@ -98,26 +64,6 @@ public class NetworkServiceImplTest {
         whenGetInterfaceState("eth0");
 
         thenNetInterfaceStateIsUnknown();
-    }
-
-    @Test
-    public void shouldBeActivatedInterfaceState() throws KuraException {
-        givenNetworkService();
-        givenEthernetInterface("eth0", true, true);
-
-        whenGetInterfaceState("eth0");
-
-        thenNetInterfaceStateIsActivated();
-    }
-
-    @Test
-    public void shouldBeDisconnectedInterfaceState() throws KuraException {
-        givenNetworkService();
-        givenEthernetInterface("eth0", false, false);
-
-        whenGetInterfaceState("eth0");
-
-        thenNetInterfaceStateIsDisconnected();
     }
 
     @Test
@@ -162,38 +108,6 @@ public class NetworkServiceImplTest {
         this.networkService.setLinuxNetworkUtil(this.linuxNetworkUtil);
         this.networkService.setUsbService(usbService);
         this.networkService.setEventAdmin(eventAdmin);
-    }
-
-    private void givenCanPingGlobal() {
-        when(this.linuxNetworkUtil.canPing("8.8.8.8", 1)).thenReturn(true);
-    }
-
-    private void givenCannotPingGlobal() {
-        when(this.linuxNetworkUtil.canPing("8.8.8.8", 1)).thenReturn(false);
-        when(this.linuxNetworkUtil.canPing("8.8.4.4", 1)).thenReturn(false);
-    }
-
-    private void givenEthernetInterface(String interfaceName, boolean isUp, boolean isLinkUp) throws KuraException {
-        List<String> interfaces = new ArrayList<>();
-        interfaces.add(interfaceName);
-        when(this.linuxNetworkUtil.getAllInterfaceNames()).thenReturn(interfaces);
-        when(this.linuxNetworkUtil.isLinkUp(NetInterfaceType.ETHERNET, interfaceName)).thenReturn(isLinkUp);
-
-        LinuxIfconfig eth0Ifconfig = new LinuxIfconfig(interfaceName);
-        eth0Ifconfig.setType(NetInterfaceType.ETHERNET);
-        eth0Ifconfig.setUp(isUp);
-        when(this.linuxNetworkUtil.getInterfaceConfiguration(interfaceName)).thenReturn(eth0Ifconfig);
-    }
-
-    private void givenLoopbackInterface(boolean isUp) throws KuraException {
-        List<String> interfaces = new ArrayList<>();
-        interfaces.add("lo");
-        when(this.linuxNetworkUtil.getAllInterfaceNames()).thenReturn(interfaces);
-
-        LinuxIfconfig loIfconfig = new LinuxIfconfig("lo");
-        loIfconfig.setType(NetInterfaceType.LOOPBACK);
-        loIfconfig.setUp(isUp);
-        when(this.linuxNetworkUtil.getInterfaceConfiguration("lo")).thenReturn(loIfconfig);
     }
 
     private void givenPppInterface(String interfaceName, boolean isUp, boolean isLinkUp) throws KuraException {
@@ -271,32 +185,12 @@ public class NetworkServiceImplTest {
         events.forEach(this.networkService::handleEvent);
     }
 
-    private void thenStateIsGlobalConnected() {
-        assertEquals(NetworkState.CONNECTED_GLOBAL, this.networkState);
-    }
-
-    private void thenStateIsSiteConnected() {
-        assertEquals(NetworkState.CONNECTED_SITE, this.networkState);
-    }
-
-    private void thenStateIsLocalConnected() {
-        assertEquals(NetworkState.CONNECTED_LOCAL, this.networkState);
-    }
-
     private void thenStateIsUnknownConnected() {
         assertEquals(NetworkState.UNKNOWN, this.networkState);
     }
 
     private void thenNetInterfaceStateIsUnknown() {
         assertEquals(NetInterfaceState.UNKNOWN, this.netInterfaceState);
-    }
-
-    private void thenNetInterfaceStateIsActivated() {
-        assertEquals(NetInterfaceState.ACTIVATED, this.netInterfaceState);
-    }
-
-    private void thenNetInterfaceStateIsDisconnected() {
-        assertEquals(NetInterfaceState.DISCONNECTED, this.netInterfaceState);
     }
 
     private void thenNetworkNamesListSize(int size) {

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkAdminServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkAdminServiceImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkAdminServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkAdminServiceImplTest.java
@@ -326,7 +326,6 @@ public class NetworkAdminServiceImplTest {
             NetInterfaceConfig<? extends NetInterfaceAddressConfig> config = networkConfiguration
                     .getNetInterfaceConfig(interfaceName);
 
-            assertEquals(NetInterfaceState.ACTIVATED, config.getState());
             assertFalse(config.isAutoConnect());
 
             List<? extends NetInterfaceAddressConfig> addresses = config.getNetInterfaceAddresses();
@@ -567,7 +566,6 @@ public class NetworkAdminServiceImplTest {
             NetInterfaceConfig<? extends NetInterfaceAddressConfig> config = networkConfiguration
                     .getNetInterfaceConfig(interfaceName);
 
-            assertEquals(NetInterfaceState.ACTIVATED, config.getState());
             assertTrue(config.isAutoConnect());
 
             List<? extends NetInterfaceAddressConfig> addresses = config.getNetInterfaceAddresses();
@@ -828,7 +826,6 @@ public class NetworkAdminServiceImplTest {
             NetInterfaceConfig<? extends NetInterfaceAddressConfig> config = networkConfiguration
                     .getNetInterfaceConfig(interfaceName);
 
-            assertEquals(NetInterfaceState.ACTIVATED, config.getState());
             assertFalse(config.isAutoConnect());
 
             List<? extends NetInterfaceAddressConfig> addresses = config.getNetInterfaceAddresses();

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
@@ -432,19 +432,15 @@ public class NetworkConfigurationServiceImplTest {
         Map<String, Object> properties = configuration.getConfigurationProperties();
 
         assertNotNull(properties);
-        assertEquals(62, properties.size());
+        assertEquals(19, properties.size());
         assertEquals("eth2", properties.get("net.interface.eth2.config.name"));
         assertEquals("ETHERNET", properties.get("net.interface.eth2.type"));
-        assertFalse((boolean) properties.get("net.interface.eth2.up"));
         assertEquals("lo", properties.get("net.interface.lo.config.name"));
         assertEquals("LOOPBACK", properties.get("net.interface.lo.type"));
-        assertFalse((boolean) properties.get("net.interface.lo.up"));
         assertEquals("ppp1", properties.get("net.interface.ppp1.config.name"));
         assertEquals("MODEM", properties.get("net.interface.ppp1.type"));
-        assertFalse((boolean) properties.get("net.interface.ppp1.up"));
         assertEquals("wlan1", properties.get("net.interface.wlan1.config.name"));
         assertEquals("WIFI", properties.get("net.interface.wlan1.type"));
-        assertTrue((boolean) properties.get("net.interface.wlan1.up"));
 
         OCD ocd = configuration.getDefinition();
 

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
@@ -437,14 +437,10 @@ public class NetworkConfigurationServiceImplTest {
         Map<String, Object> properties = configuration.getConfigurationProperties();
 
         assertNotNull(properties);
-        assertEquals(19, properties.size());
-        assertEquals("eth2", properties.get("net.interface.eth2.config.name"));
+        assertEquals(6, properties.size());
         assertEquals("ETHERNET", properties.get("net.interface.eth2.type"));
-        assertEquals("lo", properties.get("net.interface.lo.config.name"));
         assertEquals("LOOPBACK", properties.get("net.interface.lo.type"));
-        assertEquals("ppp1", properties.get("net.interface.ppp1.config.name"));
         assertEquals("MODEM", properties.get("net.interface.ppp1.type"));
-        assertEquals("wlan1", properties.get("net.interface.wlan1.config.name"));
         assertEquals("WIFI", properties.get("net.interface.wlan1.type"));
 
         OCD ocd = configuration.getDefinition();
@@ -461,13 +457,6 @@ public class NetworkConfigurationServiceImplTest {
 
         int adsConfigured = 0;
         for (AD ad : ads) {
-            if ("net.interface.eth2.config.autoconnect".equals(ad.getId())) {
-                assertEquals("net.interface.eth2.config.autoconnect", ad.getName());
-                assertEquals("BOOLEAN", ad.getType().name());
-                assertTrue(ad.isRequired());
-                adsConfigured++;
-            }
-
             if ("net.interface.eth2.config.dhcpClient4.enabled".equals(ad.getId())) {
                 assertEquals("net.interface.eth2.config.dhcpClient4.enabled", ad.getName());
                 assertEquals("BOOLEAN", ad.getType().name());
@@ -552,31 +541,10 @@ public class NetworkConfigurationServiceImplTest {
                 adsConfigured++;
             }
 
-            if ("net.interface.eth2.config.mtu".equals(ad.getId())) {
-                assertEquals("net.interface.eth2.config.mtu", ad.getName());
-                assertEquals("INTEGER", ad.getType().name());
-                assertTrue(ad.isRequired());
-                adsConfigured++;
-            }
-
             if ("net.interface.eth2.config.nat.enabled".equals(ad.getId())) {
                 assertEquals("net.interface.eth2.config.nat.enabled", ad.getName());
                 assertEquals("BOOLEAN", ad.getType().name());
                 assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.eth2.config.winsServers".equals(ad.getId())) {
-                assertEquals("net.interface.eth2.config.winsServers", ad.getName());
-                assertEquals("STRING", ad.getType().name());
-                assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.lo.config.autoconnect".equals(ad.getId())) {
-                assertEquals("net.interface.lo.config.autoconnect", ad.getName());
-                assertEquals("BOOLEAN", ad.getType().name());
-                assertTrue(ad.isRequired());
                 adsConfigured++;
             }
 
@@ -598,20 +566,6 @@ public class NetworkConfigurationServiceImplTest {
                 assertEquals("net.interface.lo.config.ip4.prefix", ad.getName());
                 assertEquals("SHORT", ad.getType().name());
                 assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.lo.config.mtu".equals(ad.getId())) {
-                assertEquals("net.interface.lo.config.mtu", ad.getName());
-                assertEquals("INTEGER", ad.getType().name());
-                assertTrue(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.wlan1.config.autoconnect".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.config.autoconnect", ad.getName());
-                assertEquals("BOOLEAN", ad.getType().name());
-                assertTrue(ad.isRequired());
                 adsConfigured++;
             }
 
@@ -699,13 +653,6 @@ public class NetworkConfigurationServiceImplTest {
                 adsConfigured++;
             }
 
-            if ("net.interface.wlan1.config.mtu".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.config.mtu", ad.getName());
-                assertEquals("INTEGER", ad.getType().name());
-                assertTrue(ad.isRequired());
-                adsConfigured++;
-            }
-
             if ("net.interface.wlan1.config.nat.enabled".equals(ad.getId())) {
                 assertEquals("net.interface.wlan1.config.nat.enabled", ad.getName());
                 assertEquals("BOOLEAN", ad.getType().name());
@@ -769,22 +716,8 @@ public class NetworkConfigurationServiceImplTest {
                 adsConfigured++;
             }
 
-            if ("net.interface.wlan1.config.wifi.master.broadcast".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.config.wifi.master.broadcast", ad.getName());
-                assertEquals("BOOLEAN", ad.getType().name());
-                assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
             if ("net.interface.wlan1.config.wifi.master.channel".equals(ad.getId())) {
                 assertEquals("net.interface.wlan1.config.wifi.master.channel", ad.getName());
-                assertEquals("STRING", ad.getType().name());
-                assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.wlan1.config.wifi.master.hardwareMode".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.config.wifi.master.hardwareMode", ad.getName());
                 assertEquals("STRING", ad.getType().name());
                 assertFalse(ad.isRequired());
                 adsConfigured++;
@@ -825,48 +758,6 @@ public class NetworkConfigurationServiceImplTest {
                 adsConfigured++;
             }
 
-            if ("net.interface.wlan1.config.winsServers".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.config.winsServers", ad.getName());
-                assertEquals("STRING", ad.getType().name());
-                assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.wlan1.usb.manufacturer".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.usb.manfacturer", ad.getName());
-                assertEquals("STRING", ad.getType().name());
-                assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.wlan1.usb.manufacturer.id".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.usb.manfacturer.id", ad.getName());
-                assertEquals("STRING", ad.getType().name());
-                assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.wlan1.usb.port".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.usb.port", ad.getName());
-                assertEquals("STRING", ad.getType().name());
-                assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.wlan1.usb.product".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.usb.product", ad.getName());
-                assertEquals("STRING", ad.getType().name());
-                assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
-            if ("net.interface.wlan1.usb.product.id".equals(ad.getId())) {
-                assertEquals("net.interface.wlan1.usb.product.id", ad.getName());
-                assertEquals("STRING", ad.getType().name());
-                assertFalse(ad.isRequired());
-                adsConfigured++;
-            }
-
             if ("net.interface.wlan1.wifi.capabilities".equals(ad.getId())) {
                 assertEquals("net.interface.wlan1.wifi.capabilities", ad.getName());
                 assertEquals("STRING", ad.getType().name());
@@ -881,7 +772,7 @@ public class NetworkConfigurationServiceImplTest {
                 adsConfigured++;
             }
         }
-        assertEquals(60, adsConfigured);
+        assertEquals(45, adsConfigured);
     }
 
 }

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
@@ -31,6 +31,7 @@ import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -54,6 +55,8 @@ import org.eclipse.kura.net.NetInterfaceAddressConfig;
 import org.eclipse.kura.net.NetInterfaceConfig;
 import org.eclipse.kura.net.NetInterfaceType;
 import org.eclipse.kura.net.NetworkService;
+import org.eclipse.kura.net.modem.ModemDevice;
+import org.eclipse.kura.usb.UsbModemDevice;
 import org.eclipse.kura.usb.UsbNetDevice;
 import org.eclipse.kura.usb.UsbService;
 import org.junit.Test;
@@ -211,7 +214,7 @@ public class NetworkConfigurationServiceImplTest {
             Event event = invocation.getArgumentAt(0, Event.class);
 
             assertEquals("org/eclipse/kura/net/admin/event/NETWORK_EVENT_CONFIG_CHANGE_TOPIC", event.getTopic());
-            assertEquals(6, event.getPropertyNames().length); // 4+topics!
+            assertEquals(12, event.getPropertyNames().length);
 
             assertEquals("MODEM", event.getProperty("net.interface.1-2.3.type"));
 
@@ -243,6 +246,8 @@ public class NetworkConfigurationServiceImplTest {
 
         NetworkService nsMock = mock(NetworkService.class);
         when(nsMock.getModemPppInterfaceName("1-2.3")).thenReturn("ppp3");
+        ModemDevice modemDevice = new UsbModemDevice("1111", "2222", "Acme", "CoolModem", "1", "2.3");
+        when(nsMock.getModemDevice("1-2.3")).thenReturn(Optional.of(modemDevice));
         svc.setNetworkService(nsMock);
 
         Map<String, Object> properties = new HashMap<>();

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/visitor/linux/HostapdConfigTest.java
@@ -419,14 +419,6 @@ public class HostapdConfigTest {
         result = (String) TestUtil.invokePrivate(writer, "updateWepPassKey", wifiConfig, hostapd);
         assertEquals("wep_key0=61736466676173646667617364666761\n", result);
 
-        wifiConfig.setPasskey(null);
-        try {
-            result = (String) TestUtil.invokePrivate(writer, "updateWepPassKey", wifiConfig, hostapd);
-            fail("Exception was expected");
-        } catch (NullPointerException e) {
-            // OK
-        }
-
         // test wrong password lengths
         wifiConfig.setPasskey("");
         try {


### PR DESCRIPTION
This PR tries to clean the network properties and the related snapshot.
The properties for the status of the networking have been removed from the snapshot. Now, it contains only the desidered configuration. Moreover, the monitors have been modified for logging the complete Network configuration (with current values) when an event for status changed is fired.

