### PR TITLE
Unlock radio mode and channel selection in WiFi station mode

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.ui.xml
@@ -273,5 +273,16 @@
                 </b:Panel>
             </b:ModalBody>
         </b:Modal>
+        <b:Modal closable="true" dataKeyboard="false" dataBackdrop="STATIC" ui:field="regDomModal" b:id="regDomModal">
+            <b:ModalBody>
+                <b:Panel>
+                    <b:PanelBody>
+                        <b:Alert type="DANGER" ui:field="unavailableChannelError">
+                            <b.html:Text ui:field="unavailableChannelErrorText" />
+                        </b:Alert>
+                    </b:PanelBody>
+                </b:Panel>
+            </b:ModalBody>
+        </b:Modal>        
     </b:Container>
 </ui:UiBinder> 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.ui.xml
@@ -273,7 +273,7 @@
                 </b:Panel>
             </b:ModalBody>
         </b:Modal>
-        <b:Modal closable="true" dataKeyboard="false" dataBackdrop="STATIC" ui:field="regDomModal" b:id="regDomModal">
+        <b:Modal closable="true" dataKeyboard="false" dataBackdrop="STATIC" ui:field="regDomErrorModal" b:id="regDomErrorModal">
             <b:ModalBody>
                 <b:Panel>
                     <b:PanelBody>

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -562,6 +562,7 @@ netWifiBgScanInterval=The bgscan interval must be a numerical value
 netWifiBgScanIntervalValues=The bgscan short interval value must be less than the long value
 netWifiChannelList=Channel List
 netWifiChannelListLabel=Channel List
+netWifiChannelMissingError=The chosen network uses a channel that is not allowed within the currently configured Regulatory Domain.
 netWifiCountryCode=Country Code
 netWifiCountryCodeLabel=Country Code
 

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -562,7 +562,7 @@ netWifiBgScanInterval=The bgscan interval must be a numerical value
 netWifiBgScanIntervalValues=The bgscan short interval value must be less than the long value
 netWifiChannelList=Channel List
 netWifiChannelListLabel=Channel List
-netWifiChannelMissingError=The chosen network uses a channel that is not allowed within the currently configured Regulatory Domain.
+netWifiChannelMissingError=The chosen network uses a channel that is not allowed within the currently configured Regulatory Domain or the selected Radio Mode doesn't support the chosen channel.
 netWifiCountryCode=Country Code
 netWifiCountryCodeLabel=Country Code
 


### PR DESCRIPTION
Now radio mode is unlocked in WiFi station mode.
Now in station mode it is possible to select the channel to use from the bottom drop-down menu.
If the network search function is used, the suggested channel will be checked against the current device regdom.
