### PR TITLE
Removed /etc/network/interfaces.tmp after it has been consumed

### DIFF
--- a/kura/org.eclipse.kura.linux.debian.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.debian.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
@@ -430,21 +430,23 @@ public class NetInterfaceConfigSerializationServiceImpl implements NetInterfaceC
         }
 
         // move tmp configuration file into its final destination
-        copyConfigFile(srcFile, dstFile);
+        copyAndDeleteTmpConfigFile(srcFile, dstFile);
     }
 
-    private void copyConfigFile(File srcFile, File dstFile) throws KuraException {
+    private void copyAndDeleteTmpConfigFile(File tmpSrcFile, File dstFile) throws KuraException {
         try {
-            if (!FileUtils.contentEquals(srcFile, dstFile)) {
+            if (!FileUtils.contentEquals(tmpSrcFile, dstFile)) {
                 // File.renameTo performs rather badly on Windows, if the file already exists
-                Files.move(Paths.get(srcFile.getAbsolutePath()), Paths.get(dstFile.getAbsolutePath()),
+                Files.move(Paths.get(tmpSrcFile.getAbsolutePath()), Paths.get(dstFile.getAbsolutePath()),
                         StandardCopyOption.REPLACE_EXISTING);
             } else {
                 logger.info("Not rewriting network interfaces file because it is the same");
             }
+
+            Files.deleteIfExists(Paths.get(tmpSrcFile.getAbsolutePath()));
         } catch (IOException e) {
             throw new KuraIOException(e,
-                    "Failed to rename tmp config file " + srcFile.getName() + " to " + dstFile.getName());
+                    "Failed to rename tmp config file " + tmpSrcFile.getName() + " to " + dstFile.getName());
         }
     }
 

--- a/kura/org.eclipse.kura.linux.redhat.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.redhat.provider/src/main/java/org/eclipse/kura/internal/linux/net/config/NetInterfaceConfigSerializationServiceImpl.java
@@ -236,21 +236,23 @@ public class NetInterfaceConfigSerializationServiceImpl implements NetInterfaceC
         }
 
         // move tmp configuration file into its final destination
-        copyConfigFile(srcFile, dstFile);
+        copyAndDeleteTmpConfigFile(srcFile, dstFile);
     }
 
-    private void copyConfigFile(File srcFile, File dstFile) throws KuraException {
+    private void copyAndDeleteTmpConfigFile(File tmpSrcFile, File dstFile) throws KuraException {
         try {
-            if (!FileUtils.contentEquals(srcFile, dstFile)) {
+            if (!FileUtils.contentEquals(tmpSrcFile, dstFile)) {
                 // File.renameTo performs rather badly on Windows, if the file already exists
-                Files.move(Paths.get(srcFile.getAbsolutePath()), Paths.get(dstFile.getAbsolutePath()),
+                Files.move(Paths.get(tmpSrcFile.getAbsolutePath()), Paths.get(dstFile.getAbsolutePath()),
                         StandardCopyOption.REPLACE_EXISTING);
             } else {
                 logger.info("Not rewriting network interfaces file because it is the same");
             }
+
+            Files.deleteIfExists(Paths.get(tmpSrcFile.getAbsolutePath()));
         } catch (IOException e) {
             throw new KuraIOException(e,
-                    "Failed to rename tmp config file " + srcFile.getName() + " to " + dstFile.getName());
+                    "Failed to rename tmp config file " + tmpSrcFile.getName() + " to " + dstFile.getName());
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

This PR removes the `/etc/network/interfaces.tmp` after it has been consumed. Previously, this file was created but never removed.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
