### PR TITLE
ci: add missing `uptick_snapshot_to_patch_release` configuration

### DIFF
--- a/.github/version_uptick_configs/uptick_snapshot_to_patch_release.yml
+++ b/.github/version_uptick_configs/uptick_snapshot_to_patch_release.yml
@@ -1,0 +1,38 @@
+---
+exclusions:
+  - "**/.git/**/*"
+  - "**/target/**/*"
+  - "**/RELEASE_INFO/**/*"
+  - "**/.settings/**/*"
+  - "**/.classpath"
+  - "**/.project"
+  - "./distrib/esf-addon-archetype/src/main/resources/**/*"
+  - "./kura/tools/archetype/example/src/main/resources/**/*"
+  - "./target-platform/javax.bluetooth-parent/javax.bluetooth/src/**/*"
+
+tasks:
+  - selector:
+      or:
+        - and:
+          - group_id: "org.eclipse.kura"
+          - artifact_id: "distrib"
+        - and:
+          - group_id: "org.eclipse.kura"
+          - artifact_id: "tools"
+        - and:
+          - group_id: "org.eclipse.kura"
+          - artifact_id: "target-platform"
+        - and:
+          - group_id: "org.eclipse.kura"
+          - artifact_id: "examples"
+        - and:
+          - group_id: "org.eclipse.kura.tools"
+          - artifact_id: "archetype"
+        - and:
+          - group_id: "org.eclipse.kura"
+          - artifact_id: "kura"
+    actions:
+      - print
+      - transform_version:
+        - snapshot: remove
+

--- a/.github/version_uptick_configs/uptick_snapshot_to_patch_release.yml
+++ b/.github/version_uptick_configs/uptick_snapshot_to_patch_release.yml
@@ -1,14 +1,13 @@
 ---
 exclusions:
   - "**/.git/**/*"
+  - "**/.github/**/*"
   - "**/target/**/*"
   - "**/RELEASE_INFO/**/*"
   - "**/.settings/**/*"
   - "**/.classpath"
   - "**/.project"
-  - "./distrib/esf-addon-archetype/src/main/resources/**/*"
   - "./kura/tools/archetype/example/src/main/resources/**/*"
-  - "./target-platform/javax.bluetooth-parent/javax.bluetooth/src/**/*"
 
 tasks:
   - selector:

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -30,16 +30,16 @@ jobs:
     - name: Download ESF version upticker tool
       uses: carlosperate/download-file-action@v1
       with:
-        file-url: https://kura-repo.s3.us-west-2.amazonaws.com/esf_upticker_tool/version-uptick-0.1.0-linux-x86_64
+        file-url: https://kura-repo.s3.us-west-2.amazonaws.com/esf_upticker_tool/version-uptick-0.2.0-linux-x86_64
 
     - name: Make the uptick tool executable
       run: |
-        chmod +x ./version-uptick-0.1.0-linux-x86_64
+        chmod +x ./version-uptick-0.2.0-linux-x86_64
       shell: bash
 
     - name: Run the uptick tool
       run: |
-        ./version-uptick-0.1.0-linux-x86_64 \
+        ./version-uptick-0.2.0-linux-x86_64 \
         --commit --trace process-versions \
         --config-path .github/version_uptick_configs/${{ github.event.inputs.uptick_config }} \
         --root-dir .
@@ -47,7 +47,7 @@ jobs:
 
     - name: Cleanup uptick tool
       run: |
-        rm ./version-uptick-0.1.0-linux-x86_64
+        rm ./version-uptick-0.2.0-linux-x86_64
       shell: bash
 
     - name: Get version

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -14,6 +14,7 @@ on:
             - uptick_major_on_develop_branch.yml
             - uptick_minor_on_develop_branch.yml
             - uptick_patch_on_maintenance_branch.yml
+            - uptick_snapshot_to_patch_release.yml
             - uptick_snapshot_to_release.yml
           required: true
 


### PR DESCRIPTION
Added missing configuration for the uptick workflow for the case in which we needed to perform a release of a patch on a maintenance branch.

Contrary to the `uptick_snapshot_to_release` in which *all* bundles are upticked, when we perform a release of a patch only the bundles that were modified will need to be upticked. This configuration allows this behaviour.

Additionally the uptick tool was updated to allow for correct upticking of nested projects.