### PR TITLE
Force ipv4 in gpsd.socket on Jetson Nano

### DIFF
--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/iptables.init
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/iptables.init
@@ -48,6 +48,7 @@ COMMIT
 -A input-kura -i eth0 -p tcp -m tcp --dport 443 -j ACCEPT
 -A input-kura -i eth0 -p tcp -m tcp --dport 4443 -j ACCEPT
 -A input-kura -i eth0 -p tcp -m tcp --dport 22 -j ACCEPT
+-A input-kura -i lo -p tcp -m tcp --dport 2947 -j ACCEPT
 -A input-kura -i lo -j ACCEPT
 -A input-kura -m state --state RELATED,ESTABLISHED -j ACCEPT
 -A input-kura -p icmp -m icmp --icmp-type 8 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -68,11 +68,8 @@ systemctl enable firewall
 #copy snapshot_0.xml
 cp ${INSTALL_DIR}/kura/user/snapshots/snapshot_0.xml ${INSTALL_DIR}/kura/.data/snapshot_0.xml
 
-#disable gpsd-related services
-systemctl stop gpsd.service
-systemctl disable gpsd.service
-systemctl stop gpsd.socket
-systemctl disable gpsd.socket
+#force gpsd.socket to use only ipv4
+sed -i "s/\(ListenStream=\[::1\]\)/# \1/g" /lib/systemd/system/gpsd.socket
 
 #disable NTP service
 if command -v timedatectl > /dev/null ; then

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -68,6 +68,12 @@ systemctl enable firewall
 #copy snapshot_0.xml
 cp ${INSTALL_DIR}/kura/user/snapshots/snapshot_0.xml ${INSTALL_DIR}/kura/.data/snapshot_0.xml
 
+#disable gpsd-related services
+systemctl stop gpsd.service
+systemctl disable gpsd.service
+systemctl stop gpsd.socket
+systemctl disable gpsd.socket
+
 #disable NTP service
 if command -v timedatectl > /dev/null ; then
     timedatectl set-ntp false

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
@@ -17,7 +17,7 @@
     <esf:configuration pid="org.eclipse.kura.net.admin.FirewallConfigurationService">
 	<esf:properties>
 	    <esf:property array="false" encrypted="false" name="firewall.open.ports" type="String">
-                <esf:value>22,tcp,,eth0,,,,#;443,tcp,,eth0,,,,#;4443,tcp,,eth0,,,,#;1450,tcp,,eth0,,,,#;5002,tcp,127.0.0.1/32,,,,,#;53,udp,,eth0,,,,#;67,udp,,eth0,,,,#;8000,tcp,,eth0,,,,#</esf:value>
+                <esf:value>22,tcp,,eth0,,,,#;443,tcp,,eth0,,,,#;4443,tcp,,eth0,,,,#;1450,tcp,,eth0,,,,#;5002,tcp,127.0.0.1/32,,,,,#;53,udp,,eth0,,,,#;67,udp,,eth0,,,,#;8000,tcp,,eth0,,,,#;2947,tcp,,lo,,,,#</esf:value>
             </esf:property>
 	    <esf:property array="false" encrypted="false" name="firewall.port.forwarding" type="String">
                 <esf:value></esf:value>


### PR DESCRIPTION
Disabled `gpsd`-related services

**Description of the solution adopted:**

Currently on the Jetson Nano profile `systemctl` reports a failure with:

```
jetson@jetson-nano:~$ systemctl list-units --failed
UNIT LOAD ACTIVE SUB DESCRIPTION
● gpsd.socket loaded failed failed GPS (Global Positioning System) Daemon Sockets
LOAD = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB = The low-level unit activation state, values depend on unit type.
1 loaded units listed. Pass --all to see loaded but inactive units, too.
To show all installed unit files use 'systemctl list-unit-files'.
```

because:

```
jetson@jetson-nano:~$ sudo systemctl status gpsd.socket
● gpsd.socket - GPS (Global Positioning System) Daemon Sockets
Loaded: loaded (/lib/systemd/system/gpsd.socket; enabled; vendor preset: enabled)
Active: failed (Result: resources)
Listen: /var/run/gpsd.sock (Stream)
[::1]:2947 (Stream)
127.0.0.1:2947 (Stream)
mar 16 11:56:17 jetson-nano systemd[1]: gpsd.socket: Failed to listen on sockets: Cannot assign requested address
mar 16 11:56:17 jetson-nano systemd[1]: gpsd.socket: Failed with result 'resources'.
mar 16 11:56:17 jetson-nano systemd[1]: Failed to listen on GPS (Global Positioning System) Daemon Sockets.
```

With this PR we ensure both `gpsd.service` and `gpsd.socket` are disabled on Kura installation.

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>