### PR TITLE
feat: Add container entrypoint override support to container orchestrator

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
@@ -48,6 +48,7 @@ public class ContainerConfiguration {
     private Map<String, String> containerLoggerParameters;
     private String containerLoggingType;
     private ImageConfiguration imageConfig;
+    private List<String> entryPoint;
 
     private ContainerConfiguration() {
     }
@@ -201,6 +202,17 @@ public class ContainerConfiguration {
     }
 
     /**
+     * Returns a List<String> of container entry points. If this field is left empty
+     * the default container entrypoint will be used.
+     *
+     * @return
+     * @since 2.6
+     */
+    public List<String> getEntryPoint() {
+        return this.entryPoint;
+    }
+
+    /**
      * Creates a builder for creating a new {@link ContainerConfiguration} instance.
      *
      * @return the builder.
@@ -213,7 +225,8 @@ public class ContainerConfiguration {
     public int hashCode() {
         return Objects.hash(this.containerDevices, this.containerEnvVars, this.containerLoggerParameters,
                 this.containerLoggingType, this.containerName, this.containerPortsExternal, this.containerPortsInternal,
-                this.containerPrivileged, this.containerVolumes, this.isFrameworkManaged, this.imageConfig);
+                this.containerPrivileged, this.containerVolumes, this.isFrameworkManaged, this.imageConfig,
+                this.entryPoint);
     }
 
     @Override
@@ -235,7 +248,8 @@ public class ContainerConfiguration {
                 && Objects.equals(this.containerPrivileged, other.containerPrivileged)
                 && Objects.equals(this.containerVolumes, other.containerVolumes)
                 && Objects.equals(this.isFrameworkManaged, other.isFrameworkManaged)
-                && Objects.equals(this.imageConfig, other.imageConfig);
+                && Objects.equals(this.imageConfig, other.imageConfig)
+                && Objects.equals(this.entryPoint, other.entryPoint);
     }
 
     public static final class ContainerConfigurationBuilder {
@@ -251,6 +265,7 @@ public class ContainerConfiguration {
         private Map<String, String> containerLoggerParameters;
         private String containerLoggingType;
         private ImageConfigurationBuilder imageConfigBuilder = new ImageConfiguration.ImageConfigurationBuilder();
+        private List<String> EntryPoint = new LinkedList<>();
 
         public ContainerConfigurationBuilder setContainerName(String serviceName) {
             this.containerName = serviceName;
@@ -322,6 +337,11 @@ public class ContainerConfiguration {
             return this;
         }
 
+        public ContainerConfigurationBuilder setEntryPoint(List<String> entryPoint) {
+            this.EntryPoint = entryPoint;
+            return this;
+        }
+
         /**
          * Set the {@link ImageConfiguration}
          * 
@@ -349,6 +369,7 @@ public class ContainerConfiguration {
             result.containerLoggerParameters = this.containerLoggerParameters;
             result.containerLoggingType = this.containerLoggingType;
             result.imageConfig = this.imageConfigBuilder.build();
+            result.entryPoint = requireNonNull(this.EntryPoint, "Container EntryPoint list must not be null");
 
             return result;
         }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
@@ -28,7 +28,7 @@ import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * Object which represents a container configuration used to request the
- * generation of a new container instance.
+ * generation of a new container instance. 
  *
  * @noimplement This interface is not intended to be implemented by clients.
  * @since 2.3

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
@@ -28,7 +28,7 @@ import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * Object which represents a container configuration used to request the
- * generation of a new container instance. 
+ * generation of a new container instance.
  *
  * @noimplement This interface is not intended to be implemented by clients.
  * @since 2.3

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
@@ -202,8 +202,7 @@ public class ContainerConfiguration {
     }
 
     /**
-     * Returns a List<String> of container entry points. If this field is left empty
-     * the default container entrypoint will be used.
+     * Returns a List<String> of container entry points. An empty list can be returned if no entrypoints are specified.
      *
      * @return
      * @since 2.6

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
@@ -265,7 +265,7 @@ public class ContainerConfiguration {
         private Map<String, String> containerLoggerParameters;
         private String containerLoggingType;
         private ImageConfigurationBuilder imageConfigBuilder = new ImageConfiguration.ImageConfigurationBuilder();
-        private List<String> EntryPoint = new LinkedList<>();
+        private List<String> entryPoint = new LinkedList<>();
 
         public ContainerConfigurationBuilder setContainerName(String serviceName) {
             this.containerName = serviceName;
@@ -338,7 +338,7 @@ public class ContainerConfiguration {
         }
 
         public ContainerConfigurationBuilder setEntryPoint(List<String> entryPoint) {
-            this.EntryPoint = entryPoint;
+            this.entryPoint = entryPoint;
             return this;
         }
 
@@ -369,7 +369,7 @@ public class ContainerConfiguration {
             result.containerLoggerParameters = this.containerLoggerParameters;
             result.containerLoggingType = this.containerLoggingType;
             result.imageConfig = this.imageConfigBuilder.build();
-            result.entryPoint = requireNonNull(this.EntryPoint, "Container EntryPoint list must not be null");
+            result.entryPoint = requireNonNull(this.entryPoint, "Container EntryPoint list must not be null");
 
             return result;
         }

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -432,8 +432,8 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
             HostConfig configuration = new HostConfig();
 
             commandBuilder = containerEnviromentVariablesHandler(containerDescription, commandBuilder);
-            
-            commandBuilder = containerEntrypointHandler(containerDescription, commandBuilder);            
+
+            commandBuilder = containerEntrypointHandler(containerDescription, commandBuilder);
 
             // Host Configuration Related
             configuration = containerVolumeMangamentHandler(containerDescription, configuration);
@@ -565,16 +565,16 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
         return commandBuilder;
 
     }
-    
+
     private CreateContainerCmd containerEntrypointHandler(ContainerConfiguration containerDescription,
             CreateContainerCmd commandBuilder) {
-        
+
         if (containerDescription.getEntryPoint().isEmpty() || containerDescription.getEntryPoint() == null) {
             return commandBuilder;
         }
 
         return commandBuilder.withEntrypoint(containerDescription.getEntryPoint());
-        
+
     }
 
     private HostConfig containerVolumeMangamentHandler(ContainerConfiguration containerDescription,
@@ -628,7 +628,6 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
 
         return hostConfiguration;
 
-    }
     }
 
     private boolean doesImageExist(String imageName, String imageTag) {

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -34,6 +34,7 @@ import org.eclipse.kura.container.orchestration.ContainerOrchestrationService;
 import org.eclipse.kura.container.orchestration.ContainerState;
 import org.eclipse.kura.container.orchestration.ImageConfiguration;
 import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
+import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor.ImageInstanceDescriptorBuilder;
 import org.eclipse.kura.container.orchestration.PasswordRegistryCredentials;
 import org.eclipse.kura.container.orchestration.RegistryCredentials;
 import org.eclipse.kura.container.orchestration.listener.ContainerOrchestrationServiceListener;
@@ -767,10 +768,16 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
         List<ImageInstanceDescriptor> result = new ArrayList<>();
         images.forEach(image -> {
             InspectImageResponse iir = this.dockerClient.inspectImageCmd(image.getId()).exec();
-            result.add(
-                    ImageInstanceDescriptor.builder().setImageName(getImageName(image)).setImageTag(getImageTag(image))
-                            .setImageId(image.getId()).setImageAuthor(iir.getAuthor()).setImageArch(iir.getArch())
-                            .setimageSize(iir.getSize().longValue()).setImageLabels(image.getLabels()).build());
+            
+            ImageInstanceDescriptorBuilder imageBuilder = ImageInstanceDescriptor.builder().setImageName(getImageName(image)).setImageTag(getImageTag(image))
+                    .setImageId(image.getId()).setImageAuthor(iir.getAuthor()).setImageArch(iir.getArch())
+                    .setimageSize(iir.getSize().longValue());
+            
+            if (image.getLabels() != null) {
+                imageBuilder.setImageLabels(image.getLabels());
+            }
+            
+            result.add(imageBuilder.build());
         });
         return result;
     }

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -432,6 +432,8 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
             HostConfig configuration = new HostConfig();
 
             commandBuilder = containerEnviromentVariablesHandler(containerDescription, commandBuilder);
+            
+            commandBuilder = containerEntrypointHandler(containerDescription, commandBuilder);            
 
             // Host Configuration Related
             configuration = containerVolumeMangamentHandler(containerDescription, configuration);
@@ -563,6 +565,17 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
         return commandBuilder;
 
     }
+    
+    private CreateContainerCmd containerEntrypointHandler(ContainerConfiguration containerDescription,
+            CreateContainerCmd commandBuilder) {
+        
+        if (containerDescription.getEntryPoint().isEmpty() || containerDescription.getEntryPoint() == null) {
+            return commandBuilder;
+        }
+
+        return commandBuilder.withEntrypoint(containerDescription.getEntryPoint());
+        
+    }
 
     private HostConfig containerVolumeMangamentHandler(ContainerConfiguration containerDescription,
             HostConfig hostConfiguration) {
@@ -615,6 +628,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
 
         return hostConfiguration;
 
+    }
     }
 
     private boolean doesImageExist(String imageName, String imageTag) {

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -92,6 +92,11 @@
             type="String" cardinality="1"
             required="false" default="" />
             
+        <AD id="container.entrypoint" name="Entrypoint Override"
+            description="Comma separated list which is used to override the command used to start a container. Example: ./test.sh,-v,-d,--human-readable"
+            type="String" cardinality="1"
+            required="false" default="" />
+            
         <AD id="container.volume" name="Volume Mount"
             description="The path on the container at which you would like to mount a file or folder. Example: /path/on/host1:/path/on/container1, /path/on/host2:/path/on/container2." 
             type="String" cardinality="1"

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
@@ -300,7 +300,7 @@ public class ContainerInstance implements ConfigurableComponent, ContainerOrches
             }
             
             try {
-                ContainerInstance.this.containerOrchestrationService.stopContainer(this.containerId);
+                ContainerInstance.this.containerOrchestrationService.deleteContainer(this.containerId);
             } catch (Exception e) {
                 logger.error("Error deleting microservice {}", this.options.getContainerName(), e);
             }

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
@@ -295,9 +295,14 @@ public class ContainerInstance implements ConfigurableComponent, ContainerOrches
         private void deleteContainer() {
             try {
                 ContainerInstance.this.containerOrchestrationService.stopContainer(this.containerId);
-                ContainerInstance.this.containerOrchestrationService.deleteContainer(this.containerId);
             } catch (Exception e) {
                 logger.error("Error stopping microservice {}", this.options.getContainerName(), e);
+            }
+            
+            try {
+                ContainerInstance.this.containerOrchestrationService.stopContainer(this.containerId);
+            } catch (Exception e) {
+                logger.error("Error deleting microservice {}", this.options.getContainerName(), e);
             }
         }
 

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
@@ -108,7 +108,7 @@ public class ContainerInstance implements ConfigurableComponent, ContainerOrches
 
         this.state = newState;
     }
-    
+
     private Optional<ContainerInstanceDescriptor> getExistingContainer(final String containerName) {
         return containerOrchestrationService.listContainerDescriptors().stream()
                 .filter(c -> c.getContainerName().equals(containerName)).findAny();

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
@@ -166,7 +166,6 @@ public class ContainerInstanceOptions {
 
         return stringList;
     }
-    
 
     public boolean isEnabled() {
         return this.enabled;
@@ -240,9 +239,9 @@ public class ContainerInstanceOptions {
     public int getImageDownloadTimeout() {
         return this.imageDownloadTimeout;
     }
-    
-    public List<String> getEntryPoint(){
-    	return this.containerEntryPoint;
+
+    public List<String> getEntryPoint() {
+        return this.containerEntryPoint;
     }
 
     private ImageConfiguration buildImageConfig() {

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
@@ -54,6 +54,7 @@ public class ContainerInstanceOptions {
     private static final Property<String> REGISTRY_PASSWORD = new Property<>("registry.password", "");
     private static final Property<Integer> IMAGES_DOWNLOAD_TIMEOUT = new Property<>("container.image.download.timeout",
             500);
+    private static final Property<String> CONTAINER_ENTRY_POINT = new Property<>("container.entrypoint", "");
 
     private final boolean enabled;
     private final String image;
@@ -74,6 +75,7 @@ public class ContainerInstanceOptions {
     private final Optional<String> registryUsername;
     private final Optional<String> registryPassword;
     private final int imageDownloadTimeout;
+    private final List<String> containerEntryPoint;
 
     public ContainerInstanceOptions(final Map<String, Object> properties) {
         if (isNull(properties)) {
@@ -99,6 +101,7 @@ public class ContainerInstanceOptions {
         this.registryUsername = REGISTRY_USERNAME.getOptional(properties);
         this.registryPassword = REGISTRY_PASSWORD.getOptional(properties);
         this.imageDownloadTimeout = IMAGES_DOWNLOAD_TIMEOUT.get(properties);
+        this.containerEntryPoint = parseStringListSplitByComma(CONTAINER_ENTRY_POINT.get(properties));
     }
 
     private Map<String, String> parseVolume(String volumeString) {
@@ -149,20 +152,21 @@ public class ContainerInstanceOptions {
         return envList;
     }
 
-    private List<String> parseDeviceStrings(String containerDevice) {
+    private List<String> parseStringListSplitByComma(String stringToSplit) {
 
-        List<String> deviceList = new LinkedList<>();
+        List<String> stringList = new LinkedList<>();
 
-        if (containerDevice.isEmpty()) {
-            return deviceList;
+        if (stringToSplit.isEmpty()) {
+            return stringList;
         }
 
-        for (String entry : containerDevice.trim().split(",")) {
-            deviceList.add(entry.trim());
+        for (String entry : stringToSplit.trim().split(",")) {
+            stringList.add(entry.trim());
         }
 
-        return deviceList;
+        return stringList;
     }
+    
 
     public boolean isEnabled() {
         return this.enabled;
@@ -197,7 +201,7 @@ public class ContainerInstanceOptions {
     }
 
     public List<String> getContainerDeviceList() {
-        return parseDeviceStrings(this.containerDevice);
+        return parseStringListSplitByComma(this.containerDevice);
     }
 
     public boolean getPrivilegedMode() {
@@ -236,6 +240,10 @@ public class ContainerInstanceOptions {
     public int getImageDownloadTimeout() {
         return this.imageDownloadTimeout;
     }
+    
+    public List<String> getEntryPoint(){
+    	return this.containerEntryPoint;
+    }
 
     private ImageConfiguration buildImageConfig() {
         return new ImageConfiguration.ImageConfigurationBuilder().setImageName(image).setImageTag(imageTag)
@@ -249,7 +257,7 @@ public class ContainerInstanceOptions {
                 .setInternalPorts(getContainerPortsInternal()).setEnvVars(getContainerEnvList())
                 .setVolumes(getContainerVolumeList()).setPrivilegedMode(this.privilegedMode)
                 .setDeviceList(getContainerDeviceList()).setFrameworkManaged(true).setLoggingType(getLoggingType())
-                .setLoggerParameters(getLoggerParameters()).build();
+                .setLoggerParameters(getLoggerParameters()).setEntryPoint(getEntryPoint()).build();
     }
 
     private List<Integer> parsePortString(String ports) {

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
@@ -161,7 +161,9 @@ public class ContainerInstanceOptions {
         }
 
         for (String entry : stringToSplit.trim().split(",")) {
-            stringList.add(entry.trim());
+            if (entry.trim().length() > 0) {
+                stringList.add(entry.trim());                
+            }
         }
 
         return stringList;

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
@@ -278,7 +278,7 @@ public class ContainerInstanceOptions {
                 this.containerLoggingParameters, this.containerName, this.containerVolumeString, this.containerVolumes,
                 this.enabled, this.externalPorts, this.image, this.imageDownloadTimeout, this.imageTag,
                 this.internalPorts, this.maxDownloadRetries, this.privilegedMode, this.registryPassword,
-                this.registryURL, this.registryUsername, this.retryInterval);
+                this.registryURL, this.registryUsername, this.retryInterval, this.containerEntryPoint);
     }
 
     @Override
@@ -305,6 +305,7 @@ public class ContainerInstanceOptions {
                 && Objects.equals(this.registryPassword, other.registryPassword)
                 && Objects.equals(this.registryURL, other.registryURL)
                 && Objects.equals(this.registryUsername, other.registryUsername)
+                && Objects.equals(this.containerEntryPoint, other.containerEntryPoint)
                 && this.retryInterval == other.retryInterval;
     }
 

--- a/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceOptionsTest.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 
 import org.eclipse.kura.container.orchestration.ContainerConfiguration;
 import org.eclipse.kura.container.orchestration.PasswordRegistryCredentials;
+import org.eclipse.kura.util.configuration.Property;
 import org.junit.Test;
 
 public class ContainerInstanceOptionsTest {
@@ -50,6 +51,7 @@ public class ContainerInstanceOptionsTest {
     private static final String DEFAULT_REGISTRY_USERNAME = "";
     private static final String DEFAULT_REGISTRY_PASSWORD = "";
     private static final int DEFAULT_IMAGES_DOWNLOAD_TIMEOUT = 500;
+    private static final String DEFAULT_CONTAINER_ENTRY_POINT = "";
 
     private static final String CONTAINER_ENV = "container.env";
     private static final String CONTAINER_PORTS_INTERNAL = "container.ports.internal";
@@ -69,6 +71,7 @@ public class ContainerInstanceOptionsTest {
     private static final String REGISTRY_USERNAME = "registry.username";
     private static final String REGISTRY_PASSWORD = "registry.password";
     private static final String IMAGES_DOWNLOAD_TIMEOUT = "container.image.download.timeout";
+    private static final String CONTAINER_ENTRY_POINT = "container.entrypoint";
 
     private Map<String, Object> properties;
 
@@ -639,6 +642,7 @@ public class ContainerInstanceOptionsTest {
         this.properties.put(REGISTRY_USERNAME, DEFAULT_REGISTRY_USERNAME);
         this.properties.put(REGISTRY_PASSWORD, DEFAULT_REGISTRY_PASSWORD);
         this.properties.put(IMAGES_DOWNLOAD_TIMEOUT, DEFAULT_IMAGES_DOWNLOAD_TIMEOUT);
+        this.properties.put(CONTAINER_ENTRY_POINT, DEFAULT_CONTAINER_ENTRY_POINT);
     }
 
     private void givenDifferentProperties() {
@@ -659,6 +663,7 @@ public class ContainerInstanceOptionsTest {
         this.newProperties.put(REGISTRY_USERNAME, "test");
         this.newProperties.put(REGISTRY_PASSWORD, "test");
         this.newProperties.put(IMAGES_DOWNLOAD_TIMEOUT, 100);
+        this.newProperties.put(CONTAINER_ENTRY_POINT, "./test.py,-v,-m,--human-readable");
     }
 
     private void givenConfigurableGenericDockerServiceOptions() {

--- a/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceOptionsTest.java
@@ -615,6 +615,14 @@ public class ContainerInstanceOptionsTest {
 
         thenIsNotNullContainerDescriptor();
     }
+    
+    @Test
+    public void testExtraCommaInEntryPointFeild() {
+        givenDifferentProperties();
+        givenDiffrentConfigurableGenericDockerServiceOptions();
+        
+        thenCheckIfExtraCommasAreIgnored();
+    }
 
     private void givenNullProperties() {
         this.properties = null;
@@ -663,11 +671,15 @@ public class ContainerInstanceOptionsTest {
         this.newProperties.put(REGISTRY_USERNAME, "test");
         this.newProperties.put(REGISTRY_PASSWORD, "test");
         this.newProperties.put(IMAGES_DOWNLOAD_TIMEOUT, 100);
-        this.newProperties.put(CONTAINER_ENTRY_POINT, "./test.py,-v,-m,--human-readable");
+        this.newProperties.put(CONTAINER_ENTRY_POINT, "./test.py,-v,-m,--human-readable,,,");
     }
 
     private void givenConfigurableGenericDockerServiceOptions() {
         this.cgdso = new ContainerInstanceOptions(this.properties);
+    }
+    
+    private void givenDiffrentConfigurableGenericDockerServiceOptions() {
+        this.cgdso = new ContainerInstanceOptions(this.newProperties);
     }
 
     private void givenEnabled(boolean b) {
@@ -919,5 +931,9 @@ public class ContainerInstanceOptionsTest {
 
     private void thenIsNotNullContainerDescriptor() {
         assertNotNull(this.containerDescriptor);
+    }
+    
+    private void thenCheckIfExtraCommasAreIgnored() {
+        assertEquals(Arrays.asList("./test.py","-v","-m","--human-readable"), this.cgdso.getEntryPoint());
     }
 }


### PR DESCRIPTION
This PR adds the ability to change a container's entry point from the container.provider.instance in the provided metatype.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/29900100/166930016-337e2b5c-a6a0-4478-b9e6-4040d7463bba.png)

This PR also includes fixes for the following bugs:

1) broken containers would be restarted instead of replaced when changing parameters under the container.provider
2) listContainerImages would sometimes provide a null when listing images.


**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
