### PR TITLE
fix: Port forward ports order as it was swapped

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -1191,8 +1191,8 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
                 portForwarding.append(((IP4Address) IPAddress.parseHostAddress(entry.getAddress())).getHostAddress())
                         .append(",");
                 portForwarding.append(entry.getProtocol()).append(",");
-                portForwarding.append(entry.getOutPort()).append(",");
                 portForwarding.append(entry.getInPort()).append(",");
+                portForwarding.append(entry.getOutPort()).append(",");
                 if (entry.getMasquerade().equals("yes")) {
                     portForwarding.append("true");
                 } else {


### PR DESCRIPTION
Signed-off-by: Maiero <matteo.maiero@eurotech.com>

Steps to recreate issue:
1. Login as admin
2. Go to Firewall → Port Forwarding
3. Click New 
4. Configure as follows:Input Interface* → eth1 Output Interface* → eth0 LAN Address* → 172.50.1.20 Protocol → tcp Internal Port* → 4050 External Port* → 3040 Enable Masquerading → yes Permitted Network → empty Permitted MAC Address → empty Source Port or Port Range → empty 
5. Click Apply 
6. Go to the terminal and execute “iptables -t nat -L -n -v“

7. Note that output contains:

0     0 DNAT       tcp  --  eth1   *       0.0.0.0/0            0.0.0.0/0            tcp dpt:4050 to:172.50.1.20:3040

On Kura 5.1.1 it was like this:

0     0 DNAT       tcp  --  eth1   *       0.0.0.0/0            0.0.0.0/0            tcp dpt:3040 to:172.50.1.20:4050