### PR TITLE
refactor(ai.triton.server): deprecate TritonServerService

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerService.xml
@@ -15,8 +15,8 @@
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kura.ai.triton.server.TritonServerService" 
-         name="Nvidia Triton Server" 
-         description="Configuration for the Nvidia Triton Server">
+         name="Nvidia Triton Server (Deprecated)" 
+         description="Configuration for the Nvidia Triton Server. **Deprecated** use TritonServerRemoteService or TritonServerNativeService instead.">
 
          <AD id="enable.local"  
             name="Local Nvidia Triton Server"

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
@@ -14,6 +14,12 @@ package org.eclipse.kura.ai.triton.server;
 
 import org.eclipse.kura.executor.CommandExecutorService;
 
+/*
+ * @deprecated since version 1.1 in favor of
+ * {@link org.eclipse.kura.ai.triton.server.TritonServerRemoteServiceImpl} and
+ * {@link org.eclipse.kura.ai.triton.server.TritonServerNativeServiceImpl}.
+ */
+@Deprecated
 public class TritonServerServiceOrigImpl extends TritonServerServiceAbs {
 
     @Override

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceOrigImpl.java
@@ -14,10 +14,10 @@ package org.eclipse.kura.ai.triton.server;
 
 import org.eclipse.kura.executor.CommandExecutorService;
 
-/*
+/**
  * @deprecated since version 1.1 in favor of
- * {@link org.eclipse.kura.ai.triton.server.TritonServerRemoteServiceImpl} and
- * {@link org.eclipse.kura.ai.triton.server.TritonServerNativeServiceImpl}.
+ *             {@link org.eclipse.kura.ai.triton.server.TritonServerRemoteServiceImpl} and
+ *             {@link org.eclipse.kura.ai.triton.server.TritonServerNativeServiceImpl}.
  */
 @Deprecated
 public class TritonServerServiceOrigImpl extends TritonServerServiceAbs {


### PR DESCRIPTION
The purpose of this PR is to deprecate the `TritonServerServiceOrigImpl` Factory Component which exposes the functionalities of the `TritonServerService`.

The component will be substituted by:
- `TritonServerRemoteServiceImpl` which will expose the `TritonServerRemoteService` factory component with relative metatype
- `TritonServerNativeServiceImpl` which will expose the `TritonServerNativeService` factory component with relative metatype

Coming soon™ (in the upcoming PRs):
- [X] `TritonServerRemoteServiceImpl` which will expose the `TritonServerRemoteService` factory component with relative metatype
- [ ] `TritonServerNativeServiceImpl` which will expose the `TritonServerNativeService` factory component with relative metatype
- [X] `TritonServerServiceOrigImpl` deprecation in favour of the new factory components
- [ ] `TritonServerContainerServiceImpl` which will expose the `TritonServerContainerService` factory component with relative metatype

~@pierantoniomerlino @MMaiero @nicolatimeus RFC: Here I'm using the `deprecate` commit type which will be added in the Release Notes in the "Deprecated APIs" section. Is it ok or should we reserve this commit type for *APIs* deprecation only? If we want to reserve it for APIs only I will change the commit type to `refactor`.~ -> We decided to use the `refactor` type.