### PR TITLE
fix(ai.triton): wait for engine to be ready before loading models

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -148,23 +148,26 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
     }
 
     protected void loadModels() {
-        if (!this.options.isLocalEnabled()) {
-            int counter = 0;
-            while (!isEngineReady()) {
-                if (counter++ >= 6) {
-                    logger.warn("Cannot load models since server is not ready.");
-                    return;
-                }
-                TritonServerLocalManager.sleepFor(250);
-            }
-            this.options.getModels().forEach(modelName -> {
-                try {
-                    loadModel(modelName, Optional.empty());
-                } catch (KuraException e) {
-                    logger.error("Cannot load model " + modelName, e);
-                }
-            });
+        if (this.options.isLocalEnabled() || this.options.getModels().isEmpty()) {
+            return;
         }
+
+        int counter = 0;
+        while (!isEngineReady()) {
+            if (counter++ >= 6) {
+                logger.warn("Cannot load models since server is not ready.");
+                return;
+            }
+            TritonServerLocalManager.sleepFor(250);
+        }
+
+        this.options.getModels().forEach(modelName -> {
+            try {
+                loadModel(modelName, Optional.empty());
+            } catch (KuraException e) {
+                logger.error("Cannot load model " + modelName, e);
+            }
+        });
     }
 
     @Override

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -148,35 +148,27 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
     }
 
     protected void loadModels() {
-        if (this.options.isLocalEnabled() || this.options.getModels().isEmpty()) {
-            return;
-        }
-
-        boolean engineIsReady = false;
-        int counter = 0;
-        do {
+        if (!this.options.isLocalEnabled()) {
+            int index = 0;
             try {
-                engineIsReady = isEngineReady();
+                while (!isEngineReady()) {
+                    if (index++ >= 6) {
+                        logger.warn("Cannot load models since server is not ready.");
+                        return;
+                    }
+                    TritonServerLocalManager.sleepFor(10);
+                }
             } catch (KuraException e) {
                 logger.debug("Cannot read engine status", e);
             }
-
-            if (!engineIsReady) {
-                if (counter++ > 5) {
-                    logger.warn("Cannot load models since server is not ready.");
-                    return;
+            this.options.getModels().forEach(modelName -> {
+                try {
+                    loadModel(modelName, Optional.empty());
+                } catch (KuraException e) {
+                    logger.error("Cannot load model " + modelName, e);
                 }
-                TritonServerLocalManager.sleepFor(250);
-            }
-        } while (!engineIsReady);
-
-        this.options.getModels().forEach(modelName -> {
-            try {
-                loadModel(modelName, Optional.empty());
-            } catch (KuraException e) {
-                logger.error("Cannot load model " + modelName, e);
-            }
-        });
+            });
+        }
     }
 
     @Override

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -149,9 +149,9 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
     protected void loadModels() {
         if (!this.options.isLocalEnabled()) {
-            int index = 0;
+            int counter = 0;
             while (!isEngineReady()) {
-                if (index++ >= 6) {
+                if (counter++ >= 6) {
                     logger.warn("Cannot load models since server is not ready.");
                     return;
                 }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
@@ -153,11 +153,7 @@ public abstract class TritonServerServiceStepDefinitions {
     }
 
     protected void whenAskingIfEngineIsReady() {
-        try {
-            this.isEngineReady = this.tritonServerService.isEngineReady();
-        } catch (KuraException e) {
-            this.exceptionCaught = true;
-        }
+        this.isEngineReady = this.tritonServerService.isEngineReady();
     }
 
     protected void whenTritonServerIsActivated(Map<String, Object> properties) {


### PR DESCRIPTION
Fixed model loading attempts in `loadModels` method.

**Description of the solution adopted:** 
Before this PR the bundle was performing a single attempt at checking the Triton server health and immediately exiting the `while` loop after `isEngineReady` threw the exception caused by the Triton server not answering.

With this PR the exception thrown by the `isEngineReady` method is caught within the method itself and thus enable the successive Triton engine health checks.

I've also added a longer `sleep` time because this was what worked in my tests.

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>
