### PR TITLE
Incorrect keystore password after rollback to snapshot0

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -245,6 +245,8 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
             this.keystoreServiceOptions = new KeystoreServiceOptions(props, this.cryptoService);
 
             updatePasswordInConfigService(newPassword);
+            this.cryptoService.setKeyStorePassword(this.keystoreServiceOptions.getKeystorePath(),
+                    this.keystoreServiceOptions.getKeystorePassword(this.cryptoService));
         } catch (Exception e) {
             logger.warn("Keystore password change failed", e);
         }


### PR DESCRIPTION
FilesystemKeystoreServiceImpl#changeDefaultKeystorePassword() now save the generated password in store.save
