### PR TITLE
fix(example.ble.sensortag.dbus): Fixed sensortag example

### DIFF
--- a/kura/org.eclipse.kura.driver.ble.sensortag.provider/src/main/java/org/eclipse/kura/internal/driver/ble/sensortag/TiSensorTag.java
+++ b/kura/org.eclipse.kura.driver.ble.sensortag.provider/src/main/java/org/eclipse/kura/internal/driver/ble/sensortag/TiSensorTag.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
 
-import org.eclipse.kura.KuraBluetoothConnectionException;
 import org.eclipse.kura.KuraBluetoothIOException;
 import org.eclipse.kura.KuraBluetoothResourceNotFoundException;
 import org.eclipse.kura.KuraException;

--- a/kura/org.eclipse.kura.driver.ble.sensortag.provider/src/main/java/org/eclipse/kura/internal/driver/ble/sensortag/TiSensorTag.java
+++ b/kura/org.eclipse.kura.driver.ble.sensortag.provider/src/main/java/org/eclipse/kura/internal/driver/ble/sensortag/TiSensorTag.java
@@ -98,7 +98,7 @@ public class TiSensorTag {
             if (!isConnected() || !this.device.isServicesResolved()) {
                 throw new ConnectionException("Connection failed");
             }
-        } catch (KuraBluetoothConnectionException e) {
+        } catch (Exception e) {
             throw new ConnectionException(e);
         }
     }
@@ -139,7 +139,7 @@ public class TiSensorTag {
             if (isConnected()) {
                 throw new ConnectionException("Disconnection failed");
             }
-        } catch (KuraBluetoothConnectionException e) {
+        } catch (Exception e) {
             throw new ConnectionException(e);
         }
         // Wait a while after disconnection


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR allows the TiSensorTag DBUS example to run even if there are errors in connecting/reading a device.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** With this PR, the thread that is responsible to scan for devices and read the sensor data to continue to run even if something went wrong. So, the thread is not killed and the example continue to work.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>
