### PR TITLE
Fixed mixing DHCP ntp options and system specific configuration

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -78,6 +78,9 @@ if command -v timedatectl > /dev/null ;
     timedatectl set-ntp false
 fi
 
+#disable asking NTP servers to the DHCP server
+sed -i "s/, ntp-servers//g" /etc/dhcp/dhclient.conf
+
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd
 systemctl disable systemd-timesyncd

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -82,6 +82,17 @@ if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
     chmod -x /etc/network/if-up.d/ntpdate
 fi
 
+#disable populating chrony config with the NTP servers
+#advertised over DHCP
+if [ -f "/etc/dhcp/dhclient-exit-hooks.d/ntpdate" ] ; then
+    rm /etc/dhcp/dhclient-exit-hooks.d/ntpdate
+fi
+
+#remove NTP servers advertised over DHCP
+if [ -f "/run/ntpdate.dhcp" ] ; then
+    rm /run/ntpdate.dhcp
+fi
+
 #prevent time sync services from starting
 systemctl stop systemd-timedated
 systemctl disable systemd-timedated

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -82,17 +82,13 @@ if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
     chmod -x /etc/network/if-up.d/ntpdate
 fi
 
-#disable populating chrony config with the NTP servers
-#advertised over DHCP
-if [ -f "/etc/dhcp/dhclient-exit-hooks.d/ntpdate" ] ; then
-    rm /etc/dhcp/dhclient-exit-hooks.d/ntpdate
-fi
-if [ -f "/etc/dhcp/dhclient-exit-hooks.d/timesyncd" ] ; then
-    rm /etc/dhcp/dhclient-exit-hooks.d/timesyncd
-fi
-if [ -f "/etc/dhcp/dhclient-exit-hooks.d/chrony" ] ; then
-    rm /etc/dhcp/dhclient-exit-hooks.d/chrony
-fi
+#disable hook script populating chrony
+#config with the NTP servers advertised over DHCP
+NTP_DHCP_HOOK_SCRIPTS="/etc/dhcp/dhclient-exit-hooks.d/ntpdate /etc/dhcp/dhclient-exit-hooks.d/timesyncd /etc/dhcp/dhclient-exit-hooks.d/chrony"
+for FILE in $NTP_DHCP_HOOK_SCRIPTS
+do
+    rm $FILE
+done
 
 #remove NTP servers advertised over DHCP
 if [ -f "/run/ntpdate.dhcp" ] ; then

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -87,10 +87,22 @@ fi
 if [ -f "/etc/dhcp/dhclient-exit-hooks.d/ntpdate" ] ; then
     rm /etc/dhcp/dhclient-exit-hooks.d/ntpdate
 fi
+if [ -f "/etc/dhcp/dhclient-exit-hooks.d/timesyncd" ] ; then
+    rm /etc/dhcp/dhclient-exit-hooks.d/timesyncd
+fi
+if [ -f "/etc/dhcp/dhclient-exit-hooks.d/chrony" ] ; then
+    rm /etc/dhcp/dhclient-exit-hooks.d/chrony
+fi
 
 #remove NTP servers advertised over DHCP
 if [ -f "/run/ntpdate.dhcp" ] ; then
     rm /run/ntpdate.dhcp
+fi
+if [ -f "/run/systemd/timesyncd.conf.d/01-dhclient.conf" ] ; then
+    rm /run/systemd/timesyncd.conf.d/01-dhclient.conf
+fi
+if ls /var/lib/dhcp/chrony.servers.* 1> /dev/null 2>&1; then
+    rm /var/lib/dhcp/chrony.servers.*
 fi
 
 #prevent time sync services from starting

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -90,16 +90,12 @@ do
     rm $FILE
 done
 
-#remove NTP servers advertised over DHCP
-if [ -f "/run/ntpdate.dhcp" ] ; then
-    rm /run/ntpdate.dhcp
-fi
-if [ -f "/run/systemd/timesyncd.conf.d/01-dhclient.conf" ] ; then
-    rm /run/systemd/timesyncd.conf.d/01-dhclient.conf
-fi
-if ls /var/lib/dhcp/chrony.servers.* 1> /dev/null 2>&1; then
-    rm /var/lib/dhcp/chrony.servers.*
-fi
+#remove already captured NTP servers
+NTP_SERVER_FILES="/run/ntpdate.dhcp /run/systemd/timesyncd.conf.d/01-dhclient.conf /var/lib/dhcp/chrony.servers.*"
+for FILE in $(ls $NTP_SERVER_FILES 2>/dev/null)
+do
+    rm $FILE
+done
 
 #prevent time sync services from starting
 systemctl stop systemd-timedated

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -82,20 +82,8 @@ if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
     chmod -x /etc/network/if-up.d/ntpdate
 fi
 
-#disable hook script populating chrony
-#config with the NTP servers advertised over DHCP
-NTP_DHCP_HOOK_SCRIPTS="/etc/dhcp/dhclient-exit-hooks.d/ntpdate /etc/dhcp/dhclient-exit-hooks.d/timesyncd /etc/dhcp/dhclient-exit-hooks.d/chrony"
-for FILE in $NTP_DHCP_HOOK_SCRIPTS
-do
-    rm $FILE
-done
-
-#remove already captured NTP servers
-NTP_SERVER_FILES="/run/ntpdate.dhcp /run/systemd/timesyncd.conf.d/01-dhclient.conf /var/lib/dhcp/chrony.servers.*"
-for FILE in $(ls $NTP_SERVER_FILES 2>/dev/null)
-do
-    rm $FILE
-done
+#disable asking NTP servers to the DHCP server
+sed -i "s/, ntp-servers//g" /etc/dhcp/dhclient.conf
 
 #prevent time sync services from starting
 systemctl stop systemd-timedated

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -78,6 +78,9 @@ if command -v timedatectl > /dev/null ;
     timedatectl set-ntp false
 fi
 
+#disable asking NTP servers to the DHCP server
+sed -i "s/, ntp-servers//g" /etc/dhcp/dhclient.conf
+
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd
 systemctl disable systemd-timesyncd

--- a/kura/distrib/src/main/resources/raspberry-pi/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi/kura_install.sh
@@ -75,6 +75,9 @@ if command -v timedatectl > /dev/null ;
     timedatectl set-ntp false
 fi
 
+#disable asking NTP servers to the DHCP server
+sed -i "s/, ntp-servers//g" /etc/dhcp/dhclient.conf
+
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd
 systemctl disable systemd-timesyncd


### PR DESCRIPTION
Disabled use of NTP servers advertised over DHCP protocol for Kura network-enabled profiles.

**Description of the solution adopted:**

`chrony` used to use the NTP server advertised on DHCP instead of the ones provided through the Kura configuration.

With these changes, during Kura installation, we update the `dhclient` configuration file under `/etc/dhcp/dhclient.conf` to not ask for the NTP servers advertised by the DHCP server and therefore ignore the servers provided in this way.

**Any side note on the changes made:** 

An alternative solution to the one adopted in this PR is to delete the hook scripts of `dhclient` located in: 
- `/etc/dhcp/dhclient-exit-hooks.d/ntpdate`
- `/etc/dhcp/dhclient-exit-hooks.d/timesyncd`
- `/etc/dhcp/dhclient-exit-hooks.d/chrony`

which update the NTP server available to `chrony` through the files located in:
- `/run/ntpdate.dhcp` 
- `/run/systemd/timesyncd.conf.d/01-dhclient.conf`
- `/var/lib/dhcp/chrony.servers.$interface`

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>