### PR TITLE
fix(container_orchestrator): Add filter for "sha" word in container name

### DIFF
--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -182,14 +182,20 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
 
     private String getContainerVersion(Container container) {
         String version = "";
-        if (container.getImage().split(":").length > 1) {
-            version = container.getImage().split(":")[1];
+        String[] image = container.getImage().split(":");
+        if (image.length > 1 && !image[0].startsWith("sha256")) {
+            version = image[1];
         }
         return version;
     }
 
     private String getContainerTag(Container container) {
-        return container.getImage().split(":")[0];
+        String[] image = container.getImage().split(":");
+        if (image[0].startsWith("sha256")) {
+            return "none";
+        } else {
+            return image[0];
+        }
     }
 
     private List<Integer> parseExternalPortsFromDockerPs(ContainerPort[] ports) {


### PR DESCRIPTION
This PR adds a filter for the parser of the container name.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** It seems that in some corner cases the container name is replaced with a hash in the form `sha:XXXXXXXXX` and the parser interprets the `sha` as the name and `XXXXXXXX` as version. This PR filters the `sha` name, setting a `none` name and empty version.

Signed-off-by: Merlino <pierantonio.merlino@eurotech.com>