### PR TITLE
Preventing systemd-tmpfiles cleanup

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -518,11 +518,12 @@ fi]]>
 
 			<zipfileset file="src/main/resources/common/monitrc.raspbian"
 				prefix="${build.output.name}/${install.folder}" />
-			<zipfileset file="src/main/resources/${build.name}/kura-tmpfiles.conf"
-				prefix="${build.output.name}/${install.folder}" />
 			<zipfileset file="src/main/resources/${build.name}/network.interfaces"
 				prefix="${build.output.name}/${install.folder}" />
 
+
+			<zipfileset file="src/main/resources/common/kura-tmpfiles.conf"
+				prefix="${build.output.name}/${install.folder}" />
 
 			<zipfileset file="src/main/resources/common/logrotate.conf"
 				prefix="${build.output.name}/${install.folder}" />

--- a/kura/distrib/src/main/resources/common/kura-tmpfiles.conf
+++ b/kura/distrib/src/main/resources/common/kura-tmpfiles.conf
@@ -1,0 +1,4 @@
+# Kura specific file. Do not edit!
+
+x /tmp/.kura
+x /tmp/kura

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/kura_install.sh
@@ -38,7 +38,7 @@ fi
 #set up users and grant permissions to them
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
 chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
-${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i 
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i
 
 systemctl stop apparmor
 systemctl disable apparmor
@@ -67,8 +67,11 @@ systemctl disable chrony
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#set up systemd-tmpfiles
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
+
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 chmod +x ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 
-keytool -genkey -alias localhost -keyalg RSA -keysize 2048 -keystore /opt/eclipse/kura/user/security/httpskeystore.ks -deststoretype pkcs12 -dname "CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, S=Ontario, C=CA" -ext ku=digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment,keyAgreement,keyCertSign -ext eku=serverAuth,clientAuth,codeSigning,timeStamping -validity 1000 -storepass changeit -keypass changeit  
+keytool -genkey -alias localhost -keyalg RSA -keysize 2048 -keystore /opt/eclipse/kura/user/security/httpskeystore.ks -deststoretype pkcs12 -dname "CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, S=Ontario, C=CA" -ext ku=digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment,keyAgreement,keyCertSign -ext eku=serverAuth,clientAuth,codeSigning,timeStamping -validity 1000 -storepass changeit -keypass changeit

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -120,6 +120,9 @@ chmod 600 /etc/bind/rndc.key
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#set up systemd-tmpfiles
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
+
 # disable dhcpcd service - kura is the network manager
 systemctl stop dhcpcd
 systemctl disable dhcpcd

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/kura_install.sh
@@ -30,6 +30,9 @@ mkdir -p ${INSTALL_DIR}/kura/data
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#set up systemd-tmpfiles
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
+
 # setup snapshot_0 recovery folder
 if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
     mkdir ${INSTALL_DIR}/kura/.data

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -112,6 +112,9 @@ chmod 600 /etc/bind/rndc.key
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#set up systemd-tmpfiles
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
+
 # disable dhcpcd service - kura is the network manager
 systemctl stop dhcpcd
 systemctl disable dhcpcd

--- a/kura/distrib/src/main/resources/raspberry-pi-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-nn/kura_install.sh
@@ -55,6 +55,9 @@ systemctl disable chrony
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#set up systemd-tmpfiles
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
+
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 chmod +x ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20-nn/kura_install.sh
@@ -51,10 +51,12 @@ systemctl disable systemd-timesyncd
 systemctl stop chrony
 systemctl disable chrony
 
-
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
+
+#set up systemd-tmpfiles
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
 
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -115,6 +115,9 @@ chmod 600 /etc/bind/rndc.key
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#set up systemd-tmpfiles
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
+
 # disable dhcpcd service - kura is the network manager
 systemctl stop dhcpcd
 systemctl disable dhcpcd

--- a/kura/distrib/src/main/resources/raspberry-pi/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi/kura_install.sh
@@ -16,7 +16,7 @@ INSTALL_DIR=/opt/eclipse
 
 #create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
-        
+
 #set up Kura init
 sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
 systemctl daemon-reload
@@ -105,10 +105,13 @@ if [ ! -f "/etc/bind/rndc.key" ] ; then
 fi
 chown bind:bind /etc/bind/rndc.key
 chmod 600 /etc/bind/rndc.key
-        
+
 #set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
+
+#set up systemd-tmpfiles
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
 
 # disable dhcpcd service - kura is the network manager
 systemctl stop dhcpcd
@@ -145,4 +148,4 @@ else
     done
 fi
 
-keytool -genkey -alias localhost -keyalg RSA -keysize 2048 -keystore /opt/eclipse/kura/user/security/httpskeystore.ks -deststoretype pkcs12 -dname "CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, S=Ontario, C=CA" -ext ku=digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment,keyAgreement,keyCertSign -ext eku=serverAuth,clientAuth,codeSigning,timeStamping -validity 1000 -storepass changeit -keypass changeit  
+keytool -genkey -alias localhost -keyalg RSA -keysize 2048 -keystore /opt/eclipse/kura/user/security/httpskeystore.ks -deststoretype pkcs12 -dname "CN=Kura, OU=Kura, O=Eclipse Foundation, L=Ottawa, S=Ontario, C=CA" -ext ku=digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment,keyAgreement,keyCertSign -ext eku=serverAuth,clientAuth,codeSigning,timeStamping -validity 1000 -storepass changeit -keypass changeit

--- a/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
@@ -30,6 +30,9 @@ mkdir -p ${INSTALL_DIR}/kura/data
 cp ${INSTALL_DIR}/kura/install/logrotate.conf /etc/logrotate.conf
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 
+#set up systemd-tmpfiles
+cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
+
 # setup snapshot_0 recovery folder
 if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
     mkdir ${INSTALL_DIR}/kura/.data


### PR DESCRIPTION
Updated Kura installer to install the required `systemd-tmpfiles` configuration file to prevent it to delete Kura-owned files.

**Description of the solution adopted:**

Added `kura-tmpfiles.conf` in the `common` folder and updated all the installer script to install it under `/etc/tmpfiles.d` folder.

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>
