### PR TITLE
refactor(ai.triton): remove model load from Triton server startup

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
@@ -146,9 +146,6 @@ public class TritonServerLocalManager {
         commandString.add("--grpc-port=" + this.options.getGrpcPort());
         commandString.add("--metrics-port=" + this.options.getMetricsPort());
         commandString.add("--model-control-mode=explicit");
-        if (!this.options.getModels().isEmpty()) {
-            this.options.getModels().forEach(model -> commandString.add("--load-model=" + model));
-        }
         commandString.add("2>&1");
         commandString.add("|");
         commandString.add("systemd-cat");

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -148,7 +148,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
     }
 
     protected void loadModels() {
-        if (this.options.isLocalEnabled() || this.options.getModels().isEmpty()) {
+        if (this.options.getModels().isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
Removed model load from Triton server startup command so that all model lifecycle is handled by the `TritonServerServiceImpl`.

This is necessary for the upcoming model encryption feature.

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>
