### PR TITLE
Restored baseline plugin analysis

### DIFF
--- a/kura/org.eclipse.kura.api/pom.xml
+++ b/kura/org.eclipse.kura.api/pom.xml
@@ -27,7 +27,6 @@
 
     <properties>
         <kura.basedir>${project.basedir}/..</kura.basedir>
-        <org.eclipse.kura.api.lastversion>2.3.1</org.eclipse.kura.api.lastversion>
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test/*/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
@@ -36,11 +35,6 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
-                <configuration>
-                    <base>
-                        <version>${org.eclipse.kura.api.lastversion}</version>
-                    </base>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/kura/org.eclipse.kura.api/pom.xml
+++ b/kura/org.eclipse.kura.api/pom.xml
@@ -27,67 +27,12 @@
 
     <properties>
         <kura.basedir>${project.basedir}/..</kura.basedir>
+        <org.eclipse.kura.api.lastversion>2.3.1</org.eclipse.kura.api.lastversion>
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test/*/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0-alpha-1</version>
-                <executions>
-                    <execution>
-                        <id>read-previous-release</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>read-project-properties</goal>
-                        </goals>
-                        <configuration>
-                            <files>
-                                <file>${basedir}/../distrib/RELEASE_INFO/version.properties</file>
-                            </files>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>read-previous-release-versions</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>read-project-properties</goal>
-                        </goals>
-                        <configuration>
-                            <files>
-                                <file>${basedir}/../distrib/RELEASE_INFO/${kura.project.version.previous}/config/kura.build.properties</file>
-                            </files>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-			<!-- This is needed to force the initial baseline (1.1.1) -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>previous-api-version</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <exportAntProperties>true</exportAntProperties>
-                            <tasks>
-                                <condition property="org.eclipse.kura.api.lastversion" value="1.1.1"
-                                    else="${org.eclipse.kura.api.version}">
-                                    <equals arg1="${org.eclipse.kura.api.version}" arg2="1.1.0" />
-                                </condition>
-                            </tasks>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Restores the API baseline analysis by setting the previous api bundle version in the `org.eclipse.kura.api` package instead of the no longer maintained `distrib/RELEASE-INFO` folder
