### PR TITLE
H2DB store wire component checks on user input

### DIFF
--- a/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.H2DbWireRecordStore.xml
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.H2DbWireRecordStore.xml
@@ -34,7 +34,7 @@
             required="true"
             default="10000"
             description="Maximum table size"
-            min="0">
+            min="1">
         </AD>
         
         <AD id="cleanup.records.keep"

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
@@ -89,6 +89,9 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
 
     private static final String[] TABLE_TYPE = new String[] { "TABLE" };
 
+    private static final String NULL_TABLE_NAME_ERROR_MSG = "Table name cannot be null";
+    private static final String NULL_WIRE_RECORD_ERROR_MSG = "";
+
     private H2DbServiceHelper dbHelper;
 
     private H2DbService dbService;
@@ -197,9 +200,22 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
     private void truncate(final int noOfRecordsToKeep) {
         final String tableName = this.wireRecordStoreOptions.getTableName();
         final String sqlTableName = this.dbHelper.sanitizeSqlTableAndColumnName(tableName);
-        final int tableSize = this.wireRecordStoreOptions.getMaximumTableSize();
+        final int maxTableSize = this.wireRecordStoreOptions.getMaximumTableSize();
 
         try {
+
+            int entriesToDeleteCount;
+            if (maxTableSize < noOfRecordsToKeep) {
+                logger.info("{} > {}, using {} = {}.", H2DbWireRecordStoreOptions.CLEANUP_RECORDS_KEEP,
+                        H2DbWireRecordStoreOptions.MAXIMUM_TABLE_SIZE, H2DbWireRecordStoreOptions.CLEANUP_RECORDS_KEEP,
+                        H2DbWireRecordStoreOptions.MAXIMUM_TABLE_SIZE);
+                entriesToDeleteCount = getTableSize() - maxTableSize;
+            } else {
+                entriesToDeleteCount = maxTableSize - noOfRecordsToKeep;
+            }
+
+            logger.debug("Entries to delete: {}.", entriesToDeleteCount);
+
             this.dbHelper.withConnection(c -> {
                 final String catalog = c.getCatalog();
                 final DatabaseMetaData dbMetaData = c.getMetaData();
@@ -212,11 +228,11 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
                         } else {
                             logger.info("Partially emptying table {}", sqlTableName);
                             this.dbHelper.execute(c, MessageFormat.format(SQL_DELETE_RANGE_TABLE, sqlTableName,
-                                    Integer.toString(tableSize - noOfRecordsToKeep)));
+                                    Integer.toString(entriesToDeleteCount)));
                         }
                     }
                 }
-                return (Void) null;
+                return null;
             });
         } catch (final SQLException sqlException) {
             logger.error("Error in truncating the table {}...", sqlTableName, sqlException);
@@ -278,7 +294,7 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
      *             if the provided argument is null
      */
     private void store(final WireRecord wireRecord) {
-        requireNonNull(wireRecord, "Wire Record cannot be null");
+        requireNonNull(wireRecord, NULL_WIRE_RECORD_ERROR_MSG);
         int retryCount = 0;
         final String tableName = this.wireRecordStoreOptions.getTableName();
         do {
@@ -339,7 +355,7 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
      *             if the provided argument is null
      */
     private void reconcileTable(final String tableName) throws SQLException {
-        requireNonNull(tableName, "Table name cannot be null");
+        requireNonNull(tableName, NULL_TABLE_NAME_ERROR_MSG);
         final String sqlTableName = this.dbHelper.sanitizeSqlTableAndColumnName(tableName);
 
         this.dbHelper.withConnection(c -> {
@@ -356,14 +372,14 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
                             "(TIMESTAMP DESC)");
                 }
             }
-            return (Void) null;
+            return null;
         });
     }
 
     private void createIndex(String indexname, String table, String order) throws SQLException {
         this.dbHelper.withConnection(c -> {
             this.dbHelper.execute(c, MessageFormat.format(SQL_CREATE_TABLE_INDEX, indexname, table, order));
-            return (Void) null;
+            return null;
         });
         logger.info("Index {} created, order is {}", indexname, order);
     }
@@ -381,8 +397,8 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
      *             if any of the provided arguments is null
      */
     private void reconcileColumns(final String tableName, final WireRecord wireRecord) throws SQLException {
-        requireNonNull(tableName, "Table name cannot be null");
-        requireNonNull(wireRecord, "Wire Record cannot be null");
+        requireNonNull(tableName, NULL_TABLE_NAME_ERROR_MSG);
+        requireNonNull(wireRecord, NULL_WIRE_RECORD_ERROR_MSG);
 
         final Map<String, Integer> columns = CollectionUtil.newHashMap();
 
@@ -416,7 +432,7 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
                 }
             }
 
-            return (Void) null;
+            return null;
         });
     }
 
@@ -433,8 +449,8 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
      *             if any of the provided arguments is null
      */
     private void insertDataRecord(final String tableName, final WireRecord wireRecord) throws SQLException {
-        requireNonNull(tableName, "Table name cannot be null");
-        requireNonNull(wireRecord, "Wire Record cannot be null");
+        requireNonNull(tableName, NULL_TABLE_NAME_ERROR_MSG);
+        requireNonNull(wireRecord, NULL_WIRE_RECORD_ERROR_MSG);
 
         final Map<String, TypedValue<?>> wireRecordProperties = wireRecord.getProperties();
 
@@ -443,7 +459,7 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
                     new Date().getTime())) {
                 stmt.execute();
                 c.commit();
-                return (Void) null;
+                return null;
             }
 
         });

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStore.java
@@ -90,7 +90,7 @@ public class H2DbWireRecordStore implements WireEmitter, WireReceiver, Configura
     private static final String[] TABLE_TYPE = new String[] { "TABLE" };
 
     private static final String NULL_TABLE_NAME_ERROR_MSG = "Table name cannot be null";
-    private static final String NULL_WIRE_RECORD_ERROR_MSG = "";
+    private static final String NULL_WIRE_RECORD_ERROR_MSG = "WireRecord cannot be null";
 
     private H2DbServiceHelper dbHelper;
 

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreOptions.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreOptions.java
@@ -28,9 +28,9 @@ final class H2DbWireRecordStoreOptions {
 
     private static final int DEFAULT_MAXIMUM_TABLE_SIZE = 10000;
 
-    private static final String MAXIMUM_TABLE_SIZE = "maximum.table.size";
+    protected static final String MAXIMUM_TABLE_SIZE = "maximum.table.size";
 
-    private static final String CLEANUP_RECORDS_KEEP = "cleanup.records.keep";
+    protected static final String CLEANUP_RECORDS_KEEP = "cleanup.records.keep";
 
     private static final String TABLE_NAME = "table.name";
 

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreOptions.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreOptions.java
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/src/main/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreOptions.java
@@ -32,7 +32,7 @@ final class H2DbWireRecordStoreOptions {
 
     protected static final String CLEANUP_RECORDS_KEEP = "cleanup.records.keep";
 
-    private static final String TABLE_NAME = "table.name";
+    protected static final String TABLE_NAME = "table.name";
 
     private final Map<String, Object> properties;
 

--- a/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/h2db/store/test/H2DbWireRecordStoreTest.java
+++ b/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/h2db/store/test/H2DbWireRecordStoreTest.java
@@ -202,8 +202,9 @@ public class H2DbWireRecordStoreTest {
         resultSet.next();
         int count = resultSet.getInt(1);
         assertEquals("Unexpected number of records", maxSize, count);
-        
-        resultSet = connection.prepareStatement("SELECT ID FROM " + tableName + " ORDER BY ID ASC LIMIT 1").executeQuery();
+
+        resultSet = connection.prepareStatement("SELECT ID FROM " + tableName + " ORDER BY ID ASC LIMIT 1")
+                .executeQuery();
         resultSet.next();
         int oldID = resultSet.getInt(1);
 
@@ -221,12 +222,13 @@ public class H2DbWireRecordStoreTest {
         resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
         resultSet.next();
         count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records", cleanupSize + 5L, count);
-        
-        resultSet = connection.prepareStatement("SELECT ID FROM " + tableName + " ORDER BY ID ASC LIMIT 1").executeQuery();
+        assertEquals("Unexpected number of records", cleanupSize + 4L, count);
+
+        resultSet = connection.prepareStatement("SELECT ID FROM " + tableName + " ORDER BY ID ASC LIMIT 1")
+                .executeQuery();
         resultSet.next();
         int newID = resultSet.getInt(1);
-        
+
         assertTrue("Cleanup remove failure", newID > oldID);
     }
 

--- a/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/h2db/store/test/H2DbWireRecordStoreTest.java
+++ b/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/h2db/store/test/H2DbWireRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreTest.java
+++ b/kura/test/org.eclipse.kura.wire.h2db.component.provider.test/src/test/java/org/eclipse/kura/internal/wire/h2db/store/H2DbWireRecordStoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,37 +18,386 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.sql.Blob;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Map.Entry;
 
-import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.db.H2DbService;
-import org.eclipse.kura.internal.wire.h2db.common.H2DbServiceHelper;
 import org.eclipse.kura.type.BooleanValue;
 import org.eclipse.kura.type.ByteArrayValue;
+import org.eclipse.kura.type.DataType;
 import org.eclipse.kura.type.DoubleValue;
 import org.eclipse.kura.type.FloatValue;
 import org.eclipse.kura.type.IntegerValue;
 import org.eclipse.kura.type.LongValue;
 import org.eclipse.kura.type.StringValue;
 import org.eclipse.kura.type.TypedValue;
+import org.eclipse.kura.type.TypedValues;
 import org.eclipse.kura.wire.WireEnvelope;
 import org.eclipse.kura.wire.WireHelperService;
 import org.eclipse.kura.wire.WireRecord;
 import org.eclipse.kura.wire.WireSupport;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.osgi.service.component.ComponentContext;
 
 public class H2DbWireRecordStoreTest {
+
+    private ComponentContext ctx;
+    private Connection dbConnection;
+    private H2DbService dbServiceMock;
+    private H2DbWireRecordStore storeWireComp;
+    private Map<String, Object> properties = new HashMap<>();
+    private WireEnvelope wireEnvelope;
+
+    private static final Map<String, TypedValue<?>> SIMPLE_DATA = new HashMap<String, TypedValue<?>>() {
+
+        private static final long serialVersionUID = 1L;
+
+        {
+            put("key", new StringValue("value"));
+        }
+    };
+
+    private static final Map<String, TypedValue<?>> ALL_TYPES_DATA = new HashMap<String, TypedValue<?>>() {
+
+        private static final long serialVersionUID = 2L;
+
+        {
+            put("k_str", new StringValue("v_str"));
+            put("k_int", new IntegerValue(11));
+            put("k_blob", new ByteArrayValue(new byte[] { 0x00, 0x01, 0x02 }));
+            put("k_bool", new BooleanValue(true));
+            put("k_double", new DoubleValue((double) 2.0));
+            put("k_long", new LongValue((long) 0.3));
+            put("k_float", new FloatValue((float) 13));
+        }
+    };
+
+    private static final String TEST_TABLE_NAME = "WR_DATA";
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void shouldStoreSimpleWireEnvelope() {
+        givenProperties(TEST_TABLE_NAME, 10, 0);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+
+        whenWireEnvelopesReceived(1);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 1);
+        thenTableContainsData(TEST_TABLE_NAME, SIMPLE_DATA);
+    }
+
+    @Test
+    public void shouldStoreAllTypesWireEnvelope() {
+        givenProperties(TEST_TABLE_NAME, 10, 0);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(ALL_TYPES_DATA);
+
+        whenWireEnvelopesReceived(1);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 7);
+        thenTableContainsData(TEST_TABLE_NAME, ALL_TYPES_DATA);
+    }
+
+    @Test
+    public void truncateShouldKeepNoRecords() {
+        givenProperties(TEST_TABLE_NAME, 10, 0);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+
+        whenWireEnvelopesReceived(11);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 1);
+    }
+
+    @Test
+    public void truncateShouldNotTrigger() {
+        givenProperties(TEST_TABLE_NAME, 10, 0);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+
+        whenWireEnvelopesReceived(10);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 10);
+    }
+
+    @Test
+    public void truncateShouldKeepMaxSizeRecords() {
+        givenProperties(TEST_TABLE_NAME, 10, 11);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+
+        whenWireEnvelopesReceived(20);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 10);
+    }
+
+    @Test
+    public void truncateShouldKeepMaxSizeRecords2() {
+        givenProperties(TEST_TABLE_NAME, 10, 10);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+
+        whenWireEnvelopesReceived(20);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 10);
+    }
+
+    @Test
+    public void truncateShouldRespectNRecordsToKeep() {
+        givenProperties(TEST_TABLE_NAME, 10, 5);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+
+        whenWireEnvelopesReceived(11);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 5);
+    }
+
+    @Test
+    public void limitCaseTest() {
+        givenProperties(TEST_TABLE_NAME, 1, 1);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+
+        whenWireEnvelopesReceived(10);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 1);
+    }
+
+    @Test
+    public void limitCaseTest2() {
+        givenProperties(TEST_TABLE_NAME, 1, 0);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+
+        whenWireEnvelopesReceived(10);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 1);
+    }
+
+    @Test
+    public void updateMaxTableSize() {
+        givenProperties(TEST_TABLE_NAME, 10, 0);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+        givenWireEnvelopesReceived(10);
+        givenProperties(TEST_TABLE_NAME, 5, 0);
+
+        whenUpdate();
+        whenWireEnvelopesReceived(1);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 1);
+    }
+
+    @Test
+    public void updateNonExistentTableName() {
+        givenProperties(TEST_TABLE_NAME, 10, 0);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+        givenWireEnvelopesReceived(10);
+        givenProperties("NEW_TABLE", 5, 0);
+
+        whenUpdate();
+
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 10);
+        thenTableEntriesCountIs("NEW_TABLE", 0);
+    }
+
+    @Test
+    public void truncateShouldRemoveOldest() {
+        givenProperties(TEST_TABLE_NAME, 10, 0);
+        givenActivatedStoreComponent();
+        givenWireEnvelope(SIMPLE_DATA);
+
+        whenWireEnvelopesReceived(11);
+
+        thenOneTableExists(TEST_TABLE_NAME);
+        thenTableEntriesCountIs(TEST_TABLE_NAME, 1);
+        thenLastInsertedIdIs(TEST_TABLE_NAME, 11);
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenProperties(String tableName, int maxTableSize, int nRecordsToKeep) {
+        this.properties.put(H2DbWireRecordStoreOptions.TABLE_NAME, tableName);
+        this.properties.put(H2DbWireRecordStoreOptions.MAXIMUM_TABLE_SIZE, maxTableSize);
+        this.properties.put(H2DbWireRecordStoreOptions.CLEANUP_RECORDS_KEEP, nRecordsToKeep);
+    }
+
+    private void givenActivatedStoreComponent() {
+        this.storeWireComp = new H2DbWireRecordStore();
+
+        WireHelperService whsMock = mock(WireHelperService.class);
+        WireSupport wireSupportMock = mock(WireSupport.class);
+        when(whsMock.newWireSupport(this.storeWireComp, null)).thenReturn(wireSupportMock);
+
+        this.storeWireComp.bindWireHelperService(whsMock);
+
+        this.ctx = mock(ComponentContext.class);
+        this.storeWireComp.activate(this.ctx, this.properties);
+        this.storeWireComp.bindDbService(dbServiceMock);
+    }
+
+    private void givenWireEnvelope(Map<String, TypedValue<?>> data) {
+
+        String emitterPid = "emitter-example";
+        List<WireRecord> wireRecords = new ArrayList<WireRecord>();
+        Map<String, TypedValue<?>> recordProps;
+        WireRecord record;
+
+        for (Entry<String, TypedValue<?>> entry : data.entrySet()) {
+            recordProps = new HashMap<String, TypedValue<?>>();
+            recordProps.put(entry.getKey(), entry.getValue());
+            record = new WireRecord(recordProps);
+            wireRecords.add(record);
+        }
+
+        this.wireEnvelope = new WireEnvelope(emitterPid, wireRecords);
+    }
+
+    private void givenWireEnvelopesReceived(int nWireEnvelopes) {
+        for (int i = 0; i < nWireEnvelopes; i++) {
+            this.storeWireComp.onWireReceive(this.wireEnvelope);
+        }
+    }
+
+    /*
+     * When
+     */
+
+    private void whenWireEnvelopesReceived(int nWireEnvelopes) {
+        for (int i = 0; i < nWireEnvelopes; i++) {
+            this.storeWireComp.onWireReceive(this.wireEnvelope);
+        }
+    }
+
+    private void whenColumnTypeChanged(String key, DataType newType, String newValue) {
+        Map<String, TypedValue<?>> recordProps = new HashMap<>();
+        recordProps.put("blobkey", TypedValues.parseTypedValue(newType, newValue));
+
+        WireRecord record = new WireRecord(recordProps);
+        List<WireRecord> wireRecords = new ArrayList<WireRecord>();
+        wireRecords.add(record);
+        this.wireEnvelope = new WireEnvelope("pid", wireRecords);
+
+        this.storeWireComp.onWireReceive(this.wireEnvelope);
+    }
+
+    private void whenUpdate() {
+        this.storeWireComp.updated(this.properties);
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenOneTableExists(String tableName) {
+        try {
+            DatabaseMetaData metaData = this.dbConnection.getMetaData();
+            ResultSet tables = metaData.getTables(null, null, tableName, null);
+            tables.first();
+            String dbTableName = tables.getString("TABLE_NAME");
+
+            assertTrue("Only one table was expected", tables.isLast());
+            assertEquals(tableName, dbTableName);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void thenTableEntriesCountIs(String tableName, int expectedNumberOfEntries) {
+        try {
+            ResultSet resultSet = this.dbConnection.prepareStatement("SELECT count(*) FROM " + tableName)
+                    .executeQuery();
+            resultSet.next();
+            int count = resultSet.getInt(1);
+            assertEquals(expectedNumberOfEntries, count);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void thenTableContainsData(String tableName, Map<String, TypedValue<?>> data) {
+        try {
+            ResultSet resultSet = this.dbConnection.prepareStatement("SELECT * FROM " + tableName).executeQuery();
+
+            // each line contains the inserted values
+            for (Entry<String, TypedValue<?>> entry : data.entrySet()) {
+                resultSet.next();
+
+                long tim = resultSet.getLong(1);
+                assertTrue(tim <= System.currentTimeMillis());
+
+                Object dbValue = resultSet.getObject(entry.getKey());
+                Object entryValue = entry.getValue().getValue();
+
+                if (dbValue instanceof Blob) {
+                    // comparing byte arrays is always tricky
+                    Blob blob = (Blob) dbValue;
+                    byte[] expected = (byte[]) entryValue;
+                    assertTrue(Arrays.equals(expected, blob.getBytes(1, expected.length)));
+                } else if (entryValue instanceof Float) {
+                    assertEquals(entryValue.toString(), dbValue.toString()); // toString for avoiding conversions
+                } else {
+                    assertEquals(entryValue, dbValue);
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void thenLastInsertedIdIs(String tableName, int lastId) {
+        try {
+            ResultSet resultSet = this.dbConnection.prepareStatement("SELECT ID FROM " + tableName).executeQuery();
+
+            int id = 0;
+            while (resultSet.next()) {
+                id = resultSet.getInt("ID");
+            }
+
+            assertEquals(lastId, id);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /*
+     * Utilities
+     */
 
     @BeforeClass
     public static void setup() {
@@ -59,352 +408,36 @@ public class H2DbWireRecordStoreTest {
         }
     }
 
-    private Connection getConnection() throws SQLException {
-        Connection connection = DriverManager.getConnection("jdbc:h2:mem:kuradb", "SA", "");
-        return connection;
+    @Before
+    public void clean() {
+        try {
+            this.dbConnection = DriverManager.getConnection("jdbc:h2:mem:kuradb", "SA", "");
+            this.dbServiceMock = mock(H2DbService.class);
+
+            when(this.dbServiceMock.withConnection(anyObject())).thenAnswer(invocation -> {
+                return invocation.getArgumentAt(0, H2DbService.ConnectionCallable.class).call(this.dbConnection);
+            });
+
+            when(this.dbServiceMock.getConnection()).thenReturn(this.dbConnection);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        this.properties.clear();
+        this.properties.put(H2DbWireRecordStoreOptions.TABLE_NAME, TEST_TABLE_NAME);
     }
 
-    private H2DbService createMockH2DbService(final Connection connection) throws SQLException {
-        final H2DbService dbServiceMock = mock(H2DbService.class);
-        when(dbServiceMock.withConnection(anyObject())).thenAnswer(invocation -> {
-            return invocation.getArgumentAt(0, H2DbService.ConnectionCallable.class).call(connection);
-        });
-        when(dbServiceMock.getConnection()).thenReturn(connection);
-        return dbServiceMock;
+    @After
+    public void closeDbConnection() {
+        this.storeWireComp.deactivate(this.ctx);
+        this.storeWireComp.unbindDbService(this.dbServiceMock);
+
+        try {
+            this.dbConnection.prepareStatement("SHUTDOWN").execute();
+            Thread.sleep(500); // wait until db has been closed
+            this.dbConnection.close();
+        } catch (SQLException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
-
-    @Test
-    public void testSequence() throws SQLException {
-        // create DB, insert a few wire records, check they are actually in there, trigger column type update,
-        // update configuration
-
-        Connection connection = getConnection();
-
-        H2DbService dbServiceMock = createMockH2DbService(connection);
-
-        H2DbWireRecordStore store = new H2DbWireRecordStore();
-        
-        WireHelperService whsMock = mock(WireHelperService.class);
-        WireSupport wireSupportMock = mock(WireSupport.class);
-        when(whsMock.newWireSupport(store, null)).thenReturn(wireSupportMock);
-
-        store.bindWireHelperService(whsMock);
-
-        ComponentContext ctx = mock(ComponentContext.class);
-        Map<String, Object> props = new HashMap<String, Object>();
-        String tableName = "H2_STORE_TEST";
-        props.put("table.name", tableName);
-
-        // init
-        store.activate(ctx, props);
-        store.bindDbService(dbServiceMock);
-
-        String emitterPid = "emitter";
-        List<WireRecord> wireRecords = new ArrayList<WireRecord>();
-        Map<String, TypedValue<?>> recordProps = new HashMap<String, TypedValue<?>>();
-        TypedValue<?> val = new StringValue("val");
-        recordProps.put("key", val);
-        WireRecord record = new WireRecord(recordProps);
-        wireRecords.add(record);
-        WireEnvelope wireEvelope = new WireEnvelope(emitterPid, wireRecords);
-
-        ResultSet resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        int startCount = resultSet.getInt(1);
-
-        // store one record
-        store.onWireReceive(wireEvelope);
-
-        DatabaseMetaData metaData = connection.getMetaData();
-        ResultSet tables = metaData.getTables(null, null, tableName, null);
-        tables.first();
-        String dbTableName = tables.getString("TABLE_NAME");
-
-        // only one table was created with the correct name
-        assertTrue("Only one table was expected", tables.isLast());
-        assertEquals(tableName, dbTableName);
-
-        resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        int count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records in the database.", startCount + 1, count);
-
-        resultSet = connection.prepareStatement("SELECT * FROM " + tableName).executeQuery();
-        resultSet.next();
-        long tim = resultSet.getLong(1);
-        String strval = resultSet.getString("key");
-
-        assertTrue(resultSet.isLast());
-        assertTrue(tim <= System.currentTimeMillis());
-        assertEquals("val", strval);
-
-        // add couple more
-        store.onWireReceive(wireEvelope);
-
-        recordProps = new HashMap<String, TypedValue<?>>();
-        val = new ByteArrayValue("val".getBytes());
-        recordProps.put("blobkey", val);
-        record = new WireRecord(recordProps);
-        wireRecords.add(record);
-        recordProps = new HashMap<String, TypedValue<?>>();
-        val = new BooleanValue(true);
-        recordProps.put("boolkey", val);
-        val = new DoubleValue(1.234);
-        recordProps.put("dblkey", val);
-        val = new IntegerValue(1234);
-        recordProps.put("intkey", val);
-        val = new LongValue(1234L);
-        recordProps.put("longkey", val);
-        val = new FloatValue(123.2f);
-        recordProps.put("floatkey", val);
-        record = new WireRecord(recordProps);
-        wireRecords.add(record);
-        store.onWireReceive(wireEvelope); // adds 3, now
-
-        resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records", 5, count);
-
-        // change one of the column types
-        recordProps = new HashMap<String, TypedValue<?>>();
-        val = new FloatValue(1234.5f);
-        recordProps.put("blobkey", val);
-        record = new WireRecord(recordProps);
-        wireRecords = new ArrayList<WireRecord>();
-        wireRecords.add(record);
-        wireEvelope = new WireEnvelope(emitterPid, wireRecords);
-        store.onWireReceive(wireEvelope); // adds 1 more
-
-        resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records", 6, count);
-
-        // update the configuration
-        store.updated(props);
-        
-        // deinit
-        store.deactivate(null);
-        connection.prepareStatement("SHUTDOWN").execute();
-    }
-
-    @Test
-    public void testCleanupSequence() throws SQLException {
-        // create DB, insert a few wire records, check they are actually in there and clean the DB
-        Connection connection = getConnection();
-
-        H2DbService dbServiceMock = createMockH2DbService(connection);
-
-        H2DbWireRecordStore store = new H2DbWireRecordStore();
-
-        WireHelperService whsMock = mock(WireHelperService.class);
-        WireSupport wireSupportMock = mock(WireSupport.class);
-        when(whsMock.newWireSupport(store, null)).thenReturn(wireSupportMock);
-
-        store.bindWireHelperService(whsMock);
-
-        ComponentContext ctx = mock(ComponentContext.class);
-        Map<String, Object> props = new HashMap<String, Object>();
-        String tableName = "H2_STORE_TEST";
-        props.put("table.name", tableName);
-        props.put("cleanup.records.keep", 3);
-        props.put("maximum.table.size", 5);
-
-        // init
-        store.activate(ctx, props);
-        store.bindDbService(dbServiceMock);
-
-        String emitterPid = "emitter";
-        List<WireRecord> wireRecords = new ArrayList<WireRecord>();
-        Map<String, TypedValue<?>> recordProps = new HashMap<String, TypedValue<?>>();
-        TypedValue<?> val = new StringValue("val");
-        recordProps.put("key", val);
-        WireRecord record = new WireRecord(recordProps);
-        wireRecords.add(record);
-        WireEnvelope wireEvelope = new WireEnvelope(emitterPid, wireRecords);
-
-        // store a few records
-        for (int i = 0; i < 3; i++) {
-            store.onWireReceive(wireEvelope);
-        }
-        // wait for the executor to do its duty and DB operation to finish
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            // OK
-        }
-
-        ResultSet resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        int count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records", 3, count);
-
-        // store a few records
-        for (int i = 0; i < 5; i++) {
-            store.onWireReceive(wireEvelope);
-        }
-        // wait for the executor to do its duty and DB operation to finish
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            // OK
-        }
-
-        resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records", 4, count);
-
-        // deinit
-        store.deactivate(null);
-        connection.prepareStatement("SHUTDOWN").execute();
-    }
-
-    @Test
-    public void testCleanupSequenceLarge() throws SQLException {
-        // create DB, insert many wire records, check they are actually in there and clean the DB
-
-        Connection connection = getConnection();
-
-        H2DbService dbServiceMock = createMockH2DbService(connection);
-
-        H2DbWireRecordStore store = new H2DbWireRecordStore();
-
-        WireHelperService whsMock = mock(WireHelperService.class);
-        WireSupport wireSupportMock = mock(WireSupport.class);
-        when(whsMock.newWireSupport(store, null)).thenReturn(wireSupportMock);
-
-        store.bindWireHelperService(whsMock);
-
-        ComponentContext ctx = mock(ComponentContext.class);
-        Map<String, Object> props = new HashMap<String, Object>();
-        String tableName = "H2_STORE_TEST";
-        props.put("table.name", tableName);
-        props.put("cleanup.records.keep", 1100);
-        props.put("maximum.table.size", 1200);
-
-        // init
-        store.activate(ctx, props);
-        store.bindDbService(dbServiceMock);
-
-        String emitterPid = "emitter";
-        List<WireRecord> wireRecords = new ArrayList<WireRecord>();
-        Map<String, TypedValue<?>> recordProps = new HashMap<String, TypedValue<?>>();
-        TypedValue<?> val = new StringValue("val");
-        recordProps.put("key", val);
-        WireRecord record = new WireRecord(recordProps);
-        wireRecords.add(record);
-        WireEnvelope wireEvelope = new WireEnvelope(emitterPid, wireRecords);
-
-        // store a few records
-        for (int i = 0; i < 1100; i++) {
-            store.onWireReceive(wireEvelope);
-        }
-        // wait for the executor to do its duty and DB operation to finish
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            // OK
-        }
-
-        ResultSet resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        int count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records", 1100, count);
-
-        // store a few records
-        for (int i = 0; i < 150; i++) {
-            store.onWireReceive(wireEvelope);
-        }
-        // wait for the executor to do its duty and DB operation to finish
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            // OK
-        }
-
-        resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records", 1150, count);
-
-        // deinit
-        store.deactivate(null);
-        connection.prepareStatement("SHUTDOWN").execute();
-    }
-
-    @Test
-    public void testTruncateSequence() throws SQLException {
-        // create DB, insert many wire records truncating the DB in the process, check that enough are in there after
-
-        Connection connection = getConnection();
-
-        H2DbService dbServiceMock = createMockH2DbService(connection);
-
-        H2DbWireRecordStore store = new H2DbWireRecordStore();
-
-        WireHelperService whsMock = mock(WireHelperService.class);
-        WireSupport wireSupportMock = mock(WireSupport.class);
-        when(whsMock.newWireSupport(store, null)).thenReturn(wireSupportMock);
-
-        store.bindWireHelperService(whsMock);
-
-        ComponentContext ctx = mock(ComponentContext.class);
-        Map<String, Object> props = new HashMap<String, Object>();
-        String tableName = "H2_STORE_TEST";
-        props.put("table.name", tableName);
-        props.put("cleanup.records.keep", 0);
-        props.put("maximum.table.size", 1100);
-
-        // init
-        store.activate(ctx, props);
-        store.bindDbService(dbServiceMock);
-
-        String emitterPid = "emitter";
-        List<WireRecord> wireRecords = new ArrayList<WireRecord>();
-        Map<String, TypedValue<?>> recordProps = new HashMap<String, TypedValue<?>>();
-        TypedValue<?> val = new StringValue("val");
-        recordProps.put("key", val);
-        WireRecord record = new WireRecord(recordProps);
-        wireRecords.add(record);
-        WireEnvelope wireEvelope = new WireEnvelope(emitterPid, wireRecords);
-
-        // store a few records
-        for (int i = 0; i < 1000; i++) {
-            store.onWireReceive(wireEvelope);
-        }
-        // wait for the executor to do its duty and DB operation to finish
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            // OK
-        }
-
-        ResultSet resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        int count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records", 1000, count);
-
-        // store a few records
-        for (int i = 0; i < 500; i++) {
-            store.onWireReceive(wireEvelope);
-        }
-        // wait for the executor to do its duty and DB operation to finish
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            // OK
-        }
-
-        resultSet = connection.prepareStatement("SELECT count(*) FROM " + tableName).executeQuery();
-        resultSet.next();
-        count = resultSet.getInt(1);
-        assertEquals("Unexpected number of records", 400, count);
-
-        // deinit
-        store.deactivate(null);
-        connection.prepareStatement("SHUTDOWN").execute();
-    }
-
 }


### PR DESCRIPTION
Added some checks to the user-definable properties `maximum.table.size` and `cleanup.records.keep`.

**Related Issue:** N/A.

**Description of the solution adopted:** Prior to this PR, if the user set `cleanup.records.keep > maximum.table.size` the cleanup to the DB tables won't happen. In particular, the table truncation was executed by selecting the oldest `maximum.table.size - cleanup.records.keep` entries, which could assume negative values causing an error. Several checks are now implemented and the minimum value for `maximum.table.size` property is set to 1.

Unit tests have been refactored according to Gherkin style and updated with new corner-case checks.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
