### PR TITLE
refactor(ai.triton.server): reorder Triton configuration form

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -17,6 +17,15 @@
     <OCD id="org.eclipse.kura.ai.triton.server.TritonServerService" 
          name="Nvidia Triton Server" 
          description="Configuration for the Nvidia Triton Server">
+
+         <AD id="enable.local"  
+            name="Local Nvidia Triton Server"
+            type="Boolean"
+            cardinality="0" 
+            required="true"
+            default="false" 
+            description="If enabled, a local native Nvidia Triton Server is started. In this case, the model repository and backends path are mandatory. Moreover, the server address property is overridden and set to localhost.">
+        </AD>
         
         <AD id="server.address"  
             name="Nvidia Triton Server address"
@@ -38,24 +47,6 @@
             description="The ports used to connect to the server for HTTP, GPRC and Metrics services.">
         </AD>
 
-        <AD id="models"  
-            name="Inference Models"
-            type="String"
-            cardinality="0" 
-            required="false"
-            default="" 
-            description="A comma separated list of inference model names that the server will load.">
-        </AD>
-        
-         <AD id="enable.local"  
-            name="Local Nvidia Triton Server"
-            type="Boolean"
-            cardinality="0" 
-            required="true"
-            default="false" 
-            description="If enabled, a local native Nvidia Triton Server is started. In this case, the model repository and backends path are mandatory. Moreover, the server address property is overridden and set to localhost.">
-        </AD>
-        
         <AD id="local.model.repository.path"  
             name="Local model repository path"
             type="String"
@@ -73,6 +64,15 @@
             default="" 
             description="Only for local instance, specify the password to be used for decrypting models stored in the model repository. If none is specified, models are supposed to be plaintext.">
        </AD>
+
+        <AD id="models"  
+            name="Inference Models"
+            type="String"
+            cardinality="0" 
+            required="false"
+            default="" 
+            description="A comma separated list of inference model names that the server will load.">
+        </AD>
         
         <AD id="local.backends.path"  
             name="Local backends path"


### PR DESCRIPTION
Reordered Triton configuration form as following:
- Local Instance selector at the top of the page since it's the most important one
- Models to be loaded moved lower than the model repository path (reasoning is: in the path you look for the available models, then I’ll give you the ones to be loaded)

Screenshot:
![Screenshot 2022-05-24 at 15 46 45](https://user-images.githubusercontent.com/22748355/170051352-4c58c09e-6dde-439a-8a1b-b9cacfc736e5.png)

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>