### PR TITLE
ci: fix backport action PR titles

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,3 +14,4 @@ jobs:
         uses: tibdex/backport@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          title_template: "{{originalTitle}} [backport]"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,17 +1,28 @@
 name: Backport
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
       - labeled
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
     name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
     steps:
-      - name: Backport
-        uses: tibdex/backport@v1
+      - uses: tibdex/backport@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          title_template: "{{originalTitle}} [backport]"
+          title_template: "<%= title %> [backport <%= base %>]"
+


### PR DESCRIPTION
The `backport` action was opening PR titles with the automatically generated title in the format: 
```
[Backport <target>]: <original title>
```
 This was not compliant with the recently adopted Conventional Commit specification.

With this PR the `backport` action will open PR with the title: 
```
<original title> [backport <target>]
```

Additionally the action version was updated and the workflow was updated to the [latest version suggested by the author](https://github.com/tibdex/backport/blob/main/.github/workflows/backport.yml).

Signed-off-by: Mattia Dal Ben <matthewdibi@gmail.com>