### PR TITLE
fix(core.deployment): prevent unnecessary modifications inside the packages folder.

### DIFF
--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -368,13 +368,14 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
             dpFile = getFileFromFilesystem(url);
         }
 
+        File dpPersistentFile = null;
         DeploymentPackage dp = null;
         try (InputStream dpInputStream = new FileInputStream(dpFile);) {
             dp = this.deploymentAdmin.installDeploymentPackage(dpInputStream);
 
             String dpFsName = dp.getName() + "_" + dp.getVersion() + ".dp";
             String dpPersistentFilePath = this.packagesPath + File.separator + dpFsName;
-            File dpPersistentFile = new File(dpPersistentFilePath);
+            dpPersistentFile = new File(dpPersistentFilePath);
 
             // Now we need to copy the deployment package file to the Kura
             // packages directory unless it's already there.
@@ -387,8 +388,8 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         } finally {
             // The file from which we have installed the deployment package will be deleted
             // unless it's a persistent deployment package file.
-            File packagesFolder = new File(this.packagesPath);
-            if (!dpFile.getCanonicalPath().startsWith(packagesFolder.getCanonicalPath())) {
+            if (dpPersistentFile != null && dpPersistentFile.exists()
+                    && !dpFile.getCanonicalPath().equals(dpPersistentFile.getCanonicalPath())) {
                 Files.delete(dpFile.toPath());
                 logger.debug("Deleted file: {}", dpFile.getName());
             }
@@ -471,7 +472,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         }
 
         if (oldDeployedPackages.equals(deployedPackages)) {
-           return;
+            return;
         }
 
         try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -446,7 +446,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
             return;
         }
 
-        if(oldDeployedPackages.equals(deployedPackages)) {
+        if (oldDeployedPackages.equals(deployedPackages)) {
             return;
         }
 

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -470,14 +470,16 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
             return;
         }
 
-        if (!oldDeployedPackages.equals(deployedPackages)) {
-            try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
-                deployedPackages.store(fos, null);
-                fos.flush();
-                fos.getFD().sync();
-            } catch (IOException e) {
-                logger.error("Error writing package configuration file", e);
-            }
+        if (oldDeployedPackages.equals(deployedPackages)) {
+           return;
+        }
+
+        try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
+            deployedPackages.store(fos, null);
+            fos.flush();
+            fos.getFD().sync();
+        } catch (IOException e) {
+            logger.error("Error writing package configuration file", e);
         }
     }
 }

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -446,14 +446,16 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
             return;
         }
 
-        if (!oldDeployedPackages.equals(deployedPackages)) {
-            try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
-                deployedPackages.store(fos, null);
-                fos.flush();
-                fos.getFD().sync();
-            } catch (IOException e) {
-                logger.error("Error writing package configuration file", e);
-            }
+        if(oldDeployedPackages.equals(deployedPackages)) {
+            return;
+        }
+
+        try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
+            deployedPackages.store(fos, null);
+            fos.flush();
+            fos.getFD().sync();
+        } catch (IOException e) {
+            logger.error("Error writing package configuration file", e);
         }
     }
 

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  * Contributors:
  *  Eurotech
  *  Red Hat Inc
+ *  3 PORT d.o.o.
  *******************************************************************************/
 package org.eclipse.kura.deployment.agent.impl;
 
@@ -436,6 +437,8 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
 
     private void addPackageToConfFile(String packageName, String packageUrl) {
         Properties deployedPackages = readDeployedPackages();
+        Properties oldDeployedPackages = new Properties();
+        oldDeployedPackages.putAll(deployedPackages);
         deployedPackages.setProperty(packageName, packageUrl);
 
         if (this.dpaConfPath == null) {
@@ -443,17 +446,21 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
             return;
         }
 
-        try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
-            deployedPackages.store(fos, null);
-            fos.flush();
-            fos.getFD().sync();
-        } catch (IOException e) {
-            logger.error("Error writing package configuration file", e);
+        if (!oldDeployedPackages.equals(deployedPackages)) {
+            try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
+                deployedPackages.store(fos, null);
+                fos.flush();
+                fos.getFD().sync();
+            } catch (IOException e) {
+                logger.error("Error writing package configuration file", e);
+            }
         }
     }
 
     private void removePackageFromConfFile(String packageName) {
         Properties deployedPackages = readDeployedPackages();
+        Properties oldDeployedPackages = new Properties();
+        oldDeployedPackages.putAll(deployedPackages);
         deployedPackages.remove(packageName);
 
         if (this.dpaConfPath == null) {
@@ -461,12 +468,14 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
             return;
         }
 
-        try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
-            deployedPackages.store(fos, null);
-            fos.flush();
-            fos.getFD().sync();
-        } catch (IOException e) {
-            logger.error("Error writing package configuration file", e);
+        if (!oldDeployedPackages.equals(deployedPackages)) {
+            try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
+                deployedPackages.store(fos, null);
+                fos.flush();
+                fos.getFD().sync();
+            } catch (IOException e) {
+                logger.error("Error writing package configuration file", e);
+            }
         }
     }
 }

--- a/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
+++ b/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  *  Eurotech
+ *  3 PORT d.o.o.
  ******************************************************************************/
 package org.eclipse.kura.core.deployment.install;
 
@@ -92,6 +93,7 @@ public class InstallImplTest {
         CloudDeploymentHandlerV2 callbackMock = mock(CloudDeploymentHandlerV2.class);
         String kuraDataDir = "/tmp";
         InstallImpl ii = new InstallImpl(callbackMock, kuraDataDir, null);
+        ii.setPackagesPath(kuraDataDir);
 
         final String clientId = "clientid";
         final long jobid = 1234;

--- a/kura/test/org.eclipse.kura.deployment.agent.test/src/test/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgentTest.java
+++ b/kura/test/org.eclipse.kura.deployment.agent.test/src/test/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgentTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  *  Eurotech
+ *  3 PORT d.o.o.
  ******************************************************************************/
 package org.eclipse.kura.deployment.agent.impl;
 
@@ -18,8 +19,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -367,7 +370,11 @@ public class DeploymentAgentTest {
     public void testAddPackageToConfFileStoreException() throws Throwable {
         // test adding packages to configuration file, but fail doing so
 
-        final Properties deployedPackages = mock(Properties.class);
+        final Properties deployedPackages = spy(new Properties());
+
+        when(deployedPackages.entrySet()).thenCallRealMethod();
+        doCallRealMethod().when(deployedPackages).setProperty(anyObject(), anyObject());
+
         DeploymentAgent svc = new DeploymentAgent() {
 
             @Override
@@ -416,7 +423,12 @@ public class DeploymentAgentTest {
     public void testRemovePackageToConfFileStoreException() throws Throwable {
         // test removing packages from configuration file, but fail doing so
 
-        final Properties deployedPackages = mock(Properties.class);
+        final Properties props = new Properties();
+        props.put("testdp", "file:///tmp/testdp.dp");
+
+        final Properties deployedPackages = spy(props);
+        when(deployedPackages.entrySet()).thenCallRealMethod();
+
         DeploymentAgent svc = new DeploymentAgent() {
 
             @Override
@@ -442,7 +454,12 @@ public class DeploymentAgentTest {
     public void testRemovePackageToConfFile() throws Throwable {
         // test removing packages from configuration file
 
-        final Properties deployedPackages = mock(Properties.class);
+        final Properties props = new Properties();
+        props.put("testdp", "file:///tmp/testdp.dp");
+
+        final Properties deployedPackages = spy(props);
+        when(deployedPackages.entrySet()).thenCallRealMethod();
+
         DeploymentAgent svc = new DeploymentAgent() {
 
             @Override


### PR DESCRIPTION
On every restart Kura updates the dpa.properties file even if there are no changes in installed packages.

Prevent changes to the dpa.properties file if properties do not change.
Save .dp files with consistent naming "NAME_VERSION.dp".
Fixed a bug in which installed .dp files would be copied to a new dp file named "NAME_VERSION.dp" on startup if they are not already named this way.

Signed-off-by: Andrej Krota <andrej.krota@gmail.com>

