### PR TITLE
build(ai.triton.server): Moved os-maven-plugin to plugins section.

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/pom.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/pom.xml
@@ -36,14 +36,20 @@
 	</properties>
 	
 	<build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.2</version>
-            </extension>
-        </extensions>
         <plugins>
+            <plugin>
+              <groupId>kr.motd.maven</groupId>
+              <artifactId>os-maven-plugin</artifactId>
+              <version>1.7.0</version>
+              <executions>
+                <execution>
+                  <phase>initialize</phase>
+                  <goals>
+                    <goal>detect</goal>
+                  </goals>
+                </execution>
+              </executions>
+            </plugin>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>


### PR DESCRIPTION
This commit fixes protobuf sources generation within Eclipse lifecycle.