### PR TITLE
Kura container management (Container Provider - Factory) [depends on PR 1] #2

### DIFF
--- a/kura/distrib/config/kura.build.properties
+++ b/kura/distrib/config/kura.build.properties
@@ -122,3 +122,4 @@ org.eclipse.kura.driver.ble.xdk.version=1.1.0-SNAPSHOT
 org.eclipse.kura.wire.script.filter.version=1.1.0-SNAPSHOT
 
 org.eclipse.kura.container.orchestration.provider.version=1.0.0-SNAPSHOT
+org.eclipse.kura.container.provider.version=1.0.0-SNAPSHOT

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -580,6 +580,11 @@
                                     <artifactId>org.eclipse.kura.wire.ai.component.provider</artifactId>
                                     <version>${org.eclipse.kura.wire.ai.component.provider.version}</version>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kura</groupId>
+                                    <artifactId>org.eclipse.kura.container.provider</artifactId>
+                                    <version>${org.eclipse.kura.container.provider.version}</version>
+                                </artifactItem>
                             </artifactItems>
                             <stripVersion>true</stripVersion>
                             <outputDirectory>${project.basedir}/target/plugins</outputDirectory>
@@ -727,6 +732,7 @@
                                 <move file="target/plugins/org.eclipse.kura.rest.wire.provider.jar" tofile="target/plugins/org.eclipse.kura.rest.wire.provider_${org.eclipse.kura.rest.configuration.provider.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.container.orchestration.provider.jar" tofile="target/plugins/org.eclipse.kura.container.orchestration.provider_${org.eclipse.kura.container.orchestration.provider.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.wire.ai.component.provider.jar" tofile="target/plugins/org.eclipse.kura.wire.ai.component.provider_${org.eclipse.kura.wire.ai.component.provider.version}.jar" />
+                                <move file="target/plugins/org.eclipse.kura.container.provider.jar" tofile="target/plugins/org.eclipse.kura.container.provider_${org.eclipse.kura.container.provider.version}.jar" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -195,9 +195,6 @@
 		<antcall target="linux.bluetooth-config" />
 		<antcall target="linux.watchdog-config" />
 
-		<antcall target="container-orchestration-config" />
-
-
 		<!-- Added Camel bundles configs -->
 		<antcall target="camel-config" />
 
@@ -745,8 +742,6 @@ fi]]>
 		<antcall target="linux-redhat-jars" />
 		<antcall target="linux-systemd-jars" />
 		<antcall target="nvidia-jetson-nano-jars" />
-
-		<antcall target="container-orchestrator-jars" />
 
 		<echo message="Building Kura Distribution for ${build.name}-jars..." />
 

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -195,6 +195,8 @@
 		<antcall target="linux.bluetooth-config" />
 		<antcall target="linux.watchdog-config" />
 
+		<antcall target="container-orchestration-config" />
+
 
 		<!-- Added Camel bundles configs -->
 		<antcall target="camel-config" />
@@ -743,6 +745,8 @@ fi]]>
 		<antcall target="linux-redhat-jars" />
 		<antcall target="linux-systemd-jars" />
 		<antcall target="nvidia-jetson-nano-jars" />
+
+		<antcall target="container-orchestrator-jars" />
 
 		<echo message="Building Kura Distribution for ${build.name}-jars..." />
 
@@ -1814,6 +1818,8 @@ fi]]>
 			file="${project.build.directory}/${build.output.name}/config.ini">
 			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.container.orchestration.provider_${org.eclipse.kura.container.orchestration.provider.version}.jar@4:start" />
+			<entry key="osgi.bundles" operation="+"
+				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.container.provider_${org.eclipse.kura.container.provider.version}.jar@4:start" />
 		</propertyfile>
 	</target>
 	<target name="container-orchestrator-jar">
@@ -1821,6 +1827,9 @@ fi]]>
 			update="true">
 			<zipfileset
 				file="${project.build.directory}/plugins/org.eclipse.kura.container.orchestration.provider_${org.eclipse.kura.container.orchestration.provider.version}.jar"
+				prefix="${build.output.name}/${plugins.folder}" />
+			<zipfileset
+				file="${project.build.directory}/plugins/org.eclipse.kura.container.provider_${org.eclipse.kura.container.provider.version}.jar"
 				prefix="${build.output.name}/${plugins.folder}" />
 		</zip>
 	</target>

--- a/kura/org.eclipse.kura.container.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.container.provider/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Configurable custom container service
+Bundle-SymbolicName: org.eclipse.kura.container.provider;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: EUROTECH
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Import-Package: org.eclipse.kura.container.orchestration.provider;version="[1.0,2.0)",
+ org.eclipse.kura;version="[1.3,2.0)",
+ org.eclipse.kura.configuration;version="[1.2,1.3)",
+ org.eclipse.kura.crypto;version="[1.3,2.0)",
+ org.eclipse.kura.util.configuration;version="[1.0,2.0)",
+ org.osgi.service.component;version="1.4.0",
+ org.slf4j;version="1.7.25"
+Service-Component: OSGI-INF/*.xml
+Bundle-ActivationPolicy: lazy

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/genericdocker.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/genericdocker.xml
@@ -1,0 +1,21 @@
+<!--
+     Copyright (c) 2022 Eurotech and/or its affiliates and others
+   
+     This program and the accompanying materials are made
+     available under the terms of the Eclipse Public License 2.0
+     which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+ 	SPDX-License-Identifier: EPL-2.0
+ 	
+ 	Contributors:
+ 	 Eurotech
+ -->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" enabled="true" activate="activate" configuration-policy="require" deactivate="deactivate" modified="updated" name="org.eclipse.kura.container.provider.ConfigurableGenericDockerService">
+   <implementation class="org.eclipse.kura.container.provider.ConfigurableGenericDockerService"/>
+   <service>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
+   </service>
+   <property name="service.pid" value="org.eclipse.kura.container.provider.ConfigurableGenericDockerService"/>
+   
+   <reference cardinality="1..1" interface="org.eclipse.kura.container.orchestration.provider.DockerService" name="DockerService" policy="static" bind="setDockerService" unbind="unsetDockerService"/>
+</scr:component>

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ConfigurableGenericDockerService.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ConfigurableGenericDockerService.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (c) 2022 Eurotech and/or its affiliates and others
+   
+     This program and the accompanying materials are made
+     available under the terms of the Eclipse Public License 2.0
+     which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+ 	SPDX-License-Identifier: EPL-2.0
+ 	
+ 	Contributors:
+ 	 Eurotech
+ -->
+<MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
+    <OCD id="org.eclipse.kura.container.provider.ConfigurableGenericDockerService" name="Docker Custom Service"
+        description="Allows for the creation of docker containers.">
+
+        <AD id="container.enabled" name="Enabled" type="Boolean" cardinality="1" required="true" default="false"
+            description="Enables this container">
+        </AD>
+
+        <AD id="container.image" name="Image name" description="The image the docker container will be created with. This utility will pull images from docker hub."
+            type="String" cardinality="1" required="true" default="nginx" />
+
+        <AD id="container.image.tag" name="Image tag"
+            description="Describes which image version that should be pulled from docker hub." type="String"
+            cardinality="1" required="true" default="latest" />
+
+        <AD id="container.ports.internal" name="Internal ports"
+            description="A comma seperated list of ports. Note, the number of internal ports must be equal to the number of external ports. Example: 80, 443." type="String" cardinality="1" required="true"
+            default="80" />
+
+        <AD id="container.ports.external" name="External ports"
+            description="A comma seperated list of ports. Note, the number of external ports must be equal to the number of internal ports. Example: 8080, 443." type="String" cardinality="1" required="true"
+            default="8080" />
+
+        <AD id="container.privileged" name="Privileged Mode" type="Boolean" cardinality="1" required="true" default="false"
+            description="Give the container privileged access. (Warning: use this option at your own risk as privileged containers can be dangerous.)">
+        </AD>
+        
+        <AD id="container.env" name="Environment Variables"
+            description="Additional container enviroment variables. Example: example_var_1=123, example_var_2=123." type="String" cardinality="1"
+            required="false" default="" />
+            
+        <AD id="container.volume" name="Volume Mount"
+            description="The path on the container at which you would like to mount a file or folder. Example: /path/on/host1:/path/on/container1, /path/on/host2:/path/on/container2." type="String" cardinality="1"
+            required="false" default="" />
+            
+        <AD id="container.device" name="Peripheral Device"
+            description="Used to pass physical devices to a container. Example: /dev/gpiomem, /dev/ttyUSB0. (Generally Requires privileged mode to be enabled.)" type="String" cardinality="1"
+            required="false" default="" />
+            
+
+    </OCD>
+    <Designate pid="org.eclipse.kura.container.provider.ConfigurableGenericDockerService"
+        factoryPid="org.eclipse.kura.container.provider.ConfigurableGenericDockerService">
+        <Object ocdref="org.eclipse.kura.container.provider.ConfigurableGenericDockerService" />
+    </Designate>
+</MetaData>

--- a/kura/org.eclipse.kura.container.provider/about.html
+++ b/kura/org.eclipse.kura.container.provider/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>November 30, 2017</p>
+<h3>License</h3>
+
+<p>
+    The Eclipse Foundation makes available all content in this plug-in
+    (&quot;Content&quot;). Unless otherwise indicated below, the Content
+    is provided to you under the terms and conditions of the Eclipse
+    Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+    available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.
+</p>
+
+<p>
+    If you did not receive this Content directly from the Eclipse
+    Foundation, the Content is being redistributed by another party
+    (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the
+    Redistributor's license that was provided with the Content. If no such
+    license exists, contact the Redistributor. Unless otherwise indicated
+    below, the terms and conditions of the EPL still apply to any source
+    code in the Content and such source code may be obtained at <a
+        href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/kura/org.eclipse.kura.container.provider/about_files/epl-v20.html
+++ b/kura/org.eclipse.kura.container.provider/about_files/epl-v20.html
@@ -1,0 +1,301 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>Eclipse Public License - Version 2.0</title>
+  <style type="text/css">
+    body {
+      margin: 1.5em 3em;
+    }
+    h1{
+      font-size:1.5em;
+    }
+    h2{
+      font-size:1em;
+      margin-bottom:0.5em;
+      margin-top:1em;
+    }
+    p {
+      margin-top:  0.5em;
+      margin-bottom: 0.5em;
+    }
+    ul, ol{
+      list-style-type:none;
+    }
+  </style>
+</head>
+<body>
+<h1>Eclipse Public License - v 2.0</h1>
+<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+  PUBLIC LICENSE (&ldquo;AGREEMENT&rdquo;). ANY USE, REPRODUCTION OR DISTRIBUTION
+  OF THE PROGRAM CONSTITUTES RECIPIENT&#039;S ACCEPTANCE OF THIS AGREEMENT.
+</p>
+<h2 id="definitions">1. DEFINITIONS</h2>
+<p>&ldquo;Contribution&rdquo; means:</p>
+<ul>
+  <li>a) in the case of the initial Contributor, the initial content
+    Distributed under this Agreement, and
+  </li>
+  <li>
+    b) in the case of each subsequent Contributor:
+    <ul>
+      <li>i) changes to the Program, and</li>
+      <li>ii) additions to the Program;</li>
+    </ul>
+    where such changes and/or additions to the Program originate from
+    and are Distributed by that particular Contributor. A Contribution
+    &ldquo;originates&rdquo; from a Contributor if it was added to the Program by such
+    Contributor itself or anyone acting on such Contributor&#039;s behalf.
+    Contributions do not include changes or additions to the Program that
+    are not Modified Works.
+  </li>
+</ul>
+<p>&ldquo;Contributor&rdquo; means any person or entity that Distributes the Program.</p>
+<p>&ldquo;Licensed Patents&rdquo; mean patent claims licensable by a Contributor which
+  are necessarily infringed by the use or sale of its Contribution alone
+  or when combined with the Program.
+</p>
+<p>&ldquo;Program&rdquo; means the Contributions Distributed in accordance with this
+  Agreement.
+</p>
+<p>&ldquo;Recipient&rdquo; means anyone who receives the Program under this Agreement
+  or any Secondary License (as applicable), including Contributors.
+</p>
+<p>&ldquo;Derivative Works&rdquo; shall mean any work, whether in Source Code or other
+  form, that is based on (or derived from) the Program and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship.
+</p>
+<p>&ldquo;Modified Works&rdquo; shall mean any work in Source Code or other form that
+  results from an addition to, deletion from, or modification of the
+  contents of the Program, including, for purposes of clarity any new file
+  in Source Code form that contains any contents of the Program. Modified
+  Works shall not include works that contain only declarations, interfaces,
+  types, classes, structures, or files of the Program solely in each case
+  in order to link to, bind by name, or subclass the Program or Modified
+  Works thereof.
+</p>
+<p>&ldquo;Distribute&rdquo; means the acts of a) distributing or b) making available
+  in any manner that enables the transfer of a copy.
+</p>
+<p>&ldquo;Source Code&rdquo; means the form of a Program preferred for making
+  modifications, including but not limited to software source code,
+  documentation source, and configuration files.
+</p>
+<p>&ldquo;Secondary License&rdquo; means either the GNU General Public License,
+  Version 2.0, or any later versions of that license, including any
+  exceptions or additional permissions as identified by the initial
+  Contributor.
+</p>
+<h2 id="grant-of-rights">2. GRANT OF RIGHTS</h2>
+<ul>
+  <li>a) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free copyright
+    license to reproduce, prepare Derivative Works of, publicly display,
+    publicly perform, Distribute and sublicense the Contribution of such
+    Contributor, if any, and such Derivative Works.
+  </li>
+  <li>b) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free patent
+    license under Licensed Patents to make, use, sell, offer to sell,
+    import and otherwise transfer the Contribution of such Contributor,
+    if any, in Source Code or other form. This patent license shall
+    apply to the combination of the Contribution and the Program if,
+    at the time the Contribution is added by the Contributor, such
+    addition of the Contribution causes such combination to be covered
+    by the Licensed Patents. The patent license shall not apply to any
+    other combinations which include the Contribution. No hardware per
+    se is licensed hereunder.
+  </li>
+  <li>c) Recipient understands that although each Contributor grants the
+    licenses to its Contributions set forth herein, no assurances are
+    provided by any Contributor that the Program does not infringe the
+    patent or other intellectual property rights of any other entity.
+    Each Contributor disclaims any liability to Recipient for claims
+    brought by any other entity based on infringement of intellectual
+    property rights or otherwise. As a condition to exercising the rights
+    and licenses granted hereunder, each Recipient hereby assumes sole
+    responsibility to secure any other intellectual property rights needed,
+    if any. For example, if a third party patent license is required to
+    allow Recipient to Distribute the Program, it is Recipient&#039;s
+    responsibility to acquire that license before distributing the Program.
+  </li>
+  <li>d) Each Contributor represents that to its knowledge it has sufficient
+    copyright rights in its Contribution, if any, to grant the copyright
+    license set forth in this Agreement.
+  </li>
+  <li>e) Notwithstanding the terms of any Secondary License, no Contributor
+    makes additional grants to any Recipient (other than those set forth
+    in this Agreement) as a result of such Recipient&#039;s receipt of the
+    Program under the terms of a Secondary License (if permitted under
+    the terms of Section 3).
+  </li>
+</ul>
+<h2 id="requirements">3. REQUIREMENTS</h2>
+<p>3.1 If a Contributor Distributes the Program in any form, then:</p>
+<ul>
+  <li>a) the Program must also be made available as Source Code, in
+    accordance with section 3.2, and the Contributor must accompany
+    the Program with a statement that the Source Code for the Program
+    is available under this Agreement, and informs Recipients how to
+    obtain it in a reasonable manner on or through a medium customarily
+    used for software exchange; and
+  </li>
+  <li>
+    b) the Contributor may Distribute the Program under a license
+    different than this Agreement, provided that such license:
+    <ul>
+      <li>i) effectively disclaims on behalf of all other Contributors all
+        warranties and conditions, express and implied, including warranties
+        or conditions of title and non-infringement, and implied warranties
+        or conditions of merchantability and fitness for a particular purpose;
+      </li>
+      <li>ii) effectively excludes on behalf of all other Contributors all
+        liability for damages, including direct, indirect, special, incidental
+        and consequential damages, such as lost profits;
+      </li>
+      <li>iii) does not attempt to limit or alter the recipients&#039; rights in the
+        Source Code under section 3.2; and
+      </li>
+      <li>iv) requires any subsequent distribution of the Program by any party
+        to be under a license that satisfies the requirements of this section 3.
+      </li>
+    </ul>
+  </li>
+</ul>
+<p>3.2 When the Program is Distributed as Source Code:</p>
+<ul>
+  <li>a) it must be made available under this Agreement, or if the Program (i)
+    is combined with other material in a separate file or files made available
+    under a Secondary License, and (ii) the initial Contributor attached to
+    the Source Code the notice described in Exhibit A of this Agreement,
+    then the Program may be made available under the terms of such
+    Secondary Licenses, and
+  </li>
+  <li>b) a copy of this Agreement must be included with each copy of the Program.</li>
+</ul>
+<p>3.3 Contributors may not remove or alter any copyright, patent, trademark,
+  attribution notices, disclaimers of warranty, or limitations of liability
+  (&lsquo;notices&rsquo;) contained within the Program from any copy of the Program which
+  they Distribute, provided that Contributors may add their own appropriate
+  notices.
+</p>
+<h2 id="commercial-distribution">4. COMMERCIAL DISTRIBUTION</h2>
+<p>Commercial distributors of software may accept certain responsibilities
+  with respect to end users, business partners and the like. While this
+  license is intended to facilitate the commercial use of the Program, the
+  Contributor who includes the Program in a commercial product offering should
+  do so in a manner which does not create potential liability for other
+  Contributors. Therefore, if a Contributor includes the Program in a
+  commercial product offering, such Contributor (&ldquo;Commercial Contributor&rdquo;)
+  hereby agrees to defend and indemnify every other Contributor
+  (&ldquo;Indemnified Contributor&rdquo;) against any losses, damages and costs
+  (collectively &ldquo;Losses&rdquo;) arising from claims, lawsuits and other legal actions
+  brought by a third party against the Indemnified Contributor to the extent
+  caused by the acts or omissions of such Commercial Contributor in connection
+  with its distribution of the Program in a commercial product offering.
+  The obligations in this section do not apply to any claims or Losses relating
+  to any actual or alleged intellectual property infringement. In order to
+  qualify, an Indemnified Contributor must: a) promptly notify the
+  Commercial Contributor in writing of such claim, and b) allow the Commercial
+  Contributor to control, and cooperate with the Commercial Contributor in,
+  the defense and any related settlement negotiations. The Indemnified
+  Contributor may participate in any such claim at its own expense.
+</p>
+<p>For example, a Contributor might include the Program
+  in a commercial product offering, Product X. That Contributor is then a
+  Commercial Contributor. If that Commercial Contributor then makes performance
+  claims, or offers warranties related to Product X, those performance claims
+  and warranties are such Commercial Contributor&#039;s responsibility alone.
+  Under this section, the Commercial Contributor would have to defend claims
+  against the other Contributors related to those performance claims and
+  warranties, and if a court requires any other Contributor to pay any damages
+  as a result, the Commercial Contributor must pay those damages.
+</p>
+<h2 id="warranty">5. NO WARRANTY</h2>
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED
+  BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN &ldquo;AS IS&rdquo; BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
+  WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
+  MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is
+  solely responsible for determining the appropriateness of using and
+  distributing the Program and assumes all risks associated with its
+  exercise of rights under this Agreement, including but not limited to the
+  risks and costs of program errors, compliance with applicable laws, damage
+  to or loss of data, programs or equipment, and unavailability or
+  interruption of operations.
+</p>
+<h2 id="disclaimer">6. DISCLAIMER OF LIABILITY</h2>
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED
+  BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY
+  LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+  OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS),
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS
+  GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+</p>
+<h2 id="general">7. GENERAL</h2>
+<p>If any provision of this Agreement is invalid or unenforceable under
+  applicable law, it shall not affect the validity or enforceability of the
+  remainder of the terms of this Agreement, and without further action by the
+  parties hereto, such provision shall be reformed to the minimum extent
+  necessary to make such provision valid and enforceable.
+</p>
+<p>If Recipient institutes patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+  (excluding combinations of the Program with other software or hardware)
+  infringes such Recipient&#039;s patent(s), then such Recipient&#039;s rights granted
+  under Section 2(b) shall terminate as of the date such litigation is filed.
+</p>
+<p>All Recipient&#039;s rights under this Agreement shall terminate if it fails to
+  comply with any of the material terms or conditions of this Agreement and
+  does not cure such failure in a reasonable period of time after becoming
+  aware of such noncompliance. If all Recipient&#039;s rights under this Agreement
+  terminate, Recipient agrees to cease use and distribution of the Program
+  as soon as reasonably practicable. However, Recipient&#039;s obligations under
+  this Agreement and any licenses granted by Recipient relating to the
+  Program shall continue and survive.
+</p>
+<p>Everyone is permitted to copy and distribute copies of this Agreement,
+  but in order to avoid inconsistency the Agreement is copyrighted and may
+  only be modified in the following manner. The Agreement Steward reserves
+  the right to publish new versions (including revisions) of this Agreement
+  from time to time. No one other than the Agreement Steward has the right
+  to modify this Agreement. The Eclipse Foundation is the initial Agreement
+  Steward. The Eclipse Foundation may assign the responsibility to serve as
+  the Agreement Steward to a suitable separate entity. Each new version of
+  the Agreement will be given a distinguishing version number. The Program
+  (including Contributions) may always be Distributed subject to the version
+  of the Agreement under which it was received. In addition, after a new
+  version of the Agreement is published, Contributor may elect to Distribute
+  the Program (including its Contributions) under the new version.
+</p>
+<p>Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+  receives no rights or licenses to the intellectual property of any
+  Contributor under this Agreement, whether expressly, by implication,
+  estoppel or otherwise. All rights in the Program not expressly granted
+  under this Agreement are reserved. Nothing in this Agreement is intended
+  to be enforceable by any entity that is not a Contributor or Recipient.
+  No third-party beneficiary rights are created under this Agreement.
+</p>
+<h2 id="exhibit-a">Exhibit A &ndash; Form of Secondary Licenses Notice</h2>
+<p>&ldquo;This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set forth
+  in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+  version(s), and exceptions or additional permissions here}.&rdquo;
+</p>
+<blockquote>
+  <p>Simply including a copy of this Agreement, including this Exhibit A
+    is not sufficient to license the Source Code under Secondary Licenses.
+  </p>
+  <p>If it is not possible or desirable to put the notice in a particular file,
+    then You may include the notice in a location (such as a LICENSE file in a
+    relevant directory) where a recipient would be likely to look for
+    such a notice.
+  </p>
+  <p>You may add additional accurate notices of copyright ownership.</p>
+</blockquote>
+</body>
+</html>

--- a/kura/org.eclipse.kura.container.provider/build.properties
+++ b/kura/org.eclipse.kura.container.provider/build.properties
@@ -1,0 +1,4 @@
+bin.includes = .,\
+               META-INF/,\
+               OSGI-INF/
+source.. = src/main/java/

--- a/kura/org.eclipse.kura.container.provider/pom.xml
+++ b/kura/org.eclipse.kura.container.provider/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (c) 2022 Eurotech and/or its affiliates and others
+   
+     This program and the accompanying materials are made
+     available under the terms of the Eclipse Public License 2.0
+     which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+ 	SPDX-License-Identifier: EPL-2.0
+ 	
+ 	Contributors:
+ 	 Eurotech
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>org.eclipse.kura</groupId>
+      <artifactId>kura</artifactId>
+      <version>5.1.0-SNAPSHOT</version>
+    </parent>
+
+  <artifactId>org.eclipse.kura.container.provider</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>eclipse-plugin</packaging>
+
+
+  <properties>
+    <kura.basedir>${project.basedir}/..</kura.basedir>
+    <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test/*/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+</properties>
+
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.eclipse.tycho</groupId>
+      <artifactId>tycho-packaging-plugin</artifactId>
+      <version>${tycho-version}</version>
+    </plugin>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-jarsigner-plugin</artifactId>
+      <version>1.4</version>
+    </plugin>
+    <plugin>
+	  <groupId>de.dentrassi.maven</groupId>
+	  <artifactId>osgi-dp</artifactId>
+	  <version>0.4.1</version>
+		<executions>
+			<execution>
+				<goals>
+					<goal>build</goal>
+				</goals>
+			</execution>
+		</executions>
+	</plugin>
+  </plugins>
+  <pluginManagement>
+    <plugins>
+      <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+      <plugin>
+        <groupId>org.eclipse.m2e</groupId>
+        <artifactId>lifecycle-mapping</artifactId>
+        <version>1.0.0</version>
+        <configuration>
+          <lifecycleMappingMetadata>
+            <pluginExecutions>
+              <pluginExecution>
+                <pluginExecutionFilter>
+                  <groupId>
+                    org.codehaus.mojo
+                  </groupId>
+                  <artifactId>
+                    properties-maven-plugin
+                  </artifactId>
+                  <versionRange>
+                    [1.0-alpha-1,)
+                  </versionRange>
+                  <goals>
+                    <goal>read-project-properties</goal>
+                  </goals>
+                </pluginExecutionFilter>
+                <action>
+                  <ignore />
+                </action>
+              </pluginExecution>
+              <pluginExecution>
+                <pluginExecutionFilter>
+                  <groupId>
+                    org.codehaus.mojo
+                  </groupId>
+                  <artifactId>
+                    build-helper-maven-plugin
+                  </artifactId>
+                  <versionRange>
+                    [1.9,)
+                  </versionRange>
+                  <goals>
+                    <goal>
+                      regex-property
+                    </goal>
+                  </goals>
+                </pluginExecutionFilter>
+                <action>
+                  <ignore></ignore>
+                </action>
+              </pluginExecution>
+            </pluginExecutions>
+          </lifecycleMappingMetadata>
+        </configuration>
+      </plugin>
+    </plugins>
+  </pluginManagement>
+</build>
+</project>

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ConfigurableGenericDockerService.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ConfigurableGenericDockerService.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+  * Copyright (c) 2022 Eurotech and/or its affiliates and others
+  * 
+  * This program and the accompanying materials are made
+  * available under the terms of the Eclipse Public License 2.0
+  * which is available at https://www.eclipse.org/legal/epl-2.0/
+  * 
+  * SPDX-License-Identifier: EPL-2.0
+  * 
+  * Contributors:
+  *  Eurotech
+  *******************************************************************************/
+
+package org.eclipse.kura.container.provider;
+
+import static java.util.Objects.isNull;
+
+import java.util.Map;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.configuration.ConfigurableComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.eclipse.kura.container.orchestration.provider.DockerService;
+
+public class ConfigurableGenericDockerService implements ConfigurableComponent {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConfigurableGenericDockerService.class);
+    private static final String APP_ID = "org.eclipse.kura.container.provider.ConfigurableGenericDockerService";
+    public static final String DEFAULT_INSTANCE_PID = APP_ID;
+
+    private ConfigurableGenericDockerServiceOptions serviceOptions;
+
+    private DockerService dockerService;
+
+    public void setDockerService(DockerService dockerService) {
+        this.dockerService = dockerService;
+    }
+
+    public void unsetDockerService(DockerService dockerService) {
+        if (this.dockerService == dockerService) {
+            this.dockerService = null;
+        }
+    }
+
+    // ----------------------------------------------------------------
+    //
+    // Activation APIs
+    //
+    // ----------------------------------------------------------------
+
+    public void activate(final Map<String, Object> properties) {
+        logger.info("activating...");
+
+        updated(properties);
+
+        logger.info("activating...done");
+    }
+
+    public void updated(Map<String, Object> properties) {
+        ConfigurableGenericDockerServiceOptions newProps = new ConfigurableGenericDockerServiceOptions(properties);
+
+        if (newProps.equals(this.serviceOptions)) {
+            return;
+        }
+
+        if (!isNull(this.serviceOptions) && this.serviceOptions.isEnabled()) {
+            stopRunningMicroservice();
+        }
+        this.serviceOptions = newProps;
+
+        if (this.serviceOptions.isEnabled()) {
+            startNewMicroservice();
+        }
+    }
+
+    public void deactivate() {
+        logger.info("deactivate...");
+        logger.info("cleaning up related container: {}", this.serviceOptions.getContainerName());
+
+        if (this.serviceOptions.isEnabled()) {
+            stopRunningMicroservice();
+        }
+
+        logger.info("deactivate...done");
+    }
+
+    // ----------------------------------------------------------------
+    //
+    // Private methods
+    //
+    // ----------------------------------------------------------------
+
+    private void startNewMicroservice() {
+        if (isNull(this.serviceOptions) || isNull(this.dockerService)) {
+            return;
+        }
+        try {
+            this.dockerService.startContainer(this.serviceOptions.getContainerDescriptor());
+        } catch (KuraException e) {
+            logger.error("Error managing microservice state", e);
+        }
+    }
+
+    private void stopRunningMicroservice() {
+        if (isNull(this.serviceOptions) || isNull(this.dockerService)) {
+            return;
+        }
+        try {
+            this.dockerService.stopContainer(this.serviceOptions.getContainerDescriptor());
+        } catch (KuraException e) {
+            logger.error("Error stopping microservice {}", this.serviceOptions.getContainerName(), e);
+        }
+    }
+}

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ConfigurableGenericDockerServiceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ConfigurableGenericDockerServiceOptions.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+  * Copyright (c) 2022 Eurotech and/or its affiliates and others
+  * 
+  * This program and the accompanying materials are made
+  * available under the terms of the Eclipse Public License 2.0
+  * which is available at https://www.eclipse.org/legal/epl-2.0/
+  * 
+  * SPDX-License-Identifier: EPL-2.0
+  * 
+  * Contributors:
+  *  Eurotech
+  *******************************************************************************/
+
+package org.eclipse.kura.container.provider;
+
+import static java.util.Objects.isNull;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.kura.util.configuration.Property;
+
+import org.eclipse.kura.container.orchestration.provider.ContainerDescriptor;
+
+public class ConfigurableGenericDockerServiceOptions {
+
+    private static final Property<Boolean> IS_ENABLED = new Property<>("container.enabled", false);
+    private static final Property<String> CONTAINER_IMAGE = new Property<>("container.image", "nginx");
+    private static final Property<String> CONTAINER_IMAGE_TAG = new Property<>("container.image.tag", "latest");
+    private static final Property<String> CONTAINER_NAME = new Property<>("kura.service.pid", "kura_test_container");
+    private static final Property<String> CONTAINER_PORTS_EXTERNAL = new Property<>("container.ports.external", "");
+    private static final Property<String> CONTAINER_PORTS_INTERNAL = new Property<>("container.ports.internal", "");
+    private static final Property<String> CONTAINER_ENV = new Property<>("container.env", "");
+    private static final Property<String> CONTAINER_VOLUME = new Property<>("container.volume", "");
+    private static final Property<String> CONTAINER_DEVICE = new Property<>("container.device", "");
+    private static final Property<Boolean> CONTAINER_PRIVILEGED = new Property<>("container.privileged", false);
+
+    private final boolean enabled;
+    private final String image;
+    private final String imageTag;
+    private final String containerName;
+    private final int[] internalPorts;
+    private final int[] externalPorts;
+    private final String containerEnv;
+    private final String containerVolumeString;
+    private final String containerDevice;
+    private final boolean privilegedMode;
+    private final Map<String, String> containerVolumes;
+
+    public ConfigurableGenericDockerServiceOptions(final Map<String, Object> properties) {
+        if (isNull(properties)) {
+            throw new IllegalArgumentException("Properties cannot be null!");
+        }
+
+        this.enabled = IS_ENABLED.get(properties);
+        this.image = CONTAINER_IMAGE.get(properties);
+        this.imageTag = CONTAINER_IMAGE_TAG.get(properties);
+        this.containerName = CONTAINER_NAME.get(properties);
+        this.internalPorts = parsePortString(CONTAINER_PORTS_INTERNAL.get(properties));
+        this.externalPorts = parsePortString(CONTAINER_PORTS_EXTERNAL.get(properties));
+        this.containerEnv = CONTAINER_ENV.get(properties);
+        this.containerVolumeString = CONTAINER_VOLUME.get(properties);
+        this.containerVolumes = parseVolume(this.containerVolumeString);
+        this.containerDevice = CONTAINER_DEVICE.get(properties);
+        this.privilegedMode = CONTAINER_PRIVILEGED.get(properties);
+    }
+
+    private Map<String, String> parseVolume(String volumeString) {
+        Map<String, String> map = new HashMap<>();
+
+        if (this.containerVolumeString.isEmpty()) {
+            return map;
+        }
+
+        for (String entry : volumeString.trim().split(",")) {
+            String[] tempEntry = entry.split(":");
+            if (tempEntry.length == 2) {
+                map.put(tempEntry[0].trim(), tempEntry[1].trim());
+            }
+        }
+
+        return map;
+    }
+
+    private List<String> parseEnvVars(String containerVolumeString) {
+        List<String> envList = new LinkedList<>();
+
+        if (containerVolumeString.isEmpty()) {
+            return envList;
+        }
+
+        for (String entry : containerVolumeString.trim().split(",")) {
+            envList.add(entry.trim());
+        }
+
+        return envList;
+    }
+
+    private List<String> parseDeviceStrings(String containerDevice) {
+
+        List<String> deviceList = new LinkedList<>();
+
+        if (containerDevice.isEmpty()) {
+            return deviceList;
+        }
+
+        for (String entry : containerDevice.trim().split(",")) {
+            deviceList.add(entry.trim());
+        }
+
+        return deviceList;
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public String getContainerImage() {
+        return this.image;
+    }
+
+    public String getContainerImageTag() {
+        return this.imageTag;
+    }
+
+    public String getContainerName() {
+        return this.containerName;
+    }
+
+    public int[] getContainerPortsInternal() {
+        return this.internalPorts;
+    }
+
+    public int[] getContainerPortsExternal() {
+        return this.externalPorts;
+    }
+
+    public Map<String, String> getContainerVolumeList() {
+        return parseVolume(this.containerVolumeString);
+    }
+
+    public List<String> getContainerEnvList() {
+        return parseEnvVars(this.containerEnv);
+    }
+
+    public List<String> getContainerDeviceList() {
+        return parseDeviceStrings(this.containerDevice);
+    }
+
+    public boolean getPrivilegedMode() {
+        return this.privilegedMode;
+    }
+
+    public ContainerDescriptor getContainerDescriptor() {
+        return ContainerDescriptor.builder().setContainerName(getContainerName()).setContainerImage(getContainerImage())
+                .setContainerImageTag(getContainerImageTag()).setExternalPort(getContainerPortsExternal())
+                .setInternalPort(getContainerPortsInternal()).addEnvVar(getContainerEnvList())
+                .setVolume(getContainerVolumeList()).setPrivilegedMode(this.privilegedMode)
+                .setDeviceList(getContainerDeviceList()).build();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(this.externalPorts);
+        result = prime * result + Arrays.hashCode(this.internalPorts);
+        result = prime * result + Objects.hash(this.containerDevice, this.containerEnv, this.containerName,
+                this.containerVolumes, this.enabled, this.image, this.imageTag);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConfigurableGenericDockerServiceOptions other = (ConfigurableGenericDockerServiceOptions) obj;
+        return Objects.equals(this.containerDevice, other.containerDevice)
+                && Objects.equals(this.containerEnv, other.containerEnv)
+                && Objects.equals(this.containerName, other.containerName)
+                && Objects.equals(this.containerVolumes, other.containerVolumes) && this.enabled == other.enabled
+                && Arrays.equals(this.externalPorts, other.externalPorts) && Objects.equals(this.image, other.image)
+                && Objects.equals(this.imageTag, other.imageTag)
+                && Arrays.equals(this.internalPorts, other.internalPorts);
+    }
+
+    private int[] parsePortString(String ports) {
+        int[] tempArray = new int[] {};
+        if (ports.isEmpty()) {
+            return tempArray;
+        }
+
+        String[] tempString = ports.trim().replace(" ", "").split(",");
+        tempArray = new int[tempString.length];
+        for (int i = 0; i < tempString.length; i++) {
+            tempArray[i] = Integer.parseInt(tempString[i].trim().replace("-", ""));
+        }
+
+        return tempArray;
+    }
+
+}

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ConfigurableGenericDockerServiceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ConfigurableGenericDockerServiceOptions.java
@@ -185,11 +185,12 @@ public class ConfigurableGenericDockerServiceOptions {
         ConfigurableGenericDockerServiceOptions other = (ConfigurableGenericDockerServiceOptions) obj;
         return Objects.equals(this.containerDevice, other.containerDevice)
                 && Objects.equals(this.containerEnv, other.containerEnv)
-                && Objects.equals(this.containerName, other.containerName)
-                && Objects.equals(this.containerVolumes, other.containerVolumes) && this.enabled == other.enabled
-                && Arrays.equals(this.externalPorts, other.externalPorts) && Objects.equals(this.image, other.image)
+                && Objects.equals(this.containerName, other.containerName) && Objects.equals(this.image, other.image)
                 && Objects.equals(this.imageTag, other.imageTag)
-                && Arrays.equals(this.internalPorts, other.internalPorts);
+                && Objects.equals(this.containerVolumes, other.containerVolumes) && this.enabled == other.enabled
+                && Arrays.equals(this.externalPorts, other.externalPorts)
+                && Arrays.equals(this.internalPorts, other.internalPorts)
+                && Objects.equals(this.privilegedMode, other.privilegedMode);
     }
 
     private int[] parsePortString(String ports) {

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -128,6 +128,8 @@
 
         <module>org.eclipse.kura.wire.ai.component.provider</module>
 
+        <module>org.eclipse.kura.container.provider</module>
+
         <module>features</module>
         <module>emulator</module>
 

--- a/kura/test/org.eclipse.kura.container.provider.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.container.provider.test/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.container.provider.test
+Bundle-SymbolicName: org.eclipse.kura.container.provider.test
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Eurotech
+Fragment-Host: org.eclipse.kura.container.provider
+Automatic-Module-Name: org.eclipse.kura.container.provider.test
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Import-Package: com.eclipsesource.json;version="0.9.5",
+ org.eclipse.kura;version="1.6.0",
+ org.junit;version="4.12.0",
+ org.mockito;version="1.10.19",
+ org.mockito.invocation;version="1.10.19",
+ org.mockito.stubbing;version="1.10.19"
+Require-Bundle: org.eclipse.osgi

--- a/kura/test/org.eclipse.kura.container.provider.test/build.properties
+++ b/kura/test/org.eclipse.kura.container.provider.test/build.properties
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2021 Eurotech and/or its affiliates. All rights reserved. 
+#
+bin.includes = .,\
+               META-INF/
+source.. = src/main/java/

--- a/kura/test/org.eclipse.kura.container.provider.test/pom.xml
+++ b/kura/test/org.eclipse.kura.container.provider.test/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (c) 2022 Eurotech and/or its affiliates and others
+   
+     This program and the accompanying materials are made
+     available under the terms of the Eclipse Public License 2.0
+     which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+ 	SPDX-License-Identifier: EPL-2.0
+ 	
+ 	Contributors:
+ 	 Eurotech
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.kura</groupId>
+        <artifactId>test</artifactId>
+        <version>5.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>org.eclipse.kura.container.provider.test</artifactId>
+    <packaging>eclipse-test-plugin</packaging>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <kura.basedir>${project.basedir}/../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compiletests</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ConfigurableDockerGenericDockerServiceTest.java
+++ b/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ConfigurableDockerGenericDockerServiceTest.java
@@ -1,0 +1,231 @@
+/*******************************************************************************
+  * Copyright (c) 2022 Eurotech and/or its affiliates and others
+  * 
+  * This program and the accompanying materials are made
+  * available under the terms of the Eclipse Public License 2.0
+  * which is available at https://www.eclipse.org/legal/epl-2.0/
+  * 
+  * SPDX-License-Identifier: EPL-2.0
+  * 
+  * Contributors:
+  *  Eurotech
+  *******************************************************************************/
+
+package org.eclipse.kura.container.provider;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.kura.KuraException;
+import org.junit.Test;
+
+import org.eclipse.kura.container.orchestration.provider.ContainerDescriptor;
+import org.eclipse.kura.container.orchestration.provider.DockerService;
+
+public class ConfigurableDockerGenericDockerServiceTest {
+
+    private static final String CONTAINER_PATH_FILE_PATH = "container.path.filePath";
+    private static final String CONTAINER_PATH_DESTINATION = "container.path.destination";
+    private static final String CONTAINER_ENV1 = "container.env1";
+    private static final String CONTAINER_ARGS = "container.args";
+    private static final String CONTAINER_PORTS_INTERNAL = "container.ports.internal";
+    private static final String CONTAINER_PORTS_EXTERNAL = "container.ports.external";
+    private static final String CONTAINER_NAME = "container.name";
+    private static final String CONTAINER_IMAGE_TAG = "container.image.tag";
+    private static final String CONTAINER_IMAGE = "container.image";
+    private static final String CONTAINER_ENABLED = "container.enabled";
+    private static final String CONTAINER_DEVICE = "container.Device";
+
+    private DockerService dockerService;
+    private Map<String, Object> properties;
+    private ConfigurableGenericDockerService configurableGenericDockerService;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testServiceActivateNullProperties() throws KuraException {
+        givenNullProperties();
+        givenConfigurableGenericDockerService();
+        givenDockerService();
+
+        whenActivateInstance();
+    }
+
+    @Test
+    public void testServiceActivateEmptyProperties() throws KuraException {
+        givenEmptyProperties();
+        givenConfigurableGenericDockerService();
+        givenDockerService();
+
+        whenActivateInstance();
+
+        thenNotStoppedMicroservice();
+        thenNotStartedMicroservice();
+
+    }
+
+    @Test
+    public void testServiceActivateWithPropertiesDisabled() throws KuraException {
+        givenFullProperties(false);
+        givenConfigurableGenericDockerService();
+        givenDockerService();
+
+        whenActivateInstance();
+
+        thenNotStoppedMicroservice();
+        thenNotStartedMicroservice();
+
+    }
+
+    @Test
+    public void testServiceActivateWithPropertiesEnabled() throws KuraException {
+        givenFullProperties(true);
+        givenConfigurableGenericDockerService();
+        givenDockerService();
+
+        whenActivateInstance();
+
+        thenNotStoppedMicroservice();
+        thenStartedMicroservice();
+
+    }
+
+    @Test
+    public void testServiceUpdateSameProperties() throws KuraException {
+        givenFullProperties(false);
+        givenConfigurableGenericDockerService();
+        givenDockerService();
+        givenActivateInstance();
+
+        whenUpdateInstance();
+
+        thenNotStoppedMicroservice();
+        thenNotStartedMicroservice();
+
+    }
+
+    @Test
+    public void testServiceUpdateEnable() throws KuraException {
+        givenFullProperties(false);
+        givenConfigurableGenericDockerService();
+        givenDockerService();
+        givenActivateInstance();
+        givenFullProperties(true);
+
+        whenUpdateInstance();
+
+        thenNotStoppedMicroservice();
+        thenStartedMicroservice();
+
+    }
+
+    @Test
+    public void testServiceUpdateDisable() throws KuraException {
+        givenFullProperties(true);
+        givenConfigurableGenericDockerService();
+        givenDockerService();
+        givenActivateInstance();
+        givenDockerService();
+        givenFullProperties(false);
+
+        whenUpdateInstance();
+
+        thenStoppedMicroservice();
+        thenNotStartedMicroservice();
+    }
+
+    @Test
+    public void testServiceDeactivateNoRunningContainers() throws KuraException {
+        givenFullProperties(false);
+        givenConfigurableGenericDockerService();
+        givenDockerService();
+        givenActivateInstance();
+
+        whenDeactivateInstance();
+
+        thenNotStoppedMicroservice();
+        thenNotStartedMicroservice();
+    }
+
+    @Test
+    public void testServiceDeactivateRunningContainers() throws KuraException {
+        givenFullProperties(true);
+        givenConfigurableGenericDockerService();
+        givenDockerService();
+        givenActivateInstance();
+        givenDockerService();
+
+        whenDeactivateInstance();
+
+        thenStoppedMicroservice();
+        thenNotStartedMicroservice();
+    }
+
+    private void givenDockerService() {
+        this.dockerService = mock(DockerService.class);
+        this.configurableGenericDockerService.setDockerService(this.dockerService);
+    }
+
+    private void givenNullProperties() {
+        this.properties = null;
+    }
+
+    private void givenEmptyProperties() {
+        this.properties = new HashMap<>();
+    }
+
+    private void givenFullProperties(boolean enabled) {
+        this.properties = new HashMap<>();
+        this.properties.put(CONTAINER_ENABLED, enabled);
+        this.properties.put(CONTAINER_IMAGE, "myimage");
+        this.properties.put(CONTAINER_IMAGE_TAG, "mytag");
+        this.properties.put(CONTAINER_NAME, "myname");
+        this.properties.put(CONTAINER_PORTS_EXTERNAL, "");
+        this.properties.put(CONTAINER_PORTS_INTERNAL, "");
+        this.properties.put(CONTAINER_ARGS, "");
+        this.properties.put(CONTAINER_ENV1, "");
+        this.properties.put(CONTAINER_PATH_DESTINATION, "");
+        this.properties.put(CONTAINER_PATH_FILE_PATH, "");
+        this.properties.put(CONTAINER_DEVICE, "");
+    }
+
+    private void givenConfigurableGenericDockerService() {
+        this.configurableGenericDockerService = new ConfigurableGenericDockerService();
+    }
+
+    private void givenActivateInstance() {
+        whenActivateInstance();
+    }
+
+    private void whenActivateInstance() {
+        this.configurableGenericDockerService.activate(this.properties);
+    }
+
+    private void whenUpdateInstance() {
+        this.configurableGenericDockerService.updated(this.properties);
+    }
+
+    private void whenDeactivateInstance() {
+        this.configurableGenericDockerService.deactivate();
+    }
+
+    private void thenStoppedMicroservice() throws KuraException {
+        verify(this.dockerService, times(1)).stopContainer(any(ContainerDescriptor.class));
+    }
+
+    private void thenNotStoppedMicroservice() throws KuraException {
+        verify(this.dockerService, times(0)).stopContainer(any(ContainerDescriptor.class));
+    }
+
+    private void thenNotStartedMicroservice() throws KuraException {
+        verify(this.dockerService, times(0)).startContainer(any(ContainerDescriptor.class));
+    }
+
+    private void thenStartedMicroservice() throws KuraException {
+        verify(this.dockerService, times(1)).startContainer(any(ContainerDescriptor.class));
+    }
+
+}

--- a/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ConfigurableDockerGernericDockerServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ConfigurableDockerGernericDockerServiceOptionsTest.java
@@ -1,0 +1,551 @@
+/*******************************************************************************
+  * Copyright (c) 2022 Eurotech and/or its affiliates and others
+  * 
+  * This program and the accompanying materials are made
+  * available under the terms of the Eclipse Public License 2.0
+  * which is available at https://www.eclipse.org/legal/epl-2.0/
+  * 
+  * SPDX-License-Identifier: EPL-2.0
+  * 
+  * Contributors:
+  *  Eurotech
+  *******************************************************************************/
+package org.eclipse.kura.container.provider;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.eclipse.kura.container.orchestration.provider.ContainerDescriptor;
+
+public class ConfigurableDockerGernericDockerServiceOptionsTest {
+
+    private static final boolean DEFAULT_ENABLED = false;
+    private static final String DEFAULT_PORTS_EXTERNAL = "";
+    private static final String DEFAULT_CONTAINER_NAME = "kura_test_container";
+    private static final String DEFAULT_IMAGE_TAG = "latest";
+    private static final String DEFAULT_IMAGE = "hello-world";
+    private static final String DEFAULT_PORTS_INTERNAL = "";
+    private static final String DEFAULT_CONTAINER_ENV = "";
+    private static final String DEFAULT_CONTAINER_PATH_DESTINATION = "";
+    private static final String DEFAULT_CONTAINER_PATH_FILE_PATH = "";
+    private static final String DEFAULT_CONTAINER_DEVICE = "";
+
+    private static final String CONTAINER_ENV = "container.env";
+    private static final String CONTAINER_PORTS_INTERNAL = "container.ports.internal";
+    private static final String CONTAINER_PORTS_EXTERNAL = "container.ports.external";
+    private static final String CONTAINER_NAME = "kura.service.pid";
+    private static final String CONTAINER_IMAGE_TAG = "container.image.tag";
+    private static final String CONTAINER_IMAGE = "container.image";
+    private static final String CONTAINER_ENABLED = "container.enabled";
+    private static final String CONTAINER_DEVICE = "container.device";
+    private static final String CONTAINER_VOLUME = "container.volume";
+
+    private Map<String, Object> properties;
+
+    private ConfigurableGenericDockerServiceOptions cgdso;
+
+    private boolean enabled;
+    private String image;
+    private String imageTag;
+    private String containerName;
+    private List<String> containerEnv;
+    private Map<String, String> containerVolumes;
+    private List<String> containerDevice;
+    private int[] portsAvailable;
+    private boolean equals;
+    private int hashCode;
+
+    private ContainerDescriptor containerDescriptor;
+
+    private Map<String, Object> newProperties;
+
+    @Test
+    public void testEnabledDefault() {
+
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenIsEnabled();
+
+        thenEnabledStateIs(false);
+
+    }
+
+    @Test
+    public void testEnabled() {
+
+        givenEmptyProperties();
+        givenEnabled(true);
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenIsEnabled();
+
+        thenEnabledStateIs(true);
+
+    }
+
+    @Test
+    public void testImageDefault() {
+
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetImage();
+
+        thenImage(DEFAULT_IMAGE);
+
+    }
+
+    @Test
+    public void testImage() {
+
+        givenEmptyProperties();
+        givenImage("test");
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetImage();
+
+        thenImage("test");
+    }
+
+    @Test
+    public void testImageTagDefault() {
+
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetImageTag();
+
+        thenImageTag(DEFAULT_IMAGE_TAG);
+
+    }
+
+    @Test
+    public void testImageTag() {
+
+        givenEmptyProperties();
+        givenImageTag("test");
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetImageTag();
+
+        thenImageTag("test");
+    }
+
+    @Test
+    public void testContainerNameDefault() {
+
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerName();
+
+        thenContainerName(DEFAULT_CONTAINER_NAME);
+
+    }
+
+    @Test
+    public void testContainerName() {
+
+        givenEmptyProperties();
+        givenContainerName("test");
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerName();
+
+        thenContainerName("test");
+    }
+
+    @Test
+    public void testContainerEnvDefault() {
+
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerEnv();
+
+        thenContainerEnvIsEmpty();
+
+    }
+
+    @Test
+    public void testContainerEnv() {
+
+        givenEmptyProperties();
+        givenContainerEnv("test=123");
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerEnv();
+
+        thenContainerEnv("test=123");
+    }
+
+    @Test
+    public void testContainerVolumeDefault() {
+
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerVolume();
+
+        thenContainerVolumeIsEmpty();
+
+    }
+
+    @Test
+    public void testContainerVolume() {
+
+        givenEmptyProperties();
+        givenContainerVolume("test", "test");
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerVolume();
+
+        thenContainerVolume("test", "test");
+    }
+
+    @Test
+    public void testContainerDeviceDefault() {
+
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerDevice();
+
+        thenContainerDeviceIsEmpty();
+
+    }
+
+    @Test
+    public void testContainerDevice() {
+
+        givenEmptyProperties();
+        givenContainerDevice("test");
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerDevice();
+
+        thenContainerDevice("test");
+    }
+
+    @Test
+    public void shouldSupportMultipleExternalPortsInOneString() {
+
+        String ports = "22, 56, 77, 567, 4455";
+        int[] portResult = { 22, 56, 77, 567, 4455 };
+
+        givenEmptyProperties();
+        givenPortsConfiguration(CONTAINER_PORTS_EXTERNAL, ports);
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerPortsExternal();
+
+        thenPortResult(portResult);
+
+    }
+
+    @Test
+    public void shouldSupportSingleExternalPortsInOneString() {
+
+        String ports = "22";
+        int[] portResult = { 22 };
+
+        givenEmptyProperties();
+        givenPortsConfiguration(CONTAINER_PORTS_EXTERNAL, ports);
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerPortsExternal();
+
+        thenPortResult(portResult);
+
+    }
+
+    @Test
+    public void shouldSupportSingleBrokenExternalPortsInOneString() {
+
+        String ports = "22,";
+        int[] portResult = { 22 };
+
+        givenEmptyProperties();
+        givenPortsConfiguration(CONTAINER_PORTS_EXTERNAL, ports);
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerPortsExternal();
+
+        thenPortResult(portResult);
+
+    }
+
+    @Test
+    public void testMultipleInternalPortsInOneString() {
+        String ports = "22, 56, 77, 567, 4455";
+        int[] portResult = { 22, 56, 77, 567, 4455 };
+
+        givenEmptyProperties();
+        givenPortsConfiguration(CONTAINER_PORTS_INTERNAL, ports);
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerPortsInternal();
+
+        thenPortResult(portResult);
+    }
+
+    @Test
+    public void testMultipleBrokenInternalPortsInOneString() {
+        String ports = "56 ,";
+        int[] portResult = { 56 };
+
+        givenEmptyProperties();
+        givenPortsConfiguration(CONTAINER_PORTS_INTERNAL, ports);
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerPortsInternal();
+
+        thenPortResult(portResult);
+    }
+
+    @Test
+    public void testSingleInternalPortsInOneString() {
+        String ports = "56";
+        int[] portResult = { 56 };
+
+        givenEmptyProperties();
+        givenPortsConfiguration(CONTAINER_PORTS_INTERNAL, ports);
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerPortsInternal();
+
+        thenPortResult(portResult);
+    }
+
+    @Test
+    public void testOptionsEqualsSameObject() {
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetEquals(this.cgdso);
+        whenGetHashCode(this.cgdso);
+
+        thenIsEqual();
+        thenIsSameHashCode();
+    }
+
+    @Test
+    public void testOptionsEqualsNewSameObject() {
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetEquals(new ConfigurableGenericDockerServiceOptions(this.properties));
+
+        thenIsEqual();
+        thenIsNotSameHashCode();
+    }
+
+    @Test
+    public void testOptionsEqualsDifferentObject() {
+        givenEmptyProperties();
+        givenDifferentProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetEquals(new ConfigurableGenericDockerServiceOptions(this.newProperties));
+
+        thenIsNotEqual();
+        thenIsNotSameHashCode();
+    }
+
+    @Test
+    public void testGetContainerDescriptor() {
+        givenEmptyProperties();
+        givenConfigurableGenericDockerServiceOptions();
+
+        whenGetContainerDescriptor();
+
+        thenIsNotNullContainerDescriptor();
+    }
+
+    private void givenEmptyProperties() {
+        this.properties = new HashMap<>();
+        this.properties.put(CONTAINER_ENABLED, DEFAULT_ENABLED);
+        this.properties.put(CONTAINER_IMAGE, DEFAULT_IMAGE);
+        this.properties.put(CONTAINER_IMAGE_TAG, DEFAULT_IMAGE_TAG);
+        this.properties.put(CONTAINER_NAME, DEFAULT_CONTAINER_NAME);
+        this.properties.put(CONTAINER_PORTS_EXTERNAL, DEFAULT_PORTS_EXTERNAL);
+        this.properties.put(CONTAINER_PORTS_INTERNAL, DEFAULT_PORTS_INTERNAL);
+        this.properties.put(CONTAINER_ENV, DEFAULT_CONTAINER_ENV);
+        this.properties.put(CONTAINER_VOLUME,
+                DEFAULT_CONTAINER_PATH_FILE_PATH + ":" + DEFAULT_CONTAINER_PATH_DESTINATION);
+        this.properties.put(CONTAINER_DEVICE, DEFAULT_CONTAINER_DEVICE);
+    }
+
+    private void givenDifferentProperties() {
+        this.newProperties = new HashMap<>();
+        this.newProperties.put(CONTAINER_ENABLED, true);
+        this.newProperties.put(CONTAINER_IMAGE, "myimage");
+        this.newProperties.put(CONTAINER_IMAGE_TAG, "mytag");
+        this.newProperties.put(CONTAINER_NAME, "myname");
+        this.newProperties.put(CONTAINER_PORTS_EXTERNAL, "");
+        this.newProperties.put(CONTAINER_PORTS_INTERNAL, "");
+        this.newProperties.put(CONTAINER_ENV, "");
+        this.newProperties.put(CONTAINER_VOLUME, "diffrent:diffrent");
+        this.newProperties.put(CONTAINER_DEVICE, "");
+    }
+
+    private void givenConfigurableGenericDockerServiceOptions() {
+        this.cgdso = new ConfigurableGenericDockerServiceOptions(this.properties);
+    }
+
+    private void givenEnabled(boolean b) {
+        this.properties.put(CONTAINER_ENABLED, b);
+    }
+
+    private void givenImage(String value) {
+        this.properties.put(CONTAINER_IMAGE, value);
+    }
+
+    private void givenImageTag(String value) {
+        this.properties.put(CONTAINER_IMAGE_TAG, value);
+    }
+
+    private void givenContainerName(String value) {
+        this.properties.put(CONTAINER_NAME, value);
+    }
+
+    private void givenContainerEnv(String value) {
+        this.properties.put(CONTAINER_ENV, value);
+    }
+
+    private void givenContainerVolume(String source, String dest) {
+        this.properties.put(CONTAINER_VOLUME, source + ":" + dest);
+    }
+
+    private void givenContainerDevice(String value) {
+        this.properties.put(CONTAINER_DEVICE, value);
+    }
+
+    private void givenPortsConfiguration(String portProperty, String Ports) {
+        this.properties.put(portProperty, Ports);
+    }
+
+    private void whenIsEnabled() {
+        this.enabled = this.cgdso.isEnabled();
+    }
+
+    private void whenGetImage() {
+        this.image = this.cgdso.getContainerImage();
+    }
+
+    private void whenGetImageTag() {
+        this.imageTag = this.cgdso.getContainerImageTag();
+    }
+
+    private void whenGetContainerName() {
+        this.containerName = this.cgdso.getContainerName();
+    }
+
+    private void whenGetContainerEnv() {
+        this.containerEnv = this.cgdso.getContainerEnvList();
+    }
+
+    private void whenGetContainerVolume() {
+        this.containerVolumes = this.cgdso.getContainerVolumeList();
+    }
+
+    private void whenGetContainerDevice() {
+        this.containerDevice = this.cgdso.getContainerDeviceList();
+    }
+
+    private void whenGetContainerPortsExternal() {
+        this.portsAvailable = this.cgdso.getContainerPortsExternal();
+    }
+
+    private void whenGetContainerPortsInternal() {
+        this.portsAvailable = this.cgdso.getContainerPortsInternal();
+    }
+
+    private void whenGetEquals(ConfigurableGenericDockerServiceOptions options) {
+        this.equals = this.cgdso.equals(options);
+    }
+
+    private void whenGetHashCode(ConfigurableGenericDockerServiceOptions options) {
+        this.hashCode = options.hashCode();
+    }
+
+    private void whenGetContainerDescriptor() {
+        this.containerDescriptor = this.cgdso.getContainerDescriptor();
+    }
+
+    private void thenEnabledStateIs(boolean b) {
+        assertEquals(b, this.enabled);
+    }
+
+    private void thenImage(String expectedValue) {
+        assertEquals(expectedValue, this.image);
+    }
+
+    private void thenImageTag(String expectedValue) {
+        assertEquals(expectedValue, this.imageTag);
+    }
+
+    private void thenContainerName(String expectedValue) {
+        assertEquals(expectedValue, this.containerName);
+    }
+
+    private void thenContainerEnv(String expectedValue) {
+        assertTrue(this.containerEnv.contains(expectedValue));
+    }
+
+    private void thenContainerEnvIsEmpty() {
+        assertTrue(this.containerEnv.isEmpty());
+    }
+
+    private void thenContainerVolume(String expectedSourceValue, String expectedDestinationValue) {
+        assertTrue(this.containerVolumes.containsKey(expectedSourceValue));
+        assertTrue(this.containerVolumes.containsValue(expectedDestinationValue));
+    }
+
+    private void thenContainerVolumeIsEmpty() {
+        assertTrue(this.containerVolumes.isEmpty());
+    }
+
+    private void thenContainerDevice(String expectedValue) {
+        assertTrue(this.containerDevice.contains(expectedValue));
+    }
+
+    private void thenContainerDeviceIsEmpty() {
+        assertTrue(this.containerDevice.isEmpty());
+    }
+
+    private void thenPortResult(int[] portResult) {
+        assertArrayEquals(portResult, this.portsAvailable);
+    }
+
+    private void thenIsEqual() {
+        assertTrue(this.equals);
+    }
+
+    private void thenIsNotEqual() {
+        assertFalse(this.equals);
+    }
+
+    private void thenIsSameHashCode() {
+        assertEquals(this.cgdso.hashCode(), this.hashCode);
+    }
+
+    private void thenIsNotSameHashCode() {
+        assertNotEquals(this.cgdso.hashCode(), this.hashCode);
+    }
+
+    private void thenIsNotNullContainerDescriptor() {
+        assertNotNull(this.containerDescriptor);
+    }
+}

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -906,6 +906,7 @@
         <module>org.eclipse.kura.util.test.driver</module>
         <module>org.eclipse.kura.container.orchestration.provider.test</module>
         <module>org.eclipse.kura.wire.ai.component.provider.test</module>
+        <module>org.eclipse.kura.container.provider.test</module>
         <!--
         <module>org.eclipse.kura.raspberrypi.sensehat.test</module>
         -->

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -126,5 +126,11 @@ org.apache.felix.useradmin.version=1.0.4.k1
 moquette-broker.version=1.0.0-SNAPSHOT
 org.apache.log4j2-api-config.version=1.0.0
 
+<<<<<<< HEAD
 #Container Orchestration Bundles
 org.eclipse.kura.container.orchestration.provider.version=1.0.0-SNAPSHOT
+=======
+
+
+org.eclipse.kura.container.provider.version=1.0.0-SNAPSHOT
+>>>>>>> c928f74c89 (contribution of of container provider)

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -125,12 +125,3 @@ org.apache.felix.useradmin.version=1.0.4.k1
 #test dependencies versions
 moquette-broker.version=1.0.0-SNAPSHOT
 org.apache.log4j2-api-config.version=1.0.0
-
-<<<<<<< HEAD
-#Container Orchestration Bundles
-org.eclipse.kura.container.orchestration.provider.version=1.0.0-SNAPSHOT
-=======
-
-
-org.eclipse.kura.container.provider.version=1.0.0-SNAPSHOT
->>>>>>> c928f74c89 (contribution of of container provider)


### PR DESCRIPTION
This PR contains a bundle which uses the org.eclipse.kura.container.orchestraion.provider, and provides a configurable-component factory that allows the user to define containers.

Description of the solution adopted:
This solution utilizes a bundle (org.eclipse.kura.container.orchestration.provider) added in a previous PR

Parameters set in a configurable component generates a org.eclipse.kura.container.orchestration.provider.ContainerDescriptor, that is then past to the container-api to instruct a getaways docker-engine to make containers.

Screenshots: If applicable, add screenshots to help explain your solution

![image](https://user-images.githubusercontent.com/29900100/153934872-007a73cb-a625-42e9-90b5-0dd57fc8a85d.png)


Any side note on the changes made: Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]