### PR TITLE
build: Upgraded bouncycastle to 1.71

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -943,6 +943,10 @@ fi]]>
 				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/bcpkix_${org.bouncycastle.jar.version}.jar@3" />
 			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/bcprov_${org.bouncycastle.jar.version}.jar@3" />
+            <entry key="osgi.bundles" operation="+"
+                value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/bctls_${org.bouncycastle.jar.version}.jar@3" />
+            <entry key="osgi.bundles" operation="+"
+                value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/bcutil_${org.bouncycastle.jar.version}.jar@3" />
 			<entry key="osgi.bundles" operation="+"
 				value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/bluez-dbus-osgi_${bluez-dbus-osgi.version}.jar@3" />
 			<entry key="osgi.bundles" operation="+"

--- a/kura/distrib/src/main/resources/common/Kura_Emulator.launch
+++ b/kura/distrib/src/main/resources/common/Kura_Emulator.launch
@@ -34,6 +34,8 @@
     <setAttribute key="selected_target_bundles">
         <setEntry value="bcpkix@default:default"/>
         <setEntry value="bcprov@default:default"/>
+        <setEntry value="bctls@default:default"/>
+        <setEntry value="bcutil@default:default"/>
         <setEntry value="com.eclipsesource.jaxrs.jersey-min@default:default"/>
         <setEntry value="com.eclipsesource.jaxrs.provider.gson@default:default"/>
         <setEntry value="com.eclipsesource.jaxrs.provider.security@default:default"/>

--- a/kura/emulator/org.eclipse.kura.emulator/src/main/resources/Kura_Emulator.launch
+++ b/kura/emulator/org.eclipse.kura.emulator/src/main/resources/Kura_Emulator.launch
@@ -34,6 +34,8 @@
     <setAttribute key="selected_target_bundles">
         <setEntry value="bcpkix@default:default"/>
         <setEntry value="bcprov@default:default"/>
+        <setEntry value="bctls@default:default"/>
+        <setEntry value="bcutil@default:default"/>
         <setEntry value="com.eclipsesource.jaxrs.jersey-min@default:default"/>
         <setEntry value="com.eclipsesource.jaxrs.provider.gson@default:default"/>
         <setEntry value="com.eclipsesource.jaxrs.provider.security@default:default"/>

--- a/kura/org.eclipse.kura.api/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.api/META-INF/MANIFEST.MF
@@ -78,6 +78,7 @@ Import-Package: javax.comm;version="1.2.0",
  javax.usb;version="1.0.2",
  org.apache.commons.io.output;version="2.4.0",
  org.apache.logging.log4j;version="2.8.2",
+ org.bouncycastle.pkcs;version="1.71.0",
  org.osgi.annotation.versioning;version="[1.0.0,2.0.0)";resolution:=optional,
  org.osgi.framework;version="[1.5.0,2.0.0)",
  org.osgi.service.component;version="1.2.0",
@@ -86,4 +87,5 @@ Import-Package: javax.comm;version="1.2.0",
  org.osgi.service.wireadmin;version="1.0.1",
  org.osgi.util.measurement;version="1.0.1",
  org.osgi.util.position;version="1.0.1"
+
 Bundle-ActivationPolicy: lazy

--- a/kura/setups/launchers/Eclipse Kura Emulator.launch
+++ b/kura/setups/launchers/Eclipse Kura Emulator.launch
@@ -24,6 +24,8 @@
 <setAttribute key="selected_target_bundles">
 <setEntry value="bcpkix@default:default"/>
 <setEntry value="bcprov@default:default"/>
+<setEntry value="bctls@default:default"/>
+<setEntry value="bcutil@default:default"/>
 <setEntry value="com.eclipsesource.jaxrs.jersey-min@default:default"/>
 <setEntry value="com.eclipsesource.jaxrs.provider.gson@default:default"/>
 <setEntry value="com.eclipsesource.jaxrs.provider.security@default:default"/>

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -76,8 +76,8 @@ jakarta.xml.soap-api.version=1.4.2
 jaxb-osgi.version=2.3.3
 osgi-resource-locator.version=1.0.3
 
-org.bouncycastle.version=1.68
-org.bouncycastle.jar.version=1.68.0
+org.bouncycastle.version=1.71
+org.bouncycastle.jar.version=1.71.0
 
 com.eurotech.gpsd4java.version=1.0.0
 

--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -494,13 +494,23 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.bouncycastle</groupId>
-                                    <artifactId>bcpkix-jdk15on</artifactId>
+                                    <artifactId>bcpkix-jdk18on</artifactId>
                                     <version>${org.bouncycastle.version}</version>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.bouncycastle</groupId>
-                                    <artifactId>bcprov-jdk15on</artifactId>
+                                    <artifactId>bcprov-jdk18on</artifactId>
                                     <version>${org.bouncycastle.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.bouncycastle</groupId>
+                                    <artifactId>bctls-jdk18on</artifactId>
+                                    <version>${org.bouncycastle.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                  <groupId>org.bouncycastle</groupId>
+                                  <artifactId>bcutil-jdk18on</artifactId>
+                                  <version>${org.bouncycastle.version}</version>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>com.eurotech</groupId>
@@ -610,8 +620,10 @@
                                 <move file="target/source/plugins/geronimo-jta_1.1_spec.jar" tofile="target/source/plugins/geronimo-jta_1.1_spec_${org.apache.geronimo.specs.jta.version}.jar"/>
                                 <move file="target/source/plugins/org.apache.activemq.artemis.jar" tofile="target/source/plugins/org.apache.activemq.artemis_${org.apache.activemq.artemis.version}.jar"/>
                                 <move file="target/source/plugins/org.apache.felix.useradmin.jar" tofile="target/source/plugins/org.apache.felix.useradmin_${org.apache.felix.useradmin.version}.jar"/>
-                                <move file="target/source/plugins/bcpkix-jdk15on.jar" tofile="target/source/plugins/org.bouncycastle.bcpkix-jdk15on_${org.bouncycastle.version}.jar"/>
-                                <move file="target/source/plugins/bcprov-jdk15on.jar" tofile="target/source/plugins/org.bouncycastle.bcprov-jdk15on_${org.bouncycastle.version}.jar"/>
+                                <move file="target/source/plugins/bcpkix-jdk18on.jar" tofile="target/source/plugins/org.bouncycastle.bcpkix-jdk18on_${org.bouncycastle.version}.jar"/>
+                                <move file="target/source/plugins/bcprov-jdk18on.jar" tofile="target/source/plugins/org.bouncycastle.bcprov-jdk18on_${org.bouncycastle.version}.jar"/>
+                                <move file="target/source/plugins/bctls-jdk18on.jar" tofile="target/source/plugins/org.bouncycastle.bctls-jdk18on_${org.bouncycastle.version}.jar"/>
+                                <move file="target/source/plugins/bcutil-jdk18on.jar" tofile="target/source/plugins/org.bouncycastle.bcutil-jdk18on_${org.bouncycastle.version}.jar"/>
                                 <move file="target/source/plugins/gpsd4java.jar" tofile="target/source/plugins/com.eurotech.gpsd4java_${com.eurotech.gpsd4java.version}.jar"/>
                             </tasks>
                         </configuration>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -43,6 +43,16 @@
 
     <repositories>
         <repository>
+            <id>Kura Releases</id>
+            <name>Kura Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/kura-releases/</url>
+        </repository>
+        <repository>
+            <id>Kura Snapshots</id>
+            <name>Kura Repository - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
+        </repository>
+        <repository>
             <id>kura_addons</id>
             <name>Kura Addons Maven Repository</name>
             <url>${kura.addons.url}</url>
@@ -54,16 +64,6 @@
         <repository>
             <id>Eclipse Paho Repo</id>
             <url>https://repo.eclipse.org/content/repositories/paho-releases/</url>
-        </repository>
-        <repository>
-            <id>Kura Releases</id>
-            <name>Kura Repository - Releases</name>
-            <url>https://repo.eclipse.org/content/repositories/kura-releases/</url>
-        </repository>
-        <repository>
-            <id>Kura Snapshots</id>
-            <name>Kura Repository - Snapshots</name>
-            <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Upgraded bouncycastle to 1.71 to get the following fix as stated in the release note here: https://www.bouncycastle.org/releasenotes.html

2.3.2 Defects Fixed
ESTService could fail for some valid Content-Type headers. This has been fixed.