### PR TITLE
feat(web2): password change feature

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -771,7 +771,7 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
             // TODO: implement the old password verification on server side
         } else {
             gwtXSRFService.generateSecurityToken(asyncCallback(
-                token -> gwtSessionService.updatePassword(newPassword, asyncCallback(onSuccess, onFailure)),
+                    token -> gwtSessionService.updatePassword(token, newPassword, asyncCallback(onSuccess, onFailure)),
                 onFailure));
         }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -765,18 +765,24 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
                 token -> gwtSessionService.getUserOptions(token, asyncCallback(onSuccess, onFailure)), onFailure));
     }
 
-    private void setNewPassword(final String newPassword, final Consumer<Void> onSuccess,
+    private void setNewPassword(Optional<String> oldPassword, final String newPassword, final Consumer<Void> onSuccess,
             final Consumer<Throwable> onFailure) {
-        gwtXSRFService.generateSecurityToken(asyncCallback(
+        if (oldPassword.isPresent()) {
+            // TODO: implement the old password verification on server side
+        } else {
+            gwtXSRFService.generateSecurityToken(asyncCallback(
                 token -> gwtSessionService.updatePassword(newPassword, asyncCallback(onSuccess, onFailure)),
                 onFailure));
+        }
 
     }
 
     private void changePassword(final Consumer<Void> onSuccess, final Consumer<Throwable> onFailure) {
         final PasswordChangeModal passwordChangeModal = new PasswordChangeModal();
         getGwtConsoleUserOptions(
-                options -> passwordChangeModal.pickPassword(options, p -> setNewPassword(p, onSuccess, onFailure)),
+                options -> passwordChangeModal.pickPassword(this.userData.checkPermission(KuraPermission.ADMIN),
+                        options,
+                        (oldPass, newPass) -> setNewPassword(oldPass, newPass, onSuccess, onFailure)),
                 onFailure);
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -764,17 +764,8 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
             }
         });
         
-        this.gwtXSRFService.generateSecurityToken(new AsyncCallback<GwtXSRFToken>() {
-
-            @Override
-            public void onFailure(Throwable caught) {
-                EntryClassUi.this.changePassword.setVisible(false);
-                EntryClassUi.this.headerChangePassword.setVisible(false);
-            }
-
-            @Override
-            public void onSuccess(GwtXSRFToken token) {
-                EntryClassUi.this.gwtSessionService.getUserConfig(token, new AsyncCallback<GwtUserConfig>() {
+        RequestQueue.submit(c -> gwtXSRFService.generateSecurityToken(
+                c.callback(token -> gwtSessionService.getUserConfig(token, new AsyncCallback<GwtUserConfig>() {
 
                     @Override
                     public void onFailure(Throwable caught) {
@@ -783,8 +774,8 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
                     }
 
                     @Override
-                    public void onSuccess(GwtUserConfig result) {
-                        if (result.isPasswordAuthEnabled()) {
+                    public void onSuccess(GwtUserConfig config) {
+                        if (config.isPasswordAuthEnabled()) {
                             EntryClassUi.this.changePassword.addClickHandler(changePasswordHandler);
                             EntryClassUi.this.headerChangePassword.addClickHandler(changePasswordHandler);
                         } else {
@@ -792,10 +783,8 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
                             EntryClassUi.this.headerChangePassword.setVisible(false);
                         }
                     }
-                });
-
-            }
-        });
+                })))
+        );
     }
 
     private void logout() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -181,9 +181,13 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
     @UiField
     Panel sidenavOverlay;
     @UiField
-    Button logoutButton;
+    Label logout;
     @UiField
-    Button headerLogoutButton;
+    Label headerLogout;
+    @UiField
+    Label changePassword;
+    @UiField
+    Label headerChangePassword;
     @UiField
     NavPills sidenavPills;
     @UiField
@@ -306,7 +310,7 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
             }
         });
 
-        initLogoutButtons();
+        initDropdownMenu();
         initServicesTree();
         initExtensions();
     }
@@ -721,16 +725,24 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
 
     }
 
-    private void initLogoutButtons() {
+    private void initDropdownMenu() {
         final ClickHandler logoutHandler = e -> confirmIfUiDirty(() -> logout());
+        final ClickHandler changePasswordHandler = e -> confirmIfUiDirty(() -> changePassword());
 
-        this.logoutButton.addClickHandler(logoutHandler);
-        this.headerLogoutButton.addClickHandler(logoutHandler);
+        this.logout.addClickHandler(logoutHandler);
+        this.headerLogout.addClickHandler(logoutHandler);
+
+        this.changePassword.addClickHandler(changePasswordHandler);
+        this.headerChangePassword.addClickHandler(changePasswordHandler);
     }
 
     private void logout() {
         RequestQueue.submit(c -> this.gwtXSRFService.generateSecurityToken(
                 c.callback(token -> this.gwtSessionService.logout(token, c.callback(ok -> Window.Location.reload())))));
+    }
+
+    private void changePassword() {
+        // TODO
     }
 
     private void initServicesTree() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -72,6 +72,7 @@ import org.eclipse.kura.web2.ext.WidgetFactory;
 import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Column;
+import org.gwtbootstrap3.client.ui.Container;
 import org.gwtbootstrap3.client.ui.FormLabel;
 import org.gwtbootstrap3.client.ui.Icon;
 import org.gwtbootstrap3.client.ui.ListBox;
@@ -205,6 +206,14 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
     Row mainContainer;
     @UiField
     DropdownNotification dropdownNotification;
+    @UiField
+    Button dropdownButton;
+    @UiField
+    Button dropdownHeaderButton;
+    @UiField
+    Container dropdownContainer;
+    @UiField
+    Container dropdownContainerHeader;
 
     private static final Messages MSGS = GWT.create(Messages.class);
     private static final EntryClassUIUiBinder uiBinder = GWT.create(EntryClassUIUiBinder.class);
@@ -218,6 +227,7 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
             "service.pid=*SslManagerService", "service.pid=*FirewallConfigurationService",
             "service.pid=*WireGraphService", "objectClass=org.eclipse.kura.wire.WireComponent",
             "objectClass=org.eclipse.kura.driver.Driver", "kura.ui.service.hide=true")));
+    private static final String DROPDOWN_MENU_HIDDEN_STYLE_NAME = "hide-dropdown";
 
     private static PopupPanel waitModal;
 
@@ -734,6 +744,24 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
 
         this.logout.addClickHandler(logoutHandler);
         this.headerLogout.addClickHandler(logoutHandler);
+
+        this.dropdownContainer.addStyleName(DROPDOWN_MENU_HIDDEN_STYLE_NAME);
+        this.dropdownContainerHeader.addStyleName(DROPDOWN_MENU_HIDDEN_STYLE_NAME);
+
+        this.dropdownButton.addClickHandler(e -> {
+            if (EntryClassUi.this.dropdownContainer.getStyleName().contains(DROPDOWN_MENU_HIDDEN_STYLE_NAME)) {
+                EntryClassUi.this.dropdownContainer.removeStyleName(DROPDOWN_MENU_HIDDEN_STYLE_NAME);
+            } else {
+                EntryClassUi.this.dropdownContainer.addStyleName(DROPDOWN_MENU_HIDDEN_STYLE_NAME);
+            }
+        });
+        this.dropdownHeaderButton.addClickHandler(e -> {
+            if (EntryClassUi.this.dropdownContainerHeader.getStyleName().contains(DROPDOWN_MENU_HIDDEN_STYLE_NAME)) {
+                EntryClassUi.this.dropdownContainerHeader.removeStyleName(DROPDOWN_MENU_HIDDEN_STYLE_NAME);
+            } else {
+                EntryClassUi.this.dropdownContainerHeader.addStyleName(DROPDOWN_MENU_HIDDEN_STYLE_NAME);
+            }
+        });
 
         this.changePassword.addClickHandler(changePasswordHandler);
         this.headerChangePassword.addClickHandler(changePasswordHandler);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -131,7 +131,6 @@
 									addStyleNames="glyphicon glyphicon-menu-hamburger sidebar-button"></b:Button>
 								<b:Panel addStyleNames="{style.image} headerLogo" />
 								
-								<!-- WORK IN PROGRESS -->
 								<b:Container addStyleNames="dropdown-settings header-dropdown-settings">
 								    <b:Icon addStyleNames="{style.user-icon}" type="USER" size="LARGE" />
 									<b.html:Span addStyleNames="{style.user-name}" ui:field="userNameSmall" />
@@ -140,6 +139,7 @@
 										<b.html:Span text="Logout" ui:field="h_todecide2" />
 									</b:Container>
 								</b:Container>
+								
 							</b:PanelHeader>
 						</b:Panel>
 					</b:Column>
@@ -240,7 +240,7 @@
 						</b:Column>
 					</b:Row>
 				</b:Column>
-				<!-- WORK IN PROGRESS -->
+				
 				<b:Container addStyleNames="dropdown-settings">
 				    <b:Icon addStyleNames="{style.user-icon}" type="USER" size="LARGE" />
 					<b.html:Span text="Logged in as" />
@@ -250,6 +250,7 @@
 						<b.html:Span text="Logout" ui:field="todecide2" />
 					</b:Container>
 				</b:Container>
+				
 				<b:Row addStyleNames='main-content'>
 					<b:Panel>
 						<b:PanelBody>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -135,8 +135,8 @@
 								    <b:Icon addStyleNames="{style.user-icon}" type="USER" size="LARGE" />
 									<b.html:Span addStyleNames="{style.user-name}" ui:field="userNameSmall" />
 									<b:Container addStyleNames="dropdown-settings-content">
-										<b.html:Span text="Change password" ui:field="h_todecide1" />
-										<b.html:Span text="Logout" ui:field="h_todecide2" />
+										<g:Label text="Change password" ui:field="headerChangePassword" />
+										<g:Label text="Logout" ui:field="headerLogout" />
 									</b:Container>
 								</b:Container>
 								
@@ -246,8 +246,8 @@
 					<b.html:Span text="Logged in as" />
 					<b.html:Span addStyleNames="{style.user-name}" ui:field="userNameLarge" />
 					<b:Container addStyleNames="dropdown-settings-content">
-						<b.html:Span text="Change password" ui:field="todecide1" />
-						<b.html:Span text="Logout" ui:field="todecide2" />
+						<g:Label text="Change password" ui:field="changePassword" />
+						<g:Label text="Logout" ui:field="logout" />
 					</b:Container>
 				</b:Container>
 				

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -134,7 +134,8 @@
 								<b:Container addStyleNames="dropdown-settings header-dropdown-settings">
 								    <b:Icon addStyleNames="{style.user-icon}" type="USER" size="LARGE" />
 									<b.html:Span addStyleNames="{style.user-name}" ui:field="userNameSmall" />
-									<b:Container addStyleNames="dropdown-settings-content">
+									<b:Button ui:icon="GEAR" />
+									<b:Container ui:field="dropdownContainer" addStyleNames="dropdown-settings-content">
 										<g:Label text="Change password" ui:field="headerChangePassword" />
 										<g:Label text="Logout" ui:field="headerLogout" />
 									</b:Container>
@@ -245,6 +246,7 @@
 				    <b:Icon addStyleNames="{style.user-icon}" type="USER" size="LARGE" />
 					<b.html:Span text="Logged in as" />
 					<b.html:Span addStyleNames="{style.user-name}" ui:field="userNameLarge" />
+					<b:Button ui:icon="GEAR" />
 					<b:Container addStyleNames="dropdown-settings-content">
 						<g:Label text="Change password" ui:field="changePassword" />
 						<g:Label text="Logout" ui:field="logout" />

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -134,8 +134,8 @@
 								<b:Container addStyleNames="dropdown-settings header-dropdown-settings">
 								    <b:Icon addStyleNames="{style.user-icon}" type="USER" size="LARGE" />
 									<b.html:Span addStyleNames="{style.user-name}" ui:field="userNameSmall" />
-									<b:Button ui:icon="GEAR" />
-									<b:Container ui:field="dropdownContainer" addStyleNames="dropdown-settings-content">
+									<b:Button ui:field="dropdownHeaderButton" ui:icon="GEAR" />
+									<b:Container ui:field="dropdownContainerHeader" addStyleNames="dropdown-settings-content">
 										<g:Label text="Change password" ui:field="headerChangePassword" />
 										<g:Label text="Logout" ui:field="headerLogout" />
 									</b:Container>
@@ -246,8 +246,8 @@
 				    <b:Icon addStyleNames="{style.user-icon}" type="USER" size="LARGE" />
 					<b.html:Span text="Logged in as" />
 					<b.html:Span addStyleNames="{style.user-name}" ui:field="userNameLarge" />
-					<b:Button ui:icon="GEAR" />
-					<b:Container addStyleNames="dropdown-settings-content">
+					<b:Button ui:field="dropdownButton" ui:icon="GEAR" />
+					<b:Container ui:field="dropdownContainer" addStyleNames="dropdown-settings-content">
 						<g:Label text="Change password" ui:field="changePassword" />
 						<g:Label text="Logout" ui:field="logout" />
 					</b:Container>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.ui.xml
@@ -130,11 +130,15 @@
 								<b:Button ui:field="sidenavButton"
 									addStyleNames="glyphicon glyphicon-menu-hamburger sidebar-button"></b:Button>
 								<b:Panel addStyleNames="{style.image} headerLogo" />
-								<b:Container fluid="true" addStyleNames="logout-ui header-logout-ui">
+								
+								<!-- WORK IN PROGRESS -->
+								<b:Container addStyleNames="dropdown-settings header-dropdown-settings">
 								    <b:Icon addStyleNames="{style.user-icon}" type="USER" size="LARGE" />
 									<b.html:Span addStyleNames="{style.user-name}" ui:field="userNameSmall" />
-									<b:Button text="Logout" icon="SIGN_OUT" size="SMALL" addStyleNames="logout-button"
-										ui:field="headerLogoutButton" />
+									<b:Container addStyleNames="dropdown-settings-content">
+										<b.html:Span text="Change password" ui:field="h_todecide1" />
+										<b.html:Span text="Logout" ui:field="h_todecide2" />
+									</b:Container>
 								</b:Container>
 							</b:PanelHeader>
 						</b:Panel>
@@ -236,12 +240,15 @@
 						</b:Column>
 					</b:Row>
 				</b:Column>
-				<b:Container fluid="true" addStyleNames="logout-ui">
+				<!-- WORK IN PROGRESS -->
+				<b:Container addStyleNames="dropdown-settings">
 				    <b:Icon addStyleNames="{style.user-icon}" type="USER" size="LARGE" />
 					<b.html:Span text="Logged in as" />
 					<b.html:Span addStyleNames="{style.user-name}" ui:field="userNameLarge" />
-					<b:Button text="Logout" icon="SIGN_OUT" size="SMALL" addStyleNames="logout-button"
-										ui:field="logoutButton" />
+					<b:Container addStyleNames="dropdown-settings-content">
+						<b.html:Span text="Change password" ui:field="todecide1" />
+						<b.html:Span text="Logout" ui:field="todecide2" />
+					</b:Container>
 				</b:Container>
 				<b:Row addStyleNames='main-content'>
 					<b:Panel>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.java
@@ -394,7 +394,7 @@ public class LoginUi extends Composite implements Context {
         private void setNewPassword(final String newPassword, final Consumer<Void> onSuccess,
                 final Consumer<Throwable> onFailure) {
             gwtXsrfService.generateSecurityToken(asyncCallback(
-                    token -> gwtSessionService.updatePassword(newPassword, asyncCallback(onSuccess, onFailure)),
+                    token -> gwtSessionService.updatePassword(token, newPassword, asyncCallback(onSuccess, onFailure)),
                     onFailure));
 
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.java
@@ -401,8 +401,8 @@ public class LoginUi extends Composite implements Context {
 
         private void changePassword(final Consumer<Void> onSuccess, final Consumer<Throwable> onFailure) {
 
-            getGwtConsoleUserOptions(options -> this.passwordChangeModal.pickPassword(options,
-                    p -> setNewPassword(p, onSuccess, onFailure)), onFailure);
+            getGwtConsoleUserOptions(options -> this.passwordChangeModal.pickPassword(true, options,
+                    (oldPass, newPass) -> setNewPassword(newPass, onSuccess, onFailure)), onFailure);
         }
 
         private <T> AsyncCallback<T> asyncCallback(final Consumer<T> onSuccess, final Consumer<Throwable> onFailure) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.java
@@ -391,18 +391,19 @@ public class LoginUi extends Composite implements Context {
                     token -> gwtSessionService.getUserOptions(token, asyncCallback(onSuccess, onFailure)), onFailure));
         }
 
-        private void setNewPassword(final String newPassword, final Consumer<Void> onSuccess,
+        private void setNewPassword(final String oldPassword, final String newPassword, final Consumer<Void> onSuccess,
                 final Consumer<Throwable> onFailure) {
             gwtXsrfService.generateSecurityToken(asyncCallback(
-                    token -> gwtSessionService.updatePassword(token, newPassword, asyncCallback(onSuccess, onFailure)),
+                    token -> gwtSessionService.updatePassword(token, oldPassword, newPassword,
+                            asyncCallback(onSuccess, onFailure)),
                     onFailure));
 
         }
 
         private void changePassword(final Consumer<Void> onSuccess, final Consumer<Throwable> onFailure) {
 
-            getGwtConsoleUserOptions(options -> this.passwordChangeModal.pickPassword(true, options,
-                    (oldPass, newPass) -> setNewPassword(newPass, onSuccess, onFailure)), onFailure);
+            getGwtConsoleUserOptions(options -> this.passwordChangeModal.pickPassword(options,
+                    (oldPass, newPass) -> setNewPassword(oldPass, newPass, onSuccess, onFailure)), onFailure);
         }
 
         private <T> AsyncCallback<T> asyncCallback(final Consumer<T> onSuccess, final Consumer<Throwable> onFailure) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.java
@@ -106,7 +106,10 @@ public class PasswordChangeModal extends Composite {
             e.cancel();
             trySubmit();
         });
-        this.okButton.addClickHandler(e -> trySubmit());
+        this.okButton.addClickHandler(e -> {
+            e.preventDefault();
+            trySubmit();
+        });
     }
 
     private void trySubmit() {
@@ -115,8 +118,7 @@ public class PasswordChangeModal extends Composite {
         }
 
         passwordChangeModal.hide();
-        callback.ifPresent(
-                c -> c.onPasswordChanged(oldPassword.getValue(), newPassword.getValue()));
+        callback.ifPresent(c -> c.onPasswordChanged(oldPassword.getValue(), newPassword.getValue()));
     }
 
     private void validate() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import org.eclipse.kura.web.client.ui.validator.GwtValidators;
 import org.eclipse.kura.web.shared.model.GwtConsoleUserOptions;
 import org.gwtbootstrap3.client.ui.Button;
-import org.gwtbootstrap3.client.ui.FormGroup;
 import org.gwtbootstrap3.client.ui.Input;
 import org.gwtbootstrap3.client.ui.Modal;
 import org.gwtbootstrap3.client.ui.form.error.BasicEditorError;
@@ -46,8 +45,6 @@ public class PasswordChangeModal extends Composite {
     @UiField
     Modal passwordChangeModal;
     @UiField
-    FormGroup oldPasswordGroup;
-    @UiField
     Input oldPassword;
     @UiField
     Input newPassword;
@@ -57,8 +54,6 @@ public class PasswordChangeModal extends Composite {
     Button okButton;
     @UiField
     FormPanel passwordChangeForm;
-
-    private boolean isAdmin;
 
     private Optional<Callback> callback = Optional.empty();
 
@@ -115,19 +110,13 @@ public class PasswordChangeModal extends Composite {
     }
 
     private void trySubmit() {
-        Optional<String> oldPassword = Optional.ofNullable(this.oldPassword.getValue());
-        
-        if (!this.isAdmin && !oldPassword.isPresent()) {
-            return;
-        }
-        
-        if (!newPassword.validate() || !confirmNewPassword.validate()) {
+        if (!oldPassword.validate() || !newPassword.validate() || !confirmNewPassword.validate()) {
             return;
         }
 
         passwordChangeModal.hide();
         callback.ifPresent(
-                c -> c.onPasswordChanged(oldPassword, newPassword.getValue()));
+                c -> c.onPasswordChanged(oldPassword.getValue(), newPassword.getValue()));
     }
 
     private void validate() {
@@ -159,9 +148,7 @@ public class PasswordChangeModal extends Composite {
         });
     }
 
-    public void pickPassword(boolean isAdmin, final GwtConsoleUserOptions options, final Callback callback) {
-        this.isAdmin = isAdmin;
-        this.oldPasswordGroup.setVisible(!this.isAdmin);
+    public void pickPassword(final GwtConsoleUserOptions options, final Callback callback) {
         this.oldPassword.setValue("");
         this.newPassword.setValue("");
         this.confirmNewPassword.setValue("");
@@ -173,6 +160,6 @@ public class PasswordChangeModal extends Composite {
 
     public interface Callback {
 
-        public void onPasswordChanged(final Optional<String> oldPassword, final String newPassword);
+        public void onPasswordChanged(final String oldPassword, final String newPassword);
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.ui.xml
@@ -31,6 +31,18 @@
 			b:id="passwordChangeModal" title="{msgs.loginPasswordChangeRequired}">
 			<b:ModalBody>
 				<b:FieldSet>
+				
+					<b:FormGroup ui:field="oldPasswordGroup">
+						<b:FormLabel for="oldPassword"
+							text="Confirm current password" />
+						<b:InputGroup>
+							<b:InputGroupAddon icon="KEY" iconSize="LARGE" />
+							<b:Input b:id="oldPassword" ui:field="oldPassword"
+								type="PASSWORD" />
+						</b:InputGroup>
+						<b:HelpBlock iconType="EXCLAMATION_TRIANGLE" />
+					</b:FormGroup>
+					
 					<b:FormGroup>
 						<b:FormLabel for="newPassword"
 							text="{msgs.loginNewPasswordFieldLabel}" />
@@ -41,6 +53,7 @@
 						</b:InputGroup>
 						<b:HelpBlock iconType="EXCLAMATION_TRIANGLE" />
 					</b:FormGroup>
+					
 					<b:FormGroup>
 						<b:FormLabel for="confirmNewPassword"
 							text="{msgs.loginNewPasswordConfirmLabel}" />
@@ -51,6 +64,7 @@
 						</b:InputGroup>
 						<b:HelpBlock iconType="EXCLAMATION_TRIANGLE" />
 					</b:FormGroup>
+					
 				</b:FieldSet>
 			</b:ModalBody>
 			<b:ModalFooter>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.ui.xml
@@ -32,7 +32,7 @@
 			<b:ModalBody>
 				<b:FieldSet>
 				
-					<b:FormGroup ui:field="oldPasswordGroup">
+					<b:FormGroup>
 						<b:FormLabel for="oldPassword"
 							text="Confirm current password" />
 						<b:InputGroup>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/PasswordChangeModal.ui.xml
@@ -34,7 +34,7 @@
 				
 					<b:FormGroup>
 						<b:FormLabel for="oldPassword"
-							text="Confirm current password" />
+							text="{msgs.loginOldPasswordFieldLabel}" />
 						<b:InputGroup>
 							<b:InputGroupAddon icon="KEY" iconSize="LARGE" />
 							<b:Input b:id="oldPassword" ui:field="oldPassword"

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtSessionServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtSessionServiceImpl.java
@@ -100,12 +100,34 @@ public class GwtSessionServiceImpl extends OsgiRemoteServiceServlet implements G
     }
 
     @Override
-    public void updatePassword(GwtXSRFToken xsrfToken, String newPassword) throws GwtKuraException {
+    public void updatePassword(GwtXSRFToken xsrfToken, String oldPassword, String newPassword) throws GwtKuraException {
         checkXSRFToken(xsrfToken);
 
         final HttpServletRequest request = getThreadLocalRequest();
         final HttpSession session = request.getSession(false);
 
+        String username = getSessionUsername(session);
+
+        try {
+            this.userManager.authenticateWithPassword(username, oldPassword);
+        } catch (KuraException e) {
+            logger.warn("Wrong password");
+            throw new GwtKuraException(GwtKuraErrorCode.INVALID_USERNAME_PASSWORD);
+        }
+        
+        try {
+            if (!this.userManager.setUserPassword(username, newPassword)) {
+                throw new GwtKuraException(GwtKuraErrorCode.PASSWORD_CHANGE_SAME_PASSWORD);
+            }
+        } catch (final KuraException e) {
+            logger.warn("Failed to update user password", e);
+            throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR);
+        }
+
+        setAuthenticated(session, username);
+    }
+
+    private String getSessionUsername(HttpSession session) throws GwtKuraException {
         if (session == null) {
             throw new GwtKuraException(GwtKuraErrorCode.UNAUTHENTICATED);
         }
@@ -116,16 +138,11 @@ public class GwtSessionServiceImpl extends OsgiRemoteServiceServlet implements G
             throw new GwtKuraException(GwtKuraErrorCode.UNAUTHENTICATED);
         }
 
-        try {
-            if (!this.userManager.setUserPassword((String) username, newPassword)) {
-                throw new GwtKuraException(GwtKuraErrorCode.PASSWORD_CHANGE_SAME_PASSWORD);
-            }
-        } catch (final KuraException e) {
-            logger.warn("failed to update user password", e);
-            throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR);
-        }
+        return (String) username;
+    }
 
-        Console.instance().setAuthenticated(session, (String) username,
+    private void setAuthenticated(HttpSession session, String username) throws GwtKuraException {
+        Console.instance().setAuthenticated(session, username,
                 AuditContext.current().orElseThrow(() -> new GwtKuraException("Audit context is not available")));
         session.removeAttribute(Attributes.LOCKED.getValue());
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtSessionServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtSessionServiceImpl.java
@@ -100,7 +100,8 @@ public class GwtSessionServiceImpl extends OsgiRemoteServiceServlet implements G
     }
 
     @Override
-    public void updatePassword(String newPassword) throws GwtKuraException {
+    public void updatePassword(GwtXSRFToken xsrfToken, String newPassword) throws GwtKuraException {
+        checkXSRFToken(xsrfToken);
 
         final HttpServletRequest request = getThreadLocalRequest();
         final HttpSession session = request.getSession(false);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtSessionServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtSessionServiceImpl.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kura.web.server;
 
+import java.util.Optional;
+
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -107,6 +109,12 @@ public class GwtSessionServiceImpl extends OsgiRemoteServiceServlet implements G
         final HttpSession session = request.getSession(false);
 
         String username = getSessionUsername(session);
+
+        Optional<GwtUserConfig> userConfig = this.userManager.getUserConfig(username);
+
+        if (!userConfig.isPresent() || !userConfig.get().isPasswordAuthEnabled()) {
+            throw new GwtKuraException(GwtKuraErrorCode.OPERATION_NOT_SUPPORTED);
+        }
 
         try {
             this.userManager.authenticateWithPassword(username, oldPassword);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtSessionService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtSessionService.java
@@ -31,5 +31,5 @@ public interface GwtSessionService extends RemoteService {
 
     public GwtUserConfig getUserConfig(GwtXSRFToken token) throws GwtKuraException;
 
-    public void updatePassword(final String newPassword) throws GwtKuraException;
+    public void updatePassword(GwtXSRFToken token, final String newPassword) throws GwtKuraException;
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtSessionService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtSessionService.java
@@ -31,5 +31,6 @@ public interface GwtSessionService extends RemoteService {
 
     public GwtUserConfig getUserConfig(GwtXSRFToken token) throws GwtKuraException;
 
-    public void updatePassword(GwtXSRFToken token, final String newPassword) throws GwtKuraException;
+    public void updatePassword(GwtXSRFToken token, final String oldPassword, final String newPassword)
+            throws GwtKuraException;
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtSessionService.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/service/GwtSessionService.java
@@ -31,6 +31,7 @@ public interface GwtSessionService extends RemoteService {
 
     public GwtUserConfig getUserConfig(GwtXSRFToken token) throws GwtKuraException;
 
+    @Audit(componentName = "UI Session", description = "Password update")
     public void updatePassword(GwtXSRFToken token, final String oldPassword, final String newPassword)
             throws GwtKuraException;
 }

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -784,6 +784,7 @@ loginNewPasswordConfirmLabel=Confirm Password
 loginWebUiAccessNotEnabled=Web UI access is not enabled.
 loginUsernameFieldLabel=Enter username
 loginPasswordFieldLabel=Enter password
+loginOldPasswordFieldLabel=Enter old password
 loginPasswordAuthMethod=Password
 loginPasswordChangeSame=The provided password is the same as the previous one, please retry specifying a different password.
 loginInternalError=An internal error occurred.

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -508,7 +508,7 @@ Sidenav START
   	padding-top: 0.4cm;
   	right: 0;
 	text-align: right;
-	width: 250px !important;
+	width: fit-content !important;
 	margin-right: 0px !important;
 }
 

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -485,7 +485,7 @@ Sidenav START
 		transform: translateX(-6cm);
 	}
 	
-	.logout-ui:not(.header-logout-ui) {
+	.dropdown-settings:not(.header-dropdown-settings) {
 		display: none;
 	}
 	
@@ -502,6 +502,42 @@ Sidenav START
 	width: 100vw;
 	height: 100vh;
 	overflow: hidden;
+}
+
+.dropdown-settings {
+  	padding-top: 0.4cm;
+  	right: 0;
+	text-align: right;
+	width: 200px !important;
+	margin-right: 0px !important;
+}
+
+.dropdown-settings-content {
+	position: absolute;
+	right: 15px;
+	text-align: right;
+	width: 150px !important; /* leave 50px less than the width of dropdown-settings */
+	display: none;
+	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+	z-index: 100;
+	padding-left: 0px !important;
+	padding-right: 0px !important;
+}
+
+.dropdown-settings-content * {
+	background-color: white;
+	color: black;
+	padding: 10px;
+	text-decoration: none;
+	display: block;
+}
+
+.dropdown-settings-content *:hover {
+	background-color: #f1f1f1
+}
+
+.dropdown-settings:hover .dropdown-settings-content {
+	display: block;
 }
 
 .nav li a {
@@ -526,18 +562,7 @@ Sidenav START
 	background-color: white;
 }
 
-.logout-ui {
-	padding-top: 0.2cm;
-	text-align: right;
-	padding-left: 15px !important;
-    padding-right: 15px !important;
-}
-		
-.logout-button {
-	display: inline;
-}
-
-.header-bar .logout-ui {
+.header-bar .dropdown-settings {
 	position: absolute;
 	right: 0;
 	top: 0.2cm;

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -517,11 +517,18 @@ Sidenav START
 	right: 15px;
 	text-align: right;
 	width: 200px !important; /* leave 50px less than the width of dropdown-settings */
-	display: none;
-	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+	box-shadow: 0px 10px 7px 5px rgba(0,0,0,0.2);
 	z-index: 100;
 	padding-left: 0px !important;
 	padding-right: 0px !important;
+}
+
+.hide-dropdown {
+	display: none !important;
+}
+
+.dropdown-settings-content:not(.hide-dropdown) {
+	display: block !important;
 }
 
 .dropdown-settings-content * {
@@ -534,10 +541,6 @@ Sidenav START
 
 .dropdown-settings-content *:hover {
 	background-color: #f1f1f1
-}
-
-.dropdown-settings:hover .dropdown-settings-content {
-	display: block;
 }
 
 .nav li a {

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -508,7 +508,7 @@ Sidenav START
   	padding-top: 0.4cm;
   	right: 0;
 	text-align: right;
-	width: 200px !important;
+	width: 250px !important;
 	margin-right: 0px !important;
 }
 
@@ -516,7 +516,7 @@ Sidenav START
 	position: absolute;
 	right: 15px;
 	text-align: right;
-	width: 150px !important; /* leave 50px less than the width of dropdown-settings */
+	width: 200px !important; /* leave 50px less than the width of dropdown-settings */
 	display: none;
 	box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
 	z-index: 100;


### PR DESCRIPTION
This PR introduces a new feature that allows the logged user to change its password.

**Related Issue:** N/A.

**Description of the solution adopted:** The header has been modified to include a dropdown settings menuthat can be triggered by clicking on the cog button next to the username. The menu contains the usual "Logout" button and the new "Change password".

When clicking on "Change password", the password change dialog appears.

The `updatePassword` RPC of the GWT session service has been modified to be more secure by requiring the old password.

**Screenshots:**

Screenshot 1: *Dropdown menu.*

<img width="508" alt="Screenshot 2022-04-22 at 10 57 03" src="https://user-images.githubusercontent.com/39562568/164670746-c78fbee6-ce25-4ab6-a6bf-1de4328809a3.png">

Screenshot 2: *Password change modal.*

<img width="1276" alt="Screenshot 2022-04-22 at 11 12 03" src="https://user-images.githubusercontent.com/39562568/164675593-dba4d65a-cbb1-4f52-90d3-48cb1b8e3446.png">

**Any side note on the changes made:** N/A.
