### PR TITLE
AI Wire Component distrib

### DIFF
--- a/kura/distrib/config/kura.build.properties
+++ b/kura/distrib/config/kura.build.properties
@@ -109,6 +109,7 @@ org.eclipse.kura.log.filesystem.provider.version=1.0.0-SNAPSHOT
 org.eclipse.kura.rest.configuration.provider.version=1.0.0-SNAPSHOT
 org.eclipse.kura.request.handler.jaxrs.version=1.0.0-SNAPSHOT
 org.eclipse.kura.rest.wire.provider.version=1.0.0-SNAPSHOT
+org.eclipse.kura.wire.ai.component.provider.version=1.0.0-SNAPSHOT
 
 ## features versions
 org.eclipse.kura.driver.opcua.version=1.1.0-SNAPSHOT

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -575,6 +575,11 @@
                                     <artifactId>org.eclipse.kura.container.orchestration.provider</artifactId>
                                     <version>${org.eclipse.kura.container.orchestration.provider.version}</version>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.kura</groupId>
+                                    <artifactId>org.eclipse.kura.wire.ai.component.provider</artifactId>
+                                    <version>${org.eclipse.kura.wire.ai.component.provider.version}</version>
+                                </artifactItem>
                             </artifactItems>
                             <stripVersion>true</stripVersion>
                             <outputDirectory>${project.basedir}/target/plugins</outputDirectory>
@@ -721,6 +726,7 @@
                                 <move file="target/plugins/org.eclipse.kura.request.handler.jaxrs.jar" tofile="target/plugins/org.eclipse.kura.request.handler.jaxrs_${org.eclipse.kura.request.handler.jaxrs.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.rest.wire.provider.jar" tofile="target/plugins/org.eclipse.kura.rest.wire.provider_${org.eclipse.kura.rest.configuration.provider.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.container.orchestration.provider.jar" tofile="target/plugins/org.eclipse.kura.container.orchestration.provider_${org.eclipse.kura.container.orchestration.provider.version}.jar" />
+                                <move file="target/plugins/org.eclipse.kura.wire.ai.component.provider.jar" tofile="target/plugins/org.eclipse.kura.wire.ai.component.provider_${org.eclipse.kura.wire.ai.component.provider.version}.jar" />
                             </tasks>
                         </configuration>
                     </execution>
@@ -1949,6 +1955,7 @@
                                         <copy file="${project.build.directory}/plugins/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider_${org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider.version}.jar" todir="${project.build.directory}/staging/target-definition/equinox_3.16.0/repository/plugins" />
 
                                         <copy file="${project.build.directory}/plugins/org.eclipse.kura.cloudconnection.raw.mqtt.provider_${org.eclipse.kura.cloudconnection.raw.mqtt.provider.version}.jar" todir="${project.build.directory}/staging/target-definition/equinox_3.16.0/repository/plugins" />
+                                        <copy file="${project.build.directory}/plugins/org.eclipse.kura.wire.ai.component.provider_${org.eclipse.kura.wire.ai.component.provider.version}.jar" todir="${project.build.directory}/staging/target-definition/equinox_3.16.0/repository/plugins" />
                                     </target>
                                 </configuration>
                             </execution>
@@ -2242,6 +2249,12 @@
                                             <groupId>org.eclipse.kura.feature</groupId>
                                             <artifactId>org.eclipse.kura.driver.ble.xdk</artifactId>
                                             <version>${org.eclipse.kura.driver.ble.xdk.version}</version>
+                                            <type>dp</type>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>org.eclipse.kura.feature</groupId>
+                                            <artifactId>org.eclipse.kura.wire.ai.component.provider</artifactId>
+                                            <version>${org.eclipse.kura.wire.ai.component.provider.version}</version>
                                             <type>dp</type>
                                         </artifactItem>
                                     </artifactItems>

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -145,6 +145,10 @@
 			</and>
 		</condition>
 
+		<condition property="is.nvidia.jetson.nano">
+			<contains string="${build.name}" substring="nvidia-jetson-nano" />
+		</condition>
+
 		<copy file="src/main/resources/${build.name}/snapshot_0.xml"
 			tofile="${project.build.directory}/${build.output.name}/snapshot_0.xml" />
 		<copy file="src/main/osgi/equinox_3.16.0/configuration/config.ini"
@@ -245,7 +249,7 @@
 		<antcall target="linux-debian-config" />
 		<antcall target="linux-redhat-config" />
 		<antcall target="linux-systemd-config" />
-
+		<antcall target="ai-wire-config" />
 
 		<!-- Add mToolkit to config.ini -->
 		<propertyfile
@@ -738,6 +742,7 @@ fi]]>
 		<antcall target="linux-debian-jars" />
 		<antcall target="linux-redhat-jars" />
 		<antcall target="linux-systemd-jars" />
+		<antcall target="nvidia-jetson-nano-jars" />
 
 		<echo message="Building Kura Distribution for ${build.name}-jars..." />
 
@@ -1596,6 +1601,14 @@ fi]]>
 		</propertyfile>
 	</target>
 
+	<target name="ai-wire-config" if="is.nvidia.jetson.nano">
+		<propertyfile
+			file="${project.build.directory}/${build.output.name}/config.ini">
+			<entry key="osgi.bundles" operation="+"
+				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.wire.ai.component.provider_${org.eclipse.kura.wire.ai.component.provider.version}.jar@4:start" />
+		</propertyfile>
+	</target>
+
 	<target name="emulator-jars" if="is.nn">
 		<zip destfile="${project.build.directory}/${build.output.name}.zip"
 			update="true">
@@ -1652,6 +1665,15 @@ fi]]>
 			update="true">
 			<zipfileset
 				file="${project.build.directory}/plugins/org.eclipse.kura.linux.systemd.provider_${org.eclipse.kura.linux.systemd.provider.version}.jar"
+				prefix="${build.output.name}/${plugins.folder}" />
+		</zip>
+	</target>
+
+	<target name="nvidia-jetson-nano-jars" if="is.nvidia.jetson.nano">
+		<zip destfile="${project.build.directory}/${build.output.name}.zip"
+			update="true">
+			<zipfileset
+				file="${project.build.directory}/plugins/org.eclipse.kura.wire.ai.component.provider_${org.eclipse.kura.wire.ai.component.provider.version}.jar"
 				prefix="${build.output.name}/${plugins.folder}" />
 		</zip>
 	</target>

--- a/kura/features/org.eclipse.kura.wire.ai.component.provider/build.properties
+++ b/kura/features/org.eclipse.kura.wire.ai.component.provider/build.properties
@@ -1,0 +1,15 @@
+###############################################################################
+ # Copyright (c) 2022 Eurotech and/or its affiliates and others
+ #
+ #  This program and the accompanying materials are made
+ #  available under the terms of the Eclipse Public License 2.0
+ #  which is available at https://www.eclipse.org/legal/epl-2.0/
+ #
+ #  SPDX-License-Identifier: EPL-2.0
+ #
+ #  Contributors:
+ #   Eurotech
+ ###############################################################################
+
+ bin.includes = feature.xml,\
+                feature.properties

--- a/kura/features/org.eclipse.kura.wire.ai.component.provider/feature.properties
+++ b/kura/features/org.eclipse.kura.wire.ai.component.provider/feature.properties
@@ -1,0 +1,27 @@
+###############################################################################
+ # Copyright (c) 2022 Eurotech and/or its affiliates and others
+ #
+ #  This program and the accompanying materials are made
+ #  available under the terms of the Eclipse Public License 2.0
+ #  which is available at https://www.eclipse.org/legal/epl-2.0/
+ #
+ #  SPDX-License-Identifier: EPL-2.0
+ #
+ #  Contributors:
+ #   Eurotech
+ ###############################################################################
+
+ featureName=Eclipse Kura - AI Wire Component
+ providerName=Eclipse Kura
+ description=AI Wire Component feature
+
+ copyright=\
+ Copyright (c) 2022 Eurotech and/or its affiliates and others\n\
+ \n\
+ This program and the accompanying materials are made\n\
+ available under the terms of the Eclipse Public License 2.0\n\
+ which accompanies this distribution, and is available at\n\
+ which is available at https://www.eclipse.org/legal/epl-2.0/\n\
+ \n\
+ SPDX-License-Identifier: EPL-2.0\n
+ 

--- a/kura/features/org.eclipse.kura.wire.ai.component.provider/feature.xml
+++ b/kura/features/org.eclipse.kura.wire.ai.component.provider/feature.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <feature
+       id="org.eclipse.kura.wire.ai.component.provider"
+       label="%featureName"
+       version="1.0.0.qualifier"
+       provider-name="%providerName"
+       license-feature="org.eclipse.license"
+       license-feature-version="0.0.0">
+
+    <description>
+       %description
+    </description>
+
+    <copyright>
+       %copyright
+    </copyright>
+
+    <license url="%licenseURL">
+       %license
+    </license>
+
+    <plugin
+          id="org.eclipse.kura.wire.ai.component.provider"
+          download-size="0"
+          install-size="0"
+          version="0.0.0"
+          unpack="false"/>
+
+ </feature>

--- a/kura/features/org.eclipse.kura.wire.ai.component.provider/pom.xml
+++ b/kura/features/org.eclipse.kura.wire.ai.component.provider/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+ <!--
+ 	
+ 	Copyright (c) 2022 Eurotech and/or its affiliates and others
+   
+     This program and the accompanying materials are made
+     available under the terms of the Eclipse Public License 2.0
+     which is available at https://www.eclipse.org/legal/epl-2.0/
+  
+ 	SPDX-License-Identifier: EPL-2.0
+ 	
+ 	Contributors:
+ 	 Eurotech
+
+ -->
+ <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+ 	<modelVersion>4.0.0</modelVersion>
+
+ 	<parent>
+ 		<groupId>org.eclipse.kura.feature</groupId>
+ 		<artifactId>features</artifactId>
+ 		<version>5.1.0-SNAPSHOT</version>
+ 		<relativePath>..</relativePath>
+ 	</parent>
+
+ 	<artifactId>org.eclipse.kura.wire.ai.component.provider</artifactId>
+ 	<version>1.0.0-SNAPSHOT</version>
+ 	<packaging>eclipse-feature</packaging>
+
+ 	<build>
+ 		<plugins>
+ 			<plugin>
+ 				<groupId>de.dentrassi.maven</groupId>
+ 				<artifactId>osgi-dp</artifactId>
+ 				<version>${osgi-dp-plugin-version}</version>
+ 				<executions>
+ 					<execution>
+ 						<goals>
+ 							<goal>build</goal>
+ 						</goals>
+ 					</execution>
+ 				</executions>
+ 			</plugin>
+ 		</plugins>
+ 	</build>
+ </project>

--- a/kura/features/pom.xml
+++ b/kura/features/pom.xml
@@ -56,11 +56,12 @@
         <module>org.eclipse.kura.driver.opcua</module>
         <module>org.eclipse.kura.driver.s7plc</module>
         <module>org.eclipse.kura.driver.ble.sensortag</module>
-	<module>org.eclipse.kura.driver.ble.xdk</module>
+        <module>org.eclipse.kura.driver.ble.xdk</module>
         <module>org.eclipse.kura.driver.eddystone</module>
         <module>org.eclipse.kura.driver.ibeacon</module>
         <module>org.eclipse.kura.wire.script.filter</module>
         <module>org.eclipse.kura.driver.gpio</module>
+        <module>org.eclipse.kura.wire.ai.component.provider</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

This PR adds the AI Wire Component to the `kura/features` as a DP, and as default plugin for the `nvidia-jetson-nano` build.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
