### PR TITLE
Fix gpio typo and contributing typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,8 @@ You can find all the details in the [Contributing via Git](http://wiki.eclipse.o
 * Fork the repository on GitHub
 * Create a new branch for your changes
 * Configure your IDE installing:
-  * The formatter profile available in kura/setup/formatting/KuraFormatter*.xml
-  * The cleanup profile available in kura/setup/formatting/KuraCleanupProfile*.xml
+  * The formatter profile available in kura/setups/formatting/KuraFormatter*.xml
+  * The cleanup profile available in kura/setups/formatting/KuraCleanupProfile*.xml
   * [SonarLint](http://www.sonarlint.org/eclipse/index.html)
 * Make your changes
 * Make sure you include test cases for non-trivial features

--- a/kura/examples/org.eclipse.kura.example.gpio/src/org/eclipse/kura/example/gpio/GpioComponent.java
+++ b/kura/examples/org.eclipse.kura.example.gpio/src/org/eclipse/kura/example/gpio/GpioComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -333,7 +333,7 @@ public class GpioComponent implements ConfigurableComponent {
         case 0:
             return KuraGPIOTrigger.NONE;
         case 2:
-            return KuraGPIOTrigger.RAISING_EDGE;
+            return KuraGPIOTrigger.RISING_EDGE;
         case 3:
             return KuraGPIOTrigger.BOTH_EDGES;
         case 1:

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/gpio/KuraGPIOTrigger.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/gpio/KuraGPIOTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,7 @@
 package org.eclipse.kura.gpio;
 
 public enum KuraGPIOTrigger {
-    RAISING_EDGE,
+    RISING_EDGE,
     FALLING_EDGE,
     BOTH_EDGES,
     HIGH_LEVEL,

--- a/kura/org.eclipse.kura.linux.gpio/src/main/java/org/eclipse/kura/linux/gpio/JdkDioPin.java
+++ b/kura/org.eclipse.kura.linux.gpio/src/main/java/org/eclipse/kura/linux/gpio/JdkDioPin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -265,7 +265,7 @@ public class JdkDioPin implements KuraGPIOPin {
             case GPIOPinConfig.TRIGGER_NONE:
                 return KuraGPIOTrigger.NONE;
             case GPIOPinConfig.TRIGGER_RISING_EDGE:
-                return KuraGPIOTrigger.RAISING_EDGE;
+                return KuraGPIOTrigger.RISING_EDGE;
             default:
                 return KuraGPIOTrigger.NONE;
             }
@@ -303,7 +303,7 @@ public class JdkDioPin implements KuraGPIOPin {
             return GPIOPinConfig.TRIGGER_LOW_LEVEL;
         case NONE:
             return GPIOPinConfig.TRIGGER_NONE;
-        case RAISING_EDGE:
+        case RISING_EDGE:
             return GPIOPinConfig.TRIGGER_RISING_EDGE;
         default:
             return -1;

--- a/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/JdkDioPinTest.java
+++ b/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/JdkDioPinTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -78,7 +78,7 @@ public class JdkDioPinTest {
 
         assertEquals(KuraGPIOMode.INPUT_PULL_UP, pin.getMode());
         assertEquals(KuraGPIODirection.INPUT, pin.getDirection());
-        assertEquals(KuraGPIOTrigger.RAISING_EDGE, pin.getTrigger());
+        assertEquals(KuraGPIOTrigger.RISING_EDGE, pin.getTrigger());
 
         assertEquals(0, (int) TestUtil.invokePrivate(pin, "getDirectionInternal"));
         assertEquals(1, (int) TestUtil.invokePrivate(pin, "getModeInternal"));


### PR DESCRIPTION
Fixed typo in KuraGPIOTrigger enum: RAISING_EDGE -> RISING_EDGE.
Fixed typo in CONTRIBUTING.md guide for formatter and cleanup directory path.
