### PR TITLE
fix(core.configuration): fix SelfConfiguringComponent default configuration retrival

### DIFF
--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
@@ -246,7 +246,7 @@ public class ContainerInstance implements ConfigurableComponent, ContainerOrches
             int maxRetries = options.getMaxDownloadRetries();
             int retryInterval = options.getRetryInterval();
 
-            final ContainerConfiguration containerCongiguration = options.getContainerConfiguration();
+            final ContainerConfiguration containerConfiguration = options.getContainerConfiguration();
 
             int retries = 0;
             while ((unlimitedRetries || retries < maxRetries) && !Thread.currentThread().isInterrupted()) {
@@ -258,7 +258,7 @@ public class ContainerInstance implements ConfigurableComponent, ContainerOrches
                     }
 
                     final String containerId = ContainerInstance.this.containerOrchestrationService
-                            .startContainer(containerCongiguration);
+                            .startContainer(containerConfiguration);
                     updateState(s -> s.onContainerReady(containerId));
 
                     return;

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -936,13 +936,13 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                     logger.error(
                             "Invalid pid for returned Configuration of SelfConfiguringComponent with pid: {} Ignoring it.",
                             pid);
-                    return null;
+                    return cc;
                 }
 
                 OCD ocd = tempCc.getDefinition();
                 if (ocd != null) {
                     Map<String, Object> props = ComponentUtil.getDefaultProperties(ocd, this.ctx);
-                    return new ComponentConfigurationImpl(pid, (Tocd) ocd, props);
+                    cc = new ComponentConfigurationImpl(pid, (Tocd) ocd, props);
                 }
             } catch (KuraException e) {
                 logger.error(GETTING_CONFIGURATION_ERROR, pid, e);

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -908,18 +908,15 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
     private ComponentConfiguration getSelfConfiguringComponentDefaultConfiguration(String pid) {
         ComponentConfiguration cc = null;
         try {
-            ServiceReference<?>[] refs = this.ctx.getBundleContext().getServiceReferences((String) null, null);
-            if (refs != null) {
-                for (ServiceReference<?> ref : refs) {
-                    String ppid = (String) ref.getProperty(KURA_SERVICE_PID);
-                    if (pid.equals(ppid)) {
-                        Object obj = this.ctx.getBundleContext().getService(ref);
-                        try {
-                            cc = getSelfConfiguringComponentDefaultConfigurationInternal(obj, pid);
-                        } finally {
-                            this.ctx.getBundleContext().ungetService(ref);
-                        }
-                    }
+            String filter = String.format("(kura.service.pid=%s)", pid);
+            ServiceReference<?>[] refs = this.ctx.getBundleContext().getServiceReferences((String) null, filter);
+            if (refs != null && refs.length > 0) {
+                ServiceReference<?> ref = refs[0];
+                Object obj = this.ctx.getBundleContext().getService(ref);
+                try {
+                    cc = getSelfConfiguringComponentDefaultConfigurationInternal(obj, pid);
+                } finally {
+                    this.ctx.getBundleContext().ungetService(ref);
                 }
             }
         } catch (InvalidSyntaxException e) {

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -56,6 +56,11 @@ import org.slf4j.LoggerFactory;
 public class ComponentUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(ComponentUtil.class);
+    private static final String OSGI_INF_METATYPE = "OSGI-INF/metatype/";
+
+    private ComponentUtil() {
+        // Do nothing...
+    }
 
     /**
      * Returns a Map with all the MetaType Object Class Definitions contained in the bundle.
@@ -77,19 +82,17 @@ public class ComponentUtil {
                 final List<String> pids = new ArrayList<>();
                 pids.addAll(Arrays.asList(mti.getPids()));
                 pids.addAll(Arrays.asList(mti.getFactoryPids()));
-                if (pids != null) {
-                    for (String pid : pids) {
+                for (String pid : pids) {
 
-                        final Tmetadata metadata;
-                        try {
-                            metadata = readMetadata(bnd, pid);
-                            if (metadata != null) {
-                                bundleMetadata.put(pid, metadata);
-                            }
-                        } catch (Exception e) {
-                            // ignore: Metadata for the specified pid is not found
-                            logger.warn("Error loading Metadata for pid " + pid, e);
+                    final Tmetadata metadata;
+                    try {
+                        metadata = readMetadata(bnd, pid);
+                        if (metadata != null) {
+                            bundleMetadata.put(pid, metadata);
                         }
+                    } catch (Exception e) {
+                        // ignore: Metadata for the specified pid is not found
+                        logger.warn("Error loading Metadata for pid " + pid, e);
                     }
                 }
             }
@@ -218,10 +221,10 @@ public class ComponentUtil {
      * @throws FactoryConfigurationError
      */
     public static Tmetadata readMetadata(Bundle bundle, String pid)
-            throws IOException, Exception, XMLStreamException, FactoryConfigurationError {
+            throws IOException, KuraException, XMLStreamException, FactoryConfigurationError {
         Tmetadata metaData = null;
         StringBuilder sbMetatypeXmlName = new StringBuilder();
-        sbMetatypeXmlName.append("OSGI-INF/metatype/").append(pid).append(".xml");
+        sbMetatypeXmlName.append(OSGI_INF_METATYPE).append(pid).append(".xml");
 
         String metatypeXmlName = sbMetatypeXmlName.toString();
         String metatypeXml = IOUtil.readResource(bundle, metatypeXmlName);
@@ -245,7 +248,7 @@ public class ComponentUtil {
      * @throws FactoryConfigurationError
      */
     public static OCD readObjectClassDefinition(URL resourceUrl)
-            throws IOException, XMLStreamException, FactoryConfigurationError, Exception {
+            throws IOException, XMLStreamException, FactoryConfigurationError, KuraException {
         OCD ocd = null;
         String metatypeXml = IOUtil.readResource(resourceUrl);
         if (metatypeXml != null) {
@@ -253,7 +256,7 @@ public class ComponentUtil {
             if (metaData.getOCD() != null && !metaData.getOCD().isEmpty()) {
                 ocd = metaData.getOCD().get(0);
             } else {
-                logger.warn("Cannot find OCD for component with url: {}", resourceUrl.toString());
+                logger.warn("Cannot find OCD for component with url: {}", resourceUrl);
             }
         }
         return ocd;
@@ -273,10 +276,10 @@ public class ComponentUtil {
      * @throws FactoryConfigurationError
      */
     public static Tocd readObjectClassDefinition(String pid)
-            throws IOException, Exception, XMLStreamException, FactoryConfigurationError {
+            throws IOException, KuraException, XMLStreamException, FactoryConfigurationError {
         Tocd ocd = null;
         StringBuilder sbMetatypeXmlName = new StringBuilder();
-        sbMetatypeXmlName.append("OSGI-INF/metatype/").append(pid).append(".xml");
+        sbMetatypeXmlName.append(OSGI_INF_METATYPE).append(pid).append(".xml");
 
         String metatypeXmlName = sbMetatypeXmlName.toString();
         String metatypeXml = IOUtil.readResource(metatypeXmlName);
@@ -306,10 +309,10 @@ public class ComponentUtil {
      * @throws FactoryConfigurationError
      */
     public static Tocd readObjectClassDefinition(Bundle bundle, String pid)
-            throws IOException, Exception, XMLStreamException, FactoryConfigurationError {
+            throws IOException, KuraException, XMLStreamException, FactoryConfigurationError {
         Tocd ocd = null;
         StringBuilder sbMetatypeXmlName = new StringBuilder();
-        sbMetatypeXmlName.append("OSGI-INF/metatype/").append(pid).append(".xml");
+        sbMetatypeXmlName.append(OSGI_INF_METATYPE).append(pid).append(".xml");
 
         String metatypeXmlName = sbMetatypeXmlName.toString();
         String metatypeXml = IOUtil.readResource(bundle, metatypeXmlName);
@@ -350,7 +353,7 @@ public class ComponentUtil {
         // then split it by comma-separate list
         // keeping in mind the possible escape sequence "\,"
         String defaultValue = attrDef.getDefault();
-        if (defaultValue == null || defaultValue.length() == 0) {
+        if (defaultValue == null) {
             return null;
         }
 
@@ -362,7 +365,7 @@ public class ComponentUtil {
             // if cardinality is greater than 0 or abs(1)
             String[] defaultValues = new String[] { defaultValue };
             int cardinality = attrDef.getCardinality();
-            if (cardinality != 0 || cardinality != 1 || cardinality != -1) {
+            if (cardinality != 0 && cardinality != 1 && cardinality != -1) {
                 defaultValues = StringUtil.splitValues(defaultValue);
             }
 

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
@@ -221,7 +221,7 @@ public class ComponentUtil {
      * @throws FactoryConfigurationError
      */
     public static Tmetadata readMetadata(Bundle bundle, String pid)
-            throws IOException, KuraException, XMLStreamException, FactoryConfigurationError {
+            throws IOException, KuraException, FactoryConfigurationError {
         Tmetadata metaData = null;
         StringBuilder sbMetatypeXmlName = new StringBuilder();
         sbMetatypeXmlName.append(OSGI_INF_METATYPE).append(pid).append(".xml");
@@ -248,7 +248,7 @@ public class ComponentUtil {
      * @throws FactoryConfigurationError
      */
     public static OCD readObjectClassDefinition(URL resourceUrl)
-            throws IOException, XMLStreamException, FactoryConfigurationError, KuraException {
+            throws IOException, FactoryConfigurationError, KuraException {
         OCD ocd = null;
         String metatypeXml = IOUtil.readResource(resourceUrl);
         if (metatypeXml != null) {
@@ -276,7 +276,7 @@ public class ComponentUtil {
      * @throws FactoryConfigurationError
      */
     public static Tocd readObjectClassDefinition(String pid)
-            throws IOException, KuraException, XMLStreamException, FactoryConfigurationError {
+            throws IOException, KuraException, FactoryConfigurationError {
         Tocd ocd = null;
         StringBuilder sbMetatypeXmlName = new StringBuilder();
         sbMetatypeXmlName.append(OSGI_INF_METATYPE).append(pid).append(".xml");
@@ -309,7 +309,7 @@ public class ComponentUtil {
      * @throws FactoryConfigurationError
      */
     public static Tocd readObjectClassDefinition(Bundle bundle, String pid)
-            throws IOException, KuraException, XMLStreamException, FactoryConfigurationError {
+            throws IOException, KuraException, FactoryConfigurationError {
         Tocd ocd = null;
         StringBuilder sbMetatypeXmlName = new StringBuilder();
         sbMetatypeXmlName.append(OSGI_INF_METATYPE).append(pid).append(".xml");

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/StringUtil.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/StringUtil.java
@@ -22,6 +22,10 @@ public class StringUtil {
     private static final char DELIMITER = ',';
     private static final char ESCAPE = '\\';
 
+    private StringUtil() {
+        // Do nothing...
+    }
+
     public static String[] splitValues(String strValues) {
         if (strValues == null) {
             return null;

--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/FirewallConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/FirewallConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -42,12 +42,7 @@ public class FirewallConfiguration {
     public static final String PORT_FORWARDING_PROP_NAME = "firewall.port.forwarding";
     public static final String NAT_PROP_NAME = "firewall.nat";
 
-    public static final String DFLT_OPEN_PORTS_VALUE = "22,tcp,,,,,,#;80,tcp,,eth0,,,,#;"
-            + "80,tcp,,eth1,,,,#;80,tcp,,wlan0,,,,#;80,tcp,10.234.0.0/16,,,,,#;1450,tcp,,eth0,,,,#;"
-            + "1450,tcp,,eth1,,,,#;1450,tcp,,wlan0,,,,#;502,tcp,127.0.0.1/32,,,,,#;53,udp,,eth0,,,,#;"
-            + "53,udp,,eth1,,,,#;53,udp,,wlan0,,,,#;67,udp,,eth0,,,,#;67,udp,,eth1,,,,#;67,udp,,wlan0,,,,#;"
-            + "8000,tcp,,eth0,,,,#;8000,tcp,,eth1,,,,#;8000,tcp,,wlan0,,,,#";
-
+    public static final String DFLT_OPEN_PORTS_VALUE = "";
     public static final String DFLT_PORT_FORWARDING_VALUE = "";
     public static final String DFLT_NAT_VALUE = "";
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -364,7 +364,7 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
         tad.setId(FirewallConfiguration.OPEN_PORTS_PROP_NAME);
         tad.setName(FirewallConfiguration.OPEN_PORTS_PROP_NAME);
         tad.setType(Tscalar.STRING);
-        tad.setCardinality(10000);
+        tad.setCardinality(1);
         tad.setRequired(true);
         tad.setDefault(FirewallConfiguration.DFLT_OPEN_PORTS_VALUE);
         tad.setDescription(NetworkAdminConfigurationMessages.getMessage(NetworkAdminConfiguration.PLATFORM_INTERFACES));
@@ -374,7 +374,7 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
         tad.setId(FirewallConfiguration.PORT_FORWARDING_PROP_NAME);
         tad.setName(FirewallConfiguration.PORT_FORWARDING_PROP_NAME);
         tad.setType(Tscalar.STRING);
-        tad.setCardinality(10000);
+        tad.setCardinality(1);
         tad.setRequired(true);
         tad.setDefault(FirewallConfiguration.DFLT_PORT_FORWARDING_VALUE);
         tad.setDescription(NetworkAdminConfigurationMessages.getMessage(NetworkAdminConfiguration.PLATFORM_INTERFACES));
@@ -384,7 +384,7 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
         tad.setId(FirewallConfiguration.NAT_PROP_NAME);
         tad.setName(FirewallConfiguration.NAT_PROP_NAME);
         tad.setType(Tscalar.STRING);
-        tad.setCardinality(10000);
+        tad.setCardinality(1);
         tad.setRequired(true);
         tad.setDefault(FirewallConfiguration.DFLT_NAT_VALUE);
         tad.setDescription(NetworkAdminConfigurationMessages.getMessage(NetworkAdminConfiguration.PLATFORM_INTERFACES));

--- a/kura/org.eclipse.kura.wire.provider/OSGI-INF/metatype/org.eclipse.kura.wire.graph.WireGraphService.xml
+++ b/kura/org.eclipse.kura.wire.provider/OSGI-INF/metatype/org.eclipse.kura.wire.graph.WireGraphService.xml
@@ -23,7 +23,7 @@
             type="String"
             cardinality="0"
             required="true"
-            default="{&quot;components&quot;:[]\,&quot;wires&quot;:[]}"
+            default="{&quot;components&quot;:[],&quot;wires&quot;:[]}"
             description="The default wire graph JSON">
         </AD>
     </OCD>

--- a/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/CfgSvcTestComponent.xml
+++ b/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/CfgSvcTestComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-  Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+  Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
   
   This program and the accompanying materials are made
   available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/CfgSvcTestSelfComponent.xml
+++ b/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/CfgSvcTestSelfComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-  Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+  Copyright (c) 2022 Eurotech and/or its affiliates and others
   
   This program and the accompanying materials are made
   available under the terms of the Eclipse Public License 2.0
@@ -14,15 +14,15 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
-    name="org.eclipse.kura.core.configuration.CfgSvcTestComponent"
+    name="org.eclipse.kura.core.configuration.CfgSvcTestSelfComponent"
     modified="updated"
     enabled="true"
     immediate="true"
-    configuration-policy="require">
-    <implementation class="org.eclipse.kura.core.configuration.CfgSvcTestComponent"/>
+    configuration-policy="optional">
+    <implementation class="org.eclipse.kura.core.configuration.CfgSvcTestSelfComponent"/>
 
-   <property name="service.pid" type="String" value="org.eclipse.kura.core.configuration.CfgSvcTestComponent"/>
+   <property name="service.pid" type="String" value="org.eclipse.kura.core.configuration.CfgSvcTestSelfComponent"/>
    <service>
-       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
+      <provide interface="org.eclipse.kura.configuration.SelfConfiguringComponent"/>
    </service>
 </scr:component>

--- a/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/ConfigurationServiceTest.xml
+++ b/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/ConfigurationServiceTest.xml
@@ -14,7 +14,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="ConfigurationServiceTest">
-   <implementation class="org.eclipse.kura.core.configuration.test.ConfigurationServiceTest"/>
+   <implementation class="org.eclipse.kura.core.configuration.ConfigurationServiceTest"/>
    <reference bind="bindConfigService"
               unbind="unbindConfigService"
               cardinality="1..1"

--- a/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/ConfigurationServiceTest.xml
+++ b/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/ConfigurationServiceTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-  Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+  Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
   
   This program and the accompanying materials are made
   available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/metatype/org.eclipse.kura.core.configuration.CfgSvcTestComponent.xml
+++ b/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/metatype/org.eclipse.kura.core.configuration.CfgSvcTestComponent.xml
@@ -14,7 +14,7 @@
 
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
-    <OCD id="org.eclipse.kura.core.configuration.test.CfgSvcTestComponent"
+    <OCD id="org.eclipse.kura.core.configuration.CfgSvcTestComponent"
          name="CfgSvcTestComponent"
          description="Component for testing Configuration Service.">
 
@@ -29,7 +29,7 @@
             description="Field for test"/>
 
     </OCD>
-    <Designate pid="org.eclipse.kura.core.configuration.test.CfgSvcTestComponent">
-        <Object ocdref="org.eclipse.kura.core.configuration.test.CfgSvcTestComponent"/>
+    <Designate pid="org.eclipse.kura.core.configuration.CfgSvcTestComponent">
+        <Object ocdref="org.eclipse.kura.core.configuration.CfgSvcTestComponent"/>
     </Designate>
 </MetaData>

--- a/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/metatype/org.eclipse.kura.core.configuration.CfgSvcTestComponent.xml
+++ b/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/metatype/org.eclipse.kura.core.configuration.CfgSvcTestComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/metatype/org.eclipse.kura.core.configuration.TestFactoryComponent.xml
+++ b/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/metatype/org.eclipse.kura.core.configuration.TestFactoryComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/metatype/org.eclipse.kura.core.configuration.TestFactoryComponent.xml
+++ b/kura/test/org.eclipse.kura.core.configuration.test/OSGI-INF/metatype/org.eclipse.kura.core.configuration.TestFactoryComponent.xml
@@ -14,7 +14,7 @@
 
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
-    <OCD id="org.eclipse.kura.core.configuration.test.TestFactoryComponent"
+    <OCD id="org.eclipse.kura.core.configuration.TestFactoryComponent"
          name="TestFactoryComponent"
          description="Component for testing Configuration Service factory.">
 
@@ -29,8 +29,8 @@
             description="Field for test"/>
 
     </OCD>
-    <Designate pid="org.eclipse.kura.core.configuration.test.TestFactoryComponent"
-            factoryPid="org.eclipse.kura.core.configuration.test.TestFactoryComponent">
-        <Object ocdref="org.eclipse.kura.core.configuration.test.TestFactoryComponent"/>
+    <Designate pid="org.eclipse.kura.core.configuration.TestFactoryComponent"
+            factoryPid="org.eclipse.kura.core.configuration.TestFactoryComponent">
+        <Object ocdref="org.eclipse.kura.core.configuration.TestFactoryComponent"/>
     </Designate>
 </MetaData>

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/CfgSvcTestComponent.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/CfgSvcTestComponent.java
@@ -10,7 +10,7 @@
  * Contributors:
  *  Eurotech
  ******************************************************************************/
-package org.eclipse.kura.core.configuration.test;
+package org.eclipse.kura.core.configuration;
 
 import java.util.Map;
 import java.util.Map.Entry;

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/CfgSvcTestSelfComponent.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/CfgSvcTestSelfComponent.java
@@ -1,0 +1,59 @@
+package org.eclipse.kura.core.configuration;
+
+import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_PID;
+import static org.osgi.framework.Constants.SERVICE_PID;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.configuration.ComponentConfiguration;
+import org.eclipse.kura.configuration.SelfConfiguringComponent;
+import org.eclipse.kura.core.configuration.metatype.ObjectFactory;
+import org.eclipse.kura.core.configuration.metatype.Tad;
+import org.eclipse.kura.core.configuration.metatype.Tocd;
+import org.eclipse.kura.core.configuration.metatype.Tscalar;
+
+public class CfgSvcTestSelfComponent implements SelfConfiguringComponent {
+
+    public static final String PID = "org.eclipse.kura.core.configuration.CfgSvcTestSelfComponent";
+
+    @Override
+    public ComponentConfiguration getConfiguration() throws KuraException {
+        try {
+            Map<String, Object> componentConfigurationProperties = new HashMap<>();
+            componentConfigurationProperties.put(KURA_SERVICE_PID, PID);
+            componentConfigurationProperties.put(SERVICE_PID, PID);
+            return new ComponentConfigurationImpl(PID, getDefinition(), componentConfigurationProperties);
+        } catch (Exception e) {
+            throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+        }
+    }
+
+    private Tocd getDefinition() throws KuraException {
+
+        ObjectFactory objectFactory = new ObjectFactory();
+        Tocd tocd = objectFactory.createTocd();
+
+        tocd.setName("CfgSvcTestSelfComponent");
+        tocd.setId(PID);
+        tocd.setDescription("Self Configuring Component Test");
+
+        Tad tad = objectFactory.createTad();
+        tad.setId("TestADId");
+        tad.setName("TestADName");
+        tad.setType(Tscalar.STRING);
+        tad.setCardinality(1);
+        tad.setRequired(true);
+        tad.setDefault("TestADDefaultValue");
+        tad.setDescription("This is only a test parameter.");
+        tocd.addAD(tad);
+
+        return tocd;
+    }
+
+    public void updated(Map<String, Object> properties) {
+
+    }
+}

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/CfgSvcTestSelfComponent.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/CfgSvcTestSelfComponent.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.core.configuration;
 
 import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_PID;

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
@@ -805,16 +805,19 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testEncryptConfigsNoConfigs() throws Throwable {
+    public void testEncryptConfigsNoConfigs() {
         // empty list
-
+        boolean exceptionCaught = false;
         ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
 
         List<? extends ComponentConfiguration> configs = new ArrayList<>();
 
-        TestUtil.invokePrivate(cs, "encryptConfigs", configs);
-
-        // runs without problems, but there's nothing else to check, here
+        try {
+            TestUtil.invokePrivate(cs, "encryptConfigs", configs);
+        } catch (Throwable t) {
+            exceptionCaught = true;
+        }
+        assertFalse(exceptionCaught);
     }
 
     @Test
@@ -2565,20 +2568,6 @@ public class ConfigurationServiceJunitTest {
         assertTrue("method called", calls[0]);
 
         verify(cfgMock, times(1)).update((Dictionary<String, ?>) anyObject());
-    }
-
-    @Test
-    public void testRegisterComponentConfigurationAllNulls() {
-        // only null inputs
-        ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
-
-        String pid = null;
-        String servicePid = null;
-        String factoryPid = null;
-
-        cs.registerComponentConfiguration(pid, servicePid, factoryPid);
-
-        // no checks really possible...
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
@@ -70,7 +70,7 @@ import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.runtime.ServiceComponentRuntime;
 import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
 
-public class ConfigurationServiceTest {
+public class ConfigurationServiceJunitTest {
 
     @Test
     public void testGetFactoryComponentPids() throws NoSuchFieldException, KuraException {


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR fixes the retrival of the default configuration for `SelfConfiguringComponent`s.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** As done for the `ConfigurableComponent`s, the `getDefaultComponentConfiguration` in the `ConfigurationServiceImpl` is modified to handle also the default configurations of `SelfConfiguringComponent`s. Using the rest call `{app}}/services/configuration/v2/configurableComponents/configurations/byPid/_default` for a `SelfConfiguringComponent` like the `FirewallConfigurationService`, now it is possible to get the default configuration.
