### PR TITLE
ci: fix error in retrieving project version for automation workflows

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Get version
       id: get-version
-      uses: JActions/maven-version@v1.0.0
+      uses: JActions/maven-version@v1.0.1
       with:
         pom: ./kura/pom.xml
 

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -52,7 +52,9 @@ jobs:
 
     - name: Get version
       id: get-version
-      uses: JActions/maven-version@v1.0.0
+      uses: JActions/maven-version@v1.0.1
+      with:
+        pom: ./kura/pom.xml
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
Update `maven-version` action to v1.0.1 for fixing error in project version retrival.

We found an issue with the `maven-version` action when used with a repo with a `pom.xml` outside the work directory (as is the case for Kura).

It release notes automation workflow reports:
```
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:3.0.0:exec (default-cli): Goal requires a project to execute but there is no POM in this directory (/home/runner/work/kura/kura). Please verify you invoked Maven from the correct directory. -> [Help 1]
```

even though the `pom.xml` path was specified.

There was a bug in the action sources as the `pom.xml` path [was set](https://github.com/JActions/maven-version/blob/497a8ea3a19d17d429f34fefe7ad432dd05c48d4/action.yaml#L9) but [not used.](https://github.com/JActions/maven-version/blob/497a8ea3a19d17d429f34fefe7ad432dd05c48d4/action.yaml#L24). This issue was fixed in version v1.0.1

The issue was present also in the uptick automation workflow further aggravated by the lack of `pom` path setting. Both problem should be now fixed.
