### PR TITLE
Added support for larger numeric node ids in OPCUA driver

### DIFF
--- a/kura/org.eclipse.kura.driver.opcua.provider/src/main/java/org/eclipse/kura/internal/driver/opcua/OpcUaChannelDescriptor.java
+++ b/kura/org.eclipse.kura.driver.opcua.provider/src/main/java/org/eclipse/kura/internal/driver/opcua/OpcUaChannelDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,7 @@ import org.eclipse.kura.util.collection.CollectionUtil;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 
 /**
  * OPC-UA specific channel descriptor. The descriptor contains the following
@@ -197,7 +198,7 @@ public final class OpcUaChannelDescriptor implements ChannelDescriptor {
         String nodeIdString = properties.get(NODE_ID_PROP_NAME).toString();
         switch (nodeIdType) {
         case NUMERIC:
-            return new NodeId(nodeNamespaceIndex, Integer.parseInt(nodeIdString));
+            return new NodeId(nodeNamespaceIndex, UInteger.valueOf(nodeIdString));
         case STRING:
             return new NodeId(nodeNamespaceIndex, nodeIdString);
         case GUID:

--- a/kura/test/org.eclipse.kura.internal.driver.opcua.test/src/main/java/org/eclipse/kura/internal/driver/opcua/test/TestNamespace.java
+++ b/kura/test/org.eclipse.kura.internal.driver.opcua.test/src/main/java/org/eclipse/kura/internal/driver/opcua/test/TestNamespace.java
@@ -105,8 +105,8 @@ public class TestNamespace implements Namespace {
             { "XmlElementArray", Identifiers.XmlElement, new Variant(new XmlElement("<a>hello</a>")) },
             { "LocalizedTextArray", Identifiers.LocalizedText, new Variant(LocalizedText.english("localized text")) },
             { "QualifiedNameArray", Identifiers.QualifiedName, new Variant(new QualifiedName(1234, "defg")) },
-            { "NodeIdArray", Identifiers.NodeId, new Variant(new NodeId(1234, "abcd")) } };  
-    
+            { "NodeIdArray", Identifiers.NodeId, new Variant(new NodeId(1234, "abcd")) } };
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final SubscriptionModel subscriptionModel;
@@ -125,7 +125,8 @@ public class TestNamespace implements Namespace {
             NodeId folderNodeId = new NodeId(namespaceIndex, IDENTIFIER_HELLO_WORLD);
 
             UaFolderNode folderNode = new UaFolderNode(server.getNodeMap(), folderNodeId,
-                    new QualifiedName(namespaceIndex, IDENTIFIER_HELLO_WORLD), LocalizedText.english(IDENTIFIER_HELLO_WORLD));
+                    new QualifiedName(namespaceIndex, IDENTIFIER_HELLO_WORLD),
+                    LocalizedText.english(IDENTIFIER_HELLO_WORLD));
 
             server.getNodeMap().addNode(folderNode);
 
@@ -215,6 +216,18 @@ public class TestNamespace implements Namespace {
             server.getNodeMap().addNode(node);
             scalarTypesFolder.addOrganizes(node);
         }
+
+        UaVariableNode largeIndex = new UaVariableNode.UaVariableNodeBuilder(server.getNodeMap())
+                .setNodeId(new NodeId(namespaceIndex, UInteger.MAX))
+                .setAccessLevel(ubyte(AccessLevel.getMask(AccessLevel.READ_WRITE)))
+                .setUserAccessLevel(ubyte(AccessLevel.getMask(AccessLevel.READ_WRITE)))
+                .setBrowseName(new QualifiedName(namespaceIndex, "largeIndex"))
+                .setDisplayName(LocalizedText.english("largeIndex")).setDataType(Identifiers.Int32)
+                .setTypeDefinition(Identifiers.BaseDataVariableType).build();
+
+        largeIndex.setValue(new DataValue(new Variant(1234)));
+
+        server.getNodeMap().addNode(largeIndex);
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
