### PR TITLE
feat: Added support for separate truststore in SSLManagerService

### DIFF
--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.ssl.SslManagerService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.ssl.SslManagerService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -37,12 +37,21 @@
         	description="Enable or disable hostname verification." />
 
         <AD id="KeystoreService.target"
-            name="KeystoreService Target Filter"
+            name="Keystore Target Filter"
             type="String"
             cardinality="0"
             required="true"
             default="(kura.service.pid=changeme)"
-            description="Specifies, as an OSGi target filter, the pid of the KeystoreService used to manage the HTTPS Keystore.">
+            description="Specifies, as an OSGi target filter, the pid of the KeystoreService used to manage the SSL key store.">
+        </AD>
+        
+        <AD id="TruststoreKeystoreService.target"
+            name="Truststore Target Filter"
+            type="String"
+            cardinality="0"
+            required="true"
+            default="(kura.service.pid=changeme)"
+            description="Specifies, as an OSGi target filter, the pid of the KeystoreService used to manage the SSL trust Store. If the target service cannot be found, the service configured with the Keystore Target Filter parameter will be used as truststore.">
         </AD>
 
         <AD id="ssl.default.cipherSuites"

--- a/kura/org.eclipse.kura.core/OSGI-INF/ssl.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/ssl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+   Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
   
    This program and the accompanying materials are made
    available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,12 @@
            policy="dynamic"
            bind="setKeystoreService"
            unbind="unsetKeystoreService"
+           cardinality="0..1"
+           interface="org.eclipse.kura.security.keystore.KeystoreService"/>
+   <reference name="TruststoreKeystoreService"
+           policy="dynamic"
+           bind="setTruststoreKeystoreService"
+           unbind="unsetTruststoreKeystoreService"
            cardinality="0..1"
            interface="org.eclipse.kura.security.keystore.KeystoreService"/>
    <property name="kura.ui.factory.hide" type="String" value="true"/>


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

* Modified the SSLManagerService in order to allow having separate keystore and truststore KeystoreService target filters
* If the service reference by the truststore filter cannot be found, the service that matches the keystore filter will be used as truststore as well like in the current implementation
