### PR TITLE
fix(ai.triton.server): disabled size enforcement on GRPC inbound metadata

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceImpl.java
@@ -169,7 +169,8 @@ public class TritonServerServiceImpl implements InferenceEngineService, Configur
 
     private void setGrpcResources() {
         this.grpcChannel = ManagedChannelBuilder.forAddress(this.options.getAddress(), this.options.getGrpcPort())
-                .usePlaintext().maxInboundMessageSize(this.options.getGrpcMaxMessageSize()).build();
+                .usePlaintext().maxInboundMessageSize(this.options.getGrpcMaxMessageSize())
+                .maxInboundMetadataSize(Integer.MAX_VALUE).build();
         setGrpcStub(GRPCInferenceServiceGrpc.newBlockingStub(this.grpcChannel));
     }
 


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR is a simple fix to disable the enforcement on the inbound metadata size for the Triton server GRPC calls.

**Related Issue:** N/A.

**Description of the solution adopted:** Following the [ManagedChannelBuilder javadoc](https://grpc.github.io/grpc-java/javadoc/io/grpc/ManagedChannelBuilder.html#maxInboundMetadataSize-int-), the limit is removed when set to `Integer.MAX_VALUE`. Tested by sending large images (full-hd size) from a MQTT subscriber through a no-op Triton pipeline.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
