### PR TITLE
fix(ai.triton.server): resolved failed startup on configuration update with loaded models

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
@@ -119,7 +119,7 @@ public class TritonServerLocalManager {
         }
     }
 
-    private boolean isLocalServerRunning() {
+    public boolean isLocalServerRunning() {
         boolean isRunning = false;
         if (this.commandExecutorService.isRunning(TRITONSERVER)) {
             isRunning = true;

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
@@ -119,7 +119,7 @@ public class TritonServerLocalManager {
         }
     }
 
-    public boolean isLocalServerRunning() {
+    protected boolean isLocalServerRunning() {
         boolean isRunning = false;
         if (this.commandExecutorService.isRunning(TRITONSERVER)) {
             isRunning = true;

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
@@ -74,7 +74,7 @@ public class TritonServerLocalManager {
     private void startLocalServer() {
         this.commandExecutorService.execute(this.serverCommand, status -> {
             if (status.getExitStatus().isSuccessful()) {
-                logger.info("Nvidia Triton Server started");
+                logger.info("Nvidia Triton Server gracefully shutdown");
             } else {
                 logger.info("Nvidia Triton Server not started. Exit value: {}", status.getExitStatus().getExitCode());
             }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -162,7 +162,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
             logger.info("Server still running"); // DEBUG
             TritonServerLocalManager.sleepFor(250);
         }
-        logger.info("Server down");
+        logger.info("Server down"); // DEBUG
 
 
         if (this.options.modelsAreEncrypted()) {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -77,7 +77,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
     private static final Logger logger = LoggerFactory.getLogger(TritonServerServiceImpl.class);
     private static final String TEMP_DIRECTORY_PREFIX = "decrypted_models";
     private static final int N_ATTEMPT = 6;
-    private static final int WAIT_ATTEMPT_MS = 250;
+    private static final int WAIT_ATTEMPT_MS = 500;
 
     private CommandExecutorService commandExecutorService;
     private CryptoService cryptoService;

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -151,6 +151,20 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
     private void stopLocalInstance() {
         this.tritonServerLocalManager.stop();
+
+        // Wait for server to be stopped correctly
+        int counter = 0;
+        while (this.tritonServerLocalManager.isLocalServerRunning()) {
+            if (counter++ >= 6) {
+                logger.warn("Cannot stop local server instance.");
+                return;
+            }
+            logger.info("Server still running"); // DEBUG
+            TritonServerLocalManager.sleepFor(250);
+        }
+        logger.info("Server down");
+
+
         if (this.options.modelsAreEncrypted()) {
             TritonServerEncryptionUtils.cleanRepository(decryptionFolderPath);
             try {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -152,18 +152,14 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
     private void stopLocalInstance() {
         this.tritonServerLocalManager.stop();
 
-        // Wait for server to be stopped correctly
         int counter = 0;
         while (this.tritonServerLocalManager.isLocalServerRunning()) {
             if (counter++ >= 6) {
                 logger.warn("Cannot stop local server instance.");
                 return;
             }
-            logger.info("Server still running"); // DEBUG
             TritonServerLocalManager.sleepFor(250);
         }
-        logger.info("Server down"); // DEBUG
-
 
         if (this.options.modelsAreEncrypted()) {
             TritonServerEncryptionUtils.cleanRepository(decryptionFolderPath);


### PR DESCRIPTION
Fixed failed Triton Server startup when there were models loaded in the server.

**Description of the solution adopted:** If there are models loaded in Triton, it takes longer to spin down than when there's no model loaded. Since there were no checks in place for verifying Triton proper shutdown on the configuration update it was possible for the `TritonServerServiceImpl` to update the configuration without correctly restarting the Triton Server local instance.

With this PR:
- we introduce a wait on `update` and `deactivate` to check for correct shutdown of the server
- we refactored the sources so that we no longer have magic numbers in the code(`N_ATTEMPT` and `WAIT_ATTEMPT_MS` constants) 
- fixed the log entry on Triton Server shutdown
- we increased the wait time for the various checks (i.e. increased `WAIT_ATTEMPT_MS`).
