### PR TITLE
Changed Kura files permissions

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/kura_install.sh
@@ -70,6 +70,13 @@ cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 #set up systemd-tmpfiles
 cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
 
+# set up kura files permissions
+chmod 700 ${INSTALL_DIR}/kura/bin/*.sh
+chown -R kurad:kurad /opt/eclipse
+chmod -R go-rwx /opt/eclipse
+chmod a+rx /opt/eclipse    
+find /opt/eclipse/kura -type d -exec chmod u+x "{}" \;
+
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 chmod +x ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -21,7 +21,6 @@ ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
 systemctl daemon-reload
 systemctl enable kura
-chmod +x ${INSTALL_DIR}/kura/bin/*.sh
 
 # setup snapshot_0 recovery folder
 if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
@@ -168,6 +167,13 @@ for FILE in $(ls $PATTERN 2>/dev/null)
 do
   chown kurad:kurad $FILE
 done
+
+# set up kura files permissions
+chmod 700 ${INSTALL_DIR}/kura/bin/*.sh
+chown -R kurad:kurad /opt/eclipse
+chmod -R go-rwx /opt/eclipse
+chmod a+rx /opt/eclipse    
+find /opt/eclipse/kura -type d -exec chmod u+x "{}" \;
 
 # execute patch_sysctl.sh from installer install folder
 chmod 700 ${INSTALL_DIR}/kura/install/patch_sysctl.sh

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/kura_install.sh
@@ -46,6 +46,13 @@ ${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i
 #copy snapshot_0.xml
 cp ${INSTALL_DIR}/kura/user/snapshots/snapshot_0.xml ${INSTALL_DIR}/kura/.data/snapshot_0.xml
 
+# set up kura files permissions
+chmod 700 ${INSTALL_DIR}/kura/bin/*.sh
+chown -R kurad:kurad /opt/eclipse
+chmod -R go-rwx /opt/eclipse
+chmod a+rx /opt/eclipse    
+find /opt/eclipse/kura -type d -exec chmod u+x "{}" \;
+
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 chmod +x ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -166,6 +166,13 @@ do
   chown kurad:kurad $FILE
 done
 
+# set up kura files permissions
+chmod 700 ${INSTALL_DIR}/kura/bin/*.sh
+chown -R kurad:kurad /opt/eclipse
+chmod -R go-rwx /opt/eclipse
+chmod a+rx /opt/eclipse    
+find /opt/eclipse/kura -type d -exec chmod u+x "{}" \;
+
 # execute patch_sysctl.sh from installer install folder
 chmod 700 ${INSTALL_DIR}/kura/install/patch_sysctl.sh
 ${INSTALL_DIR}/kura/install/patch_sysctl.sh ${INSTALL_DIR}/kura/install/sysctl.kura.conf /etc/sysctl.conf

--- a/kura/distrib/src/main/resources/raspberry-pi-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-nn/kura_install.sh
@@ -58,6 +58,13 @@ cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 #set up systemd-tmpfiles
 cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
 
+# set up kura files permissions
+chmod 700 ${INSTALL_DIR}/kura/bin/*.sh
+chown -R kurad:kurad /opt/eclipse
+chmod -R go-rwx /opt/eclipse
+chmod a+rx /opt/eclipse    
+find /opt/eclipse/kura -type d -exec chmod u+x "{}" \;
+
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 chmod +x ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20-nn/kura_install.sh
@@ -58,6 +58,13 @@ cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate.d/kura
 #set up systemd-tmpfiles
 cp ${INSTALL_DIR}/kura/install/kura-tmpfiles.conf /etc/tmpfiles.d/kura.conf
 
+# set up kura files permissions
+chmod 700 ${INSTALL_DIR}/kura/bin/*.sh
+chown -R kurad:kurad /opt/eclipse
+chmod -R go-rwx /opt/eclipse
+chmod a+rx /opt/eclipse    
+find /opt/eclipse/kura -type d -exec chmod u+x "{}" \;
+
 #set up recover default configuration script
 cp ${INSTALL_DIR}/kura/install/recover_default_config.init ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh
 chmod +x ${INSTALL_DIR}/kura/bin/.recoverDefaultConfig.sh

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/kura_install.sh
@@ -164,6 +164,13 @@ do
   chown kurad:kurad $FILE
 done
 
+# set up kura files permissions
+chmod 700 ${INSTALL_DIR}/kura/bin/*.sh
+chown -R kurad:kurad /opt/eclipse
+chmod -R go-rwx /opt/eclipse
+chmod a+rx /opt/eclipse    
+find /opt/eclipse/kura -type d -exec chmod u+x "{}" \;
+
 # execute patch_sysctl.sh from installer install folder
 chmod 700 ${INSTALL_DIR}/kura/install/patch_sysctl.sh
 ${INSTALL_DIR}/kura/install/patch_sysctl.sh ${INSTALL_DIR}/kura/install/sysctl.kura.conf /etc/sysctl.conf

--- a/kura/distrib/src/main/resources/raspberry-pi/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi/kura_install.sh
@@ -21,7 +21,6 @@ ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
 systemctl daemon-reload
 systemctl enable kura
-chmod +x ${INSTALL_DIR}/kura/bin/*.sh
 
 # setup snapshot_0 recovery folder
 if [ ! -d ${INSTALL_DIR}/kura/.data ]; then
@@ -134,6 +133,13 @@ for FILE in $(ls $PATTERN 2>/dev/null)
 do
   chown kurad:kurad $FILE
 done
+
+# set up kura files permissions
+chmod 700 ${INSTALL_DIR}/kura/bin/*.sh
+chown -R kurad:kurad /opt/eclipse
+chmod -R go-rwx /opt/eclipse
+chmod a+rx /opt/eclipse    
+find /opt/eclipse/kura -type d -exec chmod u+x "{}" \;
 
 # execute patch_sysctl.sh from installer install folder
 chmod 700 ${INSTALL_DIR}/kura/install/patch_sysctl.sh


### PR DESCRIPTION
This PR modifies the permissions for the Kura folder.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** With this PR, the `/opt/eclipse/kura` folder will have the following permission:

```
pi@raspberrypi:~ $ sudo ls -all /opt/eclipse/kura/
total 76
drwx------ 12 kurad kurad  4096 Mar 14 15:35 .
drwxr-xr-x  3 kurad kurad  4096 Mar 14 15:31 ..
drwx------  2 kurad kurad  4096 Mar 14 15:32 .data
drwx------  2 kurad kurad  4096 Mar 14 15:32 bin
drwx------  3 kurad kurad  4096 Mar 14 16:16 console
drwx------  3 kurad kurad  4096 Mar 14 15:35 data
drwx------  2 kurad kurad  4096 Mar 14 16:16 framework
drwxr-xr-x  2 root  root   4096 Mar 14 15:32 log
drwx------  2 kurad kurad  4096 Mar 14 16:16 log4j
-rw-------  1 kurad kurad  9644 Oct  8 15:13 notice.html
drwxr-xr-x  2 kurad kurad  4096 Mar 14 15:35 packages
drwx------  2 kurad kurad 20480 Mar 14 16:17 plugins
drwx------  4 kurad kurad  4096 Mar 14 16:16 user
```

Signed-off-by: Merlino <pierantonio.merlino@eurotech.com>