### PR TITLE
feat(ai.triton.server): add Remote Triton Server Service component

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerRemoteService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerRemoteService.xml
@@ -16,7 +16,7 @@
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kura.ai.triton.server.TritonServerRemoteService"
          name="Nvidia Triton Remote Server"
-         description="Configuration for the Remote-mode Nvidia Triton Server">
+         description="Configuration for the Remote Nvidia Triton Server">
 
         <AD id="server.address"
             name="Nvidia Triton Server address"
@@ -24,7 +24,7 @@
             cardinality="0"
             required="true"
             default="localhost"
-            description="The address of the Nvidia Triton Server.">
+            description="The address of the remote Nvidia Triton Server.">
         </AD>
 
         <AD id="server.ports"

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerRemoteService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerRemoteService.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+
+	Contributors:
+	 Eurotech
+
+-->
+<MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
+    <OCD id="org.eclipse.kura.ai.triton.server.TritonServerRemoteService"
+         name="Nvidia Triton Remote Server"
+         description="Configuration for the Remote-mode Nvidia Triton Server">
+
+        <AD id="server.address"
+            name="Nvidia Triton Server address"
+            type="String"
+            cardinality="0"
+            required="true"
+            default="localhost"
+            description="The address of the Nvidia Triton Server.">
+        </AD>
+
+        <AD id="server.ports"
+            name="Nvidia Triton Server ports"
+            type="Integer"
+            cardinality="3"
+            min="1024"
+            max="65535"
+            required="true"
+            default="4000,4001,4002"
+            description="The ports used to connect to the server for HTTP, GPRC and Metrics services.">
+        </AD>
+
+        <AD id="models"
+            name="Inference Models"
+            type="String"
+            cardinality="0"
+            required="false"
+            default=""
+            description="A comma separated list of inference model names that the server will load.">
+        </AD>
+
+        <AD id="timeout"
+            name="Timeout (in seconds) for time consuming tasks"
+            type="Integer"
+            cardinality="0"
+            required="false"
+            min="1"
+            max="3600"
+            default="3"
+            description="Timeout (in seconds) for time consuming tasks like model load. If the task exceeds the timeout, the operation will be terminated with an error.">
+        </AD>
+
+        <AD id="grpc.max.size"
+        	name="Max. GRPC message size (bytes)"
+        	type="Integer"
+        	description="Maximum accepted input size for the GRPC calls.
+        	Increase this value if the model input size is bigger than the default."
+        	cardinality="0"
+        	required="true"
+        	default="4194304"
+        	min="1">
+        </AD>
+
+    </OCD>
+    <Designate factoryPid="org.eclipse.kura.ai.triton.server.TritonServerRemoteService">
+        <Object ocdref="org.eclipse.kura.ai.triton.server.TritonServerRemoteService"/>
+    </Designate>
+</MetaData>

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/org.eclipse.kura.ai.triton.server.TritonServerRemoteService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/org.eclipse.kura.ai.triton.server.TritonServerRemoteService.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+   This program and the accompanying materials are made
+   available under the terms of the Eclipse Public License 2.0
+   which is available at https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+
+	Contributors:
+	 Eurotech
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.ai.triton.server.TritonServerRemoteService">
+   <implementation class="org.eclipse.kura.ai.triton.server.TritonServerServiceRemoteImpl"/>
+   <service>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
+      <provide interface="org.eclipse.kura.ai.inference.InferenceEngineService"/>
+   </service>
+   <property name="service.pid" type="String" value="org.eclipse.kura.ai.triton.server.TritonServerRemoteService"/>
+   <reference bind="setCommandExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static" />
+   <reference bind="setCryptoService" cardinality="1..1" interface="org.eclipse.kura.crypto.CryptoService" name="CryptoService" policy="static"/>
+</scr:component>

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImpl.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.ai.triton.server;
 
 import org.eclipse.kura.executor.CommandExecutorService;

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImpl.java
@@ -1,0 +1,27 @@
+package org.eclipse.kura.ai.triton.server;
+
+import org.eclipse.kura.executor.CommandExecutorService;
+
+public class TritonServerServiceRemoteImpl extends TritonServerServiceAbs {
+
+    @Override
+    TritonServerInstanceManager createInstanceManager(TritonServerServiceOptions options,
+            CommandExecutorService executorService, String decryptionFolderPath) {
+        return new TritonServerRemoteManager();
+    }
+
+    @Override
+    boolean isConfigurationValid() {
+        return !isNullOrEmpty(this.options.getAddress());
+    }
+
+    @Override
+    boolean isModelEncryptionEnabled() {
+        return false; // Feature not supported for remote instances
+    }
+
+    @Override
+    String getServerAddress() {
+        return this.options.getAddress();
+    }
+}

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImplTest.java
@@ -50,7 +50,7 @@ public class TritonServerServiceRemoteImplTest extends TritonServerServiceStepDe
         Map<String, Object> properties = new HashMap<>();
 
         properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
-        properties.put("enable.local", null);
+        properties.put("server.address", "");
 
         return properties;
     }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImplTest.java
@@ -1,0 +1,57 @@
+package org.eclipse.kura.ai.triton.server;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TritonServerServiceRemoteImplTest extends TritonServerServiceStepDefinitions {
+
+    @Test
+    public void isConfigurationValidWorksWithDefaultConfiguration() throws IOException {
+        givenTritonServerServiceRemoteImpl(defaultProperties());
+
+        thenIsConfigurationValidReturns(true);
+    }
+
+    @Test
+    public void isConfigurationValidWorksWithInvalidRemoteConfiguration() throws IOException {
+        givenTritonServerServiceRemoteImpl(invalidRemoteProperties());
+
+        thenIsConfigurationValidReturns(false);
+    }
+
+    @Test
+    public void isModelEncryptionEnabledWorkWithDefault() throws IOException {
+        givenTritonServerServiceRemoteImpl(defaultProperties());
+
+        thenIsModelEncryptionEnabled(false);
+    }
+
+    /*
+     * Helpers
+     */
+    private Map<String, Object> invalidRemoteProperties() {
+        Map<String, Object> properties = new HashMap<>();
+
+        properties.put("server.ports", new Integer[] { 4000, 4001, 4002 });
+        properties.put("enable.local", null);
+
+        return properties;
+    }
+
+    /*
+     * Then
+     */
+    private void thenIsConfigurationValidReturns(boolean expectedValue) {
+        assertEquals(expectedValue, this.tritonServerService.isConfigurationValid());
+    }
+
+    private void thenIsModelEncryptionEnabled(boolean expectedValue) {
+        assertEquals(expectedValue, this.tritonServerService.isModelEncryptionEnabled());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceRemoteImplTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.ai.triton.server;
 
 import static org.junit.Assert.assertEquals;

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
@@ -102,6 +102,10 @@ public abstract class TritonServerServiceStepDefinitions {
         this.tritonServerService = createTritonServerServiceImpl(properties, tritonModelRepoStub, true);
     }
 
+    protected void givenTritonServerServiceRemoteImpl(Map<String, Object> properties) throws IOException {
+        this.tritonServerService = createTritonServerServiceRemoteImpl(properties, tritonModelRepoStub, true);
+    }
+
     protected void givenTritonServerServiceImplNotActive() throws IOException {
         this.tritonServerService = createTritonServerServiceImpl(null, tritonModelRepoStub, false);
     }
@@ -328,6 +332,33 @@ public abstract class TritonServerServiceStepDefinitions {
         this.ces = mock(CommandExecutorService.class);
         when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(false);
 
+        tritonServerServiceImpl.setCommandExecutorService(ces);
+
+        this.cry = mock(CryptoService.class);
+        tritonServerServiceImpl.setCryptoService(cry);
+
+        if (activate) {
+            tritonServerServiceImpl.activate(properties);
+        }
+
+        GRPCInferenceServiceGrpc.GRPCInferenceServiceImplBase serviceImpl = createGRPCMock(tritonModelRepoStub);
+
+        String serverName = InProcessServerBuilder.generateName();
+        grpcCleanup.register(
+                InProcessServerBuilder.forName(serverName).directExecutor().addService(serviceImpl).build().start());
+        ManagedChannel channel = grpcCleanup
+                .register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+        tritonServerServiceImpl.setGrpcStub(GRPCInferenceServiceGrpc.newBlockingStub(channel));
+
+        return tritonServerServiceImpl;
+    }
+
+    private TritonServerServiceAbs createTritonServerServiceRemoteImpl(Map<String, Object> properties,
+            List<String> tritonModelRepoStub, boolean activate) throws IOException {
+
+        TritonServerServiceAbs tritonServerServiceImpl = new TritonServerServiceRemoteImpl();
+
+        this.ces = mock(CommandExecutorService.class);
         tritonServerServiceImpl.setCommandExecutorService(ces);
 
         this.cry = mock(CryptoService.class);


### PR DESCRIPTION
This is the second step towards the deprecation of the current `TritonServerServiceImpl` class following #4064 

The purpose of this PR is to add the `TritonServerRemoteService` Factory Components which exposes the same functionalities as the `TritonServerService` with `local.enabled` turned off (i.e. "Remote" mode) but with a smaller configuration interface.

The final goal is to have 2 different UI pages for configuring the 2 new factory components.

See UML for reference:
![image](https://user-images.githubusercontent.com/22748355/181725124-a612881d-e196-4e41-959e-c6675364e090.png)
Highlighted green the component available with this PR
Highlighted yellow and red the upcoming components

Coming soon™ (in the upcoming PRs):
- [X] `TritonServerRemoteServiceImpl` which will expose the `TritonServerRemoteService` factory component with relative metatype
- [ ] `TritonServerNativeServiceImpl` which will expose the `TritonServerNativeService` factory component with relative metatype
- [ ] `TritonServerServiceOrigImpl` deprecation in favour of the new factory components
- [ ] `TritonServerContainerServiceImpl` which will expose the `TritonServerContainerService` factory component with relative metatype