### PR TITLE
Fix error dhcp-lease-list

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwCapabilityTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwCapabilityTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwCapabilityTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/IwCapabilityTool.java
@@ -142,7 +142,6 @@ public class IwCapabilityTool {
         final int exitValue = status.getExitStatus().getExitCode();
 
         if (!status.getExitStatus().isSuccessful()) {
-            logger.warn("error executing command --- {} --- exit value = {}", commandLine, exitValue);
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, commandLine, exitValue);
         }
 
@@ -233,7 +232,6 @@ public class IwCapabilityTool {
         CommandStatus status = executorService.execute(command);
         int exitValue = status.getExitStatus().getExitCode();
         if (!status.getExitStatus().isSuccessful()) {
-            logger.warn("error executing command --- iw reg get --- exit value = {}", exitValue);
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, String.join(" ", cmd), exitValue);
         }
         String commandOutput = new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -1673,6 +1673,8 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
     @Override
     public List<GwtWifiChannelFrequency> findFrequencies(GwtXSRFToken xsrfToken, String interfaceName,
             GwtWifiRadioMode radioMode) throws GwtKuraException {
+        checkXSRFToken(xsrfToken);
+
         logger.debug("Find Frequency Network Service impl");
         List<GwtWifiChannelFrequency> channels = new ArrayList<>();
 
@@ -1716,6 +1718,8 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
 
     @Override
     public String getWifiCountryCode(GwtXSRFToken xsrfToken) throws GwtKuraException {
+        checkXSRFToken(xsrfToken);
+
         logger.info("Get Wifi Country Code impl");
         NetworkAdminService nas = ServiceLocator.getInstance().getService(NetworkAdminService.class);
         try {
@@ -1728,6 +1732,8 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
 
     @Override
     public boolean isIEEE80211ACSupported(GwtXSRFToken xsrfToken, String ifaceName) throws GwtKuraException {
+        checkXSRFToken(xsrfToken);
+
         NetworkAdminService nas = ServiceLocator.getInstance().getService(NetworkAdminService.class);
         try {
             return nas.isWifiIEEE80211AC(ifaceName);
@@ -1755,6 +1761,8 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
 
     @Override
     public List<String> getDhcpLeases(GwtXSRFToken xsrfToken) throws GwtKuraException {
+        checkXSRFToken(xsrfToken);
+
         List<String> dhcpLease = new ArrayList<>();
 
         NetworkAdminService nas = ServiceLocator.getInstance().getService(NetworkAdminService.class);


### PR DESCRIPTION
Removed the un-useful error in log `error executing command --- [dhcp-lease-list, --parsable] --- exit value = 1` when selecting a network interface.

**Related Issue:** N/A.

**Description of the solution adopted:** Warning logs were removed from `exec` and `getWifiCountryCode` since those methods throw exceptions that should be handled/logged at a higher level.

**Screenshots:** N/A.

**Any side note on the changes made:** I caught the opportunity to add missing `GwtXSRFToken` check on the RPC methods of the `GwtNetworkService`.
