### PR TITLE
feat: Switched to libsocket-can-java with support for all Kura architectures

### DIFF
--- a/kura/org.eclipse.kura.protocol.can/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.protocol.can/META-INF/MANIFEST.MF
@@ -16,4 +16,4 @@ Export-Package: org.eclipse.kura.protocol.can;version="2.0.0"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .,
- lib/libsocket-can-java-1.0.2.jar
+ lib/libsocket-can-java-1.0.0.jar

--- a/kura/org.eclipse.kura.protocol.can/pom.xml
+++ b/kura/org.eclipse.kura.protocol.can/pom.xml
@@ -34,9 +34,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>de.entropia</groupId>
+			<groupId>com.eurotech</groupId>
 			<artifactId>libsocket-can-java</artifactId>
-			<version>1.0.2</version>
+			<version>1.0.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Switches to `com.eurotech:libsocket-can-java:1.0.0` that includes x86_64, arm32 and aarch64 support.
Pending CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=24095
