### PR TITLE
Added validation to DHCP/NAT tab

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.java
@@ -75,9 +75,9 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     @UiField
     FormLabel labelSubnet;
     @UiField
-    FormLabel labelDefaultL;
+    FormLabel labelDefaultLease;
     @UiField
-    FormLabel labelMax;
+    FormLabel labelMaxLease;
     @UiField
     FormLabel labelPass;
 
@@ -91,9 +91,9 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     @UiField
     TextBox subnet;
     @UiField
-    TextBox defaultL;
+    TextBox defaultLease;
     @UiField
-    TextBox max;
+    TextBox maxLease;
 
     @UiField
     InlineRadio radio1;
@@ -109,9 +109,9 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     @UiField
     FormGroup groupSubnet;
     @UiField
-    FormGroup groupDefaultL;
+    FormGroup groupDefaultLease;
     @UiField
-    FormGroup groupMax;
+    FormGroup groupMaxLease;
 
     @UiField
     HelpBlock helpRouter;
@@ -131,9 +131,9 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     @UiField
     HelpButton subnetHelp;
     @UiField
-    HelpButton defaultLHelp;
+    HelpButton defaultLeaseHelp;
     @UiField
-    HelpButton maxHelp;
+    HelpButton maxLeaseHelp;
     @UiField
     HelpButton passHelp;
 
@@ -175,8 +175,8 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
                 || this.groupBegin.getValidationState().equals(ValidationState.ERROR)
                 || this.groupEnd.getValidationState().equals(ValidationState.ERROR)
                 || this.groupSubnet.getValidationState().equals(ValidationState.ERROR)
-                || this.groupDefaultL.getValidationState().equals(ValidationState.ERROR)
-                || this.groupMax.getValidationState().equals(ValidationState.ERROR)) {
+                || this.groupDefaultLease.getValidationState().equals(ValidationState.ERROR)
+                || this.groupMaxLease.getValidationState().equals(ValidationState.ERROR)) {
             return false;
         } else {
             return true;
@@ -214,11 +214,11 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
             updatedNetIf.setRouterDhcpBeginAddress(this.begin.getText());
             updatedNetIf.setRouterDhcpEndAddress(this.end.getText());
             updatedNetIf.setRouterDhcpSubnetMask(this.subnet.getText());
-            if (this.defaultL.getText() != null && !"".equals(this.defaultL.getText().trim())) {
-                updatedNetIf.setRouterDhcpDefaultLease(Integer.parseInt(this.defaultL.getText()));
+            if (this.defaultLease.getText() != null && !"".equals(this.defaultLease.getText().trim())) {
+                updatedNetIf.setRouterDhcpDefaultLease(Integer.parseInt(this.defaultLease.getText()));
             }
-            if (this.max.getText() != null && !"".equals(this.max.getText().trim())) {
-                updatedNetIf.setRouterDhcpMaxLease(Integer.parseInt(this.max.getText()));
+            if (this.maxLease.getText() != null && !"".equals(this.maxLease.getText().trim())) {
+                updatedNetIf.setRouterDhcpMaxLease(Integer.parseInt(this.maxLease.getText()));
             }
             updatedNetIf.setRouterDnsPass(this.radio1.getValue());
 
@@ -243,8 +243,8 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
             this.begin.setText(this.selectedNetIfConfig.getRouterDhcpBeginAddress());
             this.end.setText(this.selectedNetIfConfig.getRouterDhcpEndAddress());
             this.subnet.setText(this.selectedNetIfConfig.getRouterDhcpSubnetMask());
-            this.defaultL.setText(String.valueOf(this.selectedNetIfConfig.getRouterDhcpDefaultLease()));
-            this.max.setText(String.valueOf(this.selectedNetIfConfig.getRouterDhcpMaxLease()));
+            this.defaultLease.setText(String.valueOf(this.selectedNetIfConfig.getRouterDhcpDefaultLease()));
+            this.maxLease.setText(String.valueOf(this.selectedNetIfConfig.getRouterDhcpMaxLease()));
             this.radio1.setValue(this.selectedNetIfConfig.getRouterDnsPass());
             this.radio2.setValue(!this.selectedNetIfConfig.getRouterDnsPass());
 
@@ -275,8 +275,8 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
             this.begin.setEnabled(false);
             this.end.setEnabled(false);
             this.subnet.setEnabled(false);
-            this.defaultL.setEnabled(false);
-            this.max.setEnabled(false);
+            this.defaultLease.setEnabled(false);
+            this.maxLease.setEnabled(false);
             this.radio1.setEnabled(false);
             this.radio2.setEnabled(false);
         } else {
@@ -284,8 +284,8 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
             this.begin.setEnabled(true);
             this.end.setEnabled(true);
             this.subnet.setEnabled(true);
-            this.defaultL.setEnabled(true);
-            this.max.setEnabled(true);
+            this.defaultLease.setEnabled(true);
+            this.maxLease.setEnabled(true);
             this.radio1.setEnabled(true);
             this.radio2.setEnabled(true);
 
@@ -295,8 +295,8 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
                 this.begin.setEnabled(false);
                 this.end.setEnabled(false);
                 this.subnet.setEnabled(false);
-                this.defaultL.setEnabled(false);
-                this.max.setEnabled(false);
+                this.defaultLease.setEnabled(false);
+                this.maxLease.setEnabled(false);
                 this.radio1.setEnabled(false);
                 this.radio2.setEnabled(false);
             } else {
@@ -304,8 +304,8 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
                 this.begin.setEnabled(true);
                 this.end.setEnabled(true);
                 this.subnet.setEnabled(true);
-                this.defaultL.setEnabled(true);
-                this.max.setEnabled(true);
+                this.defaultLease.setEnabled(true);
+                this.maxLease.setEnabled(true);
                 this.radio1.setEnabled(true);
                 this.radio2.setEnabled(true);
             }
@@ -318,8 +318,8 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.begin.setText("");
         this.end.setText("");
         this.subnet.setText("");
-        this.defaultL.setText("");
-        this.max.setText("");
+        this.defaultLease.setText("");
+        this.maxLease.setText("");
         this.radio1.setValue(true);
         this.radio2.setValue(false);
         update();
@@ -330,8 +330,8 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.groupBegin.setValidationState(ValidationState.NONE);
         this.groupEnd.setValidationState(ValidationState.NONE);
         this.groupSubnet.setValidationState(ValidationState.NONE);
-        this.groupDefaultL.setValidationState(ValidationState.NONE);
-        this.groupMax.setValidationState(ValidationState.NONE);
+        this.groupDefaultLease.setValidationState(ValidationState.NONE);
+        this.groupMaxLease.setValidationState(ValidationState.NONE);
 
         this.helpRouter.setText("");
     }
@@ -341,8 +341,8 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.beginHelp.setHelpText(MSGS.netRouterToolTipDhcpBeginAddr());
         this.endHelp.setHelpText(MSGS.netRouterToolTipDhcpEndAddr());
         this.subnetHelp.setHelpText(MSGS.netRouterToolTipDhcpSubnet());
-        this.defaultLHelp.setHelpText(MSGS.netRouterToolTipDhcpDefaultLeaseTime());
-        this.maxHelp.setHelpText(MSGS.netRouterToolTipDhcpMaxLeaseTime());
+        this.defaultLeaseHelp.setHelpText(MSGS.netRouterToolTipDhcpDefaultLeaseTime());
+        this.maxLeaseHelp.setHelpText(MSGS.netRouterToolTipDhcpMaxLeaseTime());
         this.passHelp.setHelpText(MSGS.netRouterToolTipPassDns());
     }
 
@@ -438,38 +438,40 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         });
 
         // DHCP Default Lease
-        this.labelDefaultL.setText(MSGS.netRouterDhcpDefaultLease());
-        this.defaultL.addMouseOverHandler(event -> {
+        this.labelDefaultLease.setText(MSGS.netRouterDhcpDefaultLease());
+        this.defaultLease.addMouseOverHandler(event -> {
             if (TabDhcpNatUi.this.router.isEnabled()) {
                 TabDhcpNatUi.this.helpText.clear();
                 TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpDefaultLeaseTime()));
             }
         });
-        this.defaultL.addMouseOutHandler(event -> resetHelp());
-        this.defaultL.addValueChangeHandler(event -> {
+        this.defaultLease.addMouseOutHandler(event -> resetHelp());
+        this.defaultLease.addValueChangeHandler(event -> {
             setDirty(true);
-            if (!TabDhcpNatUi.this.defaultL.getText().trim().matches(FieldType.NUMERIC.getRegex())) {
-                TabDhcpNatUi.this.groupDefaultL.setValidationState(ValidationState.ERROR);
+            if (!TabDhcpNatUi.this.defaultLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
+                    || !isPositiveInteger(TabDhcpNatUi.this.defaultLease.getText().trim())) {
+                TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.ERROR);
             } else {
-                TabDhcpNatUi.this.groupDefaultL.setValidationState(ValidationState.NONE);
+                TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.NONE);
             }
         });
 
         // DHCP Max Lease
-        this.labelMax.setText(MSGS.netRouterDhcpMaxLease());
-        this.max.addMouseOverHandler(event -> {
+        this.labelMaxLease.setText(MSGS.netRouterDhcpMaxLease());
+        this.maxLease.addMouseOverHandler(event -> {
             if (TabDhcpNatUi.this.router.isEnabled()) {
                 TabDhcpNatUi.this.helpText.clear();
                 TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpMaxLeaseTime()));
             }
         });
-        this.max.addMouseOutHandler(event -> resetHelp());
-        this.max.addValueChangeHandler(event -> {
+        this.maxLease.addMouseOutHandler(event -> resetHelp());
+        this.maxLease.addValueChangeHandler(event -> {
             setDirty(true);
-            if (!TabDhcpNatUi.this.max.getText().trim().matches(FieldType.NUMERIC.getRegex())) {
-                TabDhcpNatUi.this.groupMax.setValidationState(ValidationState.ERROR);
+            if (!TabDhcpNatUi.this.maxLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
+                    || !isPositiveInteger(TabDhcpNatUi.this.maxLease.getText().trim())) {
+                TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.ERROR);
             } else {
-                TabDhcpNatUi.this.groupMax.setValidationState(ValidationState.NONE);
+                TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.NONE);
             }
         });
 
@@ -500,5 +502,16 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     private void resetHelp() {
         this.helpText.clear();
         this.helpText.add(new Span(MSGS.netHelpDefaultHint()));
+    }
+
+    private boolean isPositiveInteger(String value) {
+        try {
+            if (Integer.parseInt(value) > 0) {
+                return true;
+            }
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        return false;
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.java
@@ -250,6 +250,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
 
     // enable/disable fields depending on values in other tabs
     private void refreshForm() {
+        resetValidations();
         GwtWifiConfig wifiConfig = this.wirelessTab.activeConfig;
         String wifiMode = null;
         if (wifiConfig != null) {
@@ -266,15 +267,6 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
             this.radio1.setEnabled(false);
             this.radio2.setEnabled(false);
         } else {
-            this.router.setEnabled(true);
-            this.begin.setEnabled(true);
-            this.end.setEnabled(true);
-            this.subnet.setEnabled(true);
-            this.defaultLease.setEnabled(true);
-            this.maxLease.setEnabled(true);
-            this.radio1.setEnabled(true);
-            this.radio2.setEnabled(true);
-
             String modeValue = this.router.getSelectedItemText();
             if (modeValue.equals(ROUTER_NAT_MESSAGE) || modeValue.equals(ROUTER_OFF_MESSAGE)) {
                 this.router.setEnabled(true);
@@ -294,6 +286,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
                 this.maxLease.setEnabled(true);
                 this.radio1.setEnabled(true);
                 this.radio2.setEnabled(true);
+                setValidations();
             }
         }
     }
@@ -378,12 +371,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.maxLease.addMouseOutHandler(event -> resetHelp());
         this.maxLease.addValueChangeHandler(event -> {
             setDirty(true);
-            if (!TabDhcpNatUi.this.maxLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
-                    || !isPositiveInteger(TabDhcpNatUi.this.maxLease.getText().trim())) {
-                TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.ERROR);
-            } else {
-                TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.NONE);
-            }
+            setMaxLeaseTimeValidation();
         });
     }
 
@@ -399,12 +387,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.defaultLease.addMouseOutHandler(event -> resetHelp());
         this.defaultLease.addValueChangeHandler(event -> {
             setDirty(true);
-            if (!TabDhcpNatUi.this.defaultLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
-                    || !isPositiveInteger(TabDhcpNatUi.this.defaultLease.getText().trim())) {
-                TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.ERROR);
-            } else {
-                TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.NONE);
-            }
+            setDefaultLeaseTimeValidation();
         });
     }
 
@@ -420,11 +403,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.subnet.addMouseOutHandler(event -> resetHelp());
         this.subnet.addValueChangeHandler(event -> {
             setDirty(true);
-            if (!TabDhcpNatUi.this.subnet.getText().matches(REGEX_IPV4)) {
-                TabDhcpNatUi.this.groupSubnet.setValidationState(ValidationState.ERROR);
-            } else {
-                TabDhcpNatUi.this.groupSubnet.setValidationState(ValidationState.NONE);
-            }
+            setDHCPSubnetMaskValidation();
         });
     }
 
@@ -440,11 +419,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.end.addMouseOutHandler(event -> resetHelp());
         this.end.addValueChangeHandler(event -> {
             setDirty(true);
-            if (!TabDhcpNatUi.this.end.getText().matches(REGEX_IPV4)) {
-                TabDhcpNatUi.this.groupEnd.setValidationState(ValidationState.ERROR);
-            } else {
-                checkDhcpRangeValidity();
-            }
+            setDHCPEndAddressValidation();
         });
     }
 
@@ -460,11 +435,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.begin.addMouseOutHandler(event -> resetHelp());
         this.begin.addValueChangeHandler(event -> {
             setDirty(true);
-            if (!TabDhcpNatUi.this.begin.getText().matches(REGEX_IPV4)) {
-                TabDhcpNatUi.this.groupBegin.setValidationState(ValidationState.ERROR);
-            } else {
-                checkDhcpRangeValidity();
-            }
+            setDHCPBeginAddressValidation();
         });
     }
 
@@ -550,4 +521,57 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         }
         return addressLong;
     }
+
+    private void setValidations() {
+        setDHCPSubnetMaskValidation();
+        setDHCPEndAddressValidation();
+        setDHCPBeginAddressValidation();
+        setMaxLeaseTimeValidation();
+        setDefaultLeaseTimeValidation();
+    }
+
+    private void setDHCPSubnetMaskValidation() {
+        if (TabDhcpNatUi.this.subnet.getText().isEmpty() || !TabDhcpNatUi.this.subnet.getText().matches(REGEX_IPV4)) {
+            TabDhcpNatUi.this.groupSubnet.setValidationState(ValidationState.ERROR);
+        } else {
+            TabDhcpNatUi.this.groupSubnet.setValidationState(ValidationState.NONE);
+        }
+    }
+
+    private void setDHCPEndAddressValidation() {
+        if (TabDhcpNatUi.this.end.getText().isEmpty() || !TabDhcpNatUi.this.end.getText().matches(REGEX_IPV4)) {
+            TabDhcpNatUi.this.groupEnd.setValidationState(ValidationState.ERROR);
+        } else {
+            checkDhcpRangeValidity();
+        }
+    }
+
+    private void setDHCPBeginAddressValidation() {
+        if (TabDhcpNatUi.this.begin.getText().isEmpty() || !TabDhcpNatUi.this.begin.getText().matches(REGEX_IPV4)) {
+            TabDhcpNatUi.this.groupBegin.setValidationState(ValidationState.ERROR);
+        } else {
+            checkDhcpRangeValidity();
+        }
+    }
+
+    private void setMaxLeaseTimeValidation() {
+        if (TabDhcpNatUi.this.maxLease.getText().isEmpty()
+                || !TabDhcpNatUi.this.maxLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
+                || !isPositiveInteger(TabDhcpNatUi.this.maxLease.getText().trim())) {
+            TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.ERROR);
+        } else {
+            TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.NONE);
+        }
+    }
+
+    private void setDefaultLeaseTimeValidation() {
+        if (TabDhcpNatUi.this.defaultLease.getText().isEmpty()
+                || !TabDhcpNatUi.this.defaultLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
+                || !isPositiveInteger(TabDhcpNatUi.this.defaultLease.getText().trim())) {
+            TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.ERROR);
+        } else {
+            TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.NONE);
+        }
+    }
+
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -171,16 +171,12 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
 
     @Override
     public boolean isValid() {
-        if (this.groupRouter.getValidationState().equals(ValidationState.ERROR)
+        return !(this.groupRouter.getValidationState().equals(ValidationState.ERROR)
                 || this.groupBegin.getValidationState().equals(ValidationState.ERROR)
                 || this.groupEnd.getValidationState().equals(ValidationState.ERROR)
                 || this.groupSubnet.getValidationState().equals(ValidationState.ERROR)
                 || this.groupDefaultLease.getValidationState().equals(ValidationState.ERROR)
-                || this.groupMaxLease.getValidationState().equals(ValidationState.ERROR)) {
-            return false;
-        } else {
-            return true;
-        }
+                || this.groupMaxLease.getValidationState().equals(ValidationState.ERROR));
     }
 
     @Override
@@ -254,16 +250,6 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
 
     // enable/disable fields depending on values in other tabs
     private void refreshForm() {
-        // if (!tcpTab.isLanEnabled()) {
-        // router.setEnabled(false);
-        // begin.setEnabled(false);
-        // end.setEnabled(false);
-        // subnet.setEnabled(false);
-        // defaultL.setEnabled(false);
-        // max.setEnabled(false);
-        // radio1.setEnabled(false);
-        // radio2.setEnabled(false);
-        // } else {
         GwtWifiConfig wifiConfig = this.wirelessTab.activeConfig;
         String wifiMode = null;
         if (wifiConfig != null) {
@@ -310,7 +296,6 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
                 this.radio2.setEnabled(true);
             }
         }
-        // }
     }
 
     private void reset() {
@@ -347,134 +332,16 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     }
 
     private void initForm() {
-        // Router Mode
-        this.labelRouter.setText(MSGS.netRouterMode());
-        int i = 0;
-        for (GwtNetRouterMode mode : GwtNetRouterMode.values()) {
-            this.router.addItem(MessageUtils.get(mode.name()));
+        initRouterMode();
+        initDHCPBeginAddress();
+        initDHCPEndAddress();
+        initDHCPSubnetMask();
+        initDefaultLeaseTime();
+        initMaxLeaseTime();
+        initPassDNS();
+    }
 
-            if (this.tcpTab.isDhcp() && mode.equals(GwtNetRouterMode.netRouterOff)) {
-                this.router.setSelectedIndex(i);
-            }
-            i++;
-        }
-        this.router.addMouseOverHandler(event -> {
-            if (TabDhcpNatUi.this.router.isEnabled()) {
-                TabDhcpNatUi.this.helpText.clear();
-                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipMode()));
-            }
-        });
-        this.router.addMouseOutHandler(event -> resetHelp());
-        this.router.addChangeHandler(event -> {
-            setDirty(true);
-            ListBox box = (ListBox) event.getSource();
-            if (TabDhcpNatUi.this.tcpTab.isDhcp() && !box.getSelectedItemText().equals(ROUTER_OFF_MESSAGE)) { // MessageUtils.get(GwtNetRouterMode.netRouterOff.name())))
-                // { TODO:check
-                TabDhcpNatUi.this.groupRouter.setValidationState(ValidationState.ERROR);
-                TabDhcpNatUi.this.helpRouter.setText(MSGS.netRouterConfiguredForDhcpError());
-                TabDhcpNatUi.this.helpRouter.setColor("red");
-            } else {
-                TabDhcpNatUi.this.groupRouter.setValidationState(ValidationState.NONE);
-                TabDhcpNatUi.this.helpRouter.setText("");
-            }
-            if (router.getSelectedIndex() == 0 || router.getSelectedIndex() == 2) {
-                alertDialog.show(MSGS.netRouterDhcpNATWarning(), Severity.ALERT, (ConfirmListener) null);
-            }
-            refreshForm();
-        });
-
-        // DHCP Beginning Address
-        this.labelBegin.setText(MSGS.netRouterDhcpBeginningAddress());
-        this.begin.addMouseOverHandler(event -> {
-            if (TabDhcpNatUi.this.router.isEnabled()) {
-                TabDhcpNatUi.this.helpText.clear();
-                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpBeginAddr()));
-            }
-        });
-        this.begin.addMouseOutHandler(event -> resetHelp());
-        this.begin.addValueChangeHandler(event -> {
-            setDirty(true);
-            if (!TabDhcpNatUi.this.begin.getText().matches(REGEX_IPV4)) {
-                TabDhcpNatUi.this.groupBegin.setValidationState(ValidationState.ERROR);
-            } else {
-                TabDhcpNatUi.this.groupBegin.setValidationState(ValidationState.NONE);
-            }
-        });
-
-        // DHCP Ending Address
-        this.labelEnd.setText(MSGS.netRouterDhcpEndingAddress());
-        this.end.addMouseOverHandler(event -> {
-            if (TabDhcpNatUi.this.router.isEnabled()) {
-                TabDhcpNatUi.this.helpText.clear();
-                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpEndAddr()));
-            }
-        });
-        this.end.addMouseOutHandler(event -> resetHelp());
-        this.end.addValueChangeHandler(event -> {
-            setDirty(true);
-            if (!TabDhcpNatUi.this.end.getText().matches(REGEX_IPV4)) {
-                TabDhcpNatUi.this.groupEnd.setValidationState(ValidationState.ERROR);
-            } else {
-                TabDhcpNatUi.this.groupEnd.setValidationState(ValidationState.NONE);
-            }
-        });
-
-        // DHCP Subnet Mask
-        this.labelSubnet.setText(MSGS.netRouterDhcpSubnetMask());
-        this.subnet.addMouseOverHandler(event -> {
-            if (TabDhcpNatUi.this.router.isEnabled()) {
-                TabDhcpNatUi.this.helpText.clear();
-                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpSubnet()));
-            }
-        });
-        this.subnet.addMouseOutHandler(event -> resetHelp());
-        this.subnet.addValueChangeHandler(event -> {
-            setDirty(true);
-            if (!TabDhcpNatUi.this.subnet.getText().matches(REGEX_IPV4)) {
-                TabDhcpNatUi.this.groupSubnet.setValidationState(ValidationState.ERROR);
-            } else {
-                TabDhcpNatUi.this.groupSubnet.setValidationState(ValidationState.NONE);
-            }
-        });
-
-        // DHCP Default Lease
-        this.labelDefaultLease.setText(MSGS.netRouterDhcpDefaultLease());
-        this.defaultLease.addMouseOverHandler(event -> {
-            if (TabDhcpNatUi.this.router.isEnabled()) {
-                TabDhcpNatUi.this.helpText.clear();
-                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpDefaultLeaseTime()));
-            }
-        });
-        this.defaultLease.addMouseOutHandler(event -> resetHelp());
-        this.defaultLease.addValueChangeHandler(event -> {
-            setDirty(true);
-            if (!TabDhcpNatUi.this.defaultLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
-                    || !isPositiveInteger(TabDhcpNatUi.this.defaultLease.getText().trim())) {
-                TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.ERROR);
-            } else {
-                TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.NONE);
-            }
-        });
-
-        // DHCP Max Lease
-        this.labelMaxLease.setText(MSGS.netRouterDhcpMaxLease());
-        this.maxLease.addMouseOverHandler(event -> {
-            if (TabDhcpNatUi.this.router.isEnabled()) {
-                TabDhcpNatUi.this.helpText.clear();
-                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpMaxLeaseTime()));
-            }
-        });
-        this.maxLease.addMouseOutHandler(event -> resetHelp());
-        this.maxLease.addValueChangeHandler(event -> {
-            setDirty(true);
-            if (!TabDhcpNatUi.this.maxLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
-                    || !isPositiveInteger(TabDhcpNatUi.this.maxLease.getText().trim())) {
-                TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.ERROR);
-            } else {
-                TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.NONE);
-            }
-        });
-
+    private void initPassDNS() {
         // Pass DNS
         this.labelPass.setText(MSGS.netRouterPassDns());
         this.radio1.setText(MSGS.trueLabel());
@@ -499,6 +366,145 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.helpTitle.setText(MSGS.netHelpTitle());
     }
 
+    private void initMaxLeaseTime() {
+        // DHCP Max Lease
+        this.labelMaxLease.setText(MSGS.netRouterDhcpMaxLease());
+        this.maxLease.addMouseOverHandler(event -> {
+            if (TabDhcpNatUi.this.router.isEnabled()) {
+                TabDhcpNatUi.this.helpText.clear();
+                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpMaxLeaseTime()));
+            }
+        });
+        this.maxLease.addMouseOutHandler(event -> resetHelp());
+        this.maxLease.addValueChangeHandler(event -> {
+            setDirty(true);
+            if (!TabDhcpNatUi.this.maxLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
+                    || !isPositiveInteger(TabDhcpNatUi.this.maxLease.getText().trim())) {
+                TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.ERROR);
+            } else {
+                TabDhcpNatUi.this.groupMaxLease.setValidationState(ValidationState.NONE);
+            }
+        });
+    }
+
+    private void initDefaultLeaseTime() {
+        // DHCP Default Lease
+        this.labelDefaultLease.setText(MSGS.netRouterDhcpDefaultLease());
+        this.defaultLease.addMouseOverHandler(event -> {
+            if (TabDhcpNatUi.this.router.isEnabled()) {
+                TabDhcpNatUi.this.helpText.clear();
+                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpDefaultLeaseTime()));
+            }
+        });
+        this.defaultLease.addMouseOutHandler(event -> resetHelp());
+        this.defaultLease.addValueChangeHandler(event -> {
+            setDirty(true);
+            if (!TabDhcpNatUi.this.defaultLease.getText().trim().matches(FieldType.NUMERIC.getRegex())
+                    || !isPositiveInteger(TabDhcpNatUi.this.defaultLease.getText().trim())) {
+                TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.ERROR);
+            } else {
+                TabDhcpNatUi.this.groupDefaultLease.setValidationState(ValidationState.NONE);
+            }
+        });
+    }
+
+    private void initDHCPSubnetMask() {
+        // DHCP Subnet Mask
+        this.labelSubnet.setText(MSGS.netRouterDhcpSubnetMask());
+        this.subnet.addMouseOverHandler(event -> {
+            if (TabDhcpNatUi.this.router.isEnabled()) {
+                TabDhcpNatUi.this.helpText.clear();
+                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpSubnet()));
+            }
+        });
+        this.subnet.addMouseOutHandler(event -> resetHelp());
+        this.subnet.addValueChangeHandler(event -> {
+            setDirty(true);
+            if (!TabDhcpNatUi.this.subnet.getText().matches(REGEX_IPV4)) {
+                TabDhcpNatUi.this.groupSubnet.setValidationState(ValidationState.ERROR);
+            } else {
+                TabDhcpNatUi.this.groupSubnet.setValidationState(ValidationState.NONE);
+            }
+        });
+    }
+
+    private void initDHCPEndAddress() {
+        // DHCP Ending Address
+        this.labelEnd.setText(MSGS.netRouterDhcpEndingAddress());
+        this.end.addMouseOverHandler(event -> {
+            if (TabDhcpNatUi.this.router.isEnabled()) {
+                TabDhcpNatUi.this.helpText.clear();
+                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpEndAddr()));
+            }
+        });
+        this.end.addMouseOutHandler(event -> resetHelp());
+        this.end.addValueChangeHandler(event -> {
+            setDirty(true);
+            if (!TabDhcpNatUi.this.end.getText().matches(REGEX_IPV4)) {
+                TabDhcpNatUi.this.groupEnd.setValidationState(ValidationState.ERROR);
+            } else {
+                checkDhcpRangeValidity();
+            }
+        });
+    }
+
+    private void initDHCPBeginAddress() {
+        // DHCP Beginning Address
+        this.labelBegin.setText(MSGS.netRouterDhcpBeginningAddress());
+        this.begin.addMouseOverHandler(event -> {
+            if (TabDhcpNatUi.this.router.isEnabled()) {
+                TabDhcpNatUi.this.helpText.clear();
+                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipDhcpBeginAddr()));
+            }
+        });
+        this.begin.addMouseOutHandler(event -> resetHelp());
+        this.begin.addValueChangeHandler(event -> {
+            setDirty(true);
+            if (!TabDhcpNatUi.this.begin.getText().matches(REGEX_IPV4)) {
+                TabDhcpNatUi.this.groupBegin.setValidationState(ValidationState.ERROR);
+            } else {
+                checkDhcpRangeValidity();
+            }
+        });
+    }
+
+    private void initRouterMode() {
+        // Router Mode
+        this.labelRouter.setText(MSGS.netRouterMode());
+        int i = 0;
+        for (GwtNetRouterMode mode : GwtNetRouterMode.values()) {
+            this.router.addItem(MessageUtils.get(mode.name()));
+
+            if (this.tcpTab.isDhcp() && mode.equals(GwtNetRouterMode.netRouterOff)) {
+                this.router.setSelectedIndex(i);
+            }
+            i++;
+        }
+        this.router.addMouseOverHandler(event -> {
+            if (TabDhcpNatUi.this.router.isEnabled()) {
+                TabDhcpNatUi.this.helpText.clear();
+                TabDhcpNatUi.this.helpText.add(new Span(MSGS.netRouterToolTipMode()));
+            }
+        });
+        this.router.addMouseOutHandler(event -> resetHelp());
+        this.router.addChangeHandler(event -> {
+            setDirty(true);
+            ListBox box = (ListBox) event.getSource();
+            if (TabDhcpNatUi.this.tcpTab.isDhcp() && !box.getSelectedItemText().equals(ROUTER_OFF_MESSAGE)) {
+                TabDhcpNatUi.this.groupRouter.setValidationState(ValidationState.ERROR);
+                TabDhcpNatUi.this.helpRouter.setText(MSGS.netRouterConfiguredForDhcpError());
+                TabDhcpNatUi.this.helpRouter.setColor("red");
+            } else {
+                TabDhcpNatUi.this.groupRouter.setValidationState(ValidationState.NONE);
+                TabDhcpNatUi.this.helpRouter.setText("");
+            }
+            if (this.router.getSelectedIndex() == 0 || this.router.getSelectedIndex() == 2) {
+                this.alertDialog.show(MSGS.netRouterDhcpNATWarning(), Severity.ALERT, (ConfirmListener) null);
+            }
+            refreshForm();
+        });
+    }
+
     private void resetHelp() {
         this.helpText.clear();
         this.helpText.add(new Span(MSGS.netHelpDefaultHint()));
@@ -513,5 +519,35 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
             return false;
         }
         return false;
+    }
+
+    private void checkDhcpRangeValidity() {
+        if (!isDhcpRangeValid()) {
+            TabDhcpNatUi.this.groupBegin.setValidationState(ValidationState.ERROR);
+            TabDhcpNatUi.this.groupEnd.setValidationState(ValidationState.ERROR);
+        } else {
+            TabDhcpNatUi.this.groupBegin.setValidationState(ValidationState.NONE);
+            TabDhcpNatUi.this.groupEnd.setValidationState(ValidationState.NONE);
+        }
+    }
+
+    private boolean isDhcpRangeValid() {
+        try {
+            long beginAddress = addressToLong(TabDhcpNatUi.this.begin.getText().trim());
+            long endAddress = addressToLong(TabDhcpNatUi.this.end.getText().trim());
+            return endAddress > beginAddress;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private long addressToLong(String address) {
+        String[] addressArray = address.split("\\.");
+        long addressLong = 0;
+        for (String addressfield : addressArray) {
+            addressLong <<= 8;
+            addressLong |= Long.parseLong(addressfield) & 0x000000ff;
+        }
+        return addressLong;
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.java
@@ -250,7 +250,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
 
     // enable/disable fields depending on values in other tabs
     private void refreshForm() {
-        resetValidations();
+        // resetValidations();
         GwtWifiConfig wifiConfig = this.wirelessTab.activeConfig;
         String wifiMode = null;
         if (wifiConfig != null) {
@@ -286,7 +286,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
                 this.maxLease.setEnabled(true);
                 this.radio1.setEnabled(true);
                 this.radio2.setEnabled(true);
-                setValidations();
+                // setValidations();
             }
         }
     }
@@ -362,6 +362,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     private void initMaxLeaseTime() {
         // DHCP Max Lease
         this.labelMaxLease.setText(MSGS.netRouterDhcpMaxLease());
+        this.labelMaxLease.setShowRequiredIndicator(true);
         this.maxLease.addMouseOverHandler(event -> {
             if (TabDhcpNatUi.this.router.isEnabled()) {
                 TabDhcpNatUi.this.helpText.clear();
@@ -378,6 +379,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     private void initDefaultLeaseTime() {
         // DHCP Default Lease
         this.labelDefaultLease.setText(MSGS.netRouterDhcpDefaultLease());
+        this.labelDefaultLease.setShowRequiredIndicator(true);
         this.defaultLease.addMouseOverHandler(event -> {
             if (TabDhcpNatUi.this.router.isEnabled()) {
                 TabDhcpNatUi.this.helpText.clear();
@@ -394,6 +396,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     private void initDHCPSubnetMask() {
         // DHCP Subnet Mask
         this.labelSubnet.setText(MSGS.netRouterDhcpSubnetMask());
+        this.labelSubnet.setShowRequiredIndicator(true);
         this.subnet.addMouseOverHandler(event -> {
             if (TabDhcpNatUi.this.router.isEnabled()) {
                 TabDhcpNatUi.this.helpText.clear();
@@ -410,6 +413,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     private void initDHCPEndAddress() {
         // DHCP Ending Address
         this.labelEnd.setText(MSGS.netRouterDhcpEndingAddress());
+        this.labelEnd.setShowRequiredIndicator(true);
         this.end.addMouseOverHandler(event -> {
             if (TabDhcpNatUi.this.router.isEnabled()) {
                 TabDhcpNatUi.this.helpText.clear();
@@ -426,6 +430,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
     private void initDHCPBeginAddress() {
         // DHCP Beginning Address
         this.labelBegin.setText(MSGS.netRouterDhcpBeginningAddress());
+        this.labelBegin.setShowRequiredIndicator(true);
         this.begin.addMouseOverHandler(event -> {
             if (TabDhcpNatUi.this.router.isEnabled()) {
                 TabDhcpNatUi.this.helpText.clear();
@@ -435,7 +440,7 @@ public class TabDhcpNatUi extends Composite implements NetworkTab {
         this.begin.addMouseOutHandler(event -> resetHelp());
         this.begin.addValueChangeHandler(event -> {
             setDirty(true);
-            setDHCPBeginAddressValidation();
+            // setDHCPBeginAddressValidation();
         });
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.ui.xml
@@ -90,22 +90,22 @@
                                     ui:field="subnet" />
                             </b:FormGroup>
 
-                            <b:FormGroup ui:field="groupDefaultL">
-                                <b:FormLabel for="defaultL"
-                                    ui:field="labelDefaultL" />
+                            <b:FormGroup ui:field="groupDefaultLease">
+                                <b:FormLabel for="defaultLease"
+                                    ui:field="labelDefaultLease" />
                                 <util:HelpButton
-                                    ui:field="defaultLHelp" />
-                                <b:TextBox b:id="defaultL"
-                                    ui:field="defaultL" />
+                                    ui:field="defaultLeaseHelp" />
+                                <b:TextBox b:id="defaultLease"
+                                    ui:field="defaultLease" />
                             </b:FormGroup>
 
-                            <b:FormGroup ui:field="groupMax">
-                                <b:FormLabel for="max"
-                                    ui:field="labelMax" />
+                            <b:FormGroup ui:field="groupMaxLease">
+                                <b:FormLabel for="maxLease"
+                                    ui:field="labelMaxLease" />
                                 <util:HelpButton
-                                    ui:field="maxHelp" />
-                                <b:TextBox b:id="max"
-                                    ui:field="max" />
+                                    ui:field="maxLeaseHelp" />
+                                <b:TextBox b:id="maxLease"
+                                    ui:field="maxLease" />
                             </b:FormGroup>
 
                             <b:FormGroup>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabDhcpNatUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -494,8 +494,8 @@ netRouterToolTipMode=Select if interface provides DHCP addresses, network addres
 netRouterToolTipDhcpBeginAddr=For DHCP, enter the first available client address.
 netRouterToolTipDhcpEndAddr=For DHCP, enter the last available client address.
 netRouterToolTipDhcpSubnet=For DHCP, enter the network mask.
-netRouterToolTipDhcpDefaultLeaseTime=For DHCP, enter the default time that a client will retain a provided IP address (e.g. 7200).
-netRouterToolTipDhcpMaxLeaseTime=For DHCP, enter the maximum time that a client will retain a provided IP address (e.g. 9600).
+netRouterToolTipDhcpDefaultLeaseTime=For DHCP, enter the default time that a client will retain a provided IP address (e.g. 7200). It must be greater than 0.
+netRouterToolTipDhcpMaxLeaseTime=For DHCP, enter the maximum time that a client will retain a provided IP address (e.g. 9600). It must be greater than 0.
 netRouterToolTipPassDns=Select whether the interface will provide DNS server information.
 
 netWifiWireless=Wireless


### PR DESCRIPTION
This PR adds validations on DHCP IP addresses and Lease times fields in the dhcp/nat tab.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** The following validations are added:

- the default and max lease time cannot be 0 or negative
- the range of the dhcp ip address are checked (end must be greater than begin)

