### PR TITLE
Attempt to remove jakarta.annotation-api

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -943,8 +943,6 @@ fi]]>
 			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/jakarta.activation-api_${jakarta.activation-api.version}.jar@2" />
 			<entry key="osgi.bundles" operation="+"
-				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/jakarta.annotation-api_${jakarta.annotation-api.version}.jar@2" />
-			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/jakarta.xml.bind-api_${jakarta.xml.bind-api.version}.jar@2" />
 			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/jakarta.xml.ws-api_${jakarta.xml.ws-api.version}.jar@2" />

--- a/kura/examples/test/org.eclipse.kura.example.wire.logic.multiport.provider.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.wire.logic.multiport.provider.test/pom.xml
@@ -402,7 +402,7 @@
                             </requirement>
                             <requirement>
                                 <type>p2-installable-unit</type>
-                                <id>jakarta.annotation-api</id>
+                                <id>com.eclipsesource.jaxrs.jersey-min</id>
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
                             <requirement>

--- a/kura/examples/test/org.eclipse.kura.example.wire.math.singleport.provider.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.wire.math.singleport.provider.test/pom.xml
@@ -406,7 +406,7 @@
                             </requirement>
                             <requirement>
                                 <type>p2-installable-unit</type>
-                                <id>jakarta.annotation-api</id>
+                                <id>com.eclipsesource.jaxrs.jersey-min</id>
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
                             <requirement>

--- a/kura/examples/test/org.eclipse.kura.example.wire.math.trig.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.wire.math.trig.test/pom.xml
@@ -406,7 +406,7 @@
                             </requirement>
                             <requirement>
                                 <type>p2-installable-unit</type>
-                                <id>jakarta.annotation-api</id>
+                                <id>com.eclipsesource.jaxrs.jersey-min</id>
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
                             <requirement>

--- a/kura/examples/test/pom.xml
+++ b/kura/examples/test/pom.xml
@@ -225,7 +225,7 @@
                             </requirement>
                             <requirement>
                                 <type>p2-installable-unit</type>
-                                <id>jakarta.annotation-api</id>
+                                <id>com.eclipsesource.jaxrs.jersey-min</id>
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
                             <requirement>

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -608,7 +608,7 @@
                                 </requirement>
                                 <requirement>
                                     <type>p2-installable-unit</type>
-                                    <id>jakarta.annotation-api</id>
+                                    <id>com.eclipsesource.jaxrs.jersey-min</id>
                                     <versionRange>0.0.0</versionRange>
                                 </requirement>
                                 <requirement>

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -70,7 +70,6 @@ org.jboss.logging.version=3.3.2.Final
 spring.version=4.3.20.RELEASE_1
 
 jakarta.activation-api.version=1.2.2
-jakarta.annotation-api.version=1.3.5
 jakarta.xml.bind-api.version=2.3.3
 jakarta.xml.ws-api.version=2.3.3
 jakarta.xml.soap-api.version=1.4.2

--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -478,11 +478,6 @@
                                     <version>${jakarta.xml.soap-api.version}</version>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>jakarta.annotation</groupId>
-                                    <artifactId>jakarta.annotation-api</artifactId>
-                                    <version>${jakarta.annotation-api.version}</version>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>com.sun.xml.bind</groupId>
                                     <artifactId>jaxb-osgi</artifactId>
                                     <version>${jaxb-osgi.version}</version>
@@ -591,7 +586,6 @@
                                 <move file="target/source/plugins/jakarta.activation-api.jar" tofile="target/source/plugins/jakarta.activation-api_${jakarta.activation-api.version}.jar"/>
                                 <move file="target/source/plugins/jakarta.xml.ws-api.jar" tofile="target/source/plugins/jakarta.xml.ws-api_${jakarta.xml.ws-api.version}.jar"/>
                                 <move file="target/source/plugins/jakarta.xml.soap-api.jar" tofile="target/source/plugins/jakarta.xml.soap-api_${jakarta.xml.soap-api.version}.jar"/>
-                                <move file="target/source/plugins/jakarta.annotation-api.jar" tofile="target/source/plugins/jakarta.annotation-api_${jakarta.annotation-api.version}.jar"/>
                                 <move file="target/source/plugins/jaxb-osgi.jar" tofile="target/source/plugins/jaxb-osgi_${jaxb-osgi.version}.jar"/>
                                 <move file="target/source/plugins/osgi-resource-locator.jar" tofile="target/source/plugins/osgi-resource-locator_${osgi-resource-locator.version}.jar"/>
                                 <move file="target/source/plugins/bluez-dbus-osgi.jar" tofile="target/source/plugins/bluez-dbus-osgi_${bluez-dbus-osgi.version}.jar"/>


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

The packages provided by `jakarta.annotation-api` (`javax.annotation`, `javax.annotation.security` and `javax.annotation.sql`) are already provided by `com.eclipsesource.jaxrs.jersey-min`.
