### PR TITLE
Removed unnecessary disable of `systemd-timedated` upon installation

### DIFF
--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -85,8 +85,6 @@ fi
 sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
 
 #prevent time sync services from starting
-systemctl stop systemd-timedated
-systemctl disable systemd-timedated
 systemctl stop systemd-timesyncd
 systemctl disable systemd-timesyncd
 # Prevent time sync with chrony from starting.


### PR DESCRIPTION
As discussed in #3927 removed unnecessary disable of `systemd-timedated` upon installation

**Related Issue:** https://github.com/eclipse/kura/pull/3927

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>
