### PR TITLE
refactor(ai.triton.server): add TritonServerServiceAbs abstract class

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -14,7 +14,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.ai.triton.server.TritonServerService">
-   <implementation class="org.eclipse.kura.ai.triton.server.TritonServerServiceImpl"/>
+   <implementation class="org.eclipse.kura.ai.triton.server.TritonServerServiceOrigImpl"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
       <provide interface="org.eclipse.kura.ai.inference.InferenceEngineService"/>

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerInstanceManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerInstanceManager.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.ai.triton.server;
+
+public interface TritonServerInstanceManager {
+
+    /**
+     * Start the managed Triton Server instance
+     */
+    public void start();
+
+    /**
+     * Stop the managed Triton Server instance
+     */
+    public void stop();
+
+    /**
+     * Stop forcefully the managed Triton Server instance
+     */
+    public void kill();
+
+    /**
+     * Check the managed Triton Server instance status
+     *
+     * @return whether the server instance is running
+     */
+    public boolean isServerRunning();
+}

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
@@ -157,7 +157,7 @@ public class TritonServerNativeManager implements TritonServerInstanceManager {
     private Command createServerCommand() {
         List<String> commandString = new ArrayList<>();
         commandString.add("tritonserver");
-        if (this.options.modelsAreEncrypted()) {
+        if (this.options.isModelEncryptionPasswordSet()) {
             commandString.add("--model-repository=" + this.decryptionFolderPath);
         } else {
             commandString.add("--model-repository=" + this.options.getModelRepositoryPath());

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
@@ -70,7 +70,7 @@ public class TritonServerNativeManager {
         this.serverCommand = createServerCommand();
         this.scheduledFuture = this.scheduledExecutorService.scheduleAtFixedRate(() -> {
             Thread.currentThread().setName(getClass().getSimpleName());
-            if (!isLocalServerRunning()) {
+            if (!isServerRunning()) {
                 startLocalServer();
             }
         }, 0, MONITOR_PERIOD, TimeUnit.SECONDS);
@@ -133,7 +133,7 @@ public class TritonServerNativeManager {
         }
     }
 
-    protected boolean isLocalServerRunning() {
+    protected boolean isServerRunning() {
         boolean isRunning = false;
         if (this.commandExecutorService.isRunning(TRITONSERVER)) {
             isRunning = true;

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
@@ -29,9 +29,9 @@ import org.eclipse.kura.executor.CommandExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TritonServerLocalManager {
+public class TritonServerNativeManager {
 
-    private static final Logger logger = LoggerFactory.getLogger(TritonServerLocalManager.class);
+    private static final Logger logger = LoggerFactory.getLogger(TritonServerNativeManager.class);
 
     private static final int MONITOR_PERIOD = 30;
     private static final String[] TRITONSERVER = new String[] { "tritonserver" };
@@ -44,7 +44,7 @@ public class TritonServerLocalManager {
     private ScheduledExecutorService scheduledExecutorService;
     private ScheduledFuture<?> scheduledFuture;
 
-    protected TritonServerLocalManager(TritonServerServiceOptions options,
+    protected TritonServerNativeManager(TritonServerServiceOptions options,
             CommandExecutorService commandExecutorService, String decryptionFolderPath) {
         this.options = options;
         this.commandExecutorService = commandExecutorService;
@@ -116,11 +116,11 @@ public class TritonServerLocalManager {
     }
 
     private synchronized void stopLocalServer() {
-        TritonServerLocalManager.this.commandExecutorService.kill(TRITONSERVER, LinuxSignal.SIGINT);
+        TritonServerNativeManager.this.commandExecutorService.kill(TRITONSERVER, LinuxSignal.SIGINT);
     }
 
     private synchronized void killLocalServer() {
-        TritonServerLocalManager.this.commandExecutorService.kill(TRITONSERVER, LinuxSignal.SIGKILL);
+        TritonServerNativeManager.this.commandExecutorService.kill(TRITONSERVER, LinuxSignal.SIGKILL);
     }
 
     private void stopScheduledExecutor() {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
@@ -29,7 +29,7 @@ import org.eclipse.kura.executor.CommandExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TritonServerNativeManager {
+public class TritonServerNativeManager implements TritonServerInstanceManager {
 
     private static final Logger logger = LoggerFactory.getLogger(TritonServerNativeManager.class);
 
@@ -52,16 +52,19 @@ public class TritonServerNativeManager {
         this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
     }
 
-    protected void start() {
+    @Override
+    public void start() {
         startLocalServerMonitor();
     }
 
-    protected void stop() {
+    @Override
+    public void stop() {
         stopLocalServerMonitor();
         stopScheduledExecutor();
     }
 
-    protected void kill() {
+    @Override
+    public void kill() {
         killLocalServerMonitor();
         stopScheduledExecutor();
     }
@@ -133,7 +136,8 @@ public class TritonServerNativeManager {
         }
     }
 
-    protected boolean isServerRunning() {
+    @Override
+    public boolean isServerRunning() {
         boolean isRunning = false;
         if (this.commandExecutorService.isRunning(TRITONSERVER)) {
             isRunning = true;

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManager.java
@@ -145,7 +145,7 @@ public class TritonServerNativeManager implements TritonServerInstanceManager {
         return isRunning;
     }
 
-    protected static void sleepFor(long timeout) {
+    private static void sleepFor(long timeout) {
         try {
             Thread.sleep(timeout);
         } catch (InterruptedException e) {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerRemoteManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerRemoteManager.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.ai.triton.server;
+
+public class TritonServerRemoteManager implements TritonServerInstanceManager {
+
+    private boolean isRunning = false;
+
+    @Override
+    public void start() {
+        this.isRunning = true;
+    }
+
+    @Override
+    public void stop() {
+        this.isRunning = false;
+    }
+
+    @Override
+    public void kill() {
+        this.isRunning = false;
+    }
+
+    @Override
+    public boolean isServerRunning() {
+        return this.isRunning;
+    }
+}

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
@@ -132,7 +132,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
     }
 
     private void startLocalInstance() {
-        if (this.options.modelsAreEncrypted()) {
+        if (this.options.isModelEncryptionPasswordSet()) {
             try {
                 this.decryptionFolderPath = TritonServerEncryptionUtils.createDecryptionFolder(TEMP_DIRECTORY_PREFIX);
             } catch (IOException e) {
@@ -157,7 +157,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
             TritonServerNativeManager.sleepFor(this.options.getRetryInterval());
         }
 
-        if (this.options.modelsAreEncrypted()) {
+        if (this.options.isModelEncryptionPasswordSet()) {
             TritonServerEncryptionUtils.cleanRepository(this.decryptionFolderPath);
             try {
                 Files.delete(Paths.get(this.decryptionFolderPath));
@@ -214,7 +214,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
 
     @Override
     public void loadModel(String modelName, Optional<String> modelPath) throws KuraException {
-        if (this.options.modelsAreEncrypted()) {
+        if (this.options.isModelEncryptionPasswordSet()) {
             String password = this.options.getModelRepositoryPassword();
             String plainPassword = String.valueOf(this.cryptoService.decryptAes(password.toCharArray()));
             String encryptedModelPath = TritonServerEncryptionUtils.getEncryptedModelPath(modelName,
@@ -236,13 +236,13 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
         try {
             this.grpcStub.repositoryModelLoad(builder.build());
         } catch (StatusRuntimeException e) {
-            if (this.options.modelsAreEncrypted()) {
+            if (this.options.isModelEncryptionPasswordSet()) {
                 TritonServerEncryptionUtils.cleanRepository(this.decryptionFolderPath);
             }
             throw new KuraIOException(e, "Cannot load the model " + modelName);
         }
 
-        if (this.options.modelsAreEncrypted()) {
+        if (this.options.isModelEncryptionPasswordSet()) {
             int counter = 0;
             while (!isModelLoaded(modelName)) {
                 if (counter++ >= this.options.getNRetries()) {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
@@ -149,7 +149,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
         this.tritonServerLocalManager.stop();
 
         int counter = 0;
-        while (this.tritonServerLocalManager.isLocalServerRunning()) {
+        while (this.tritonServerLocalManager.isServerRunning()) {
             if (counter++ >= this.options.getNRetries()) {
                 logger.warn("Cannot stop local server instance. Killing it.");
                 this.tritonServerLocalManager.kill();

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
@@ -80,7 +80,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
     private CommandExecutorService commandExecutorService;
     private CryptoService cryptoService;
     private TritonServerServiceOptions options;
-    private TritonServerLocalManager tritonServerLocalManager;
+    private TritonServerNativeManager tritonServerLocalManager;
 
     private ManagedChannel grpcChannel;
     private GRPCInferenceServiceBlockingStub grpcStub;
@@ -140,7 +140,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
             }
             logger.info("Created decryption model directory at {}", this.decryptionFolderPath);
         }
-        this.tritonServerLocalManager = new TritonServerLocalManager(this.options, this.commandExecutorService,
+        this.tritonServerLocalManager = new TritonServerNativeManager(this.options, this.commandExecutorService,
                 this.decryptionFolderPath);
         this.tritonServerLocalManager.start();
     }
@@ -154,7 +154,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
                 logger.warn("Cannot stop local server instance. Killing it.");
                 this.tritonServerLocalManager.kill();
             }
-            TritonServerLocalManager.sleepFor(this.options.getRetryInterval());
+            TritonServerNativeManager.sleepFor(this.options.getRetryInterval());
         }
 
         if (this.options.modelsAreEncrypted()) {
@@ -200,7 +200,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
                 logger.warn("Cannot load models since server is not ready.");
                 return;
             }
-            TritonServerLocalManager.sleepFor(this.options.getRetryInterval());
+            TritonServerNativeManager.sleepFor(this.options.getRetryInterval());
         }
 
         this.options.getModels().forEach(modelName -> {
@@ -249,7 +249,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
                     logger.warn("Cannot check if model was correctly loaded. Wiping decrypted model anyway");
                     break;
                 }
-                TritonServerLocalManager.sleepFor(this.options.getRetryInterval());
+                TritonServerNativeManager.sleepFor(this.options.getRetryInterval());
             }
             TritonServerEncryptionUtils.cleanRepository(this.decryptionFolderPath);
         }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
@@ -80,11 +80,12 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
     private CommandExecutorService commandExecutorService;
     private CryptoService cryptoService;
     private TritonServerServiceOptions options;
-    private TritonServerNativeManager tritonServerLocalManager;
+    private TritonServerInstanceManager tritonServerInstanceManager;
 
     private ManagedChannel grpcChannel;
     private GRPCInferenceServiceBlockingStub grpcStub;
     private String decryptionFolderPath = "";
+    private boolean decryptionFolderNeedsCleanup = false;
 
     public void setCommandExecutorService(CommandExecutorService executorService) {
         this.commandExecutorService = executorService;
@@ -93,6 +94,13 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
     public void setCryptoService(CryptoService cryptoService) {
         this.cryptoService = cryptoService;
     }
+
+    abstract TritonServerInstanceManager createInstanceManager(TritonServerServiceOptions options,
+            CommandExecutorService executorService, String decryptionFolderPath);
+
+    abstract boolean isConfigurationValid(TritonServerServiceOptions options);
+
+    abstract boolean isModelEncryptionEnabled(TritonServerServiceOptions options);
 
     protected void activate(Map<String, Object> properties) {
         logger.info("Activate TritonServerService...");
@@ -107,16 +115,14 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
             return;
         }
         this.options = newOptions;
-        if (nonNull(this.tritonServerLocalManager)) {
-            stopLocalInstance();
+
+        if (nonNull(this.tritonServerInstanceManager)) {
+            stopManagedInstance();
         }
-        if (isConfigurationValid()) {
+
+        if (isConfigurationValid(this.options)) {
             setGrpcResources();
-            if (this.options.isLocalEnabled()) {
-                startLocalInstance();
-            } else {
-                this.tritonServerLocalManager = null;
-            }
+            startManagedInstance();
             loadModels();
         } else {
             logger.warn("The provided configuration is not valid");
@@ -125,45 +131,48 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
 
     protected void deactivate() {
         logger.info("Deactivate TritonServerService...");
-        if (nonNull(this.tritonServerLocalManager)) {
-            stopLocalInstance();
-        }
+        stopManagedInstance();
         this.grpcChannel.shutdownNow();
     }
 
-    private void startLocalInstance() {
-        if (this.options.isModelEncryptionPasswordSet()) {
+    private void startManagedInstance() {
+        if (isModelEncryptionEnabled(this.options)) {
             try {
                 this.decryptionFolderPath = TritonServerEncryptionUtils.createDecryptionFolder(TEMP_DIRECTORY_PREFIX);
+                this.decryptionFolderNeedsCleanup = true;
             } catch (IOException e) {
                 logger.warn("Failed to create decryption model directory", e);
             }
-            logger.info("Created decryption model directory at {}", this.decryptionFolderPath);
+            logger.info("Using decryption model directory at path {}", this.decryptionFolderPath);
         }
-        this.tritonServerLocalManager = new TritonServerNativeManager(this.options, this.commandExecutorService,
+
+        this.tritonServerInstanceManager = createInstanceManager(this.options, this.commandExecutorService,
                 this.decryptionFolderPath);
-        this.tritonServerLocalManager.start();
+        logger.info("Created {} type", this.tritonServerInstanceManager.getClass().getSimpleName());
+
+        this.tritonServerInstanceManager.start();
     }
 
-    private void stopLocalInstance() {
-        this.tritonServerLocalManager.stop();
+    private void stopManagedInstance() {
+        this.tritonServerInstanceManager.stop();
 
         int counter = 0;
-        while (this.tritonServerLocalManager.isServerRunning()) {
+        while (this.tritonServerInstanceManager.isServerRunning()) {
             if (counter++ >= this.options.getNRetries()) {
                 logger.warn("Cannot stop local server instance. Killing it.");
-                this.tritonServerLocalManager.kill();
+                this.tritonServerInstanceManager.kill();
             }
-            TritonServerNativeManager.sleepFor(this.options.getRetryInterval());
+            sleepFor(this.options.getRetryInterval());
         }
 
-        if (this.options.isModelEncryptionPasswordSet()) {
+        if (this.decryptionFolderNeedsCleanup) {
             TritonServerEncryptionUtils.cleanRepository(this.decryptionFolderPath);
             try {
                 Files.delete(Paths.get(this.decryptionFolderPath));
             } catch (IOException e) {
                 logger.warn("Could not delete decryption folder {}", this.decryptionFolderPath, e);
             }
+            this.decryptionFolderNeedsCleanup = false;
         }
     }
 
@@ -178,14 +187,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
         this.grpcStub = grpcStub;
     }
 
-    private boolean isConfigurationValid() {
-        if (!this.options.isLocalEnabled()) {
-            return !isNullOrEmpty(this.options.getAddress());
-        }
-        return !isNullOrEmpty(this.options.getBackendsPath()) && !isNullOrEmpty(this.options.getModelRepositoryPath());
-    }
-
-    private boolean isNullOrEmpty(String property) {
+    protected boolean isNullOrEmpty(String property) {
         return isNull(property) || property.isEmpty();
     }
 
@@ -200,7 +202,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
                 logger.warn("Cannot load models since server is not ready.");
                 return;
             }
-            TritonServerNativeManager.sleepFor(this.options.getRetryInterval());
+            sleepFor(this.options.getRetryInterval());
         }
 
         this.options.getModels().forEach(modelName -> {
@@ -214,7 +216,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
 
     @Override
     public void loadModel(String modelName, Optional<String> modelPath) throws KuraException {
-        if (this.options.isModelEncryptionPasswordSet()) {
+        if (isModelEncryptionEnabled(this.options)) {
             String password = this.options.getModelRepositoryPassword();
             String plainPassword = String.valueOf(this.cryptoService.decryptAes(password.toCharArray()));
             String encryptedModelPath = TritonServerEncryptionUtils.getEncryptedModelPath(modelName,
@@ -236,20 +238,20 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
         try {
             this.grpcStub.repositoryModelLoad(builder.build());
         } catch (StatusRuntimeException e) {
-            if (this.options.isModelEncryptionPasswordSet()) {
+            if (isModelEncryptionEnabled(this.options)) {
                 TritonServerEncryptionUtils.cleanRepository(this.decryptionFolderPath);
             }
             throw new KuraIOException(e, "Cannot load the model " + modelName);
         }
 
-        if (this.options.isModelEncryptionPasswordSet()) {
+        if (isModelEncryptionEnabled(this.options)) {
             int counter = 0;
             while (!isModelLoaded(modelName)) {
                 if (counter++ >= this.options.getNRetries()) {
                     logger.warn("Cannot check if model was correctly loaded. Wiping decrypted model anyway");
                     break;
                 }
-                TritonServerNativeManager.sleepFor(this.options.getRetryInterval());
+                sleepFor(this.options.getRetryInterval());
             }
             TritonServerEncryptionUtils.cleanRepository(this.decryptionFolderPath);
         }
@@ -778,6 +780,15 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
             booleanList.add(byteValue == 0x01);
         }
         return booleanList;
+    }
+
+    private static void sleepFor(long timeout) {
+        try {
+            Thread.sleep(timeout);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug(e.getMessage(), e);
+        }
     }
 
 }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
@@ -72,9 +72,9 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
 
-public class TritonServerServiceImpl implements InferenceEngineService, ConfigurableComponent {
+public abstract class TritonServerServiceAbs implements InferenceEngineService, ConfigurableComponent {
 
-    private static final Logger logger = LoggerFactory.getLogger(TritonServerServiceImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(TritonServerServiceAbs.class);
     private static final String TEMP_DIRECTORY_PREFIX = "decrypted_models";
 
     private CommandExecutorService commandExecutorService;

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
@@ -139,7 +139,7 @@ public class TritonServerServiceOptions {
         return getStringProperty(PROPERTY_LOCAL_BACKENDS_PATH);
     }
 
-    public boolean modelsAreEncrypted() {
+    public boolean isModelEncryptionPasswordSet() {
         return !getModelRepositoryPassword().isEmpty();
     }
 

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
@@ -1,5 +1,29 @@
 package org.eclipse.kura.ai.triton.server;
 
+import org.eclipse.kura.executor.CommandExecutorService;
+
 public class TritonServerServiceOrigImpl extends TritonServerServiceAbs {
 
+    @Override
+    TritonServerInstanceManager createInstanceManager(TritonServerServiceOptions options,
+            CommandExecutorService executorService, String decryptionFolderPath) {
+        if (options.isLocalEnabled()) {
+            return new TritonServerNativeManager(options, executorService, decryptionFolderPath);
+        } else {
+            return new TritonServerRemoteManager();
+        }
+    }
+
+    @Override
+    boolean isConfigurationValid(TritonServerServiceOptions options) {
+        if (!options.isLocalEnabled()) {
+            return !isNullOrEmpty(options.getAddress());
+        }
+        return !isNullOrEmpty(options.getBackendsPath()) && !isNullOrEmpty(options.getModelRepositoryPath());
+    }
+
+    @Override
+    boolean isModelEncryptionEnabled(TritonServerServiceOptions options) {
+        return options.isLocalEnabled() && options.isModelEncryptionPasswordSet();
+    }
 }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.ai.triton.server;
 
 import org.eclipse.kura.executor.CommandExecutorService;

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
@@ -27,15 +27,15 @@ public class TritonServerServiceOrigImpl extends TritonServerServiceAbs {
     }
 
     @Override
-    boolean isConfigurationValid(TritonServerServiceOptions options) {
-        if (!options.isLocalEnabled()) {
-            return !isNullOrEmpty(options.getAddress());
+    boolean isConfigurationValid() {
+        if (!this.options.isLocalEnabled()) {
+            return !isNullOrEmpty(this.options.getAddress());
         }
-        return !isNullOrEmpty(options.getBackendsPath()) && !isNullOrEmpty(options.getModelRepositoryPath());
+        return !isNullOrEmpty(this.options.getBackendsPath()) && !isNullOrEmpty(this.options.getModelRepositoryPath());
     }
 
     @Override
-    boolean isModelEncryptionEnabled(TritonServerServiceOptions options) {
-        return options.isLocalEnabled() && options.isModelEncryptionPasswordSet();
+    boolean isModelEncryptionEnabled() {
+        return this.options.isLocalEnabled() && this.options.isModelEncryptionPasswordSet();
     }
 }

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
@@ -1,0 +1,5 @@
+package org.eclipse.kura.ai.triton.server;
+
+public class TritonServerServiceOrigImpl extends TritonServerServiceAbs {
+
+}

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManagerTest.java
@@ -13,6 +13,10 @@
 
 package org.eclipse.kura.ai.triton.server;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,21 +24,27 @@ import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.eclipse.kura.core.linux.executor.LinuxSignal;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.executor.CommandStatus;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class TritonServerNativeManagerTest {
 
     private static final String[] TRITONSERVERCMD = new String[] { "tritonserver" };
-    private static final String MOCK_DECRYPT_FOLDER = "test";
+    private static final String MOCK_DECRYPT_FOLDER = "testDecryptionFolder";
 
     private Map<String, Object> properties = new HashMap<>();
     private TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
 
     private CommandExecutorService ces;
     private TritonServerNativeManager manager;
+
+    private boolean exceptionOccurred = false;
 
     @Test
     public void killMethodShouldWork() {
@@ -44,7 +54,7 @@ public class TritonServerNativeManagerTest {
         givenServiceOptionsBuiltWith(properties);
 
         givenMockCommandExecutionService();
-        givenMockCommandExecutionServiceReturnsTritonIsRunning();
+        givenMockCommandExecutionServiceReturnsTritonIsRunning(true);
 
         givenLocalManagerBuiltWith(this.options, this.ces, MOCK_DECRYPT_FOLDER);
 
@@ -61,13 +71,83 @@ public class TritonServerNativeManagerTest {
         givenServiceOptionsBuiltWith(properties);
 
         givenMockCommandExecutionService();
-        givenMockCommandExecutionServiceReturnsTritonIsRunning();
+        givenMockCommandExecutionServiceReturnsTritonIsRunning(true);
 
         givenLocalManagerBuiltWith(this.options, this.ces, MOCK_DECRYPT_FOLDER);
 
         whenStopIsCalled();
 
         thenCommandServiceKillWasCalledWith(TRITONSERVERCMD, LinuxSignal.SIGINT);
+    }
+
+    @Test
+    public void isServerRunningWorksWhenRunning() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.TRUE);
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockCommandExecutionService();
+        givenMockCommandExecutionServiceReturnsTritonIsRunning(true);
+
+        givenLocalManagerBuiltWith(this.options, this.ces, MOCK_DECRYPT_FOLDER);
+
+        thenServerIsRunningReturns(true);
+    }
+
+    @Test
+    public void isServerRunningWorksWhenNotRunning() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.TRUE);
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockCommandExecutionService();
+        givenMockCommandExecutionServiceReturnsTritonIsRunning(false);
+
+        givenLocalManagerBuiltWith(this.options, this.ces, MOCK_DECRYPT_FOLDER);
+
+        thenServerIsRunningReturns(false);
+    }
+
+    @Test
+    public void decryptionFolderIsUsedOnlyForEncryptedModels() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.TRUE);
+        givenPropertyWith("local.model.repository.password", "password123");
+        givenPropertyWith("local.model.repository.path", "modelRepositoryPath");
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockCommandExecutionService();
+        givenMockCommandExecutionServiceReturnsTritonIsRunning(false);
+
+        givenLocalManagerBuiltWith(this.options, this.ces, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenCommandServiceExecuteWasCalledWithCommandContaining(MOCK_DECRYPT_FOLDER);
+        thenNoExceptionOccurred();
+    }
+
+    @Test
+    public void backendConfigurationIsCorrectlyUsedOnStart() {
+        givenPropertyWith("server.address", "localhost");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("enable.local", Boolean.TRUE);
+        givenPropertyWith("local.backends.config", "testConfiguration");
+        givenPropertyWith("local.model.repository.path", "modelRepositoryPath");
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockCommandExecutionService();
+        givenMockCommandExecutionServiceReturnsTritonIsRunning(false);
+
+        givenLocalManagerBuiltWith(this.options, this.ces, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenCommandServiceExecuteWasCalledWithCommandContaining("--backend-config=");
+        thenNoExceptionOccurred();
     }
 
     /*
@@ -85,8 +165,8 @@ public class TritonServerNativeManagerTest {
         this.ces = mock(CommandExecutorService.class);
     }
 
-    private void givenMockCommandExecutionServiceReturnsTritonIsRunning() {
-        when(this.ces.isRunning(new String[] { "tritonserver" })).thenReturn(true);
+    private void givenMockCommandExecutionServiceReturnsTritonIsRunning(boolean expectedState) {
+        when(this.ces.isRunning(new String[] { "tritonserver" })).thenReturn(expectedState);
     }
 
     private void givenLocalManagerBuiltWith(TritonServerServiceOptions options, CommandExecutorService ces,
@@ -105,10 +185,39 @@ public class TritonServerNativeManagerTest {
         this.manager.stop();
     }
 
+    private void whenStartIsCalled() {
+        this.manager.start();
+
+        try {
+            // Wait for monitor thread to do its job
+            Thread.sleep(10);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            this.exceptionOccurred = true;
+        }
+    }
+
     /*
      * Then
      */
     private void thenCommandServiceKillWasCalledWith(String[] expectedCmd, LinuxSignal expectedSignal) {
         verify(this.ces, times(1)).kill(expectedCmd, expectedSignal);
     }
+
+    @SuppressWarnings("unchecked")
+    private void thenCommandServiceExecuteWasCalledWithCommandContaining(String expectedString) {
+        ArgumentCaptor<Command> argument = ArgumentCaptor.forClass(Command.class);
+        verify(this.ces, times(1)).execute(argument.capture(), (Consumer<CommandStatus>) any(Object.class));
+
+        assertTrue(argument.getValue().toString().contains(expectedString));
+    }
+
+    private void thenServerIsRunningReturns(boolean expectedState) {
+        assertEquals(expectedState, this.manager.isServerRunning());
+    }
+
+    private void thenNoExceptionOccurred() {
+        assertFalse(this.exceptionOccurred);
+    }
+
 }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerNativeManagerTest.java
@@ -25,7 +25,7 @@ import org.eclipse.kura.core.linux.executor.LinuxSignal;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.junit.Test;
 
-public class TritonServerLocalManagerTest {
+public class TritonServerNativeManagerTest {
 
     private static final String[] TRITONSERVERCMD = new String[] { "tritonserver" };
     private static final String MOCK_DECRYPT_FOLDER = "test";
@@ -34,7 +34,7 @@ public class TritonServerLocalManagerTest {
     private TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
 
     private CommandExecutorService ces;
-    private TritonServerLocalManager manager;
+    private TritonServerNativeManager manager;
 
     @Test
     public void killMethodShouldWork() {
@@ -91,7 +91,7 @@ public class TritonServerLocalManagerTest {
 
     private void givenLocalManagerBuiltWith(TritonServerServiceOptions options, CommandExecutorService ces,
             String decryptionFolder) {
-        this.manager = new TritonServerLocalManager(options, ces, decryptionFolder);
+        this.manager = new TritonServerNativeManager(options, ces, decryptionFolder);
     }
 
     /*

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerRemoteManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerRemoteManagerTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+
+package org.eclipse.kura.ai.triton.server;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TritonServerRemoteManagerTest {
+
+    private TritonServerRemoteManager manager;
+
+    @Test
+    public void isServerRunningWorks() {
+        givenInstanceManager();
+
+        thenServerIsRunningReturns(false);
+    }
+
+    @Test
+    public void startMethodWorks() {
+        givenInstanceManager();
+
+        whenStartMethodIsCalled();
+
+        thenServerIsRunningReturns(true);
+    }
+
+    @Test
+    public void stopMethodWorks() {
+        givenInstanceManager();
+
+        whenStopMethodIsCalled();
+
+        thenServerIsRunningReturns(false);
+    }
+
+    @Test
+    public void killMethodWorks() {
+        givenInstanceManager();
+
+        whenKillMethodIsCalled();
+
+        thenServerIsRunningReturns(false);
+    }
+
+    /*
+     * Given
+     */
+    private void givenInstanceManager() {
+        this.manager = new TritonServerRemoteManager();
+    }
+
+    /*
+     * When
+     */
+    private void whenStartMethodIsCalled() {
+        this.manager.start();
+    }
+
+    private void whenStopMethodIsCalled() {
+        this.manager.stop();
+    }
+
+    private void whenKillMethodIsCalled() {
+        this.manager.kill();
+    }
+
+    /*
+     * Then
+     */
+    private void thenServerIsRunningReturns(boolean expectedState) {
+        assertEquals(expectedState, this.manager.isServerRunning());
+    }
+}

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
@@ -38,6 +38,7 @@ import org.eclipse.kura.KuraRuntimeException;
 import org.eclipse.kura.ai.inference.ModelInfo;
 import org.eclipse.kura.ai.inference.Tensor;
 import org.eclipse.kura.ai.inference.TensorDescriptor;
+import org.eclipse.kura.crypto.CryptoService;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.junit.Before;
@@ -95,6 +96,7 @@ public abstract class TritonServerServiceStepDefinitions {
     private List<Tensor> tensorList = new ArrayList<>();
     private boolean isEngineReady;
     private CommandExecutorService ces;
+    private CryptoService cry;
 
     protected void givenTritonServerServiceImpl(Map<String, Object> properties) throws IOException {
         this.tritonServerService = createTritonServerServiceImpl(properties, tritonModelRepoStub, true);
@@ -327,6 +329,9 @@ public abstract class TritonServerServiceStepDefinitions {
         when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(false);
 
         tritonServerServiceImpl.setCommandExecutorService(ces);
+
+        this.cry = mock(CryptoService.class);
+        tritonServerServiceImpl.setCryptoService(cry);
 
         if (activate) {
             tritonServerServiceImpl.activate(properties);

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
@@ -321,7 +321,7 @@ public abstract class TritonServerServiceStepDefinitions {
     private TritonServerServiceAbs createTritonServerServiceImpl(Map<String, Object> properties,
             List<String> tritonModelRepoStub, boolean activate) throws IOException {
 
-        TritonServerServiceAbs tritonServerServiceImpl = new TritonServerServiceAbs();
+        TritonServerServiceAbs tritonServerServiceImpl = new TritonServerServiceOrigImpl();
 
         this.ces = mock(CommandExecutorService.class);
         when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(false);

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
@@ -70,7 +70,7 @@ import io.grpc.testing.GrpcCleanupRule;
 
 public abstract class TritonServerServiceStepDefinitions {
 
-    protected TritonServerServiceImpl tritonServerService;
+    protected TritonServerServiceAbs tritonServerService;
     protected boolean methodCalled;
     protected boolean exceptionCaught;
     protected Optional<ModelInfo> modelInfo;
@@ -318,10 +318,10 @@ public abstract class TritonServerServiceStepDefinitions {
         return tensors;
     }
 
-    private TritonServerServiceImpl createTritonServerServiceImpl(Map<String, Object> properties,
+    private TritonServerServiceAbs createTritonServerServiceImpl(Map<String, Object> properties,
             List<String> tritonModelRepoStub, boolean activate) throws IOException {
 
-        TritonServerServiceImpl tritonServerServiceImpl = new TritonServerServiceImpl();
+        TritonServerServiceAbs tritonServerServiceImpl = new TritonServerServiceAbs();
 
         this.ces = mock(CommandExecutorService.class);
         when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(false);


### PR DESCRIPTION
This is the first step towards the deprecation of the current `TritonServerServiceImpl` class.

The purpose of this PR is to refactor the Triton Server bundle so that we extract the common code in an abstract class (`TritonServerServiceAbs`) which will be reused by the upcoming `TritonServerNativeServiceImpl` and `TritonServerRemoteImpl` Factory Components

The final goal is to have 2 different UI pages for configuring the 2 new factory components.

See UML for reference:
![image](https://user-images.githubusercontent.com/22748355/181218286-b7fc8ac8-8a8d-4775-801f-e282f237e347.png)
Highlighted green the component available with this PR
Highlighted yellow and red the upcoming components

With this PR we:
- Renamed `TritonServerServiceImpl` to `TritonServerServiceAbs`
- Created a new interface `TritonServerInstanceManager` which describe the expected functionalities for the Triton Server managers
- Renamed `TritonServerLocalManager` to `TritonServerNativeManager` which now extends `TritonServerInstanceManager`
- Created the new `TritonServerRemoteManager`
- Created a new `TritonServerServiceOrigImpl` which now extends `TritonServerServiceAbs` and exposes the same functionalities as the old `TritonServerServiceImpl` but leveraging the newly introduced `TritonServerInstanceManager`s

Coming soon™ (in the upcoming PRs):
- `TritonServerNativeServiceImpl` which will expose the `TritonServerNativeService` factory component with relative metatype
- `TritonServerRemoteServiceImpl` which will expose the `TritonServerRemoteService` factory component with relative metatype
- `TritonServerServiceImpl` deprecation in favour of the new factory components
- `TritonServerContainerServiceImpl` which will expose the `TritonServerContainerService` factory component with relative metatype