### PR TITLE
Removed DHCP confinguration tmp file once consumed

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/DhcpConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/DhcpConfigWriter.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -111,6 +112,8 @@ public class DhcpConfigWriter implements NetworkConfigurationVisitor {
                         } else {
                             logger.info("Not rewriting DHCP config file for {} because it is the same", interfaceName);
                         }
+
+                        Files.deleteIfExists(tmpDhcpConfigFile.toPath());
                     } catch (IOException e) {
                         throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,
                                 "error while building up new configuration files for dhcp servers", e);


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

This PR changes the `DhcpConfigWriter.writeNetInterfaceConfig` to delete the temporary `dhcpd-<if-name>.conf.tmp` file once it has been renamed to `dhcpd-<if-name>.conf`.

**Related Issue:** N/A.

**Description of the solution adopted:** Previously, the tmp file was used to write the main dhcp config file and was never deleted afterwards if the contents were the same.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
