### PR TITLE
Update default configuration for the command service Jetson Nano profile

### DIFF
--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
@@ -478,4 +478,29 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.cloud.app.command.CommandCloudApp">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="command.timeout" type="Integer">
+                <esf:value>60</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="command.working.directory" type="String">
+                <esf:value/>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="command.enable" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="privileged.command.service.enable" type="Boolean">
+                <esf:value>true</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.cloud.app.command.CommandCloudApp</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.cloud.app.command.CommandCloudApp</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="command.environment" type="String">
+                <esf:value/>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>


### PR DESCRIPTION
Since the https://github.com/eclipse/kura/issues/3598 cannot be easily fixed (it requires the compilation of `su` from `util-linux` package), this PR disables by default the unprivileged command service in the snapshot_0 for the NVIDIA Jetson Nano profile that is affected by this problem.

**Related Issue:** #3598 #3602

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>