### PR TITLE
fix(ai.triton): avoid shutting down local Triton container if config set as remote

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
@@ -146,9 +146,6 @@ public class TritonServerLocalManager {
         commandString.add("--grpc-port=" + this.options.getGrpcPort());
         commandString.add("--metrics-port=" + this.options.getMetricsPort());
         commandString.add("--model-control-mode=explicit");
-        if (!this.options.getModels().isEmpty()) {
-            this.options.getModels().forEach(model -> commandString.add("--load-model=" + model));
-        }
         commandString.add("2>&1");
         commandString.add("|");
         commandString.add("systemd-cat");

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
@@ -60,6 +60,7 @@ public class TritonServerLocalManager {
     }
 
     private void startLocalServerMonitor() {
+        this.serverCommand = createServerCommand();
         this.scheduledFuture = this.scheduledExecutorService.scheduleAtFixedRate(() -> {
             Thread.currentThread().setName(getClass().getSimpleName());
             if (!isLocalServerRunning()) {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
@@ -60,15 +60,12 @@ public class TritonServerLocalManager {
     }
 
     private void startLocalServerMonitor() {
-        if (this.options.isLocalEnabled()) {
-            this.serverCommand = createServerCommand();
-            this.scheduledFuture = this.scheduledExecutorService.scheduleAtFixedRate(() -> {
-                Thread.currentThread().setName(getClass().getSimpleName());
-                if (!isLocalServerRunning()) {
-                    startLocalServer();
-                }
-            }, 0, MONITOR_PERIOD, TimeUnit.SECONDS);
-        }
+        this.scheduledFuture = this.scheduledExecutorService.scheduleAtFixedRate(() -> {
+            Thread.currentThread().setName(getClass().getSimpleName());
+            if (!isLocalServerRunning()) {
+                startLocalServer();
+            }
+        }, 0, MONITOR_PERIOD, TimeUnit.SECONDS);
     }
 
     private void startLocalServer() {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
@@ -146,6 +146,9 @@ public class TritonServerLocalManager {
         commandString.add("--grpc-port=" + this.options.getGrpcPort());
         commandString.add("--metrics-port=" + this.options.getMetricsPort());
         commandString.add("--model-control-mode=explicit");
+        if (!this.options.getModels().isEmpty()) {
+            this.options.getModels().forEach(model -> commandString.add("--load-model=" + model));
+        }
         commandString.add("2>&1");
         commandString.add("|");
         commandString.add("systemd-cat");

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -148,25 +148,27 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
     }
 
     protected void loadModels() {
-        int index = 0;
-        try {
-            while (!isEngineReady()) {
-                if (index++ >= 6) {
-                    logger.warn("Cannot load models since server is not ready.");
-                    return;
-                }
-                TritonServerLocalManager.sleepFor(10);
-            }
-        } catch (KuraException e) {
-            logger.debug("Cannot read engine status", e);
-        }
-        this.options.getModels().forEach(modelName -> {
+        if (!this.options.isLocalEnabled()) {
+            int index = 0;
             try {
-                loadModel(modelName, Optional.empty());
+                while (!isEngineReady()) {
+                    if (index++ >= 6) {
+                        logger.warn("Cannot load models since server is not ready.");
+                        return;
+                    }
+                    TritonServerLocalManager.sleepFor(10);
+                }
             } catch (KuraException e) {
-                logger.error("Cannot load model " + modelName, e);
+                logger.debug("Cannot read engine status", e);
             }
-        });
+            this.options.getModels().forEach(modelName -> {
+                try {
+                    loadModel(modelName, Optional.empty());
+                } catch (KuraException e) {
+                    logger.error("Cannot load model " + modelName, e);
+                }
+            });
+        }
     }
 
     @Override

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -148,27 +148,25 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
     }
 
     protected void loadModels() {
-        if (!this.options.isLocalEnabled()) {
-            int index = 0;
-            try {
-                while (!isEngineReady()) {
-                    if (index++ >= 6) {
-                        logger.warn("Cannot load models since server is not ready.");
-                        return;
-                    }
-                    TritonServerLocalManager.sleepFor(10);
+        int index = 0;
+        try {
+            while (!isEngineReady()) {
+                if (index++ >= 6) {
+                    logger.warn("Cannot load models since server is not ready.");
+                    return;
                 }
-            } catch (KuraException e) {
-                logger.debug("Cannot read engine status", e);
+                TritonServerLocalManager.sleepFor(10);
             }
-            this.options.getModels().forEach(modelName -> {
-                try {
-                    loadModel(modelName, Optional.empty());
-                } catch (KuraException e) {
-                    logger.error("Cannot load model " + modelName, e);
-                }
-            });
+        } catch (KuraException e) {
+            logger.debug("Cannot read engine status", e);
         }
+        this.options.getModels().forEach(modelName -> {
+            try {
+                loadModel(modelName, Optional.empty());
+            } catch (KuraException e) {
+                logger.error("Cannot load model " + modelName, e);
+            }
+        });
     }
 
     @Override

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -88,8 +88,10 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
         this.options = new TritonServerServiceOptions(properties);
         if (isConfigurationValid()) {
             setGrpcResources();
-            this.tritonServerLocalManager = new TritonServerLocalManager(this.options, this.commandExecutorService);
-            this.tritonServerLocalManager.start();
+            if (this.options.isLocalEnabled()) {
+                this.tritonServerLocalManager = new TritonServerLocalManager(this.options, this.commandExecutorService);
+                this.tritonServerLocalManager.start();
+            }
             loadModels();
         } else {
             logger.warn("The provided configuration is not valid");
@@ -104,8 +106,12 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
         this.options = new TritonServerServiceOptions(properties);
         if (isConfigurationValid()) {
             setGrpcResources();
-            this.tritonServerLocalManager = new TritonServerLocalManager(this.options, this.commandExecutorService);
-            this.tritonServerLocalManager.start();
+            if (this.options.isLocalEnabled()) {
+                this.tritonServerLocalManager = new TritonServerLocalManager(this.options, this.commandExecutorService);
+                this.tritonServerLocalManager.start();
+            } else {
+                this.tritonServerLocalManager = null;
+            }
             loadModels();
         } else {
             logger.warn("The provided configuration is not valid");
@@ -114,7 +120,9 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
     protected void deactivate() {
         logger.info("Deactivate TritonServerService...");
-        this.tritonServerLocalManager.stop();
+        if (nonNull(this.tritonServerLocalManager)) {
+            this.tritonServerLocalManager.stop();
+        }
         this.grpcChannel.shutdownNow();
     }
 


### PR DESCRIPTION
Fixed the remote Triton instance lifecycle handling.

**Related Issue:** N/A

**Description of the solution adopted:** 
A `TritonServerLocalManager` instance was created regardless of whether the Triton instance was local or remote. This meant that a locally running Triton container was getting shut-down every time there was a change in the `TritonServerServiceImpl` preventing it from properly working and loading the models set in the configuration.

With this PR the handling of the local Triton server instance is better separated and the `TritonServerLocalManager`gets instantiated only for a local installation (a Docker container instance is modeled as a `remote` for now).

