### PR TITLE
Improved disable of NTP server request for DHCP client

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -79,7 +79,7 @@ if command -v timedatectl > /dev/null ;
 fi
 
 #disable asking NTP servers to the DHCP server
-sed -i "s/, ntp-servers//g" /etc/dhcp/dhclient.conf
+sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
 
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -83,7 +83,7 @@ if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
 fi
 
 #disable asking NTP servers to the DHCP server
-sed -i "s/, ntp-servers//g" /etc/dhcp/dhclient.conf
+sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
 
 #prevent time sync services from starting
 systemctl stop systemd-timedated

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -79,7 +79,7 @@ if command -v timedatectl > /dev/null ;
 fi
 
 #disable asking NTP servers to the DHCP server
-sed -i "s/, ntp-servers//g" /etc/dhcp/dhclient.conf
+sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
 
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd

--- a/kura/distrib/src/main/resources/raspberry-pi/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi/kura_install.sh
@@ -76,7 +76,7 @@ if command -v timedatectl > /dev/null ;
 fi
 
 #disable asking NTP servers to the DHCP server
-sed -i "s/, ntp-servers//g" /etc/dhcp/dhclient.conf
+sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
 
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd


### PR DESCRIPTION
Improvements on disabling use of NTP servers advertised over DHCP protocol for Kura network-enabled profiles.

**Related Issue:** #3861 

**Description of the solution adopted:**

Instead of simply removing the unwanted option from the DHCP client configuration, the option is now commented out. This make it easier for users to restore the configuration in case they want to.

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>