### PR TITLE
Disabled time synch services after Kura installation

### DIFF
--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -119,14 +119,13 @@ systemctl stop resolvconf.service
 systemctl disable resolvconf.service
 
 #disable NTP service
-if command -v timedatectl > /dev/null ;
-  then
+if command -v timedatectl > /dev/null ; then
     timedatectl set-ntp false
 fi
 
 #disable time synch at network start
 if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
-	chmod -x /etc/network/if-up.d/ntpdate
+    chmod -x /etc/network/if-up.d/ntpdate
 fi
 
 #prevent time sync services from starting

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -125,6 +125,8 @@ if command -v timedatectl > /dev/null ;
 fi
 
 #prevent time sync services from starting
+systemctl stop systemd-timedated
+systemctl disable systemd-timedated
 systemctl stop systemd-timesyncd
 systemctl disable systemd-timesyncd
 systemctl stop chrony

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -124,6 +124,11 @@ if command -v timedatectl > /dev/null ;
     timedatectl set-ntp false
 fi
 
+#disable time synch at network start
+if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
+	chmod -x /etc/network/if-up.d/ntpdate
+fi
+
 #prevent time sync services from starting
 systemctl stop systemd-timedated
 systemctl disable systemd-timedated

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -1,16 +1,15 @@
 #!/bin/sh
 #
-#  Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+# Copyright (c) 2022 Eurotech and/or its affiliates and others
 #
-#  This program and the accompanying materials are made
-#  available under the terms of the Eclipse Public License 2.0
-#  which is available at https://www.eclipse.org/legal/epl-2.0/
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
 #
-#  SPDX-License-Identifier: EPL-2.0
+# SPDX-License-Identifier: EPL-2.0
 #
-#  Contributors:
-#   Eurotech
-#
+# Contributors:
+#  Eurotech
 
 INSTALL_DIR=/opt/eclipse
 

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -118,6 +118,18 @@ systemctl disable systemd-resolved.service
 systemctl stop resolvconf.service
 systemctl disable resolvconf.service
 
+#disable NTP service
+if command -v timedatectl > /dev/null ;
+  then
+    timedatectl set-ntp false
+fi
+
+#prevent time sync services from starting
+systemctl stop systemd-timesyncd
+systemctl disable systemd-timesyncd
+systemctl stop chrony
+systemctl disable chrony
+
 #assigning possible .conf files ownership to kurad
 PATTERN="/etc/dhcpd*.conf* /etc/resolv.conf*"
 for FILE in $(ls $PATTERN 2>/dev/null)


### PR DESCRIPTION
Disable time synchronization services not owned by Kura on Jetson Nano during Kura installation.
Services disabled:
- `chrony`
- `systemd-timesyncd.service`
- `timedatectl` NTP service
- `systemd-timedated`

Furthermore an `ntpdate` script handled by the network config was disabled.

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>
