### PR TITLE
fix: clear isDirty flag when unsaved changes are discarded

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/EntryClassUi.java
@@ -1098,6 +1098,9 @@ public class EntryClassUi extends Composite implements Context, ServicesUi.Liste
         if (this.users.isVisible()) {
             this.usersBinder.setDirty(false);
         }
+        if (this.driversAndTwinsBinder.isVisible()) {
+            this.driversAndTwinsBinder.clearDirtyState();
+        }
     }
 
     GwtConfigComponent getSelected() {


### PR DESCRIPTION
the dirty flag is never cleared when the unsaved changes modal appears. This adds the driver's service to the force clear list so that it is cleared when user indicated they do not want to save changes

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
