### PR TITLE
feat(ble.provider): Lazy initialization of Bt DeviceManager

### DIFF
--- a/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImpl.java
+++ b/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -58,14 +58,6 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
 
     protected void activate(ComponentContext context) {
         logger.info("Activating Bluetooth Le Service...");
-        if (!startBluetoothSuppressed() && !startBluetoothUbuntuSnap() && !startBluetoothSystemd() && !startBluetoothInitd()) {
-            startBluetoothDaemon();
-        }
-        try {
-            this.deviceManager = getDeviceManager();
-        } catch (DBusException e) {
-            logger.error("Failed to start bluetooth service", e);
-        }
     }
 
     protected void deactivate(ComponentContext context) {
@@ -79,10 +71,13 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
     @Override
     public List<BluetoothLeAdapter> getAdapters() {
         List<BluetoothLeAdapter> adapters = new ArrayList<>();
-        if (this.deviceManager != null) {
-            for (BluetoothAdapter adapter : this.deviceManager.getAdapters()) {
+        try {
+            DeviceManager dm = getDeviceManager();
+            for (BluetoothAdapter adapter : dm.getAdapters()) {
                 adapters.add(new BluetoothLeAdapterImpl(adapter));
             }
+        } catch (DBusException e) {
+            logger.error("Cannot initialize BT Device Manager", e);
         }
         return adapters;
     }
@@ -90,13 +85,23 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
     @Override
     public BluetoothLeAdapter getAdapter(String interfaceName) {
         BluetoothLeAdapterImpl adapter = null;
-        if (this.deviceManager != null) {
-            BluetoothAdapter ba = this.deviceManager.getAdapter(interfaceName);
+        try {
+            DeviceManager dm = getDeviceManager();
+            BluetoothAdapter ba = dm.getAdapter(interfaceName);
             if (ba != null) {
                 adapter = new BluetoothLeAdapterImpl(ba);
             }
+        } catch (DBusException e) {
+            logger.error("Cannot initialize BT Device Manager", e);
         }
         return adapter;
+    }
+
+    private void initializeDaemon() {
+        if (!startBluetoothSuppressed() && !startBluetoothUbuntuSnap() && !startBluetoothSystemd()
+                && !startBluetoothInitd()) {
+            startBluetoothDaemon();
+        }
     }
 
     private boolean startBluetoothSystemd() {
@@ -137,8 +142,16 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
         return started;
     }
 
-    // For test only
-    public DeviceManager getDeviceManager() throws DBusException {
+    private DeviceManager getDeviceManager() throws DBusException {
+        if (this.deviceManager == null) {
+            initializeDaemon();
+            return getDeviceManagerInternal();
+        } else {
+            return this.deviceManager;
+        }
+    }
+
+    protected DeviceManager getDeviceManagerInternal() throws DBusException {
         return DeviceManager.createInstance(false);
     }
 }

--- a/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImpl.java
+++ b/kura/org.eclipse.kura.ble.provider/src/main/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImpl.java
@@ -152,6 +152,7 @@ public class BluetoothLeServiceImpl implements BluetoothLeService {
     }
 
     protected DeviceManager getDeviceManagerInternal() throws DBusException {
-        return DeviceManager.createInstance(false);
+        this.deviceManager = DeviceManager.createInstance(false);
+        return this.deviceManager;
     }
 }

--- a/kura/test/org.eclipse.kura.internal.ble.test/src/test/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.internal.ble.test/src/test/java/org/eclipse/kura/internal/ble/BluetoothLeServiceImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import org.eclipse.kura.bluetooth.le.BluetoothLeAdapter;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
@@ -50,7 +51,7 @@ public class BluetoothLeServiceImplTest {
         bluetoothLeService = new BluetoothLeServiceImpl() {
 
             @Override
-            public DeviceManager getDeviceManager() {
+            protected DeviceManager getDeviceManagerInternal() {
                 return deviceManagerMock;
             }
         };
@@ -63,37 +64,7 @@ public class BluetoothLeServiceImplTest {
     }
 
     @Test
-    public void activateSystemdTest() {
-        CommandExecutorService executorMock = mock(CommandExecutorService.class);
-        Command command = new Command("systemctl start bluetooth".split(" "));
-        CommandStatus status = new CommandStatus(command, new LinuxExitStatus(0));
-        when(executorMock.execute(command)).thenReturn(status);
-        bluetoothLeService.setExecutorService(executorMock);
-        bluetoothLeService.setSystemService(mockSystemService());
-        bluetoothLeService.activate(null);
-
-        verify(executorMock, times(1)).execute(command);
-    }
-
-    @Test
-    public void activateSysVTest() {
-        CommandExecutorService executorMock = mock(CommandExecutorService.class);
-        Command commandSystemd = new Command("systemctl start bluetooth".split(" "));
-        CommandStatus statusSystemd = new CommandStatus(commandSystemd, new LinuxExitStatus(1));
-        when(executorMock.execute(commandSystemd)).thenReturn(statusSystemd);
-        Command commandSysV = new Command("/etc/init.d/bluetooth start".split(" "));
-        CommandStatus statusSysV = new CommandStatus(commandSysV, new LinuxExitStatus(0));
-        when(executorMock.execute(commandSysV)).thenReturn(statusSysV);
-        bluetoothLeService.setExecutorService(executorMock);
-        bluetoothLeService.setSystemService(mockSystemService());
-        bluetoothLeService.activate(null);
-
-        verify(executorMock, times(1)).execute(commandSystemd);
-        verify(executorMock, times(1)).execute(commandSysV);
-    }
-
-    @Test
-    public void activateBluetoothServiceTest() {
+    public void activateTest() {
         CommandExecutorService executorMock = mock(CommandExecutorService.class);
         Command commandSystemd = new Command("systemctl start bluetooth".split(" "));
         CommandStatus statusSystemd = new CommandStatus(commandSystemd, new LinuxExitStatus(1));
@@ -108,9 +79,9 @@ public class BluetoothLeServiceImplTest {
         bluetoothLeService.setSystemService(mockSystemService());
         bluetoothLeService.activate(null);
 
-        verify(executorMock, times(1)).execute(commandSystemd);
-        verify(executorMock, times(1)).execute(commandSysV);
-        verify(executorMock, times(1)).execute(commandBTService);
+        verify(executorMock, times(0)).execute(commandSystemd);
+        verify(executorMock, times(0)).execute(commandSysV);
+        verify(executorMock, times(0)).execute(commandBTService);
     }
 
     @Test
@@ -122,7 +93,10 @@ public class BluetoothLeServiceImplTest {
         bluetoothLeService.setExecutorService(executorMock);
         bluetoothLeService.setSystemService(mockSystemService());
         bluetoothLeService.activate(null);
-        assertEquals("AA:BB:CC:DD:EE:FF", bluetoothLeService.getAdapter("hci0").getAddress());
+        BluetoothLeAdapter adapter = bluetoothLeService.getAdapter("hci0");
+
+        verify(executorMock, times(1)).execute(command);
+        assertEquals("AA:BB:CC:DD:EE:FF", adapter.getAddress());
     }
 
     @Test
@@ -134,6 +108,9 @@ public class BluetoothLeServiceImplTest {
         bluetoothLeService.setExecutorService(executorMock);
         bluetoothLeService.setSystemService(mockSystemService());
         bluetoothLeService.activate(null);
-        assertEquals("AA:BB:CC:DD:EE:FF", bluetoothLeService.getAdapters().get(0).getAddress());
+        BluetoothLeAdapter adapter = bluetoothLeService.getAdapters().get(0);
+
+        verify(executorMock, times(1)).execute(command);
+        assertEquals("AA:BB:CC:DD:EE:FF", adapter.getAddress());
     }
 }


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR moves the BT DeviceManager initialization away from the activate method.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** In this PR the BT DeviceManager initialization is done at the first request and not in the activation method. In this way we can (marginally) improve the Kura start up time.
