### PR TITLE
DHCP server lease database fix on Jetson Nano

### DIFF
--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -135,7 +135,7 @@ systemctl disable systemd-timesyncd
 systemctl stop chrony
 systemctl disable chrony
 
-#create lease database if file is missing
+#create lease database file if missing
 if [ ! -f "/var/lib/dhcp/dhcpd.leases" ] ; then
     touch /var/lib/dhcp/dhcpd.leases
 fi

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -135,6 +135,11 @@ systemctl disable systemd-timesyncd
 systemctl stop chrony
 systemctl disable chrony
 
+#create lease database if file is missing
+if [ ! -f "/var/lib/dhcp/dhcpd.leases" ] ; then
+    touch /var/lib/dhcp/dhcpd.leases
+fi
+
 #assigning possible .conf files ownership to kurad
 PATTERN="/etc/dhcpd*.conf* /etc/resolv.conf*"
 for FILE in $(ls $PATTERN 2>/dev/null)


### PR DESCRIPTION
Fixed missing lease database file for Jetson Nano by creating it on Kura installation.

**Description of the solution adopted:**

The DHCP server could not start because `dhcpd` couldn't find the lease database as reported by the log:

```
Internet Systems Consortium DHCP Server 4.3.5
Copyright 2004-2016 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/
Config file: /etc/dhcpd-eth1.conf
Database file: /var/lib/dhcp/dhcpd.leases
PID file: /var/run/dhcpd-eth1.pid
Can't open lease database /var/lib/dhcp/dhcpd.leases: No such file or directory --
  check for failed database rewrite attempt!
```

As reported [by the manual](https://manpages.debian.org/unstable/isc-dhcp-server/dhcpd.leases.5.en.html):

> When dhcpd is first installed, there is no lease database. However, dhcpd requires that a lease database be present before it will start. To make the initial lease database, just create an empty file called /var/lib/dhcpd/dhcpd.leases. You can do this with:
>
>    touch /var/lib/dhcpd/dhcpd.leases

Usually it is created upon `isc-dhcp-server` package installation but, in the Jetson Nano case, it's already installed and the `/var/lib/dhcp` directory empty.

To fix this we added a check in the Kura installer searching for the lease database file. If it can't find it, it will create a new one in `/var/lib/dhcp/dhcpd.leases`.


