### PR TITLE
fix(container.orchestrator): network-mode feild is now case-sensitive

### DIFF
--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -536,8 +536,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
 
         if (containerDescription.getContainerNetworkConfiguration().getNetworkMode().isPresent()
                 && !containerDescription.getContainerNetworkConfiguration().getNetworkMode().get().trim().isEmpty()) {
-            configuration.withNetworkMode(containerDescription.getContainerNetworkConfiguration().getNetworkMode().get()
-                    .toLowerCase().trim());
+            configuration.withNetworkMode(containerDescription.getContainerNetworkConfiguration().getNetworkMode().get().trim());
         }
 
         return configuration;

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -109,7 +109,7 @@
             
         <AD id="container.networkMode" 
             name="Networking Mode"
-            description="Used to specify what networking mode the container will use. Possible Drivers: bridge, none, container:{container id}, host" type="String" cardinality="0"
+            description="Used to specify what networking mode the container will use. Possible Drivers: bridge, none, container:{container id}, host. Note: This feild is case-sensitive." type="String" cardinality="0"
             required="false" 
             default="">
          </AD>

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -109,7 +109,7 @@
             
         <AD id="container.networkMode" 
             name="Networking Mode"
-            description="Used to specify what networking mode the container will use. Possible Drivers: bridge, none, container:{container id}, host. Note: This feild is case-sensitive." type="String" cardinality="0"
+            description="Used to specify what networking mode the container will use. Possible Drivers: bridge, none, container:{container id}, host. Note: This field is case-sensitive." type="String" cardinality="0"
             required="false" 
             default="">
          </AD>


### PR DESCRIPTION
… lower.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).


This is probably easist explained with a picture:
<img width="1160" alt="image" src="https://user-images.githubusercontent.com/29900100/171922130-dc2ed4bb-aae3-4bbd-bae6-e06621c0b903.png">  
case-sensitive network names are now supported


**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
