### PR TITLE
fix(core.keystore): Fixed ability to create a keystore without password.

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/OSGI-INF/metatype/org.eclipse.kura.core.keystore.FilesystemKeystoreServiceImpl.xml
+++ b/kura/org.eclipse.kura.core.keystore/OSGI-INF/metatype/org.eclipse.kura.core.keystore.FilesystemKeystoreServiceImpl.xml
@@ -23,7 +23,7 @@
             type="String"
             cardinality="0"
             required="true"
-            default="/tmp"
+            default="/tmp/keystore.ks"
             description="Specifies the filesystem path to a Java Keystore. If not present the file will be created.">
         </AD>
 

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
@@ -259,7 +259,6 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         }
 
         setKeystorePassword(this.loadKeystore(options), passwordChar);
-
     }
 
     private void updateKeystorePath(KeystoreServiceOptions newOptions) {

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
@@ -249,12 +249,13 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         }
 
         // Immediately save the keystore with the default password to allow to be loaded with the default password.
-        OutputStream os = new FileOutputStream(fKeyStore);
-        KeyStore newKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
-        newKeystore.load(null, passwordChar);
-        newKeystore.store(os, passwordChar);
-        os.flush();
-        os.close();
+        try (OutputStream os = new FileOutputStream(fKeyStore)) {
+
+            KeyStore newKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
+            newKeystore.load(null, passwordChar);
+            newKeystore.store(os, passwordChar);
+            os.flush();
+        }
 
         setKeystorePassword(this.loadKeystore(options), passwordChar);
 

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
@@ -249,7 +249,6 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
 
         // Immediately save the keystore with the default password to allow to be loaded with the default password.
         try (OutputStream os = new FileOutputStream(fKeyStore)) {
-
             KeyStore newKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
             newKeystore.load(null, passwordChar);
             newKeystore.store(os, passwordChar);

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
@@ -234,8 +234,7 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         return keystorePath != null && new File(keystorePath).isFile();
     }
 
-    private void createKeystore(KeystoreServiceOptions options)
-            throws IOException, KuraException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
+    private void createKeystore(KeystoreServiceOptions options) throws Exception {
         String keystorePath = options.getKeystorePath();
         char[] passwordChar = options.getKeystorePassword(this.cryptoService);
         if (keystorePath == null) {
@@ -255,6 +254,9 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
             newKeystore.load(null, passwordChar);
             newKeystore.store(os, passwordChar);
             os.flush();
+        } catch (Exception e) {
+            logger.error("Unable to load and store the keystore", e);
+            throw e;
         }
 
         setKeystorePassword(this.loadKeystore(options), passwordChar);

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.StringWriter;
 import java.math.BigInteger;
 import java.net.URI;
@@ -156,8 +157,8 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
 
         if (!keystoreExists(this.keystoreServiceOptions.getKeystorePath())) {
             try {
-                createKeystore(this.keystoreServiceOptions.getKeystorePath());
-            } catch (IOException e) {
+                createKeystore(this.keystoreServiceOptions);
+            } catch (Exception e) {
                 logger.error("Keystore file creation failed", e);
             }
         }
@@ -233,21 +234,37 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         return keystorePath != null && new File(keystorePath).isFile();
     }
 
-    private void createKeystore(String keystorePath) throws IOException {
+    private void createKeystore(KeystoreServiceOptions options)
+            throws IOException, KuraException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
+        String keystorePath = options.getKeystorePath();
+        char[] passwordChar = options.getKeystorePassword(this.cryptoService);
         if (keystorePath == null) {
             return;
         }
         File fKeyStore = new File(keystorePath);
         if (!fKeyStore.createNewFile()) {
             logger.error("Keystore file already exists at location {}", keystorePath);
+            throw new KuraException(KuraErrorCode.CONFIGURATION_ATTRIBUTE_INVALID, "keystore.path", keystorePath,
+                    "file already exists");
         }
+
+        // Immediately save the keystore with the default password to allow to be loaded with the default password.
+        OutputStream os = new FileOutputStream(fKeyStore);
+        KeyStore newKeystore = KeyStore.getInstance(KeyStore.getDefaultType());
+        newKeystore.load(null, passwordChar);
+        newKeystore.store(os, passwordChar);
+        os.flush();
+        os.close();
+
+        setKeystorePassword(this.loadKeystore(options), passwordChar);
+
     }
 
     private void updateKeystorePath(KeystoreServiceOptions newOptions) {
         if (!keystoreExists(newOptions.getKeystorePath())) {
             try {
-                createKeystore(newOptions.getKeystorePath());
-            } catch (IOException e) {
+                createKeystore(newOptions);
+            } catch (Exception e) {
                 logger.error("Keystore file creation failed", e);
             }
         }

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/KeystoreServiceOptions.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/KeystoreServiceOptions.java
@@ -36,7 +36,7 @@ public class KeystoreServiceOptions {
     static final String KEY_KEYSTORE_PASSWORD = "keystore.password";
     static final String KEY_RANDOMIZE_PASSWORD = "randomize.password";
 
-    private static final String DEFAULT_KEYSTORE_PATH = "/tmp";
+    private static final String DEFAULT_KEYSTORE_PATH = "/tmp/keystore.ks";
     private static final boolean DEFAULT_RANDOMIZE_PASSWORD = false;
     static final String DEFAULT_KEYSTORE_PASSWORD = "changeit";
 

--- a/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImplTest.java
@@ -898,7 +898,7 @@ public class FilesystemKeystoreServiceImplTest {
         assertNotNull(keystoreService.getKeyStore());
     }
 
-    @Test(expected = KuraException.class)
+    @Test
     public void testUpdatePathNotExisting() throws KuraException, GeneralSecurityException, IOException {
         Map<String, Object> properties = new HashMap<>();
         properties.put(KEY_KEYSTORE_PATH, STORE_PATH);

--- a/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/KeystoreServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/KeystoreServiceOptionsTest.java
@@ -15,15 +15,14 @@ package org.eclipse.kura.core.keystore;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Matchers.any;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.core.keystore.KeystoreServiceOptions;
 import org.eclipse.kura.crypto.CryptoService;
 import org.junit.Test;
 
@@ -53,7 +52,7 @@ public class KeystoreServiceOptionsTest {
 
         KeystoreServiceOptions keystoreServiceOptions = new KeystoreServiceOptions(properties, cryptoService);
 
-        assertEquals("/tmp", keystoreServiceOptions.getKeystorePath());
+        assertEquals("/tmp/keystore.ks", keystoreServiceOptions.getKeystorePath());
         assertArrayEquals(CHANGEIT_PASSWORD.toCharArray(), keystoreServiceOptions.getKeystorePassword(cryptoService));
     }
 


### PR DESCRIPTION
Now the default keystore password is immediatly set in the component creation.

Also the default KeystoreService configuration file location is changed from /tmp to /tmp/keystore.ks

