### PR TITLE
fix(network): DnsMonitorServiceImpl fixes

### DIFF
--- a/kura/org.eclipse.kura.net.admin/OSGI-INF/dnsMonitor.xml
+++ b/kura/org.eclipse.kura.net.admin/OSGI-INF/dnsMonitor.xml
@@ -19,9 +19,9 @@
       <provide interface="org.eclipse.kura.net.dns.DnsMonitorService"/>
       <provide interface="org.osgi.service.event.EventHandler"/>
    </service>
-   <reference bind="setNetworkConfigurationService" cardinality="1..1" interface="org.eclipse.kura.net.admin.NetworkConfigurationService" name="NetworkConfigurationService" policy="static" unbind="unsetNetworkConfigurationService"/>
-   <reference bind="setDnsServerService" cardinality="1..1" interface="org.eclipse.kura.internal.linux.net.dns.DnsServerService" name="DNSService" policy="static" unbind="unsetDnsServerService"/>
-   <reference bind="setExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static" unbind="unsetExecutorService"/>
+   <reference bind="setNetworkConfigurationService" cardinality="1..1" interface="org.eclipse.kura.net.admin.NetworkConfigurationService" name="NetworkConfigurationService" policy="static"/>
+   <reference bind="setDnsServerService" cardinality="1..1" interface="org.eclipse.kura.internal.linux.net.dns.DnsServerService" name="DNSService" policy="static"/>
+   <reference bind="setExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static"/>
    <property name="event.topics" type="String">org/eclipse/kura/net/admin/event/NETWORK_EVENT_STATUS_CHANGE_TOPIC
 org/eclipse/kura/net/admin/event/NETWORK_EVENT_CONFIG_CHANGE_TOPIC
    </property>

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
@@ -215,18 +215,21 @@ public class DnsMonitorServiceImpl implements DnsMonitorService, EventHandler {
         logger.debug("handleEvent - topic: {}", event.getTopic());
         String topic = event.getTopic();
 
-        if (topic.equals(NetworkConfigurationChangeEvent.NETWORK_EVENT_CONFIG_CHANGE_TOPIC)) {
-            try {
-                this.networkConfiguration = this.netConfigService.getNetworkConfiguration();
-            } catch (KuraException e) {
-                logger.error("Could not get network configuration", e);
+        Thread thread = new Thread(() -> {
+            if (topic.equals(NetworkConfigurationChangeEvent.NETWORK_EVENT_CONFIG_CHANGE_TOPIC)) {
+                try {
+                    this.networkConfiguration = this.netConfigService.getNetworkConfiguration();
+                } catch (KuraException e) {
+                    logger.error("Could not get network configuration", e);
+                }
+                updateDnsResolverConfig();
+                updateDnsProxyConfig();
+            } else if (topic.equals(NetworkStatusChangeEvent.NETWORK_EVENT_STATUS_CHANGE_TOPIC)) {
+                updateDnsResolverConfig();
+                updateDnsProxyConfig();
             }
-            updateDnsResolverConfig();
-            updateDnsProxyConfig();
-        } else if (topic.equals(NetworkStatusChangeEvent.NETWORK_EVENT_STATUS_CHANGE_TOPIC)) {
-            updateDnsResolverConfig();
-            updateDnsProxyConfig();
-        }
+        });
+        thread.start();
     }
 
     private void updateDnsResolverConfig() {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
@@ -77,30 +77,12 @@ public class DnsMonitorServiceImpl implements DnsMonitorService, EventHandler {
         this.netConfigService = netConfigService;
     }
 
-    public void unsetNetworkConfigurationService(NetworkConfigurationService netConfigService) {
-        if (netConfigService.equals(this.netConfigService)) {
-            this.netConfigService = null;
-        }
-    }
-
     public void setDnsServerService(DnsServerService dnsServer) {
         this.dnsServer = dnsServer;
     }
 
-    public void unsetDnsServerService(DnsServerService dnsServer) {
-        if (dnsServer.equals(this.dnsServer)) {
-            this.dnsServer = null;
-        }
-    }
-
     public void setExecutorService(CommandExecutorService executorService) {
         this.executorService = executorService;
-    }
-
-    public void unsetExecutorService(CommandExecutorService executorService) {
-        if (executorService.equals(this.executorService)) {
-            this.executorService = null;
-        }
     }
 
     protected void activate() {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
@@ -57,7 +57,7 @@ public class DnsMonitorServiceImpl implements DnsMonitorService, EventHandler {
     private static final long THREAD_INTERVAL = 60000;
     private static final long THREAD_TERMINATION_TOUT = 60; // in seconds
     private Future<?> monitorTask;
-    private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor((r) -> {
+    private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
         final Thread t = Executors.defaultThreadFactory().newThread(r);
         t.setName("DnsMonitorServiceImpl");
         return t;

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImplTest.java
@@ -52,6 +52,7 @@ import org.eclipse.kura.net.NetInterfaceConfig;
 import org.eclipse.kura.net.NetInterfaceStatus;
 import org.eclipse.kura.net.NetworkPair;
 import org.eclipse.kura.net.admin.NetworkConfigurationService;
+import org.eclipse.kura.net.admin.NetworkConfigurationServiceImpl;
 import org.eclipse.kura.net.admin.event.NetworkConfigurationChangeEvent;
 import org.eclipse.kura.net.admin.event.NetworkStatusChangeEvent;
 import org.eclipse.kura.net.dhcp.DhcpServerConfig;
@@ -103,6 +104,9 @@ public class DnsMonitorServiceImplTest {
 
         LinuxDns ldMock = mock(LinuxDns.class);
         TestUtil.setFieldValue(svc, "dnsUtil", ldMock);
+
+        NetworkConfigurationServiceImpl ncs = mock(NetworkConfigurationServiceImpl.class);
+        svc.setNetworkConfigurationService(ncs);
 
         Map<String, Object> props = new HashMap<>();
         props.put("net.interfaces", 1); // cause exception and make sure networkConfiguration remains null


### PR DESCRIPTION
This PR fixes some bugs in the `DnsMonitorServiceImpl`.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** The following fixes are added:

- fixed NPE during configuration retrieval that caused the monitor thread to die;
- fixed wrong configuration comparation check
- the `NetworkConfiguration` now is retrieved by the `NetworkConfigurationService` at each monitor run. This fixes a wrong behavior in case of multiple modems.
