### PR TITLE
refactor(ai.triton.server): remove app logic from TritonServerServiceOptions

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
@@ -102,6 +102,8 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
 
     abstract boolean isModelEncryptionEnabled();
 
+    abstract String getServerAddress();
+
     protected void activate(Map<String, Object> properties) {
         logger.info("Activate TritonServerService...");
         updated(properties);
@@ -177,7 +179,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
     }
 
     private void setGrpcResources() {
-        this.grpcChannel = ManagedChannelBuilder.forAddress(this.options.getAddress(), this.options.getGrpcPort())
+        this.grpcChannel = ManagedChannelBuilder.forAddress(getServerAddress(), this.options.getGrpcPort())
                 .usePlaintext().maxInboundMessageSize(this.options.getGrpcMaxMessageSize())
                 .maxInboundMetadataSize(Integer.MAX_VALUE).build();
         setGrpcStub(GRPCInferenceServiceGrpc.newBlockingStub(this.grpcChannel));

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
@@ -99,16 +99,7 @@ public class TritonServerServiceOptions {
     }
 
     public String getAddress() {
-        String address = "";
-        if (this.isLocal) {
-            address = "localhost";
-        } else {
-            final Object propertyAddress = this.properties.get(PROPERTY_ADDRESS);
-            if (propertyAddress instanceof String) {
-                address = ((String) propertyAddress).trim();
-            }
-        }
-        return address;
+        return getStringProperty(PROPERTY_ADDRESS);
     }
 
     public boolean isLocalEnabled() {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOptions.java
@@ -99,7 +99,12 @@ public class TritonServerServiceOptions {
     }
 
     public String getAddress() {
-        return getStringProperty(PROPERTY_ADDRESS);
+        String address = "";
+        final Object propertyAddress = this.properties.get(PROPERTY_ADDRESS);
+        if (propertyAddress instanceof String) {
+            address = ((String) propertyAddress).trim();
+        }
+        return address;
     }
 
     public boolean isLocalEnabled() {

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
@@ -38,4 +38,13 @@ public class TritonServerServiceOrigImpl extends TritonServerServiceAbs {
     boolean isModelEncryptionEnabled() {
         return this.options.isLocalEnabled() && this.options.isModelEncryptionPasswordSet();
     }
+
+    @Override
+    String getServerAddress() {
+        if (this.options.isLocalEnabled()) {
+            return "localhost";
+        } else {
+            return this.options.getAddress();
+        }
+    }
 }


### PR DESCRIPTION
This PR removes a part of the application logic from the `TritonServerServiceOptions` which now becomes a simple wrapper aroung the TritonServerService configuration.

This changes are propedeutics to the addition of the future `TritonServerNativeService` and `TritonServerRemoteService` components since they won't rely on the `local.enabled` configuration property.
