### PR TITLE
ci: add release notes generation workflow

### DIFF
--- a/.github/release_notes_template/helper.hbs
+++ b/.github/release_notes_template/helper.hbs
@@ -1,0 +1,16 @@
+Handlebars.registerHelper('firstLetters', function(input, options) {
+  const number = parseInt(options.hash['number'] || "0")
+  return input.substring(0,number);
+});
+
+Handlebars.registerHelper('date', function() {
+  const monthNames = ["January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"
+  ];
+
+  const date = new Date();
+  const month = monthNames[date.getMonth()];
+  const year = date.getYear() + 1900;
+
+  return month + " " + year;
+});

--- a/.github/release_notes_template/template.hbs
+++ b/.github/release_notes_template/template.hbs
@@ -66,6 +66,6 @@ Known Issues:
 
 Changelog:
 {{#commits}}
-  * {{firstLetters hash number='10'}} - {{#eachCommitScope .}}[{{.}}] {{/eachCommitScope}}{{{commitDescription .}}} ({{authorName}})
+  * {{firstLetters hash number='10'}} - {{{messageTitle}}} ({{authorName}})
 {{/commits}}
 {{/issues}}

--- a/.github/release_notes_template/template.hbs
+++ b/.github/release_notes_template/template.hbs
@@ -1,0 +1,71 @@
+Eclipse Kura - {{extended.version}} - {{{date}}}
+-------------------------------------------------------------------------------------------------
+Description:
+[TODO]
+
+{{#issues}}
+{{! Features section }}
+{{#ifContainsType commits type='feat'}}
+
+Features:
+  {{#commits}}
+    {{#ifCommitType . type='feat'}}
+  * {{firstLetters hash number='10'}} - {{#eachCommitScope .}}[{{.}}] {{/eachCommitScope}}{{{commitDescription .}}} ({{authorName}})
+    {{/ifCommitType}}
+  {{/commits}}
+{{/ifContainsType}}
+{{! Target environments section }}
+
+Target Environments:
+[TODO]
+{{! Breaking changes section }}
+{{#ifContainsBreaking commits}}
+
+Breaking changes:
+  {{#commits}}
+    {{#ifCommitBreaking .}}
+  * {{firstLetters hash number='10'}} - {{#eachCommitScope .}}[{{.}}] {{/eachCommitScope}}{{{commitDescription .}}} ({{authorName}})
+    {{/ifCommitBreaking}}
+  {{/commits}}
+{{/ifContainsBreaking}}
+{{! Bug Fixes section }}
+{{#ifContainsType commits type='fix'}}
+
+Bug Fixes:
+  {{#commits}}
+    {{#ifCommitType . type='fix'}}
+  * {{firstLetters hash number='10'}} - {{#eachCommitScope .}}[{{.}}] {{/eachCommitScope}}{{{commitDescription .}}} ({{authorName}})
+    {{/ifCommitType}}
+  {{/commits}}
+{{/ifContainsType}}
+{{! Deprecated APIs section }}
+{{#ifContainsType commits type='deprecate'}}
+
+Deprecated APIs:
+  {{#commits}}
+    {{#ifCommitType . type='deprecate'}}
+  * {{firstLetters hash number='10'}} - {{{commitDescription .}}} ({{authorName}})
+    {{/ifCommitType}}
+  {{/commits}}
+{{/ifContainsType}}
+{{! Target Platform updates section }}
+{{#ifContainsType commits type='build'}}
+
+Target Platform Updates:
+  {{#commits}}
+    {{#ifCommitType . type='build'}}
+  * {{firstLetters hash number='10'}} - {{{commitDescription .}}} ({{authorName}})
+    {{/ifCommitType}}
+  {{/commits}}
+{{/ifContainsType}}
+{{! Known issues section }}
+
+Known Issues:
+[TODO]
+{{! Changelog section }}
+
+Changelog:
+{{#commits}}
+  * {{firstLetters hash number='10'}} - {{#eachCommitScope .}}[{{.}}] {{/eachCommitScope}}{{{commitDescription .}}} ({{authorName}})
+{{/commits}}
+{{/issues}}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,59 @@
+name: "Release Notes automation"
+
+on:
+  workflow_dispatch:
+    inputs:
+        target_branch:
+          type: string
+          default: 'master'
+          description: Target branch
+          required: true
+        starting_commit:
+          type: string
+          description: Commit from which to start generating the release notes
+          required: true
+
+jobs:
+  main:
+    name: Generate Release Notes
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout target branch
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.target_branch }}
+        fetch-depth: '0'
+
+    - name: Get version
+      id: get-version
+      uses: JActions/maven-version@v1.0.0
+      with:
+        pom: ./kura/pom.xml
+
+    - name: Download git-changelog-command-line tool
+      id: download-changelog-cli
+      uses: clausnz/github-action-download-maven-artifact@master
+      with:
+        url: 'https://repo1.maven.org'
+        repository: 'maven2'
+        groupId: 'se.bjurr.gitchangelog'
+        artifactId: 'git-changelog-command-line'
+        version: '1.100.2'
+        extension: 'jar'
+
+    - name: Generate Release Notes
+      run: |
+        java -jar ${{ steps.download-changelog-cli.outputs.file }} \
+        -fc "${{ github.event.inputs.starting_commit }}" \
+        -ex "{\"version\":\"${{ steps.get-version.outputs.version }}\"}" \
+        -t .github/release_notes_template/template.hbs \
+        -hhf .github/release_notes_template/helper.hbs \
+        -of kura/distrib/RELEASE_NOTES.txt
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        title: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
+        commit-message: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
+        branch-suffix: short-commit-hash

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -56,4 +56,5 @@ jobs:
       with:
         title: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
         commit-message: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
+        body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.version }} version release notes"
         branch-suffix: short-commit-hash


### PR DESCRIPTION
This PR add the automatic release notes generation worflow leveraging the Conventional Commit specification.

**Description of the solution adopted:** This PR adds
- The template from which the `git-changelog-command-line` tool will generate the release notes
- The workflow which calls the various tool required for generating the release notes

The manual workflow accepts two parameters:
- `target_branch`: The branch on which to run the release notes generation tool (i.e. the release branch)
- `starting_commit`: The commit from which to start generating the release notes

The workflow will create a PR on the branch selected during the workflow running process with the newly created release notes (it will use the path `kura/distrib/RELEASE_NOTES.txt`. It will auto-detect the version from the `kura/pom.xml` file and thus it is required to update the version before running the workflow.

### Example

Here you can find the release notes generated with:
- `target_branch`: ci/release_notes_generation
- `starting_commit`: 4cdfdcb68d107a66f47136f365c390ccfb758757

[RELEASE_NOTES.txt](https://github.com/eclipse/kura/files/8844650/RELEASE_NOTES.txt)

⚠️ **Note**: Please note that commits not compliant with the Conventional Commit specification will not be sorted correctly and will appear as-is in the changelog (see attached release notes for details).

⚠️ **Note**: For this to work on branch others than the default one it needs to be backported to the desired branch. Failing to do so will generate an error during the workflow run because of the missing configuration files (the files inside `.github/release_notes_templates`)

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>