### PR TITLE
Kura installers alignment for Ubuntu profiles

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
@@ -7,7 +7,8 @@ Depends: hostapd, isc-dhcp-server, iw,
  ethtool, telnet, bluez-hcidump, 
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
- ifupdown, openjdk-8-jre-headless
+ ifupdown, openjdk-8-jre-headless, 
+ dmidecode
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -142,6 +142,12 @@ systemctl mask systemd-networkd
 systemctl mask networkd-dispatcher
 systemctl mask systemd-networkd-wait-online
 
+#disable DNS-related services - kura is the network manager
+systemctl stop systemd-resolved.service
+systemctl disable systemd-resolved.service
+systemctl stop resolvconf.service
+systemctl disable resolvconf.service
+
 #disable ModemManager
 systemctl stop ModemManager
 systemctl disable ModemManager

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 #
-#  Copyright (c) 2022 Eurotech and/or its affiliates and others
+# Copyright (c) 2022 Eurotech and/or its affiliates and others
 #
-#  This program and the accompanying materials are made
-#  available under the terms of the Eclipse Public License 2.0
-#  which is available at https://www.eclipse.org/legal/epl-2.0/
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
 #
-#  SPDX-License-Identifier: EPL-2.0
+# SPDX-License-Identifier: EPL-2.0
 #
-#  Contributors:
-#   Eurotech
+# Contributors:
+#  Eurotech
 #
 
 INSTALL_DIR=/opt/eclipse

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+#  Copyright (c) 2022 Eurotech and/or its affiliates and others
 #
 #  This program and the accompanying materials are made
 #  available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -137,6 +137,10 @@ systemctl mask systemd-networkd
 systemctl mask networkd-dispatcher
 systemctl mask systemd-networkd-wait-online
 
+#disable ModemManager
+systemctl stop ModemManager
+systemctl disable ModemManager
+
 #disable wpa_supplicant
 systemctl stop wpa_supplicant
 systemctl disable wpa_supplicant

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -38,7 +38,7 @@ fi
 #set up users and grant permissions to them
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
 chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
-${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i 
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i
 
 systemctl stop apparmor
 systemctl disable apparmor
@@ -126,11 +126,11 @@ systemctl stop NetworkManager.service
 systemctl disable NetworkManager.service
 
 #disable netplan
-systemctl disable systemd-networkd.socket 
+systemctl disable systemd-networkd.socket
 systemctl disable systemd-networkd
 systemctl disable networkd-dispatcher
 systemctl disable systemd-networkd-wait-online
-systemctl mask systemd-networkd.socket 
+systemctl mask systemd-networkd.socket
 systemctl mask systemd-networkd
 systemctl mask networkd-dispatcher
 systemctl mask systemd-networkd-wait-online
@@ -162,4 +162,4 @@ else
  done
 fi
 
-keytool -genkey -alias localhost -keyalg RSA -keysize 2048 -keystore /opt/eclipse/kura/user/security/httpskeystore.ks -deststoretype pkcs12 -dname "CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, S=Ontario, C=CA" -ext ku=digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment,keyAgreement,keyCertSign -ext eku=serverAuth,clientAuth,codeSigning,timeStamping -validity 1000 -storepass changeit -keypass changeit  
+keytool -genkey -alias localhost -keyalg RSA -keysize 2048 -keystore /opt/eclipse/kura/user/security/httpskeystore.ks -deststoretype pkcs12 -dname "CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, S=Ontario, C=CA" -ext ku=digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment,keyAgreement,keyCertSign -ext eku=serverAuth,clientAuth,codeSigning,timeStamping -validity 1000 -storepass changeit -keypass changeit

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -89,14 +89,19 @@ systemctl disable chrony
 
 #set up networking configuration
 mac_addr=$(head -1 /sys/class/net/enp2s0/address | tr '[:lower:]' '[:upper:]')
-sed "s/^ssid=kura_gateway.*/ssid=kura_gateway_${mac_addr}/" < ${INSTALL_DIR}/kura/install/hostapd.conf > /etc/hostapd-wlp4s0.conf
-cp /etc/hostapd-wlp4s0.conf ${INSTALL_DIR}/kura/.data/hostapd-wlp4s0.conf
 
 cp ${INSTALL_DIR}/kura/install/dhcpd-enp2s0.conf /etc/dhcpd-enp2s0.conf
 cp ${INSTALL_DIR}/kura/install/dhcpd-enp2s0.conf ${INSTALL_DIR}/kura/.data/dhcpd-enp2s0.conf
 
-cp ${INSTALL_DIR}/kura/install/dhcpd-wlp4s0.conf /etc/dhcpd-wlp4s0.conf
-cp ${INSTALL_DIR}/kura/install/dhcpd-wlp4s0.conf ${INSTALL_DIR}/kura/.data/dhcpd-wlp4s0.conf
+#check if wlp4s0 exists
+ethtool wlp4s0 1> /dev/null 2> /dev/null
+if [ $? -eq 0 ] ; then
+    sed "s/^ssid=kura_gateway.*/ssid=kura_gateway_${mac_addr}/" < ${INSTALL_DIR}/kura/install/hostapd.conf > /etc/hostapd-wlp4s0.conf
+    cp /etc/hostapd-wlp4s0.conf ${INSTALL_DIR}/kura/.data/hostapd-wlp4s0.conf
+
+    cp ${INSTALL_DIR}/kura/install/dhcpd-wlp4s0.conf /etc/dhcpd-wlp4s0.conf
+    cp ${INSTALL_DIR}/kura/install/dhcpd-wlp4s0.conf ${INSTALL_DIR}/kura/.data/dhcpd-wlp4s0.conf
+fi
 
 #set up bind/named
 cp ${INSTALL_DIR}/kura/install/named.conf /etc/bind/named.conf

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -121,6 +121,10 @@ systemctl disable dhcpcd
 systemctl stop isc-dhcp-server
 systemctl disable isc-dhcp-server
 
+# disable NetworkManager.service - kura is the network manager
+systemctl stop NetworkManager.service
+systemctl disable NetworkManager.service
+
 #disable netplan
 systemctl disable systemd-networkd.socket 
 systemctl disable systemd-networkd

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -81,6 +81,8 @@ fi
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd
 systemctl disable systemd-timesyncd
+systemctl stop systemd-timesyncd
+systemctl disable systemd-timesyncd
 # Prevent time sync with chrony from starting.
 systemctl stop chrony
 systemctl disable chrony

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
@@ -4,8 +4,8 @@ Section: misc
 Priority: low
 Depends: hostapd, isc-dhcp-server, iw, 
  dos2unix, bind9, unzip, 
- ethtool, telnet, bluez-hcidump, 
- wireless-tools, iptables, chrony, 
+ ethtool, telnet, ifupdown 
+ net-tools, iptables, chrony, 
  dmidecode, ntpdate, openjdk-8-jre-headless
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -10,6 +10,7 @@
 #
 # Contributors:
 #  Eurotech
+#
 
 INSTALL_DIR=/opt/eclipse
 

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -135,6 +135,10 @@ systemctl disable systemd-timesyncd
 systemctl stop chrony
 systemctl disable chrony
 
+#disable wpa_supplicant
+systemctl stop wpa_supplicant
+systemctl disable wpa_supplicant
+
 #assigning possible .conf files ownership to kurad
 PATTERN="/etc/dhcpd*.conf* /etc/resolv.conf*"
 for FILE in $(ls $PATTERN 2>/dev/null)

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -135,6 +135,10 @@ systemctl disable systemd-timesyncd
 systemctl stop chrony
 systemctl disable chrony
 
+#disable ModemManager
+systemctl stop ModemManager
+systemctl disable ModemManager
+
 #disable wpa_supplicant
 systemctl stop wpa_supplicant
 systemctl disable wpa_supplicant

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -39,6 +39,9 @@ cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/ma
 chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i
 
+systemctl stop apparmor
+systemctl disable apparmor
+
 #set up default networking file
 cp ${INSTALL_DIR}/kura/install/network.interfaces /etc/network/interfaces
 cp ${INSTALL_DIR}/kura/install/network.interfaces ${INSTALL_DIR}/kura/.data/interfaces

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -72,6 +72,25 @@ systemctl enable firewall
 #copy snapshot_0.xml
 cp ${INSTALL_DIR}/kura/user/snapshots/snapshot_0.xml ${INSTALL_DIR}/kura/.data/snapshot_0.xml
 
+#disable NTP service
+if command -v timedatectl > /dev/null ; then
+    timedatectl set-ntp false
+fi
+
+#disable time synch at network start
+if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
+    chmod -x /etc/network/if-up.d/ntpdate
+fi
+
+#prevent time sync services from starting
+systemctl stop systemd-timedated
+systemctl disable systemd-timedated
+systemctl stop systemd-timesyncd
+systemctl disable systemd-timesyncd
+# Prevent time sync with chrony from starting.
+systemctl stop chrony
+systemctl disable chrony
+
 #set up networking configuration
 cp ${INSTALL_DIR}/kura/install/dhcpd-eth0.conf /etc/dhcpd-eth0.conf
 cp ${INSTALL_DIR}/kura/install/dhcpd-eth0.conf ${INSTALL_DIR}/kura/.data/dhcpd-eth0.conf
@@ -120,24 +139,6 @@ systemctl stop systemd-resolved.service
 systemctl disable systemd-resolved.service
 systemctl stop resolvconf.service
 systemctl disable resolvconf.service
-
-#disable NTP service
-if command -v timedatectl > /dev/null ; then
-    timedatectl set-ntp false
-fi
-
-#disable time synch at network start
-if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
-    chmod -x /etc/network/if-up.d/ntpdate
-fi
-
-#prevent time sync services from starting
-systemctl stop systemd-timedated
-systemctl disable systemd-timedated
-systemctl stop systemd-timesyncd
-systemctl disable systemd-timesyncd
-systemctl stop chrony
-systemctl disable chrony
 
 #disable ModemManager
 systemctl stop ModemManager

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/deb/control/control
@@ -8,7 +8,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless
+ openjdk-8-jre-headless, dmidecode
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -123,6 +123,10 @@ systemctl disable dhcpcd
 systemctl stop isc-dhcp-server
 systemctl disable isc-dhcp-server
 
+# disable NetworkManager.service - kura is the network manager
+systemctl stop NetworkManager.service
+systemctl disable NetworkManager.service
+
 #disable netplan
 systemctl disable systemd-networkd.socket
 systemctl disable systemd-networkd

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 #
-#  Copyright (c) 2022 Eurotech and/or its affiliates and others
+# Copyright (c) 2022 Eurotech and/or its affiliates and others
 #
-#  This program and the accompanying materials are made
-#  available under the terms of the Eclipse Public License 2.0
-#  which is available at https://www.eclipse.org/legal/epl-2.0/
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
 #
-#  SPDX-License-Identifier: EPL-2.0
+# SPDX-License-Identifier: EPL-2.0
 #
-#  Contributors:
-#   Eurotech
+# Contributors:
+#  Eurotech
 #
 
 INSTALL_DIR=/opt/eclipse

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+#  Copyright (c) 2022 Eurotech and/or its affiliates and others
 #
 #  This program and the accompanying materials are made
 #  available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -40,6 +40,9 @@ cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/ma
 chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i
 
+systemctl stop apparmor
+systemctl disable apparmor
+
 #set up default networking file
 cp ${INSTALL_DIR}/kura/install/network.interfaces /etc/network/interfaces
 cp ${INSTALL_DIR}/kura/install/network.interfaces ${INSTALL_DIR}/kura/.data/interfaces
@@ -128,22 +131,9 @@ systemctl mask systemd-networkd
 systemctl mask networkd-dispatcher
 systemctl mask systemd-networkd-wait-online
 
-
 #disable wpa_supplicant
 systemctl stop wpa_supplicant
 systemctl disable wpa_supplicant
-
-#disable dhclient apparmor profile
-ln -s /etc/apparmor.d/sbin.dhclient /etc/apparmor.d/disable/
-apparmor_parser -R /etc/apparmor.d/sbin.dhclient
-
-#disable dhcpd apparmor profile
-ln -s /etc/apparmor.d/usr.sbin.dhcpd /etc/apparmor.d/disable/
-apparmor_parser -R /etc/apparmor.d/usr.sbin.dhcpd
-
-#disable dhcpd named profile
-ln -s /etc/apparmor.d/usr.sbin.named /etc/apparmor.d/disable/
-apparmor_parser -R /etc/apparmor.d/usr.sbin.named
 
 #assigning possible .conf files ownership to kurad
 PATTERN="/etc/dhcpd*.conf* /etc/resolv.conf* /etc/wpa_supplicant*.conf* /etc/hostapd*.conf*"

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -16,7 +16,7 @@ INSTALL_DIR=/opt/eclipse
 
 #create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
-        
+
 #set up Kura init
 sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
 systemctl daemon-reload
@@ -108,7 +108,7 @@ if [ ! -f "/etc/bind/rndc.key" ] ; then
 fi
 chown bind:bind /etc/bind/rndc.key
 chmod 600 /etc/bind/rndc.key
-        
+
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
@@ -122,11 +122,11 @@ systemctl stop isc-dhcp-server
 systemctl disable isc-dhcp-server
 
 #disable netplan
-systemctl disable systemd-networkd.socket 
+systemctl disable systemd-networkd.socket
 systemctl disable systemd-networkd
 systemctl disable networkd-dispatcher
 systemctl disable systemd-networkd-wait-online
-systemctl mask systemd-networkd.socket 
+systemctl mask systemd-networkd.socket
 systemctl mask systemd-networkd
 systemctl mask networkd-dispatcher
 systemctl mask systemd-networkd-wait-online
@@ -158,4 +158,4 @@ else
     done
 fi
 
-keytool -genkey -alias localhost -keyalg RSA -keysize 2048 -keystore /opt/eclipse/kura/user/security/httpskeystore.ks -deststoretype pkcs12 -dname "CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, S=Ontario, C=CA" -ext ku=digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment,keyAgreement,keyCertSign -ext eku=serverAuth,clientAuth,codeSigning,timeStamping -validity 1000 -storepass changeit -keypass changeit  
+keytool -genkey -alias localhost -keyalg RSA -keysize 2048 -keystore /opt/eclipse/kura/user/security/httpskeystore.ks -deststoretype pkcs12 -dname "CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, S=Ontario, C=CA" -ext ku=digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment,keyAgreement,keyCertSign -ext eku=serverAuth,clientAuth,codeSigning,timeStamping -validity 1000 -storepass changeit -keypass changeit

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -133,6 +133,12 @@ systemctl mask systemd-networkd
 systemctl mask networkd-dispatcher
 systemctl mask systemd-networkd-wait-online
 
+#disable DNS-related services - kura is the network manager
+systemctl stop systemd-resolved.service
+systemctl disable systemd-resolved.service
+systemctl stop resolvconf.service
+systemctl disable resolvconf.service
+
 #disable ModemManager
 systemctl stop ModemManager
 systemctl disable ModemManager

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -81,6 +81,8 @@ fi
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd
 systemctl disable systemd-timesyncd
+systemctl stop systemd-timesyncd
+systemctl disable systemd-timesyncd
 # Prevent time sync with chrony from starting.
 systemctl stop chrony
 systemctl disable chrony

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -133,6 +133,10 @@ systemctl mask systemd-networkd
 systemctl mask networkd-dispatcher
 systemctl mask systemd-networkd-wait-online
 
+#disable ModemManager
+systemctl stop ModemManager
+systemctl disable ModemManager
+
 #disable wpa_supplicant
 systemctl stop wpa_supplicant
 systemctl disable wpa_supplicant


### PR DESCRIPTION
Aligned the installers for the Ubuntu-based profiles.

**Description of the solution adopted:**

#### Nvidia Jetson Nano

Disabled the following services:
- `apparmor`
- `ModemManager`
- `wpa-supplicant`

Updated dependencies:
- Removed `wireless-tools` (no Wifi interface on the device)
- Removed `bluez-hcidump` (no Bluetooth interface on the device)
- Added `ifupdown` for consistency

#### Raspberry Pi Ubuntu 20

Disabled the following services:
- `apparmor`
- `systemd-timesyncd`
- `NetworkManager`
- `systemd-resolved`
- `resolvconf`
- `ModemManager`

Updated dependencies:
- Added `dmidecode` for consistency

#### Intel Up2 Ubuntu 20

Disabled the following services:
- `systemd-timesyncd`
- `NetworkManager`
- `systemd-resolved`
- `resolvconf`
- `ModemManager`

Updated dependencies:
- Added `dmidecode` for consistency

Added check on the existence of the `wlp4s0` interface during installation.

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>