### PR TITLE
feat(ai.triton.server): expose "timeout" parameter for long running operations

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -98,6 +98,7 @@
             cardinality="0" 
             required="false"
             min="0"
+            max="3600"
             default="3" 
             description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout the operation will be terminated with an error. If timeout is set to zero the operation will wait indefinitely">
         </AD>

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -97,10 +97,10 @@
             type="Integer"
             cardinality="0" 
             required="false"
-            min="0"
+            min="1"
             max="3600"
             default="3" 
-            description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout the operation will be terminated with an error. If timeout is set to zero the operation will wait indefinitely">
+            description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout the operation will be terminated with an error.">
         </AD>
 
     </OCD>

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -92,6 +92,15 @@
             description="Only for local instance, a semi-colon separated list of configuration for the backends. i.e. tensorflow,version=2;tensorflow,allow-soft-placement=false">
         </AD>
 
+        <AD id="timeout"  
+            name="Timeout (in seconds) for time consuming tasks"
+            type="Integer"
+            cardinality="0" 
+            required="false"
+            default="3" 
+            description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout the operation will be terminated with an error. If timeout is set to zero the operation will wait indefinitely">
+        </AD>
+
     </OCD>
     <Designate factoryPid="org.eclipse.kura.ai.triton.server.TritonServerService">
         <Object ocdref="org.eclipse.kura.ai.triton.server.TritonServerService"/>

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -100,7 +100,7 @@
             min="1"
             max="3600"
             default="3" 
-            description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout the operation will be terminated with an error.">
+            description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout, the operation will be terminated with an error.">
         </AD>
 
     </OCD>

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -97,6 +97,7 @@
             type="Integer"
             cardinality="0" 
             required="false"
+            min="0"
             default="3" 
             description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout the operation will be terminated with an error. If timeout is set to zero the operation will wait indefinitely">
         </AD>

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManager.java
@@ -61,6 +61,11 @@ public class TritonServerLocalManager {
         stopScheduledExecutor();
     }
 
+    protected void kill() {
+        killLocalServerMonitor();
+        stopScheduledExecutor();
+    }
+
     private void startLocalServerMonitor() {
         this.serverCommand = createServerCommand();
         this.scheduledFuture = this.scheduledExecutorService.scheduleAtFixedRate(() -> {
@@ -96,6 +101,11 @@ public class TritonServerLocalManager {
         stopLocalServer();
     }
 
+    private void killLocalServerMonitor() {
+        stopMonitor();
+        killLocalServer();
+    }
+
     private void stopMonitor() {
         if (nonNull(this.scheduledFuture)) {
             this.scheduledFuture.cancel(true);
@@ -107,6 +117,10 @@ public class TritonServerLocalManager {
 
     private synchronized void stopLocalServer() {
         TritonServerLocalManager.this.commandExecutorService.kill(TRITONSERVER, LinuxSignal.SIGINT);
+    }
+
+    private synchronized void killLocalServer() {
+        TritonServerLocalManager.this.commandExecutorService.kill(TRITONSERVER, LinuxSignal.SIGKILL);
     }
 
     private void stopScheduledExecutor() {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -150,10 +150,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
         int counter = 0;
         while (this.tritonServerLocalManager.isLocalServerRunning()) {
-            if (this.options.getTimeout() != 0) {
-                counter++;
-            }
-            if (counter >= this.options.getNRetries()) {
+            if (this.options.getTimeout() != 0 && counter++ >= this.options.getNRetries()) {
                 logger.warn("Cannot stop local server instance.");
                 return;
             }
@@ -198,10 +195,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
         int counter = 0;
         while (!isEngineReady()) {
-            if (this.options.getTimeout() != 0) {
-                counter++;
-            }
-            if (counter >= this.options.getNRetries()) {
+            if (this.options.getTimeout() != 0 && counter++ >= this.options.getNRetries()) {
                 logger.warn("Cannot load models since server is not ready.");
                 return;
             }
@@ -250,10 +244,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
         if (this.options.modelsAreEncrypted()) {
             int counter = 0;
             while (!isModelLoaded(modelName)) {
-                if (this.options.getTimeout() != 0) {
-                    counter++;
-                }
-                if (counter >= this.options.getNRetries()) {
+                if (this.options.getTimeout() != 0 && counter++ >= this.options.getNRetries()) {
                     logger.warn("Cannot check if model was correctly loaded. Wiping decrypted model anyway");
                     break;
                 }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -150,7 +150,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
         int counter = 0;
         while (this.tritonServerLocalManager.isLocalServerRunning()) {
-            if (this.options.getTimeout() != 0 && counter++ >= this.options.getNRetries()) {
+            if (counter++ >= this.options.getNRetries()) {
                 logger.warn("Cannot stop local server instance. Killing it.");
                 this.tritonServerLocalManager.kill();
             }
@@ -195,7 +195,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
         int counter = 0;
         while (!isEngineReady()) {
-            if (this.options.getTimeout() != 0 && counter++ >= this.options.getNRetries()) {
+            if (counter++ >= this.options.getNRetries()) {
                 logger.warn("Cannot load models since server is not ready.");
                 return;
             }
@@ -244,7 +244,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
         if (this.options.modelsAreEncrypted()) {
             int counter = 0;
             while (!isModelLoaded(modelName)) {
-                if (this.options.getTimeout() != 0 && counter++ >= this.options.getNRetries()) {
+                if (counter++ >= this.options.getNRetries()) {
                     logger.warn("Cannot check if model was correctly loaded. Wiping decrypted model anyway");
                     break;
                 }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -76,8 +76,6 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
     private static final Logger logger = LoggerFactory.getLogger(TritonServerServiceImpl.class);
     private static final String TEMP_DIRECTORY_PREFIX = "decrypted_models";
-    private static final int N_ATTEMPT = 6;
-    private static final int WAIT_ATTEMPT_MS = 500;
 
     private CommandExecutorService commandExecutorService;
     private CryptoService cryptoService;
@@ -104,6 +102,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
     public void updated(Map<String, Object> properties) {
         logger.info("Update TritonServerService...");
         TritonServerServiceOptions newOptions = new TritonServerServiceOptions(properties);
+
         if (newOptions.equals(this.options)) {
             return;
         }
@@ -151,11 +150,14 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
         int counter = 0;
         while (this.tritonServerLocalManager.isLocalServerRunning()) {
-            if (counter++ >= N_ATTEMPT) {
+            if (this.options.getTimeout() != 0) {
+                counter++;
+            }
+            if (counter >= this.options.getNRetries()) {
                 logger.warn("Cannot stop local server instance.");
                 return;
             }
-            TritonServerLocalManager.sleepFor(WAIT_ATTEMPT_MS);
+            TritonServerLocalManager.sleepFor(this.options.getRetryInterval());
         }
 
         if (this.options.modelsAreEncrypted()) {
@@ -196,11 +198,14 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
         int counter = 0;
         while (!isEngineReady()) {
-            if (counter++ >= N_ATTEMPT) {
+            if (this.options.getTimeout() != 0) {
+                counter++;
+            }
+            if (counter >= this.options.getNRetries()) {
                 logger.warn("Cannot load models since server is not ready.");
                 return;
             }
-            TritonServerLocalManager.sleepFor(WAIT_ATTEMPT_MS);
+            TritonServerLocalManager.sleepFor(this.options.getRetryInterval());
         }
 
         this.options.getModels().forEach(modelName -> {
@@ -245,11 +250,14 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
         if (this.options.modelsAreEncrypted()) {
             int counter = 0;
             while (!isModelLoaded(modelName)) {
-                if (counter++ >= N_ATTEMPT) {
+                if (this.options.getTimeout() != 0) {
+                    counter++;
+                }
+                if (counter >= this.options.getNRetries()) {
                     logger.warn("Cannot check if model was correctly loaded. Wiping decrypted model anyway");
                     break;
                 }
-                TritonServerLocalManager.sleepFor(WAIT_ATTEMPT_MS);
+                TritonServerLocalManager.sleepFor(this.options.getRetryInterval());
             }
             TritonServerEncryptionUtils.cleanRepository(this.decryptionFolderPath);
         }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -151,8 +151,8 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
         int counter = 0;
         while (this.tritonServerLocalManager.isLocalServerRunning()) {
             if (this.options.getTimeout() != 0 && counter++ >= this.options.getNRetries()) {
-                logger.warn("Cannot stop local server instance.");
-                return;
+                logger.warn("Cannot stop local server instance. Killing it.");
+                this.tritonServerLocalManager.kill();
             }
             TritonServerLocalManager.sleepFor(this.options.getRetryInterval());
         }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
@@ -80,13 +80,12 @@ public class TritonServerServiceOptions {
         }
 
         final Object propertyTimeout = this.properties.get(PROPERTY_TIMEOUT);
-        if (propertyTimeout instanceof Integer && (Integer) propertyTimeout >= 0) {
+        if (propertyTimeout instanceof Integer) {
             this.timeout = (Integer) propertyTimeout;
         } else {
             this.timeout = 3;
         }
         this.nRetries = (this.timeout * 1000) / RETRY_INTERVAL;
-
     }
 
     public String getAddress() {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
@@ -80,16 +80,8 @@ public class TritonServerServiceOptions {
         }
 
         final Object propertyTimeout = this.properties.get(PROPERTY_TIMEOUT);
-        if (propertyTimeout instanceof Integer) {
-            Integer readTimeout = (Integer) propertyTimeout;
-
-            requireNonNull(readTimeout, "timeout cannot be null");
-
-            if (readTimeout < 0) {
-                throw new KuraRuntimeException(KuraErrorCode.INVALID_PARAMETER, PROPERTY_TIMEOUT);
-            }
-
-            this.timeout = readTimeout;
+        if (propertyTimeout instanceof Integer && (Integer) propertyTimeout >= 0) {
+            this.timeout = (Integer) propertyTimeout;
         } else {
             this.timeout = 3;
         }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
@@ -80,8 +80,16 @@ public class TritonServerServiceOptions {
         }
 
         final Object propertyTimeout = this.properties.get(PROPERTY_TIMEOUT);
-        if (propertyTimeout instanceof Integer && (Integer) propertyTimeout >= 0) {
-            this.timeout = (Integer) propertyTimeout;
+        if (propertyTimeout instanceof Integer) {
+            Integer readTimeout = (Integer) propertyTimeout;
+
+            requireNonNull(readTimeout, "timeout cannot be null");
+
+            if (readTimeout < 0) {
+                throw new KuraRuntimeException(KuraErrorCode.INVALID_PARAMETER, PROPERTY_TIMEOUT);
+            }
+
+            this.timeout = readTimeout;
         } else {
             this.timeout = 3;
         }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
@@ -174,7 +174,8 @@ public class TritonServerServiceOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.grpcPort, this.httpPort, this.isLocal, this.metricsPort, this.properties);
+        return Objects.hash(this.grpcPort, this.httpPort, this.isLocal, this.metricsPort, this.timeout, this.nRetries,
+                this.properties);
     }
 
     @Override
@@ -187,7 +188,8 @@ public class TritonServerServiceOptions {
         }
         TritonServerServiceOptions other = (TritonServerServiceOptions) obj;
         return this.grpcPort == other.grpcPort && this.httpPort == other.httpPort && this.isLocal == other.isLocal
-                && this.metricsPort == other.metricsPort && Objects.equals(this.properties, other.properties);
+                && this.metricsPort == other.metricsPort && this.timeout == other.timeout
+                && this.nRetries == other.nRetries && Objects.equals(this.properties, other.properties);
     }
 
 }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
@@ -35,12 +35,17 @@ public class TritonServerServiceOptions {
     private static final String PROPERTY_LOCAL_BACKENDS_CONFIG = "local.backends.config";
     private static final String PROPERTY_MODELS = "models";
     private static final String PROPERTY_LOCAL = "enable.local";
+    private static final String PROPERTY_TIMEOUT = "timeout";
     private final Map<String, Object> properties;
+
+    private static final int RETRY_INTERVAL = 500; // ms
 
     private final int httpPort;
     private final int grpcPort;
     private final int metricsPort;
     private final boolean isLocal;
+    private final int timeout;
+    private final int nRetries;
 
     public TritonServerServiceOptions(final Map<String, Object> properties) {
         requireNonNull(properties, "Properties cannot be null");
@@ -73,6 +78,15 @@ public class TritonServerServiceOptions {
         } else {
             this.isLocal = false;
         }
+
+        final Object propertyTimeout = this.properties.get(PROPERTY_TIMEOUT);
+        if (propertyTimeout instanceof Integer && (Integer) propertyTimeout >= 0) {
+            this.timeout = (Integer) propertyTimeout;
+        } else {
+            this.timeout = 3;
+        }
+        this.nRetries = (this.timeout * 1000) / RETRY_INTERVAL;
+
     }
 
     public String getAddress() {
@@ -136,6 +150,18 @@ public class TritonServerServiceOptions {
             models = Arrays.asList(((String) propertyModels).replace(" ", "").split(","));
         }
         return models;
+    }
+
+    public int getNRetries() {
+        return this.nRetries;
+    }
+
+    public int getTimeout() {
+        return this.timeout;
+    }
+
+    public int getRetryInterval() {
+        return RETRY_INTERVAL;
     }
 
     private String getStringProperty(String propertyName) {

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManagerTest.java
@@ -14,54 +14,88 @@ import org.junit.Test;
 
 public class TritonServerLocalManagerTest {
 
+    private static final String[] TRITONSERVERCMD = new String[] { "tritonserver" };
+    private static final String MOCK_DECRYPT_FOLDER = "test";
+
+    private Map<String, Object> properties = new HashMap<>();
+    private TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+    private CommandExecutorService ces;
+    private TritonServerLocalManager manager;
+
     @Test
     public void killMethodShouldWork() {
-        // Given option
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("server.address", "localhost");
-        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
-        properties.put("enable.local", Boolean.TRUE);
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.TRUE);
+        givenServiceOptionsBuiltWith(properties);
 
-        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+        givenMockCommandExecutionService();
+        givenMockCommandExecutionServiceReturnsTritonIsRunning();
 
-        // Given command executor service
-        CommandExecutorService ces = mock(CommandExecutorService.class);
-        when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(true);
+        givenLocalManagerBuiltWith(this.options, this.ces, MOCK_DECRYPT_FOLDER);
 
-        // Given TritonServerLocalManager built with
-        TritonServerLocalManager manager = new TritonServerLocalManager(options, ces, "test");
+        whenKillIsCalled();
 
-        // When method is called
-        manager.kill();
-
-        // Then command execution kill method is called
-        String[] cmd = new String[] { "tritonserver" };
-        verify(ces, times(1)).kill(cmd, LinuxSignal.SIGKILL);
+        thenCommandServiceKillWasCalledWith(TRITONSERVERCMD, LinuxSignal.SIGKILL);
     }
 
     @Test
     public void stopMethodShouldWork() {
-        // Given option
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("server.address", "localhost");
-        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
-        properties.put("enable.local", Boolean.TRUE);
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.TRUE);
+        givenServiceOptionsBuiltWith(properties);
 
-        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+        givenMockCommandExecutionService();
+        givenMockCommandExecutionServiceReturnsTritonIsRunning();
 
-        // Given command executor service
-        CommandExecutorService ces = mock(CommandExecutorService.class);
-        when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(true);
+        givenLocalManagerBuiltWith(this.options, this.ces, MOCK_DECRYPT_FOLDER);
 
-        // Given TritonServerLocalManager built with
-        TritonServerLocalManager manager = new TritonServerLocalManager(options, ces, "test");
+        whenStopIsCalled();
 
-        // When method is called
-        manager.stop();
-
-        // Then command execution kill method is called
-        String[] cmd = new String[] { "tritonserver" };
-        verify(ces, times(1)).kill(cmd, LinuxSignal.SIGINT);
+        thenCommandServiceKillWasCalledWith(TRITONSERVERCMD, LinuxSignal.SIGINT);
     }
 
+    /*
+     * Given
+     */
+    private void givenPropertyWith(String name, Object value) {
+        this.properties.put(name, value);
+    }
+
+    private void givenServiceOptionsBuiltWith(Map<String, Object> properties) {
+        this.options = new TritonServerServiceOptions(properties);
+    }
+
+    private void givenMockCommandExecutionService() {
+        this.ces = mock(CommandExecutorService.class);
+    }
+
+    private void givenMockCommandExecutionServiceReturnsTritonIsRunning() {
+        when(this.ces.isRunning(new String[] { "tritonserver" })).thenReturn(true);
+    }
+
+    private void givenLocalManagerBuiltWith(TritonServerServiceOptions options, CommandExecutorService ces,
+            String decryptionFolder) {
+        this.manager = new TritonServerLocalManager(options, ces, decryptionFolder);
+    }
+
+    /*
+     * When
+     */
+    private void whenKillIsCalled() {
+        this.manager.kill();
+    }
+
+    private void whenStopIsCalled() {
+        this.manager.stop();
+    }
+
+    /*
+     * Then
+     */
+    private void thenCommandServiceKillWasCalledWith(String[] expectedCmd, LinuxSignal expectedSignal) {
+        verify(this.ces, times(1)).kill(expectedCmd, expectedSignal);
+    }
 }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManagerTest.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+
 package org.eclipse.kura.ai.triton.server;
 
 import static org.mockito.Mockito.mock;

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManagerTest.java
@@ -39,4 +39,29 @@ public class TritonServerLocalManagerTest {
         verify(ces, times(1)).kill(cmd, LinuxSignal.SIGKILL);
     }
 
+    @Test
+    public void stopMethodShouldWork() {
+        // Given option
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("server.address", "localhost");
+        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
+        properties.put("enable.local", Boolean.TRUE);
+
+        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+        // Given command executor service
+        CommandExecutorService ces = mock(CommandExecutorService.class);
+        when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(true);
+
+        // Given TritonServerLocalManager built with
+        TritonServerLocalManager manager = new TritonServerLocalManager(options, ces, "test");
+
+        // When method is called
+        manager.stop();
+
+        // Then command execution kill method is called
+        String[] cmd = new String[] { "tritonserver" };
+        verify(ces, times(1)).kill(cmd, LinuxSignal.SIGINT);
+    }
+
 }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerLocalManagerTest.java
@@ -1,0 +1,42 @@
+package org.eclipse.kura.ai.triton.server;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.kura.core.linux.executor.LinuxSignal;
+import org.eclipse.kura.executor.CommandExecutorService;
+import org.junit.Test;
+
+public class TritonServerLocalManagerTest {
+
+    @Test
+    public void killMethodShouldWork() {
+        // Given option
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("server.address", "localhost");
+        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
+        properties.put("enable.local", Boolean.TRUE);
+
+        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+        // Given command executor service
+        CommandExecutorService ces = mock(CommandExecutorService.class);
+        when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(true);
+
+        // Given TritonServerLocalManager built with
+        TritonServerLocalManager manager = new TritonServerLocalManager(options, ces, "test");
+
+        // When method is called
+        manager.kill();
+
+        // Then command execution kill method is called
+        String[] cmd = new String[] { "tritonserver" };
+        verify(ces, times(1)).kill(cmd, LinuxSignal.SIGKILL);
+    }
+
+}

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+
 package org.eclipse.kura.ai.triton.server;
 
 import static org.junit.Assert.assertEquals;

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
@@ -1,6 +1,7 @@
 package org.eclipse.kura.ai.triton.server;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,6 +15,8 @@ public class TritonServerServiceOptionsTest {
     private TritonServerServiceOptions otherOptions = new TritonServerServiceOptions(properties);
 
     private boolean equalsResult = false;
+    private int hashCode;
+    private int otherHashCode;
 
     @Test
     public void portOptionsShouldWork() {
@@ -154,6 +157,41 @@ public class TritonServerServiceOptionsTest {
         thenEqualsMethodShouldReturn(false);
     }
 
+    @Test
+    public void hashCodeMethodWorksWithOptionsBuiltWithSameProperties() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("timeout", null);
+        givenServiceOptionsBuiltWith(this.properties);
+        givenOtherServiceOptionsBuiltWith(this.properties);
+
+        whenHashCodeIsCalledWith(this.options);
+        whenOtherHashCodeIsCalledWith(this.otherOptions);
+
+        thenHashCodesShouldMatch();
+    }
+
+    @Test
+    public void hashCodeMethodWorksWithOptionsBuiltWithDifferentProperties() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("timeout", null);
+        givenServiceOptionsBuiltWith(this.properties);
+
+        givenPropertyWith("server.address", "192.168.1.66");
+        givenPropertyWith("server.ports", new Integer[] { 5000, 5001, 5002 });
+        givenPropertyWith("enable.local", Boolean.TRUE);
+        givenPropertyWith("timeout", 60);
+        givenOtherServiceOptionsBuiltWith(this.properties);
+
+        whenHashCodeIsCalledWith(this.options);
+        whenOtherHashCodeIsCalledWith(this.otherOptions);
+
+        thenHashCodesShouldNotMatch();
+    }
+
     /*
      * Given
      */
@@ -174,6 +212,14 @@ public class TritonServerServiceOptionsTest {
      */
     private void whenEqualsIsCalledWith(TritonServerServiceOptions lhs, TritonServerServiceOptions rhs) {
         this.equalsResult = lhs.equals(rhs);
+    }
+
+    private void whenHashCodeIsCalledWith(TritonServerServiceOptions options) {
+        this.hashCode = options.hashCode();
+    }
+
+    private void whenOtherHashCodeIsCalledWith(TritonServerServiceOptions options) {
+        this.otherHashCode = options.hashCode();
     }
 
     /*
@@ -209,5 +255,13 @@ public class TritonServerServiceOptionsTest {
 
     private void thenEqualsMethodShouldReturn(boolean value) {
         assertEquals(value, this.equalsResult);
+    }
+
+    private void thenHashCodesShouldMatch() {
+        assertEquals(this.hashCode, this.otherHashCode);
+    }
+
+    private void thenHashCodesShouldNotMatch() {
+        assertNotEquals(this.hashCode, this.otherHashCode);
     }
 }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
@@ -1,8 +1,6 @@
 package org.eclipse.kura.ai.triton.server;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -12,105 +10,137 @@ import org.junit.Test;
 public class TritonServerServiceOptionsTest {
 
     private Map<String, Object> properties = new HashMap<>();
+    private TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
 
     @Test
     public void portOptionsShouldWork() {
-        // Given
-        properties.put("server.address", "localhost");
-        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
-        properties.put("enable.local", Boolean.FALSE);
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
 
-        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+        whenServiceOptionsAreBuiltWith(properties);
 
-        // Then
-        assertEquals(4000, options.getHttpPort());
-        assertEquals(4001, options.getGrpcPort());
-        assertEquals(4002, options.getMetricsPort());
+        thenHttpPortIsEqualTo(4000);
+        thenGrpcPortIsEqualTo(4001);
+        thenMetricsPortIsEqualTo(4002);
     }
 
     @Test
     public void portOptionsShouldWorkWithNullPorts() {
-        // Given
-        properties.put("server.address", "localhost");
-        properties.put("server.ports", null);
-        properties.put("enable.local", Boolean.FALSE);
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", null);
+        givenPropertyWith("enable.local", Boolean.FALSE);
 
-        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+        whenServiceOptionsAreBuiltWith(properties);
 
-        // Then
-        assertEquals(5000, options.getHttpPort());
-        assertEquals(5001, options.getGrpcPort());
-        assertEquals(5002, options.getMetricsPort());
+        thenHttpPortIsEqualTo(5000);
+        thenGrpcPortIsEqualTo(5001);
+        thenMetricsPortIsEqualTo(5002);
     }
 
     @Test
     public void localOptionsShouldWorkWithLocal() {
-        // Given
-        properties.put("server.address", "localhost");
-        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
-        properties.put("enable.local", Boolean.TRUE);
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.TRUE);
 
-        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+        whenServiceOptionsAreBuiltWith(properties);
 
-        // Then
-        assertTrue(options.isLocalEnabled());
+        thenLocalConfigIsEqualTo(true);
     }
 
     @Test
     public void localOptionsShouldWorkWithRemote() {
-        // Given
-        properties.put("server.address", "localhost");
-        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
-        properties.put("enable.local", Boolean.FALSE);
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
 
-        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+        whenServiceOptionsAreBuiltWith(properties);
 
-        // Then
-        assertFalse(options.isLocalEnabled());
+        thenLocalConfigIsEqualTo(false);
     }
 
     @Test
     public void localOptionsShouldWorkWithNull() {
-        // Given
-        properties.put("server.address", "localhost");
-        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
-        properties.put("enable.local", null);
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", null);
 
-        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+        whenServiceOptionsAreBuiltWith(properties);
 
-        // Then
-        assertFalse(options.isLocalEnabled());
+        thenLocalConfigIsEqualTo(false);
     }
 
     @Test
     public void timeoutOptionsShouldWork() {
-        // Given
-        properties.put("server.address", "localhost");
-        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
-        properties.put("enable.local", Boolean.FALSE);
-        properties.put("timeout", 5);
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("timeout", 5);
 
-        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+        whenServiceOptionsAreBuiltWith(properties);
 
-        // Then
-        assertEquals(5, options.getTimeout());
-        assertEquals(500, options.getRetryInterval());
-        assertEquals(10, options.getNRetries());
+        thenTimeoutIsEqualTo(5);
+        thenRetryIntervalIsEqualTo(500);
+        thenNRetriesIsEqualTo(10);
     }
 
     @Test
     public void timeoutOptionsShouldWorkWithNullTimeout() {
-        // Given
-        properties.put("server.address", "localhost");
-        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
-        properties.put("enable.local", Boolean.FALSE);
-        properties.put("timeout", null);
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("timeout", null);
 
-        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+        whenServiceOptionsAreBuiltWith(properties);
 
-        // Then
-        assertEquals(3, options.getTimeout());
-        assertEquals(500, options.getRetryInterval());
-        assertEquals(6, options.getNRetries());
+        thenTimeoutIsEqualTo(3);
+        thenRetryIntervalIsEqualTo(500);
+        thenNRetriesIsEqualTo(6);
+    }
+
+    /*
+     * Given
+     */
+    private void givenPropertyWith(String name, Object value) {
+        this.properties.put(name, value);
+    }
+
+    /*
+     * When
+     */
+    private void whenServiceOptionsAreBuiltWith(Map<String, Object> properties) {
+        this.options = new TritonServerServiceOptions(properties);
+    }
+
+    /*
+     * Then
+     */
+    private void thenTimeoutIsEqualTo(int value) {
+        assertEquals(value, this.options.getTimeout());
+    }
+
+    private void thenRetryIntervalIsEqualTo(int value) {
+        assertEquals(value, this.options.getRetryInterval());
+    }
+
+    private void thenNRetriesIsEqualTo(int value) {
+        assertEquals(value, this.options.getNRetries());
+    }
+
+    private void thenHttpPortIsEqualTo(int value) {
+        assertEquals(value, this.options.getHttpPort());
+    }
+
+    private void thenGrpcPortIsEqualTo(int value) {
+        assertEquals(value, this.options.getGrpcPort());
+    }
+
+    private void thenMetricsPortIsEqualTo(int value) {
+        assertEquals(value, this.options.getMetricsPort());
+    }
+
+    private void thenLocalConfigIsEqualTo(boolean value) {
+        assertEquals(value, this.options.isLocalEnabled());
     }
 }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
@@ -17,8 +17,7 @@ public class TritonServerServiceOptionsTest {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
-
-        whenServiceOptionsAreBuiltWith(properties);
+        givenServiceOptionsBuiltWith(properties);
 
         thenHttpPortIsEqualTo(4000);
         thenGrpcPortIsEqualTo(4001);
@@ -30,8 +29,7 @@ public class TritonServerServiceOptionsTest {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", null);
         givenPropertyWith("enable.local", Boolean.FALSE);
-
-        whenServiceOptionsAreBuiltWith(properties);
+        givenServiceOptionsBuiltWith(properties);
 
         thenHttpPortIsEqualTo(5000);
         thenGrpcPortIsEqualTo(5001);
@@ -43,8 +41,7 @@ public class TritonServerServiceOptionsTest {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.TRUE);
-
-        whenServiceOptionsAreBuiltWith(properties);
+        givenServiceOptionsBuiltWith(properties);
 
         thenLocalConfigIsEqualTo(true);
     }
@@ -54,8 +51,7 @@ public class TritonServerServiceOptionsTest {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
-
-        whenServiceOptionsAreBuiltWith(properties);
+        givenServiceOptionsBuiltWith(properties);
 
         thenLocalConfigIsEqualTo(false);
     }
@@ -65,8 +61,7 @@ public class TritonServerServiceOptionsTest {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", null);
-
-        whenServiceOptionsAreBuiltWith(properties);
+        givenServiceOptionsBuiltWith(properties);
 
         thenLocalConfigIsEqualTo(false);
     }
@@ -77,8 +72,7 @@ public class TritonServerServiceOptionsTest {
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
         givenPropertyWith("timeout", 5);
-
-        whenServiceOptionsAreBuiltWith(properties);
+        givenServiceOptionsBuiltWith(properties);
 
         thenTimeoutIsEqualTo(5);
         thenRetryIntervalIsEqualTo(500);
@@ -91,8 +85,7 @@ public class TritonServerServiceOptionsTest {
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
         givenPropertyWith("timeout", null);
-
-        whenServiceOptionsAreBuiltWith(properties);
+        givenServiceOptionsBuiltWith(properties);
 
         thenTimeoutIsEqualTo(3);
         thenRetryIntervalIsEqualTo(500);
@@ -106,12 +99,14 @@ public class TritonServerServiceOptionsTest {
         this.properties.put(name, value);
     }
 
+    private void givenServiceOptionsBuiltWith(Map<String, Object> properties) {
+        this.options = new TritonServerServiceOptions(properties);
+    }
+
     /*
      * When
      */
-    private void whenServiceOptionsAreBuiltWith(Map<String, Object> properties) {
-        this.options = new TritonServerServiceOptions(properties);
-    }
+    // TODO
 
     /*
      * Then

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
@@ -11,6 +11,9 @@ public class TritonServerServiceOptionsTest {
 
     private Map<String, Object> properties = new HashMap<>();
     private TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+    private TritonServerServiceOptions otherOptions = new TritonServerServiceOptions(properties);
+
+    private boolean equalsResult = false;
 
     @Test
     public void portOptionsShouldWork() {
@@ -92,6 +95,65 @@ public class TritonServerServiceOptionsTest {
         thenNRetriesIsEqualTo(6);
     }
 
+    @Test
+    public void equalsMethodWorksWithSameOptions() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("timeout", null);
+        givenServiceOptionsBuiltWith(this.properties);
+
+        whenEqualsIsCalledWith(this.options, this.options);
+
+        thenEqualsMethodShouldReturn(true);
+    }
+
+    @Test
+    public void equalsMethodWorksWithDifferentType() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("timeout", null);
+        givenServiceOptionsBuiltWith(this.properties);
+
+        whenEqualsIsCalledWith(this.options, null);
+
+        thenEqualsMethodShouldReturn(false);
+    }
+
+    @Test
+    public void equalsMethodWorksWithOptionsBuiltWithSameProperties() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("timeout", null);
+        givenServiceOptionsBuiltWith(this.properties);
+        givenOtherServiceOptionsBuiltWith(this.properties);
+
+        whenEqualsIsCalledWith(this.options, this.otherOptions);
+
+        thenEqualsMethodShouldReturn(true);
+    }
+
+    @Test
+    public void equalsMethodWorksWithOptionsBuiltWithDifferentProperties() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("timeout", null);
+        givenServiceOptionsBuiltWith(this.properties);
+
+        givenPropertyWith("server.address", "192.168.1.66");
+        givenPropertyWith("server.ports", new Integer[] { 5000, 5001, 5002 });
+        givenPropertyWith("enable.local", Boolean.TRUE);
+        givenPropertyWith("timeout", 60);
+        givenOtherServiceOptionsBuiltWith(this.properties);
+
+        whenEqualsIsCalledWith(this.options, this.otherOptions);
+
+        thenEqualsMethodShouldReturn(false);
+    }
+
     /*
      * Given
      */
@@ -103,10 +165,16 @@ public class TritonServerServiceOptionsTest {
         this.options = new TritonServerServiceOptions(properties);
     }
 
+    private void givenOtherServiceOptionsBuiltWith(Map<String, Object> properties) {
+        this.otherOptions = new TritonServerServiceOptions(properties);
+    }
+
     /*
      * When
      */
-    // TODO
+    private void whenEqualsIsCalledWith(TritonServerServiceOptions lhs, TritonServerServiceOptions rhs) {
+        this.equalsResult = lhs.equals(rhs);
+    }
 
     /*
      * Then
@@ -137,5 +205,9 @@ public class TritonServerServiceOptionsTest {
 
     private void thenLocalConfigIsEqualTo(boolean value) {
         assertEquals(value, this.options.isLocalEnabled());
+    }
+
+    private void thenEqualsMethodShouldReturn(boolean value) {
+        assertEquals(value, this.equalsResult);
     }
 }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
@@ -19,7 +19,7 @@ public class TritonServerServiceOptionsTest {
     private int otherHashCode;
 
     @Test
-    public void portOptionsShouldWork() {
+    public void portGettersShouldWork() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -31,7 +31,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void portOptionsShouldWorkWithNullPorts() {
+    public void portGettersShouldWorkWithNullProperty() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", null);
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -43,7 +43,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void localOptionsShouldWorkWithLocal() {
+    public void isLocalGetterShouldWorkWithLocal() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.TRUE);
@@ -53,7 +53,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void localOptionsShouldWorkWithRemote() {
+    public void isLocalGetterShouldWorkWithRemote() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -63,7 +63,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void localOptionsShouldWorkWithNull() {
+    public void isLocalGetterShouldWorkWithNullProperty() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", null);
@@ -73,7 +73,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void timeoutOptionsShouldWork() {
+    public void timeoutGettersShouldWork() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -86,7 +86,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void timeoutOptionsShouldWorkWithNullTimeout() {
+    public void timeoutGettersShouldWorkWithNullProperty() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -99,7 +99,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void equalsMethodWorksWithSameOptions() {
+    public void equalsMethodShouldWorkWithSameOptions() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -112,7 +112,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void equalsMethodWorksWithDifferentType() {
+    public void equalsMethodShouldWorkWithNullArgument() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -125,7 +125,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void equalsMethodWorksWithOptionsBuiltWithSameProperties() {
+    public void equalsMethodShouldWorkWithOptionsBuiltWithSameProperties() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -139,7 +139,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void equalsMethodWorksWithOptionsBuiltWithDifferentProperties() {
+    public void equalsMethodShouldWorkWithOptionsBuiltWithDifferentProperties() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -158,7 +158,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void hashCodeMethodWorksWithOptionsBuiltWithSameProperties() {
+    public void hashCodeMethodShouldWorkWithOptionsBuiltWithSameProperties() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);
@@ -173,7 +173,7 @@ public class TritonServerServiceOptionsTest {
     }
 
     @Test
-    public void hashCodeMethodWorksWithOptionsBuiltWithDifferentProperties() {
+    public void hashCodeMethodShouldWorkWithOptionsBuiltWithDifferentProperties() {
         givenPropertyWith("server.address", "localhost");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("enable.local", Boolean.FALSE);

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
@@ -1,0 +1,116 @@
+package org.eclipse.kura.ai.triton.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TritonServerServiceOptionsTest {
+
+    private Map<String, Object> properties = new HashMap<>();
+
+    @Test
+    public void portOptionsShouldWork() {
+        // Given
+        properties.put("server.address", "localhost");
+        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
+        properties.put("enable.local", Boolean.FALSE);
+
+        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+        // Then
+        assertEquals(4000, options.getHttpPort());
+        assertEquals(4001, options.getGrpcPort());
+        assertEquals(4002, options.getMetricsPort());
+    }
+
+    @Test
+    public void portOptionsShouldWorkWithNullPorts() {
+        // Given
+        properties.put("server.address", "localhost");
+        properties.put("server.ports", null);
+        properties.put("enable.local", Boolean.FALSE);
+
+        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+        // Then
+        assertEquals(5000, options.getHttpPort());
+        assertEquals(5001, options.getGrpcPort());
+        assertEquals(5002, options.getMetricsPort());
+    }
+
+    @Test
+    public void localOptionsShouldWorkWithLocal() {
+        // Given
+        properties.put("server.address", "localhost");
+        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
+        properties.put("enable.local", Boolean.TRUE);
+
+        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+        // Then
+        assertTrue(options.isLocalEnabled());
+    }
+
+    @Test
+    public void localOptionsShouldWorkWithRemote() {
+        // Given
+        properties.put("server.address", "localhost");
+        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
+        properties.put("enable.local", Boolean.FALSE);
+
+        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+        // Then
+        assertFalse(options.isLocalEnabled());
+    }
+
+    @Test
+    public void localOptionsShouldWorkWithNull() {
+        // Given
+        properties.put("server.address", "localhost");
+        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
+        properties.put("enable.local", null);
+
+        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+        // Then
+        assertFalse(options.isLocalEnabled());
+    }
+
+    @Test
+    public void timeoutOptionsShouldWork() {
+        // Given
+        properties.put("server.address", "localhost");
+        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
+        properties.put("enable.local", Boolean.FALSE);
+        properties.put("timeout", 5);
+
+        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+        // Then
+        assertEquals(5, options.getTimeout());
+        assertEquals(500, options.getRetryInterval());
+        assertEquals(10, options.getNRetries());
+    }
+
+    @Test
+    public void timeoutOptionsShouldWorkWithNullTimeout() {
+        // Given
+        properties.put("server.address", "localhost");
+        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
+        properties.put("enable.local", Boolean.FALSE);
+        properties.put("timeout", null);
+
+        TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+        // Then
+        assertEquals(3, options.getTimeout());
+        assertEquals(500, options.getRetryInterval());
+        assertEquals(6, options.getNRetries());
+    }
+}


### PR DESCRIPTION
Exposed "timeout" parameter to the user for long running operations.

**Description of the solution adopted:** Added "timeout" (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout the operation will be terminated with an error.

This "timeout" parameter substitutes the fixed number of attempts we were performing for the above-mentioned operations since the time taken by these heavily depends on hardware and software configuration (amount of model loaded in the server).

Additionally a new `kill()` method was added to the `TritonServerLocalManager` for killing a non-responsive process.