### PR TITLE
feat(ai.triton.server): add Native Triton Server Service component

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerNativeService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerNativeService.xml
@@ -7,10 +7,10 @@
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
 
-	SPDX-License-Identifier: EPL-2.0
+    SPDX-License-Identifier: EPL-2.0
 
-	Contributors:
-	 Eurotech
+    Contributors:
+     Eurotech
 
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
@@ -86,14 +86,14 @@
         </AD>
 
         <AD id="grpc.max.size"
-        	name="Max. GRPC message size (bytes)"
-        	type="Integer"
-        	description="Maximum accepted input size for the GRPC calls.
-        	Increase this value if the model input size is bigger than the default."
-        	cardinality="0"
-        	required="true"
-        	default="4194304"
-        	min="1">
+            name="Max. GRPC message size (bytes)"
+            type="Integer"
+            description="Maximum accepted input size for the GRPC calls.
+            Increase this value if the model input size is bigger than the default."
+            cardinality="0"
+            required="true"
+            default="4194304"
+            min="1">
         </AD>
 
     </OCD>

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerNativeService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerNativeService.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+
+	Contributors:
+	 Eurotech
+
+-->
+<MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
+    <OCD id="org.eclipse.kura.ai.triton.server.TritonServerNativeService"
+         name="Nvidia Triton Server"
+         description="Configuration for the Local Native Nvidia Triton Server">
+
+        <AD id="server.ports"
+            name="Nvidia Triton Server ports"
+            type="Integer"
+            cardinality="3"
+            min="1024"
+            max="65535"
+            required="true"
+            default="4000,4001,4002"
+            description="The ports used to connect to the server for HTTP, GPRC and Metrics services.">
+        </AD>
+
+        <AD id="local.model.repository.path"
+            name="Local model repository path"
+            type="String"
+            cardinality="0"
+            required="true"
+            default=""
+            description="Specify the path on the filesystem where the models are stored.">
+       </AD>
+
+       <AD id="local.model.repository.password"
+            name="Local model decryption password"
+            type="Password"
+            cardinality="0"
+            required="false"
+            default=""
+            description="Specify the password to be used for decrypting models stored in the model repository. If none is specified, models are supposed to be plaintext.">
+       </AD>
+
+        <AD id="models"
+            name="Inference Models"
+            type="String"
+            cardinality="0"
+            required="false"
+            default=""
+            description="A comma separated list of inference model names that the server will load.">
+        </AD>
+
+        <AD id="local.backends.path"
+            name="Local backends path"
+            type="String"
+            cardinality="0"
+            required="true"
+            default=""
+            description="Specify the path on the filesystem where the backends are stored.">
+            </AD>
+
+        <AD id="local.backends.config"
+            name="Optional configuration for the local backends"
+            type="String"
+            cardinality="0"
+            required="false"
+            default=""
+            description="A semi-colon separated list of configuration for the backends. i.e. tensorflow,version=2;tensorflow,allow-soft-placement=false">
+        </AD>
+
+        <AD id="timeout"
+            name="Timeout (in seconds) for time consuming tasks"
+            type="Integer"
+            cardinality="0"
+            required="false"
+            min="1"
+            max="3600"
+            default="3"
+            description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout, the operation will be terminated with an error.">
+        </AD>
+
+        <AD id="grpc.max.size"
+        	name="Max. GRPC message size (bytes)"
+        	type="Integer"
+        	description="Maximum accepted input size for the GRPC calls.
+        	Increase this value if the model input size is bigger than the default."
+        	cardinality="0"
+        	required="true"
+        	default="4194304"
+        	min="1">
+        </AD>
+
+    </OCD>
+    <Designate factoryPid="org.eclipse.kura.ai.triton.server.TritonServerNativeService">
+        <Object ocdref="org.eclipse.kura.ai.triton.server.TritonServerNativeService"/>
+    </Designate>
+</MetaData>

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/org.eclipse.kura.ai.triton.server.TritonServerNativeService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/org.eclipse.kura.ai.triton.server.TritonServerNativeService.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+   This program and the accompanying materials are made
+   available under the terms of the Eclipse Public License 2.0
+   which is available at https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+
+	Contributors:
+	 Eurotech
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.ai.triton.server.TritonServerNativeService">
+   <implementation class="org.eclipse.kura.ai.triton.server.TritonServerServiceNativeImpl"/>
+   <service>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
+      <provide interface="org.eclipse.kura.ai.inference.InferenceEngineService"/>
+   </service>
+   <property name="service.pid" type="String" value="org.eclipse.kura.ai.triton.server.TritonServerNativeService"/>
+   <reference bind="setCommandExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static" />
+   <reference bind="setCryptoService" cardinality="1..1" interface="org.eclipse.kura.crypto.CryptoService" name="CryptoService" policy="static"/>
+</scr:component>

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceNativeImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceNativeImpl.java
@@ -1,0 +1,27 @@
+package org.eclipse.kura.ai.triton.server;
+
+import org.eclipse.kura.executor.CommandExecutorService;
+
+public class TritonServerServiceNativeImpl extends TritonServerServiceAbs {
+
+    @Override
+    TritonServerInstanceManager createInstanceManager(TritonServerServiceOptions options,
+            CommandExecutorService executorService, String decryptionFolderPath) {
+        return new TritonServerNativeManager(options, executorService, decryptionFolderPath);
+    }
+
+    @Override
+    boolean isConfigurationValid() {
+        return !isNullOrEmpty(this.options.getBackendsPath()) && !isNullOrEmpty(this.options.getModelRepositoryPath());
+    }
+
+    @Override
+    boolean isModelEncryptionEnabled() {
+        return this.options.isModelEncryptionPasswordSet();
+    }
+
+    @Override
+    String getServerAddress() {
+        return "localhost";
+    }
+}

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceNativeImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceNativeImpl.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.ai.triton.server;
 
 import org.eclipse.kura.executor.CommandExecutorService;

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceNativeImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceNativeImplTest.java
@@ -1,0 +1,101 @@
+package org.eclipse.kura.ai.triton.server;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TritonServerServiceNativeImplTest extends TritonServerServiceStepDefinitions {
+
+    @Test
+    public void isConfigurationValidWorksWithNativeConfiguration() throws IOException {
+        givenTritonServerServiceNativeImpl(validNativeProperties());
+
+        thenIsConfigurationValidReturns(true);
+    }
+
+    @Test
+    public void isConfigurationValidWorksWithInvalidBackend() throws IOException {
+        givenTritonServerServiceNativeImpl(invalidBackendNativeProperties());
+
+        thenIsConfigurationValidReturns(false);
+    }
+
+    @Test
+    public void isConfigurationValidWorksWithInvalidModelRepository() throws IOException {
+        givenTritonServerServiceNativeImpl(invalidModelRepositoryNativeProperties());
+
+        thenIsConfigurationValidReturns(false);
+    }
+
+    @Test
+    public void isModelEncryptionEnabledWorkWithNativeConfiguration() throws IOException {
+        givenTritonServerServiceNativeImpl(validNativeProperties());
+
+        thenIsModelEncryptionEnabled(false);
+    }
+
+    @Test
+    public void isModelEncryptionEnabledWorksWhenPasswordIsSet() throws IOException {
+        givenTritonServerServiceNativeImpl(validEncryptionNativeProperties());
+
+        thenIsModelEncryptionEnabled(true);
+    }
+
+    /*
+     * Helpers
+     */
+    private Map<String, Object> invalidBackendNativeProperties() {
+        Map<String, Object> properties = new HashMap<>();
+
+        properties.put("local.backends.path", null);
+        properties.put("local.model.repository.path", "/fake-repository-path");
+
+        return properties;
+    }
+
+    private Map<String, Object> invalidModelRepositoryNativeProperties() {
+        Map<String, Object> properties = new HashMap<>();
+
+        properties.put("local.backends.path", null);
+        properties.put("local.model.repository.path", "/fake-repository-path");
+
+        return properties;
+    }
+
+    private Map<String, Object> validNativeProperties() {
+        Map<String, Object> properties = new HashMap<>();
+
+        properties.put("server.ports", new Integer[] { 4001, 4002, 4003 });
+        properties.put("local.backends.path", "/fake-backends-path");
+        properties.put("local.model.repository.path", "/fake-repository-path");
+
+        return properties;
+    }
+
+    private Map<String, Object> validEncryptionNativeProperties() {
+        Map<String, Object> properties = new HashMap<>();
+
+        properties.put("server.ports", new Integer[] { 4001, 4002, 4003 });
+        properties.put("local.backends.path", "/fake-backends-path");
+        properties.put("local.model.repository.path", "/fake-repository-path");
+        properties.put("local.model.repository.password", "hutini");
+
+        return properties;
+    }
+
+    /*
+     * Then
+     */
+    private void thenIsConfigurationValidReturns(boolean expectedValue) {
+        assertEquals(expectedValue, this.tritonServerService.isConfigurationValid());
+    }
+
+    private void thenIsModelEncryptionEnabled(boolean expectedValue) {
+        assertEquals(expectedValue, this.tritonServerService.isModelEncryptionEnabled());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceNativeImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceNativeImplTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.ai.triton.server;
 
 import static org.junit.Assert.assertEquals;

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceStepDefinitions.java
@@ -106,6 +106,10 @@ public abstract class TritonServerServiceStepDefinitions {
         this.tritonServerService = createTritonServerServiceRemoteImpl(properties, tritonModelRepoStub, true);
     }
 
+    protected void givenTritonServerServiceNativeImpl(Map<String, Object> properties) throws IOException {
+        this.tritonServerService = createTritonServerServiceNativeImpl(properties, tritonModelRepoStub, true);
+    }
+
     protected void givenTritonServerServiceImplNotActive() throws IOException {
         this.tritonServerService = createTritonServerServiceImpl(null, tritonModelRepoStub, false);
     }
@@ -328,6 +332,35 @@ public abstract class TritonServerServiceStepDefinitions {
             List<String> tritonModelRepoStub, boolean activate) throws IOException {
 
         TritonServerServiceAbs tritonServerServiceImpl = new TritonServerServiceOrigImpl();
+
+        this.ces = mock(CommandExecutorService.class);
+        when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(false);
+
+        tritonServerServiceImpl.setCommandExecutorService(ces);
+
+        this.cry = mock(CryptoService.class);
+        tritonServerServiceImpl.setCryptoService(cry);
+
+        if (activate) {
+            tritonServerServiceImpl.activate(properties);
+        }
+
+        GRPCInferenceServiceGrpc.GRPCInferenceServiceImplBase serviceImpl = createGRPCMock(tritonModelRepoStub);
+
+        String serverName = InProcessServerBuilder.generateName();
+        grpcCleanup.register(
+                InProcessServerBuilder.forName(serverName).directExecutor().addService(serviceImpl).build().start());
+        ManagedChannel channel = grpcCleanup
+                .register(InProcessChannelBuilder.forName(serverName).directExecutor().build());
+        tritonServerServiceImpl.setGrpcStub(GRPCInferenceServiceGrpc.newBlockingStub(channel));
+
+        return tritonServerServiceImpl;
+    }
+
+    private TritonServerServiceAbs createTritonServerServiceNativeImpl(Map<String, Object> properties,
+            List<String> tritonModelRepoStub, boolean activate) throws IOException {
+
+        TritonServerServiceAbs tritonServerServiceImpl = new TritonServerServiceNativeImpl();
 
         this.ces = mock(CommandExecutorService.class);
         when(ces.isRunning(new String[] { "tritonserver" })).thenReturn(false);


### PR DESCRIPTION
This is the third step towards the deprecation of the current `TritonServerServiceImpl` class following #4064 

The purpose of this PR is to add the `TritonServerNativeService` Factory Components which exposes the same functionalities as the `TritonServerService` with `local.enabled` turned on (i.e. "Local" mode) but with a smaller configuration interface.

The final goal is to have 2 different UI pages for configuring the 2 new factory components.

See UML for reference:
![image](https://user-images.githubusercontent.com/22748355/182109561-cc9b8542-6d9f-49f4-af25-1c535fea6e49.png)
Highlighted green the component available with this PR
Highlighted red the upcoming components

Coming soon™ (in the upcoming PRs):
- [X] `TritonServerRemoteServiceImpl` which will expose the `TritonServerRemoteService` factory component with relative metatype
- [X] `TritonServerNativeServiceImpl` which will expose the `TritonServerNativeService` factory component with relative metatype
- [X] `TritonServerServiceOrigImpl` deprecation in favour of the new factory components
- [ ] `TritonServerContainerServiceImpl` which will expose the `TritonServerContainerService` factory component with relative metatype