### PR TITLE
Pr/raw cloud connection fix

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/cloud/RawMqttCloudEndpoint.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/cloud/RawMqttCloudEndpoint.java
@@ -14,6 +14,7 @@ package org.eclipse.kura.cloudconnection.raw.mqtt.cloud;
 
 import static org.eclipse.kura.cloudconnection.raw.mqtt.util.Utils.catchAll;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -141,7 +142,12 @@ public class RawMqttCloudEndpoint
 
     public String publish(final PublishOptions options, final KuraPayload kuraPayload) throws KuraException {
 
-        final byte[] body = kuraPayload.getBody();
+        final byte[] body;
+        if (kuraPayload.metricNames().contains("payload")) {
+            body = kuraPayload.getMetric("payload").toString().getBytes(StandardCharsets.UTF_8);
+        } else {
+            body = kuraPayload.getBody();
+        }
 
         if (body == null) {
             throw new KuraException(KuraErrorCode.INVALID_PARAMETER, null, null, "missing message body");
@@ -253,6 +259,9 @@ public class RawMqttCloudEndpoint
 
         final KuraPayload kuraPayload = new KuraPayload();
         kuraPayload.setBody(payload);
+
+        kuraPayload.addMetric("payload", new String(payload));
+        kuraPayload.addMetric("topic", topic);
 
         final Map<String, Object> messagePropertes = Collections.singletonMap(Constants.TOPIC_PROP_NAME, topic);
 

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/cloud/RawMqttCloudEndpoint.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/cloud/RawMqttCloudEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kura.cloudconnection.raw.mqtt.cloud;
 
-import static org.eclipse.kura.cloudconnecton.raw.mqtt.util.Utils.catchAll;
+import static org.eclipse.kura.cloudconnection.raw.mqtt.util.Utils.catchAll;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/publisher/PublishOptions.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/publisher/PublishOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,7 @@ import java.util.Map;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.cloudconnection.raw.mqtt.cloud.Qos;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.Property;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.Property;
 
 public class PublishOptions {
 

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/publisher/RawMqttPublisher.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/publisher/RawMqttPublisher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,10 +22,10 @@ import org.eclipse.kura.cloudconnection.listener.CloudDeliveryListener;
 import org.eclipse.kura.cloudconnection.message.KuraMessage;
 import org.eclipse.kura.cloudconnection.publisher.CloudPublisher;
 import org.eclipse.kura.cloudconnection.raw.mqtt.cloud.RawMqttCloudEndpoint;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.AbstractStackComponent;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.StackComponentOptions;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.StackComponentOptions.OptionsFactory;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.Utils;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.AbstractStackComponent;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.StackComponentOptions;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.StackComponentOptions.OptionsFactory;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/subscriber/RawMqttSubscriber.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/subscriber/RawMqttSubscriber.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,12 +18,12 @@ import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.eclipse.kura.cloudconnection.message.KuraMessage;
 import org.eclipse.kura.cloudconnection.raw.mqtt.cloud.RawMqttCloudEndpoint;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.AbstractStackComponent;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.StackComponentOptions;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.StackComponentOptions.OptionsFactory;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.Utils;
 import org.eclipse.kura.cloudconnection.subscriber.CloudSubscriber;
 import org.eclipse.kura.cloudconnection.subscriber.listener.CloudSubscriberListener;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.AbstractStackComponent;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.StackComponentOptions;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.StackComponentOptions.OptionsFactory;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/subscriber/SubscribeOptions.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/subscriber/SubscribeOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,7 @@ import java.util.Map;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.cloudconnection.raw.mqtt.cloud.Qos;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.Property;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.Property;
 import org.eclipse.kura.core.util.MqttTopicUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/util/AbstractStackComponent.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/util/AbstractStackComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
  * Contributors:
  *  Eurotech
  *******************************************************************************/
-package org.eclipse.kura.cloudconnecton.raw.mqtt.util;
+package org.eclipse.kura.cloudconnection.raw.mqtt.util;
 
 import java.util.Map;
 import java.util.Optional;
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.kura.cloudconnection.CloudEndpoint;
 import org.eclipse.kura.cloudconnection.listener.CloudConnectionListener;
 import org.eclipse.kura.cloudconnection.raw.mqtt.cloud.RawMqttCloudEndpoint;
-import org.eclipse.kura.cloudconnecton.raw.mqtt.util.StackComponentOptions.OptionsFactory;
+import org.eclipse.kura.cloudconnection.raw.mqtt.util.StackComponentOptions.OptionsFactory;
 import org.eclipse.kura.configuration.ConfigurableComponent;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Filter;

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/util/Property.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/util/Property.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
  * Contributors:
  *  Eurotech
  *******************************************************************************/
-package org.eclipse.kura.cloudconnecton.raw.mqtt.util;
+package org.eclipse.kura.cloudconnection.raw.mqtt.util;
 
 import java.util.Map;
 import java.util.function.Function;

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/util/StackComponentOptions.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/util/StackComponentOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
  * Contributors:
  *  Eurotech
  *******************************************************************************/
-package org.eclipse.kura.cloudconnecton.raw.mqtt.util;
+package org.eclipse.kura.cloudconnection.raw.mqtt.util;
 
 import java.util.Map;
 import java.util.Optional;

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/util/Utils.java
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/raw/mqtt/util/Utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
  * Contributors:
  *  Eurotech
  *******************************************************************************/
-package org.eclipse.kura.cloudconnecton.raw.mqtt.util;
+package org.eclipse.kura.cloudconnection.raw.mqtt.util;
 
 import java.util.function.Consumer;
 


### PR DESCRIPTION
This PR fixes the interaction problem between the RawMqttCloudConnection and the Wires Graph.

Thanks to @LucaDazi for the help on this one.

**Related Issue:** This PR fixes/closes #3762 

**Description of the solution adopted:** 
Upon publishing, the Cloud Connection will check whether in the KuraPayload there is a metric called "payload", and if there is, will publish that instead of the KuraPayload body.

Upon subscribing, the Cloud Connection will add the payload both to the body of the KuraPayload, and to a KuraPayload metric "payload". It will also create a KuraPayload metric "topic" containing the subscription topic

**Screenshots:** N/A

**Any side note on the changes made:** Refactoring of a package name to fix a typo
