### PR TITLE
feat(ai.triton.server): added an option to control the max. message size limit for the GRPC calls

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -106,10 +106,11 @@
         <AD id="grpc.max.size"
         	name="Max. GRPC message size (bytes)"
         	type="Integer"
-        	description="Maximum accepted input size for the GRPC calls. If left empty, a default of 4194304 bytes is used.
+        	description="Maximum accepted input size for the GRPC calls.
         	Increase this value if the model input size is bigger than the default."
         	cardinality="0"
-        	required="false"
+        	required="true"
+        	default="4194304"
         	min="1">
         </AD>        	
 

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -102,6 +102,16 @@
             default="3" 
             description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout, the operation will be terminated with an error.">
         </AD>
+        
+        <AD id="grpc.max.size"
+        	name="Max. GRPC message size (bytes)"
+        	type="Integer"
+        	description="Maximum accepted input size for the GRPC calls. If left empty, a default of 4194304 bytes is used.
+        	Increase this value if the model input size is bigger than the default."
+        	cardinality="0"
+        	required="false"
+        	min="1">
+        </AD>        	
 
     </OCD>
     <Designate factoryPid="org.eclipse.kura.ai.triton.server.TritonServerService">

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -169,7 +169,7 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
     private void setGrpcResources() {
         this.grpcChannel = ManagedChannelBuilder.forAddress(this.options.getAddress(), this.options.getGrpcPort())
-                .usePlaintext().build();
+                .usePlaintext().maxInboundMessageSize(this.options.getGrpcMaxMessageSize()).build();
         setGrpcStub(GRPCInferenceServiceGrpc.newBlockingStub(this.grpcChannel));
     }
 

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
@@ -36,9 +36,11 @@ public class TritonServerServiceOptions {
     private static final String PROPERTY_MODELS = "models";
     private static final String PROPERTY_LOCAL = "enable.local";
     private static final String PROPERTY_TIMEOUT = "timeout";
+    private static final String PROPERTY_MAX_GRPC_MESSAGE_SIZE = "grpc.max.size";
     private final Map<String, Object> properties;
 
     private static final int RETRY_INTERVAL = 500; // ms
+    private static final int DEFAULT_MAX_GRPC_MESSAGE_SIZE = 4194304; // bytes
 
     private final int httpPort;
     private final int grpcPort;
@@ -46,6 +48,7 @@ public class TritonServerServiceOptions {
     private final boolean isLocal;
     private final int timeout;
     private final int nRetries;
+    private final int grpcMaxMessageSize;
 
     public TritonServerServiceOptions(final Map<String, Object> properties) {
         requireNonNull(properties, "Properties cannot be null");
@@ -86,6 +89,13 @@ public class TritonServerServiceOptions {
             this.timeout = 3;
         }
         this.nRetries = (this.timeout * 1000) / RETRY_INTERVAL;
+
+        final Object propertyGrpcMaxMessageSize = properties.get(PROPERTY_MAX_GRPC_MESSAGE_SIZE);
+        if (propertyGrpcMaxMessageSize instanceof Integer) {
+            this.grpcMaxMessageSize = (int) propertyGrpcMaxMessageSize;
+        } else {
+            this.grpcMaxMessageSize = DEFAULT_MAX_GRPC_MESSAGE_SIZE;
+        }
     }
 
     public String getAddress() {
@@ -161,6 +171,10 @@ public class TritonServerServiceOptions {
 
     public int getRetryInterval() {
         return RETRY_INTERVAL;
+    }
+
+    public int getGrpcMaxMessageSize() {
+        return this.grpcMaxMessageSize;
     }
 
     private String getStringProperty(String propertyName) {

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptionsTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotEquals;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.kura.ai.triton.server.TritonServerServiceOptions;
 import org.junit.Test;
 
 public class TritonServerServiceOptionsTest {
@@ -205,6 +206,28 @@ public class TritonServerServiceOptionsTest {
         thenHashCodesShouldNotMatch();
     }
 
+    @Test
+    public void shouldReturnInputGrpcMaxMessageSize() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("grpc.max.size", 2000);
+        givenServiceOptionsBuiltWith(this.properties);
+
+        thenGrpcMaxMessageSizeIsEqualTo(2000);
+    }
+
+    @Test
+    public void shouldReturnDefaultGrpcMaxMessageSize() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.FALSE);
+        givenPropertyWith("grpc.max.size", null);
+        givenServiceOptionsBuiltWith(this.properties);
+
+        thenGrpcMaxMessageSizeIsEqualTo(4194304);
+    }
+
     /*
      * Given
      */
@@ -266,6 +289,10 @@ public class TritonServerServiceOptionsTest {
         assertEquals(value, this.options.isLocalEnabled());
     }
 
+    private void thenGrpcMaxMessageSizeIsEqualTo(int expectedValue) {
+        assertEquals(expectedValue, this.options.getGrpcMaxMessageSize());
+    }
+
     private void thenEqualsMethodShouldReturn(boolean value) {
         assertEquals(value, this.equalsResult);
     }
@@ -277,4 +304,5 @@ public class TritonServerServiceOptionsTest {
     private void thenHashCodesShouldNotMatch() {
         assertNotEquals(this.hashCode, this.otherHashCode);
     }
+
 }


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds the `grpc.max.size` property to control the maximum allowed message size for the GRPC call to the Triton server.

**Related Issue:** N/A.

**Description of the solution adopted:** The `this.grpcChannel` is now built by setting `maxInboundMessageSize()`. The default value of 4194304 bytes (around 4MB) is used if the property is left empty. This default value coincides with the GRPC factory setting.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
