### PR TITLE
feat: First implementation of PKCS11 KeystoreService

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core.keystore/META-INF/MANIFEST.MF
@@ -54,3 +54,4 @@ Import-Package: com.eclipsesource.json;version="0.9.5",
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.kura.core.keystore.util;version="1.1.0"
+Eclipse-BuddyPolicy: ext

--- a/kura/org.eclipse.kura.core.keystore/OSGI-INF/metatype/org.eclipse.kura.core.keystore.PKCS11KeystoreServiceImpl.xml
+++ b/kura/org.eclipse.kura.core.keystore/OSGI-INF/metatype/org.eclipse.kura.core.keystore.PKCS11KeystoreServiceImpl.xml
@@ -23,6 +23,7 @@
             type="String"
             cardinality="0"
             required="true"
+            default="/lib/libmypkcs11.so"
             description="The path to the PKCS11 implementation library shared object. e.g. /lib/libmypkcs11.so">
         </AD>
 
@@ -30,7 +31,7 @@
             name="Pin"
             type="Password"
             cardinality="0"
-            required="true"
+            required="false"
             description="The PIN to be used for PKCS11 operations.">
         </AD>
         

--- a/kura/org.eclipse.kura.core.keystore/OSGI-INF/metatype/org.eclipse.kura.core.keystore.PKCS11KeystoreServiceImpl.xml
+++ b/kura/org.eclipse.kura.core.keystore/OSGI-INF/metatype/org.eclipse.kura.core.keystore.PKCS11KeystoreServiceImpl.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+
+	Contributors:
+     Eurotech
+
+-->
+<MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
+    <OCD id="org.eclipse.kura.core.keystore.PKCS11KeystoreServiceImpl"
+         name="FilesystemKeystoreServiceImpl"
+         description="The service allows to expose a PKCS11 module as a KeystoreService. See the https://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html document for more information about the configuration parameters.">
+
+        <AD id="library.path"
+            name="PKCS11 Implementation Library Path"
+            type="String"
+            cardinality="0"
+            required="true"
+            description="The path to the PKCS11 implementation library shared object. e.g. /lib/libmypkcs11.so">
+        </AD>
+
+        <AD id="pin"
+            name="Pin"
+            type="Password"
+            cardinality="0"
+            required="true"
+            description="The PIN to be used for PKCS11 operations.">
+        </AD>
+        
+        <AD id="slot"
+            name="Slot"
+            type="Integer"
+            cardinality="0"
+            min="0"
+            required="false"
+            description="The slot parameter as an integer. This parameter is optional, at most one of the slot and slotListIndex properties can be specified.">
+        </AD>
+
+        <AD id="slot.list.index"
+            name="Slot List Index"
+            type="Integer"
+            cardinality="0"
+            required="false"
+            description="The slotListIndex parameter as an integer. This parameter is optional, at most one of the slot and slotListIndex properties can be specified.">
+        </AD>
+        
+        <AD id="enabled.mechanisms"
+            name="Enabled Mechanisms"
+            type="String"
+            cardinality="0"
+            required="false"
+            description="The enabledMechanisms parameter as a list of whitespace separated strings. The curly braces must be omitted.">
+        </AD>
+        
+        <AD id="disabled.mechanisms"
+            name="Disabled Mechanisms"
+            type="String"
+            cardinality="0"
+            required="false"
+            description="The disabledMechanisms parameter as a list of whitespace separated strings. The curly braces must be omitted.">
+        </AD>
+        
+        <AD id="attributes"
+            name="Attributes"
+            type="String"
+            cardinality="0"
+            required="false"
+            description="The attributes parameter. The value of this field will be appended to the provider configuration.|TextArea">
+        </AD>
+        
+        <AD id="crl.store.path"
+            name="CRL Store Path"
+            type="String"
+            cardinality="0"
+            required="false"
+            description="The path where to store the cached CRLs. If left empty, the CRLs will be stored in a new file in the security subfolder of the Kura user configuration directory.">
+        </AD>
+        
+        <AD id="crl.urls"
+            name="CRL URLs"
+            type="String"
+            cardinality="5"
+            required="false"
+            default=""
+            description="Alllows to specify a list of HTTP CRL distribution points that will be considered along with the HTTP distribution points specified in the trusted certificates added to keystore.">
+        </AD>
+
+        <AD id="crl.update.interval"
+            name="CRL Force Update Interval"
+            type="Long"
+            cardinality="0"
+            required="true"
+            default="1"
+            description="Defines a time interval for forcing the update of cached CRLs, this interval will be considered in addition to CRL next update date.">
+        </AD>
+
+        <AD id="crl.update.interval.time.unit"
+            name="CRL Force Update Interval Time Unit"
+            type="String"
+            cardinality="0"
+            required="true"
+            default="DAYS"
+            description="The time unit for the CRL Update Interval parameter">
+            <Option label="SECONDS" value="SECONDS" />
+            <Option label="MINUTES" value="MINUTES" />
+            <Option label="HOURS" value="HOURS" />
+            <Option label="DAYS" value="DAYS" />
+        </AD>
+
+        <AD id="crl.check.interval"
+            name="CRL Check Interval"
+            type="Long"
+            cardinality="0"
+            required="true"
+            default="5"
+            description="Defines a time interval for the periodic check of stored CRLs. Durning the periodic check the stored CRLs will be processed and updated if needed.">
+        </AD>
+
+        <AD id="crl.check.interval.time.unit"
+            name="CRL Check Interval Time Unit"
+            type="String"
+            cardinality="0"
+            required="true"
+            default="MINUTES"
+            description="The time unit for the CRL Check Interval parameter">
+            <Option label="SECONDS" value="SECONDS" />
+            <Option label="MINUTES" value="MINUTES" />
+            <Option label="HOURS" value="HOURS" />
+            <Option label="DAYS" value="DAYS" />
+        </AD>
+
+        <AD id="crl.store.path"
+            name="CRL Store Path"
+            type="String"
+            cardinality="0"
+            required="false"
+            default=""
+            description="Defines the path of the CRL store file, as an absolute path. If left empty, a default store file path will be computed by adding a .crl suffix to the value of the Keystore Path parameter.">
+        </AD>
+
+        <AD id="verify.crl"
+            name="Enable CRL Verification"
+            type="Boolean"
+            cardinality="0"
+            required="true"
+            default="true"
+            description="If set to true, the downloaded CRLs will be stored only if signed with the public key of one of trusted certificates in this keystore.">
+        </AD>
+
+    </OCD>
+
+    <Designate factoryPid="org.eclipse.kura.core.keystore.PKCS11KeystoreServiceImpl">
+        <Object ocdref="org.eclipse.kura.core.keystore.PKCS11KeystoreServiceImpl"/>
+    </Designate>
+</MetaData>

--- a/kura/org.eclipse.kura.core.keystore/OSGI-INF/org.eclipse.kura.core.keystore.pkcs11KeystoreService.xml
+++ b/kura/org.eclipse.kura.core.keystore/OSGI-INF/org.eclipse.kura.core.keystore.pkcs11KeystoreService.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+   This program and the accompanying materials are made
+   available under the terms of the Eclipse Public License 2.0
+   which is available at https://www.eclipse.org/legal/epl-2.0/
+ 
+	SPDX-License-Identifier: EPL-2.0
+	
+	Contributors:
+	 Eurotech
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="false" modified="updated" name="org.eclipse.kura.core.keystore.PKCS11KeystoreServiceImpl">
+   <implementation class="org.eclipse.kura.core.keystore.PKCS11KeystoreServiceImpl"/>
+   <service>
+      <provide interface="org.eclipse.kura.security.keystore.KeystoreService"/>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
+   </service>
+	<reference name="CryptoService"
+              interface="org.eclipse.kura.crypto.CryptoService"
+              bind="setCryptoService"
+              cardinality="1..1"
+              policy="static"/>
+    <reference name="ConfigurationService"
+              bind="setConfigurationService"
+              interface="org.eclipse.kura.configuration.ConfigurationService"/>
+    <property name="kura.ui.factory.hide" type="String" value="true"/>
+    <property name="kura.ui.service.hide" type="String" value="true"/>
+    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static"/>
+</scr:component>

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/BaseKeystoreService.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/BaseKeystoreService.java
@@ -1,0 +1,555 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.core.keystore;
+
+import static java.util.Objects.isNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStore.Entry;
+import java.security.KeyStore.PasswordProtection;
+import java.security.KeyStore.PrivateKeyEntry;
+import java.security.KeyStore.ProtectionParameter;
+import java.security.KeyStore.SecretKeyEntry;
+import java.security.KeyStore.TrustedCertificateEntry;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.CRL;
+import java.security.cert.CertStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.CollectionCertStoreParameters;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.security.auth.x500.X500Principal;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.configuration.ConfigurableComponent;
+import org.eclipse.kura.configuration.ConfigurationService;
+import org.eclipse.kura.core.keystore.crl.CRLManager;
+import org.eclipse.kura.core.keystore.crl.CRLManager.CRLVerifier;
+import org.eclipse.kura.core.keystore.crl.CRLManagerOptions;
+import org.eclipse.kura.core.keystore.crl.StoredCRL;
+import org.eclipse.kura.security.keystore.KeystoreChangedEvent;
+import org.eclipse.kura.security.keystore.KeystoreService;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.event.EventAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class BaseKeystoreService implements KeystoreService, ConfigurableComponent {
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseKeystoreService.class);
+
+    protected static final String NULL_INPUT_PARAMS_MESSAGE = "Input parameters cannot be null!";
+    protected static final String KURA_SERVICE_PID = "kura.service.pid";
+    protected static final String PEM_CERTIFICATE_REQUEST_TYPE = "CERTIFICATE REQUEST";
+
+    protected EventAdmin eventAdmin;
+
+    protected Optional<CRLManager> crlManager = Optional.empty();
+
+    protected String ownPid;
+
+    protected ComponentContext componentContext;
+
+    private CRLManagerOptions crlManagerOptions;
+
+    public void setEventAdmin(EventAdmin eventAdmin) {
+        this.eventAdmin = eventAdmin;
+    }
+
+    protected abstract KeystoreInstance loadKeystore() throws KuraException;
+
+    protected abstract void saveKeystore(KeystoreInstance keystore)
+            throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException;
+
+    protected abstract String getCrlStorePath();
+
+    @Override
+    public KeyStore getKeyStore() throws KuraException {
+
+        return loadKeystore().getKeystore();
+    }
+
+    public void activate(ComponentContext context, Map<String, Object> properties) {
+        this.componentContext = context;
+
+        this.ownPid = (String) properties.get(ConfigurationService.KURA_SERVICE_PID);
+        this.crlManagerOptions = new CRLManagerOptions(properties);
+
+        updateCRLManager(this.crlManagerOptions);
+    }
+
+    public void updated(Map<String, Object> properties) {
+        logger.info("Bundle {} is updating!", properties.get(KURA_SERVICE_PID));
+
+        final CRLManagerOptions newCRLManagerOptions = new CRLManagerOptions(properties);
+
+        if (!this.crlManagerOptions.equals(newCRLManagerOptions)) {
+            this.crlManagerOptions = newCRLManagerOptions;
+
+            updateCRLManager(newCRLManagerOptions);
+        }
+    }
+
+    public void deactivate() {
+        shutdownCRLManager();
+    }
+
+    @Override
+    public Entry getEntry(String alias) throws KuraException {
+        if (isNull(alias)) {
+            throw new IllegalArgumentException("Key Pair alias cannot be null!");
+        }
+        KeystoreInstance ks = loadKeystore();
+
+        try {
+            if (ks.getKeystore().entryInstanceOf(alias, PrivateKeyEntry.class)
+                    || ks.getKeystore().entryInstanceOf(alias, SecretKeyEntry.class)) {
+                return ks.getKeystore().getEntry(alias, new PasswordProtection(ks.getPassword()));
+            } else {
+                return ks.getKeystore().getEntry(alias, null);
+            }
+        } catch (GeneralSecurityException e) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to get the entry " + alias);
+        }
+    }
+
+    @Override
+    public void setEntry(String alias, Entry entry) throws KuraException {
+        if (isNull(alias) || alias.trim().isEmpty() || isNull(entry)) {
+            throw new IllegalArgumentException("Input cannot be null or empty!");
+        }
+        KeystoreInstance ks = loadKeystore();
+
+        final ProtectionParameter protectionParameter;
+
+        if (entry instanceof TrustedCertificateEntry) {
+            protectionParameter = null;
+        } else {
+            protectionParameter = new PasswordProtection(ks.getPassword());
+        }
+        try {
+            ks.getKeystore().setEntry(alias, entry, protectionParameter);
+            saveKeystore(ks);
+            if (!tryAddToCrlManagement(entry)) {
+                postChangedEvent();
+            }
+        } catch (GeneralSecurityException | IOException e) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to set the entry " + alias);
+        }
+
+    }
+
+    @Override
+    public Map<String, Entry> getEntries() throws KuraException {
+        Map<String, Entry> result = new HashMap<>();
+
+        KeyStore ks = getKeyStore();
+        try {
+            List<String> aliases = Collections.list(ks.aliases());
+
+            for (String alias : aliases) {
+                Entry tempEntry = getEntry(alias);
+                result.put(alias, tempEntry);
+            }
+            return result;
+        } catch (GeneralSecurityException e) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to get the entries");
+        }
+    }
+
+    @Override
+    public void deleteEntry(String alias) throws KuraException {
+        if (isNull(alias)) {
+            throw new IllegalArgumentException("Alias cannot be null!");
+        }
+        final Optional<Entry> currentEntry = Optional.ofNullable(getEntry(alias));
+
+        if (!currentEntry.isPresent()) {
+            return;
+        }
+
+        KeystoreInstance ks = loadKeystore();
+        try {
+            ks.getKeystore().deleteEntry(alias);
+            saveKeystore(ks);
+            boolean crlStoreChanged = false;
+            crlStoreChanged = tryRemoveFromCrlManagement(currentEntry.get());
+            if (!crlStoreChanged) {
+                postChangedEvent();
+            }
+        } catch (GeneralSecurityException | IOException e) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to delete entry " + alias);
+        }
+    }
+
+    @Override
+    public List<KeyManager> getKeyManagers(String algorithm) throws KuraException {
+        if (isNull(algorithm)) {
+            throw new IllegalArgumentException("Algorithm cannot be null!");
+        }
+        KeystoreInstance ks = loadKeystore();
+        try {
+            KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
+            kmf.init(ks.getKeystore(), ks.getPassword());
+
+            return Arrays.asList(kmf.getKeyManagers());
+        } catch (GeneralSecurityException e) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST, e,
+                    "Failed to get the key managers for algorithm " + algorithm);
+        }
+    }
+
+    @Override
+    public void createKeyPair(String alias, String algorithm, int keySize, String signatureAlgorithm, String attributes)
+            throws KuraException {
+        createKeyPair(alias, algorithm, keySize, signatureAlgorithm, attributes, new SecureRandom());
+    }
+
+    @Override
+    public void createKeyPair(String alias, String algorithm, int keySize, String signatureAlgorithm, String attributes,
+            SecureRandom secureRandom) throws KuraException {
+        if (isNull(algorithm) || algorithm.trim().isEmpty() || isNull(secureRandom) || isNull(alias)
+                || isNull(attributes) || attributes.trim().isEmpty() || isNull(signatureAlgorithm)
+                || signatureAlgorithm.trim().isEmpty()) {
+            throw new IllegalArgumentException("Parameters cannot be null or empty!");
+        }
+        KeyPair keyPair;
+        try {
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm, "BC");
+            keyGen.initialize(keySize, secureRandom);
+            keyPair = keyGen.generateKeyPair();
+            setEntry(alias, new PrivateKeyEntry(keyPair.getPrivate(),
+                    generateCertificateChain(keyPair, signatureAlgorithm, attributes)));
+        } catch (GeneralSecurityException | OperatorCreationException e) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST);
+        }
+    }
+
+    @Override
+    public void createKeyPair(String alias, String algorithm, AlgorithmParameterSpec algorithmParameter,
+            String signatureAlgorithm, String attributes, SecureRandom secureRandom) throws KuraException {
+
+        if (isNull(algorithm) || algorithm.trim().isEmpty() || isNull(secureRandom) || isNull(alias)
+                || isNull(attributes) || attributes.trim().isEmpty() || isNull(signatureAlgorithm)
+                || signatureAlgorithm.trim().isEmpty() || isNull(algorithmParameter)) {
+            throw new IllegalArgumentException("Parameters cannot be null or empty!");
+        }
+        KeyPair keyPair;
+        try {
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm, "BC");
+            keyGen.initialize(algorithmParameter, secureRandom);
+            keyPair = keyGen.generateKeyPair();
+            setEntry(alias, new PrivateKeyEntry(keyPair.getPrivate(),
+                    generateCertificateChain(keyPair, signatureAlgorithm, attributes)));
+        } catch (GeneralSecurityException | OperatorCreationException e) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST);
+        }
+
+    }
+
+    @Override
+    public void createKeyPair(String alias, String algorithm, AlgorithmParameterSpec algorithmParameter,
+            String signatureAlgorithm, String attributes) throws KuraException {
+        createKeyPair(alias, algorithm, algorithmParameter, signatureAlgorithm, attributes, new SecureRandom());
+
+    }
+
+    @Override
+    public String getCSR(KeyPair keypair, X500Principal principal, String signerAlg) throws KuraException {
+
+        if (isNull(principal) || isNull(keypair) || isNull(signerAlg) || signerAlg.trim().isEmpty()) {
+            throw new IllegalArgumentException(NULL_INPUT_PARAMS_MESSAGE);
+        }
+
+        try (StringWriter str = new StringWriter(); JcaPEMWriter pemWriter = new JcaPEMWriter(str);) {
+            ContentSigner signer = new JcaContentSignerBuilder(signerAlg).build(keypair.getPrivate());
+            PKCS10CertificationRequest csr = getCSRAsPKCS10Builder(keypair, principal).build(signer);
+
+            PemObject pemCSR = new PemObject(PEM_CERTIFICATE_REQUEST_TYPE, csr.getEncoded());
+
+            pemWriter.writeObject(pemCSR);
+            pemWriter.flush();
+            return str.toString();
+        } catch (IOException e) {
+            throw new KuraException(KuraErrorCode.ENCODE_ERROR, e, "Failed to get CSR");
+        } catch (OperatorCreationException e) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to get CSR");
+        }
+    }
+
+    @Override
+    public String getCSR(String alias, X500Principal principal, String signerAlg) throws KuraException {
+        if (isNull(principal) || isNull(alias) || alias.trim().isEmpty() || isNull(signerAlg)
+                || signerAlg.trim().isEmpty()) {
+            throw new IllegalArgumentException(NULL_INPUT_PARAMS_MESSAGE);
+        }
+
+        Entry entry = getEntry(alias);
+        if (entry == null) {
+            throw new KuraException(KuraErrorCode.NOT_FOUND);
+        }
+        if (!(entry instanceof PrivateKeyEntry)) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST);
+        }
+        PrivateKey privateKey = ((PrivateKeyEntry) entry).getPrivateKey();
+        PublicKey publicKey = ((PrivateKeyEntry) entry).getCertificate().getPublicKey();
+        KeyPair keyPair = new KeyPair(publicKey, privateKey);
+        return getCSR(keyPair, principal, signerAlg);
+    }
+
+    protected PKCS10CertificationRequestBuilder getCSRAsPKCS10Builder(KeyPair keyPair, X500Principal principal) {
+        if (isNull(principal) || isNull(keyPair)) {
+            throw new IllegalArgumentException(NULL_INPUT_PARAMS_MESSAGE);
+        }
+        return new JcaPKCS10CertificationRequestBuilder(principal, keyPair.getPublic());
+
+    }
+
+    @Override
+    public List<String> getAliases() throws KuraException {
+        KeyStore ks = getKeyStore();
+        try {
+            return Collections.list(ks.aliases());
+        } catch (GeneralSecurityException e) {
+            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to get aliases");
+        }
+    }
+
+    @Override
+    public Collection<CRL> getCRLs() {
+
+        final Optional<CRLManager> currentCRLManager = this.crlManager;
+
+        if (!currentCRLManager.isPresent()) {
+            return Collections.emptyList();
+        } else {
+            return new ArrayList<>(currentCRLManager.get().getCrls());
+        }
+
+    }
+
+    @Override
+    public CertStore getCRLStore() throws KuraException {
+        final Optional<CRLManager> currentCRLManager = this.crlManager;
+
+        try {
+            if (!currentCRLManager.isPresent()) {
+                return CertStore.getInstance("Collection", new CollectionCertStoreParameters());
+            } else {
+                return currentCRLManager.get().getCertStore();
+            }
+        } catch (final Exception e) {
+            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR, e);
+        }
+    }
+
+    @Override
+    public void addCRL(X509CRL crl) throws KuraException {
+        this.crlManager.ifPresent(manager -> {
+            StoredCRL storedCRL = new StoredCRL(Collections.emptySet(), crl);
+            manager.getCRLStore().storeCRL(storedCRL);
+        });
+    }
+
+    protected void postChangedEvent() {
+        this.eventAdmin.postEvent(new KeystoreChangedEvent(ownPid));
+    }
+
+    protected X509Certificate[] generateCertificateChain(KeyPair keyPair, String signatureAlgorithm, String attributes)
+            throws OperatorCreationException, CertificateException {
+        Provider bcProvider = new BouncyCastleProvider();
+        Security.addProvider(bcProvider);
+        long now = System.currentTimeMillis();
+        Date startDate = new Date(now);
+        X500Name dnName = new X500Name(attributes);
+        // Use the timestamp as serial number
+        BigInteger certSerialNumber = new BigInteger(Long.toString(now));
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(startDate);
+        calendar.add(Calendar.YEAR, 1);
+        Date endDate = calendar.getTime();
+
+        SubjectPublicKeyInfo subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
+        X509v3CertificateBuilder certificateBuilder = new X509v3CertificateBuilder(dnName, certSerialNumber, startDate,
+                endDate, dnName, subjectPublicKeyInfo);
+        ContentSigner contentSigner = new JcaContentSignerBuilder(signatureAlgorithm).setProvider(bcProvider)
+                .build(keyPair.getPrivate());
+        X509CertificateHolder certificateHolder = certificateBuilder.build(contentSigner);
+
+        return new X509Certificate[] { new JcaX509CertificateConverter().getCertificate(certificateHolder) };
+    }
+
+    protected Optional<X509Certificate> extractCertificate(final Entry entry) {
+        if (!(entry instanceof TrustedCertificateEntry)) {
+            return Optional.empty();
+        }
+
+        final TrustedCertificateEntry trustedCertificateEntry = (TrustedCertificateEntry) entry;
+        final Certificate certificate = trustedCertificateEntry.getTrustedCertificate();
+
+        if (!(certificate instanceof X509Certificate)) {
+            return Optional.empty();
+        } else {
+            return Optional.of((X509Certificate) certificate);
+        }
+
+    }
+
+    protected boolean tryAddToCrlManagement(final Entry entry) {
+        final Optional<X509Certificate> certificate = extractCertificate(entry);
+        final Optional<CRLManager> currentCrlManager = this.crlManager;
+
+        if (certificate.isPresent() && currentCrlManager.isPresent()) {
+            return currentCrlManager.get().addTrustedCertificate(certificate.get());
+        } else {
+            return false;
+        }
+    }
+
+    protected boolean tryRemoveFromCrlManagement(final Entry entry) {
+        final Optional<X509Certificate> certificate = extractCertificate(entry);
+        final Optional<CRLManager> currentCrlManager = this.crlManager;
+
+        if (certificate.isPresent() && currentCrlManager.isPresent()) {
+            return currentCrlManager.get().removeTrustedCertificate(certificate.get());
+        } else {
+            return false;
+        }
+    }
+
+    protected void updateCRLManager(final CRLManagerOptions newCRLManagerOptions) {
+        shutdownCRLManager();
+
+        if (this.crlManagerOptions.isCrlManagementEnabled()) {
+
+            final CRLManager currentCRLManager = new CRLManager(
+                    this.crlManagerOptions.getStoreFile().orElseGet(() -> new File(getCrlStorePath())), 5000,
+                    newCRLManagerOptions.getCrlCheckIntervalMs(), newCRLManagerOptions.getCrlUpdateIntervalMs(),
+                    getCRLVerifier(newCRLManagerOptions));
+
+            currentCRLManager.setListener(Optional.of(this::postChangedEvent));
+
+            for (final URI uri : newCRLManagerOptions.getCrlURIs()) {
+                currentCRLManager.addDistributionPoint(Collections.singleton(uri));
+            }
+
+            try {
+                for (final Entry e : getEntries().values()) {
+                    if (!(e instanceof TrustedCertificateEntry)) {
+                        continue;
+                    }
+
+                    final TrustedCertificateEntry certEntry = (TrustedCertificateEntry) e;
+
+                    final Certificate cert = certEntry.getTrustedCertificate();
+
+                    if (cert instanceof X509Certificate) {
+                        currentCRLManager.addTrustedCertificate((X509Certificate) cert);
+                    }
+                }
+
+            } catch (final Exception e) {
+                logger.warn("failed to add current trusted certificates to CRL manager", e);
+            }
+
+            this.crlManager = Optional.of(currentCRLManager);
+        }
+    }
+
+    protected CRLVerifier getCRLVerifier(final CRLManagerOptions options) {
+        if (!options.isCRLVerificationEnabled()) {
+            return crl -> true;
+        }
+
+        return crl -> {
+            try {
+                for (final Entry e : getEntries().values()) {
+                    if (!(e instanceof TrustedCertificateEntry)) {
+                        continue;
+                    }
+
+                    final TrustedCertificateEntry trustedCertEntry = (TrustedCertificateEntry) e;
+
+                    if (verifyCRL(crl, trustedCertEntry)) {
+                        return true;
+                    }
+                }
+                return false;
+            } catch (final Exception e) {
+                logger.warn("Exception verifying CRL", e);
+                return false;
+            }
+        };
+    }
+
+    protected void shutdownCRLManager() {
+        if (this.crlManager.isPresent()) {
+            this.crlManager.get().close();
+            this.crlManager = Optional.empty();
+        }
+    }
+
+    protected boolean verifyCRL(X509CRL crl, final TrustedCertificateEntry trustedCertEntry) {
+        try {
+            crl.verify(trustedCertEntry.getTrustedCertificate().getPublicKey());
+            return true;
+        } catch (final Exception e) {
+            return false;
+        }
+    }
+
+}

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceImpl.java
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kura.core.keystore;
 
-import static java.util.Objects.isNull;
-import static org.eclipse.kura.core.keystore.KeystoreServiceOptions.KEY_KEYSTORE_PASSWORD;
+import static org.eclipse.kura.core.keystore.FilesystemKeystoreServiceOptions.KEY_KEYSTORE_PASSWORD;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -21,110 +20,47 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.StringWriter;
 import java.math.BigInteger;
-import java.net.URI;
-import java.security.GeneralSecurityException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.KeyStore.Entry;
 import java.security.KeyStore.PasswordProtection;
-import java.security.KeyStore.PrivateKeyEntry;
-import java.security.KeyStore.ProtectionParameter;
-import java.security.KeyStore.SecretKeyEntry;
-import java.security.KeyStore.TrustedCertificateEntry;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.Provider;
-import java.security.PublicKey;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.UnrecoverableEntryException;
-import java.security.cert.CRL;
-import java.security.cert.CertStore;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
-import java.security.cert.CollectionCertStoreParameters;
-import java.security.cert.X509CRL;
-import java.security.cert.X509Certificate;
-import java.security.spec.AlgorithmParameterSpec;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.security.auth.x500.X500Principal;
-
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.cert.X509CertificateHolder;
-import org.bouncycastle.cert.X509v3CertificateBuilder;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.OperatorCreationException;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
-import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
-import org.bouncycastle.util.io.pem.PemObject;
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.KuraRuntimeException;
-import org.eclipse.kura.configuration.ConfigurableComponent;
 import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.configuration.Password;
-import org.eclipse.kura.core.keystore.crl.CRLManager;
-import org.eclipse.kura.core.keystore.crl.CRLManager.CRLVerifier;
-import org.eclipse.kura.core.keystore.crl.CRLManagerOptions;
-import org.eclipse.kura.core.keystore.crl.StoredCRL;
 import org.eclipse.kura.crypto.CryptoService;
-import org.eclipse.kura.security.keystore.KeystoreChangedEvent;
-import org.eclipse.kura.security.keystore.KeystoreService;
 import org.osgi.service.component.ComponentContext;
-import org.osgi.service.event.EventAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FilesystemKeystoreServiceImpl implements KeystoreService, ConfigurableComponent {
-
-    private static final String NULL_INPUT_PARAMS_MESSAGE = "Input parameters cannot be null!";
-    private static final String KURA_SERVICE_PID = "kura.service.pid";
-    private static final String PEM_CERTIFICATE_REQUEST_TYPE = "CERTIFICATE REQUEST";
+public class FilesystemKeystoreServiceImpl extends BaseKeystoreService {
 
     private static final Logger logger = LoggerFactory.getLogger(FilesystemKeystoreServiceImpl.class);
 
-    private ComponentContext componentContext;
-
     private CryptoService cryptoService;
     private ConfigurationService configurationService;
-    private EventAdmin eventAdmin;
 
-    private KeystoreServiceOptions keystoreServiceOptions;
-    private CRLManagerOptions crlManagerOptions;
-
-    private Optional<CRLManager> crlManager = Optional.empty();
+    private FilesystemKeystoreServiceOptions keystoreServiceOptions;
 
     private ScheduledExecutorService selfUpdaterExecutor;
     private ScheduledFuture<?> selfUpdaterFuture;
-
-    private String ownPid;
 
     // ----------------------------------------------------------------
     //
@@ -140,22 +76,18 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         this.configurationService = configurationService;
     }
 
-    public void setEventAdmin(EventAdmin eventAdmin) {
-        this.eventAdmin = eventAdmin;
-    }
-
     // ----------------------------------------------------------------
     //
     // Activation APIs
     //
     // ----------------------------------------------------------------
 
+    @Override
     public void activate(ComponentContext context, Map<String, Object> properties) {
         logger.info("Bundle {} is starting!", properties.get(KURA_SERVICE_PID));
         this.componentContext = context;
 
-        this.ownPid = (String) properties.get(ConfigurationService.KURA_SERVICE_PID);
-        this.keystoreServiceOptions = new KeystoreServiceOptions(properties, this.cryptoService);
+        this.keystoreServiceOptions = new FilesystemKeystoreServiceOptions(properties, this.cryptoService);
         this.selfUpdaterExecutor = Executors.newSingleThreadScheduledExecutor();
 
         if (!keystoreExists(this.keystoreServiceOptions.getKeystorePath())) {
@@ -170,16 +102,16 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
             setRandomPassword();
         }
 
-        this.crlManagerOptions = new CRLManagerOptions(properties);
-
-        updateCRLManager(this.crlManagerOptions);
+        super.activate(context, properties);
 
         logger.info("Bundle {} has started!", properties.get(KURA_SERVICE_PID));
     }
 
+    @Override
     public void updated(Map<String, Object> properties) {
         logger.info("Bundle {} is updating!", properties.get(KURA_SERVICE_PID));
-        KeystoreServiceOptions newOptions = new KeystoreServiceOptions(properties, this.cryptoService);
+        FilesystemKeystoreServiceOptions newOptions = new FilesystemKeystoreServiceOptions(properties,
+                this.cryptoService);
 
         if (!this.keystoreServiceOptions.equals(newOptions)) {
             logger.info("Perform update...");
@@ -190,36 +122,16 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
                 checkAndUpdateKeystorePassword(newOptions);
             }
 
-            this.keystoreServiceOptions = new KeystoreServiceOptions(properties, this.cryptoService);
+            this.keystoreServiceOptions = new FilesystemKeystoreServiceOptions(properties, this.cryptoService);
 
         }
 
-        final CRLManagerOptions newCRLManagerOptions = new CRLManagerOptions(properties);
-
-        if (!this.crlManagerOptions.equals(newCRLManagerOptions)) {
-            this.crlManagerOptions = newCRLManagerOptions;
-
-            updateCRLManager(newCRLManagerOptions);
-        }
+        super.updated(properties);
 
         logger.info("Bundle {} has updated!", properties.get(KURA_SERVICE_PID));
     }
 
-    private void checkAndUpdateKeystorePassword(final KeystoreServiceOptions options) {
-        try {
-            final LoadedKeystore ks = loadKeystore(this.keystoreServiceOptions);
-
-            final char[] configPassword = options.getKeystorePassword(cryptoService);
-
-            if (!Arrays.equals(ks.password, configPassword)) {
-                setKeystorePassword(ks, configPassword);
-            }
-
-        } catch (final Exception e) {
-            logger.warn("failed to load or update keystore password", e);
-        }
-    }
-
+    @Override
     public void deactivate() {
         logger.info("Bundle {} is deactivating!", this.keystoreServiceOptions.getProperties().get(KURA_SERVICE_PID));
 
@@ -230,14 +142,47 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
             this.selfUpdaterFuture.cancel(true);
         }
 
-        shutdownCRLManager();
+        super.deactivate();
+    }
+
+    @Override
+    protected void saveKeystore(KeystoreInstance ks)
+            throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
+        try (FileOutputStream tsOutStream = new FileOutputStream(this.keystoreServiceOptions.getKeystorePath());) {
+            ks.getKeystore().store(tsOutStream, ks.getPassword());
+        }
+    }
+
+    @Override
+    protected KeystoreInstance loadKeystore() throws KuraException {
+        return loadKeystore(this.keystoreServiceOptions);
+    }
+
+    @Override
+    protected String getCrlStorePath() {
+        return this.keystoreServiceOptions.getKeystorePath() + ".crl";
+    }
+
+    private void checkAndUpdateKeystorePassword(final FilesystemKeystoreServiceOptions options) {
+        try {
+            final KeystoreInstance ks = loadKeystore(this.keystoreServiceOptions);
+
+            final char[] configPassword = options.getKeystorePassword(cryptoService);
+
+            if (!Arrays.equals(ks.getPassword(), configPassword)) {
+                setKeystorePassword(ks, configPassword);
+            }
+
+        } catch (final Exception e) {
+            logger.warn("failed to load or update keystore password", e);
+        }
     }
 
     private boolean keystoreExists(String keystorePath) {
         return keystorePath != null && new File(keystorePath).isFile();
     }
 
-    private void createKeystore(KeystoreServiceOptions options) throws Exception {
+    private void createKeystore(FilesystemKeystoreServiceOptions options) throws Exception {
         String keystorePath = options.getKeystorePath();
         char[] passwordChar = options.getKeystorePassword(this.cryptoService);
         if (keystorePath == null) {
@@ -264,7 +209,7 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         setKeystorePassword(this.loadKeystore(options), passwordChar);
     }
 
-    private void updateKeystorePath(KeystoreServiceOptions newOptions) {
+    private void updateKeystorePath(FilesystemKeystoreServiceOptions newOptions) {
         if (!keystoreExists(newOptions.getKeystorePath())) {
             try {
                 createKeystore(newOptions);
@@ -283,7 +228,7 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
     private void setRandomPassword() {
 
         try {
-            final LoadedKeystore keystore = loadKeystore(this.keystoreServiceOptions);
+            final KeystoreInstance keystore = loadKeystore(this.keystoreServiceOptions);
 
             char[] newPassword = new BigInteger(160, new SecureRandom()).toString(32).toCharArray();
 
@@ -291,7 +236,7 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
 
             Map<String, Object> props = new HashMap<>(this.keystoreServiceOptions.getProperties());
             props.put(KEY_KEYSTORE_PASSWORD, new String(this.cryptoService.encryptAes(newPassword)));
-            this.keystoreServiceOptions = new KeystoreServiceOptions(props, this.cryptoService);
+            this.keystoreServiceOptions = new FilesystemKeystoreServiceOptions(props, this.cryptoService);
 
             updatePasswordInConfigService(newPassword);
         } catch (Exception e) {
@@ -299,10 +244,10 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         }
     }
 
-    private synchronized void saveKeystore(LoadedKeystore ks, char[] keyStorePassword)
+    private synchronized void saveKeystore(KeystoreInstance ks, char[] keyStorePassword)
             throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
-        try (FileOutputStream tsOutStream = new FileOutputStream(ks.path)) {
-            ks.keystore.store(tsOutStream, keyStorePassword);
+        try (FileOutputStream tsOutStream = new FileOutputStream(((KeystoreInstanceImpl) ks).path)) {
+            ks.getKeystore().store(tsOutStream, keyStorePassword);
         }
     }
 
@@ -311,9 +256,9 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
 
         Map<String, Object> props = new HashMap<>();
         props.putAll(this.keystoreServiceOptions.getProperties());
-        props.put(KeystoreServiceOptions.KEY_KEYSTORE_PATH, this.keystoreServiceOptions.getKeystorePath());
-        props.put(KeystoreServiceOptions.KEY_KEYSTORE_PASSWORD, new Password(newPassword));
-        props.put(KeystoreServiceOptions.KEY_RANDOMIZE_PASSWORD, false);
+        props.put(FilesystemKeystoreServiceOptions.KEY_KEYSTORE_PATH, this.keystoreServiceOptions.getKeystorePath());
+        props.put(FilesystemKeystoreServiceOptions.KEY_KEYSTORE_PASSWORD, new Password(newPassword));
+        props.put(FilesystemKeystoreServiceOptions.KEY_RANDOMIZE_PASSWORD, false);
 
         this.selfUpdaterFuture = this.selfUpdaterExecutor.scheduleAtFixedRate(() -> {
             try {
@@ -332,12 +277,12 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         }, 1000, 1000, TimeUnit.MILLISECONDS);
     }
 
-    private synchronized void setKeystorePassword(LoadedKeystore ks, char[] password) {
+    private synchronized void setKeystorePassword(KeystoreInstance ks, char[] password) {
         try {
             updateKeyEntriesPasswords(ks, password);
             saveKeystore(ks, password);
 
-            this.cryptoService.setKeyStorePassword(ks.path, password);
+            this.cryptoService.setKeyStorePassword(((KeystoreInstanceImpl) ks).path, password);
         } catch (NoSuchAlgorithmException | CertificateException | KeyStoreException | UnrecoverableEntryException
                 | IOException e) {
             logger.warn("Failed to change keystore password");
@@ -346,429 +291,22 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         }
     }
 
-    private static void updateKeyEntriesPasswords(LoadedKeystore ks, char[] newPassword)
+    private static void updateKeyEntriesPasswords(KeystoreInstance ks, char[] newPassword)
             throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableEntryException {
-        Enumeration<String> aliases = ks.keystore.aliases();
+        Enumeration<String> aliases = ks.getKeystore().aliases();
         while (aliases.hasMoreElements()) {
             String alias = aliases.nextElement();
-            if (ks.keystore.isKeyEntry(alias)) {
-                PasswordProtection oldPP = new PasswordProtection(ks.password);
-                Entry entry = ks.keystore.getEntry(alias, oldPP);
+            if (ks.getKeystore().isKeyEntry(alias)) {
+                PasswordProtection oldPP = new PasswordProtection(ks.getPassword());
+                Entry entry = ks.getKeystore().getEntry(alias, oldPP);
                 PasswordProtection newPP = new PasswordProtection(newPassword);
-                ks.keystore.setEntry(alias, entry, newPP);
+                ks.getKeystore().setEntry(alias, entry, newPP);
             }
         }
     }
 
-    @Override
-    public synchronized KeyStore getKeyStore() throws KuraException {
-        return loadKeystore(this.keystoreServiceOptions).keystore;
-    }
-
-    @Override
-    public Entry getEntry(String alias) throws KuraException {
-        if (isNull(alias)) {
-            throw new IllegalArgumentException("Key Pair alias cannot be null!");
-        }
-        LoadedKeystore ks = loadKeystore(this.keystoreServiceOptions);
-
-        try {
-            if (ks.keystore.entryInstanceOf(alias, PrivateKeyEntry.class)
-                    || ks.keystore.entryInstanceOf(alias, SecretKeyEntry.class)) {
-                return ks.keystore.getEntry(alias, new PasswordProtection(ks.password));
-            } else {
-                return ks.keystore.getEntry(alias, null);
-            }
-        } catch (GeneralSecurityException e) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to get the entry " + alias);
-        }
-    }
-
-    @Override
-    public Map<String, Entry> getEntries() throws KuraException {
-        Map<String, Entry> result = new HashMap<>();
-
-        KeyStore ks = getKeyStore();
-        try {
-            List<String> aliases = Collections.list(ks.aliases());
-
-            for (String alias : aliases) {
-                Entry tempEntry = getEntry(alias);
-                result.put(alias, tempEntry);
-            }
-            return result;
-        } catch (GeneralSecurityException e) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to get the entries");
-        }
-    }
-
-    @Override
-    public String getCSR(KeyPair keypair, X500Principal principal, String signerAlg) throws KuraException {
-
-        if (isNull(principal) || isNull(keypair) || isNull(signerAlg) || signerAlg.trim().isEmpty()) {
-            throw new IllegalArgumentException(FilesystemKeystoreServiceImpl.NULL_INPUT_PARAMS_MESSAGE);
-        }
-
-        try (StringWriter str = new StringWriter(); JcaPEMWriter pemWriter = new JcaPEMWriter(str);) {
-            ContentSigner signer = new JcaContentSignerBuilder(signerAlg).build(keypair.getPrivate());
-            PKCS10CertificationRequest csr = getCSRAsPKCS10Builder(keypair, principal).build(signer);
-
-            PemObject pemCSR = new PemObject(PEM_CERTIFICATE_REQUEST_TYPE, csr.getEncoded());
-
-            pemWriter.writeObject(pemCSR);
-            pemWriter.flush();
-            return str.toString();
-        } catch (IOException e) {
-            throw new KuraException(KuraErrorCode.ENCODE_ERROR, e, "Failed to get CSR");
-        } catch (OperatorCreationException e) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to get CSR");
-        }
-    }
-
-    @Override
-    public String getCSR(String alias, X500Principal principal, String signerAlg) throws KuraException {
-        if (isNull(principal) || isNull(alias) || alias.trim().isEmpty() || isNull(signerAlg)
-                || signerAlg.trim().isEmpty()) {
-            throw new IllegalArgumentException(FilesystemKeystoreServiceImpl.NULL_INPUT_PARAMS_MESSAGE);
-        }
-
-        Entry entry = getEntry(alias);
-        if (entry == null) {
-            throw new KuraException(KuraErrorCode.NOT_FOUND);
-        }
-        if (!(entry instanceof PrivateKeyEntry)) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST);
-        }
-        PrivateKey privateKey = ((PrivateKeyEntry) entry).getPrivateKey();
-        PublicKey publicKey = ((PrivateKeyEntry) entry).getCertificate().getPublicKey();
-        KeyPair keyPair = new KeyPair(publicKey, privateKey);
-        return getCSR(keyPair, principal, signerAlg);
-    }
-
-    private PKCS10CertificationRequestBuilder getCSRAsPKCS10Builder(KeyPair keyPair, X500Principal principal) {
-        if (isNull(principal) || isNull(keyPair)) {
-            throw new IllegalArgumentException(FilesystemKeystoreServiceImpl.NULL_INPUT_PARAMS_MESSAGE);
-        }
-        return new JcaPKCS10CertificationRequestBuilder(principal, keyPair.getPublic());
-
-    }
-
-    @Override
-    public List<KeyManager> getKeyManagers(String algorithm) throws KuraException {
-        if (isNull(algorithm)) {
-            throw new IllegalArgumentException("Algorithm cannot be null!");
-        }
-        LoadedKeystore ks = loadKeystore(this.keystoreServiceOptions);
-        try {
-            KeyManagerFactory kmf = KeyManagerFactory.getInstance(algorithm);
-            kmf.init(ks.keystore, ks.password);
-
-            return Arrays.asList(kmf.getKeyManagers());
-        } catch (GeneralSecurityException e) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST, e,
-                    "Failed to get the key managers for algorithm " + algorithm);
-        }
-    }
-
-    @Override
-    public void deleteEntry(String alias) throws KuraException {
-        if (isNull(alias)) {
-            throw new IllegalArgumentException("Alias cannot be null!");
-        }
-        final Optional<Entry> currentEntry = Optional.ofNullable(getEntry(alias));
-
-        if (!currentEntry.isPresent()) {
-            return;
-        }
-
-        LoadedKeystore ks = loadKeystore(this.keystoreServiceOptions);
-        try {
-            ks.keystore.deleteEntry(alias);
-            saveKeystore(ks);
-            boolean crlStoreChanged = false;
-            crlStoreChanged = tryRemoveFromCrlManagement(currentEntry.get());
-            if (!crlStoreChanged) {
-                postChangedEvent();
-            }
-        } catch (GeneralSecurityException | IOException e) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to delete entry " + alias);
-        }
-    }
-
-    private void saveKeystore(LoadedKeystore ks)
-            throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
-        try (FileOutputStream tsOutStream = new FileOutputStream(this.keystoreServiceOptions.getKeystorePath());) {
-            ks.keystore.store(tsOutStream, ks.password);
-        }
-    }
-
-    @Override
-    public void setEntry(String alias, Entry entry) throws KuraException {
-        if (isNull(alias) || alias.trim().isEmpty() || isNull(entry)) {
-            throw new IllegalArgumentException("Input cannot be null or empty!");
-        }
-        LoadedKeystore ks = loadKeystore(keystoreServiceOptions);
-
-        final ProtectionParameter protectionParameter;
-
-        if (entry instanceof TrustedCertificateEntry) {
-            protectionParameter = null;
-        } else {
-            protectionParameter = new PasswordProtection(ks.password);
-        }
-        try {
-            ks.keystore.setEntry(alias, entry, protectionParameter);
-            saveKeystore(ks);
-            if (!tryAddToCrlManagement(entry)) {
-                postChangedEvent();
-            }
-        } catch (GeneralSecurityException | IOException e) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to set the entry " + alias);
-        }
-    }
-
-    @Override
-    public List<String> getAliases() throws KuraException {
-        KeyStore ks = getKeyStore();
-        try {
-            return Collections.list(ks.aliases());
-        } catch (GeneralSecurityException e) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST, e, "Failed to get aliases");
-        }
-    }
-
-    @Override
-    public void createKeyPair(String alias, String algorithm, int keySize, String signatureAlgorithm, String attributes)
+    private synchronized KeystoreInstance loadKeystore(final FilesystemKeystoreServiceOptions options)
             throws KuraException {
-        createKeyPair(alias, algorithm, keySize, signatureAlgorithm, attributes, new SecureRandom());
-    }
-
-    @Override
-    public void createKeyPair(String alias, String algorithm, int keySize, String signatureAlgorithm, String attributes,
-            SecureRandom secureRandom) throws KuraException {
-        if (isNull(algorithm) || algorithm.trim().isEmpty() || isNull(secureRandom) || isNull(alias)
-                || isNull(attributes) || attributes.trim().isEmpty() || isNull(signatureAlgorithm)
-                || signatureAlgorithm.trim().isEmpty()) {
-            throw new IllegalArgumentException("Parameters cannot be null or empty!");
-        }
-        KeyPair keyPair;
-        try {
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm, "BC");
-            keyGen.initialize(keySize, secureRandom);
-            keyPair = keyGen.generateKeyPair();
-            setEntry(alias, new PrivateKeyEntry(keyPair.getPrivate(),
-                    generateCertificateChain(keyPair, signatureAlgorithm, attributes)));
-        } catch (GeneralSecurityException | OperatorCreationException e) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST);
-        }
-    }
-
-    @Override
-    public void createKeyPair(String alias, String algorithm, AlgorithmParameterSpec algorithmParameter,
-            String signatureAlgorithm, String attributes, SecureRandom secureRandom) throws KuraException {
-
-        if (isNull(algorithm) || algorithm.trim().isEmpty() || isNull(secureRandom) || isNull(alias)
-                || isNull(attributes) || attributes.trim().isEmpty() || isNull(signatureAlgorithm)
-                || signatureAlgorithm.trim().isEmpty() || isNull(algorithmParameter)) {
-            throw new IllegalArgumentException("Parameters cannot be null or empty!");
-        }
-        KeyPair keyPair;
-        try {
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm, "BC");
-            keyGen.initialize(algorithmParameter, secureRandom);
-            keyPair = keyGen.generateKeyPair();
-            setEntry(alias, new PrivateKeyEntry(keyPair.getPrivate(),
-                    generateCertificateChain(keyPair, signatureAlgorithm, attributes)));
-        } catch (GeneralSecurityException | OperatorCreationException e) {
-            throw new KuraException(KuraErrorCode.BAD_REQUEST);
-        }
-
-    }
-
-    @Override
-    public void createKeyPair(String alias, String algorithm, AlgorithmParameterSpec algorithmParameter,
-            String signatureAlgorithm, String attributes) throws KuraException {
-        createKeyPair(alias, algorithm, algorithmParameter, signatureAlgorithm, attributes, new SecureRandom());
-
-    }
-
-    public X509Certificate[] generateCertificateChain(KeyPair keyPair, String signatureAlgorithm, String attributes)
-            throws OperatorCreationException, CertificateException {
-        Provider bcProvider = new BouncyCastleProvider();
-        Security.addProvider(bcProvider);
-        long now = System.currentTimeMillis();
-        Date startDate = new Date(now);
-        X500Name dnName = new X500Name(attributes);
-        // Use the timestamp as serial number
-        BigInteger certSerialNumber = new BigInteger(Long.toString(now));
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(startDate);
-        calendar.add(Calendar.YEAR, 1);
-        Date endDate = calendar.getTime();
-
-        SubjectPublicKeyInfo subjectPublicKeyInfo = SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
-        X509v3CertificateBuilder certificateBuilder = new X509v3CertificateBuilder(dnName, certSerialNumber, startDate,
-                endDate, dnName, subjectPublicKeyInfo);
-        ContentSigner contentSigner = new JcaContentSignerBuilder(signatureAlgorithm).setProvider(bcProvider)
-                .build(keyPair.getPrivate());
-        X509CertificateHolder certificateHolder = certificateBuilder.build(contentSigner);
-
-        return new X509Certificate[] { new JcaX509CertificateConverter().getCertificate(certificateHolder) };
-    }
-
-    private void updateCRLManager(final CRLManagerOptions newCRLManagerOptions) {
-        shutdownCRLManager();
-
-        if (this.crlManagerOptions.isCrlManagementEnabled()) {
-
-            final CRLManager currentCRLManager = new CRLManager(
-                    this.crlManagerOptions.getStoreFile()
-                            .orElseGet(() -> new File(this.keystoreServiceOptions.getKeystorePath() + ".crl")),
-                    5000, newCRLManagerOptions.getCrlCheckIntervalMs(), newCRLManagerOptions.getCrlUpdateIntervalMs(),
-                    getCRLVerifier(newCRLManagerOptions));
-
-            currentCRLManager.setListener(Optional.of(this::postChangedEvent));
-
-            for (final URI uri : newCRLManagerOptions.getCrlURIs()) {
-                currentCRLManager.addDistributionPoint(Collections.singleton(uri));
-            }
-
-            try {
-                for (final Entry e : getEntries().values()) {
-                    if (!(e instanceof TrustedCertificateEntry)) {
-                        continue;
-                    }
-
-                    final TrustedCertificateEntry certEntry = (TrustedCertificateEntry) e;
-
-                    final Certificate cert = certEntry.getTrustedCertificate();
-
-                    if (cert instanceof X509Certificate) {
-                        currentCRLManager.addTrustedCertificate((X509Certificate) cert);
-                    }
-                }
-
-            } catch (final Exception e) {
-                logger.warn("failed to add current trusted certificates to CRL manager", e);
-            }
-
-            this.crlManager = Optional.of(currentCRLManager);
-        }
-    }
-
-    private CRLVerifier getCRLVerifier(final CRLManagerOptions options) {
-        if (!options.isCRLVerificationEnabled()) {
-            return crl -> true;
-        }
-
-        return crl -> {
-            try {
-                for (final Entry e : getEntries().values()) {
-                    if (!(e instanceof TrustedCertificateEntry)) {
-                        continue;
-                    }
-
-                    final TrustedCertificateEntry trustedCertEntry = (TrustedCertificateEntry) e;
-
-                    if (verifyCRL(crl, trustedCertEntry)) {
-                        return true;
-                    }
-                }
-                return false;
-            } catch (final Exception e) {
-                logger.warn("Exception verifying CRL", e);
-                return false;
-            }
-        };
-    }
-
-    private Optional<X509Certificate> extractCertificate(final Entry entry) {
-        if (!(entry instanceof TrustedCertificateEntry)) {
-            return Optional.empty();
-        }
-
-        final TrustedCertificateEntry trustedCertificateEntry = (TrustedCertificateEntry) entry;
-        final Certificate certificate = trustedCertificateEntry.getTrustedCertificate();
-
-        if (!(certificate instanceof X509Certificate)) {
-            return Optional.empty();
-        } else {
-            return Optional.of((X509Certificate) certificate);
-        }
-
-    }
-
-    private boolean tryAddToCrlManagement(final Entry entry) {
-        final Optional<X509Certificate> certificate = extractCertificate(entry);
-        final Optional<CRLManager> currentCrlManager = this.crlManager;
-
-        if (certificate.isPresent() && currentCrlManager.isPresent()) {
-            return currentCrlManager.get().addTrustedCertificate(certificate.get());
-        } else {
-            return false;
-        }
-    }
-
-    private boolean tryRemoveFromCrlManagement(final Entry entry) {
-        final Optional<X509Certificate> certificate = extractCertificate(entry);
-        final Optional<CRLManager> currentCrlManager = this.crlManager;
-
-        if (certificate.isPresent() && currentCrlManager.isPresent()) {
-            return currentCrlManager.get().removeTrustedCertificate(certificate.get());
-        } else {
-            return false;
-        }
-    }
-
-    private boolean verifyCRL(X509CRL crl, final TrustedCertificateEntry trustedCertEntry) {
-        try {
-            crl.verify(trustedCertEntry.getTrustedCertificate().getPublicKey());
-            return true;
-        } catch (final Exception e) {
-            return false;
-        }
-    }
-
-    private void shutdownCRLManager() {
-        if (this.crlManager.isPresent()) {
-            this.crlManager.get().close();
-            this.crlManager = Optional.empty();
-        }
-    }
-
-    @Override
-    public Collection<CRL> getCRLs() {
-
-        final Optional<CRLManager> currentCRLManager = this.crlManager;
-
-        if (!currentCRLManager.isPresent()) {
-            return Collections.emptyList();
-        } else {
-            return new ArrayList<>(currentCRLManager.get().getCrls());
-        }
-
-    }
-
-    @Override
-    public CertStore getCRLStore() throws KuraException {
-        final Optional<CRLManager> currentCRLManager = this.crlManager;
-
-        try {
-            if (!currentCRLManager.isPresent()) {
-                return CertStore.getInstance("Collection", new CollectionCertStoreParameters());
-            } else {
-                return currentCRLManager.get().getCertStore();
-            }
-        } catch (final Exception e) {
-            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR, e);
-        }
-    }
-
-    private void postChangedEvent() {
-        this.eventAdmin.postEvent(new KeystoreChangedEvent(this.ownPid));
-    }
-
-    private synchronized LoadedKeystore loadKeystore(final KeystoreServiceOptions options) throws KuraException {
         final List<char[]> passwords = new ArrayList<>(2);
 
         passwords.add(options.getKeystorePassword(cryptoService));
@@ -784,10 +322,10 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
             logger.debug("failed to retrieve password", e);
         }
 
-        final LoadedKeystore result = new KeystoreLoader(options.getKeystorePath(), passwords).loadKeystore();
+        final KeystoreInstance result = new KeystoreLoader(options.getKeystorePath(), passwords).loadKeystore();
 
-        if (!Arrays.equals(passwordInCrypto, result.password)) {
-            this.cryptoService.setKeyStorePassword(result.path, result.password);
+        if (!Arrays.equals(passwordInCrypto, result.getPassword())) {
+            this.cryptoService.setKeyStorePassword(((KeystoreInstanceImpl) result).path, result.getPassword());
         }
 
         return result;
@@ -816,13 +354,13 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
             return ks;
         }
 
-        LoadedKeystore loadKeystore() throws KuraException {
+        KeystoreInstance loadKeystore() throws KuraException {
 
             for (final char[] password : this.passwords) {
                 try {
                     final KeyStore keyStore = loadKeystore(path, password);
 
-                    return new LoadedKeystore(keyStore, password, this.path);
+                    return new KeystoreInstanceImpl(keyStore, password, this.path);
                 } catch (final Exception e) {
                     logger.debug("failed to load keystore", e);
                 }
@@ -833,26 +371,27 @@ public class FilesystemKeystoreServiceImpl implements KeystoreService, Configura
         }
     }
 
-    private static class LoadedKeystore {
+    private static class KeystoreInstanceImpl implements KeystoreInstance {
 
         private final KeyStore keystore;
         private final char[] password;
         private final String path;
 
-        public LoadedKeystore(final KeyStore keystore, final char[] password, final String path) {
+        public KeystoreInstanceImpl(final KeyStore keystore, final char[] password, final String path) {
             this.keystore = keystore;
             this.password = password;
             this.path = path;
         }
 
-    }
+        @Override
+        public KeyStore getKeystore() {
+            return keystore;
+        }
 
-    @Override
-    public void addCRL(X509CRL crl) throws KuraException {
-        this.crlManager.ifPresent(manager -> {
-            StoredCRL storedCRL = new StoredCRL(Collections.emptySet(), crl);
-            manager.getCRLStore().storeCRL(storedCRL);
-        });
-    }
+        @Override
+        public char[] getPassword() {
+            return password;
+        }
 
+    }
 }

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceOptions.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceOptions.java
@@ -27,9 +27,9 @@ import org.eclipse.kura.crypto.CryptoService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KeystoreServiceOptions {
+public class FilesystemKeystoreServiceOptions {
 
-    private static final Logger logger = LoggerFactory.getLogger(KeystoreServiceOptions.class);
+    private static final Logger logger = LoggerFactory.getLogger(FilesystemKeystoreServiceOptions.class);
 
     private static final String KEY_SERVICE_PID = "kura.service.pid";
     static final String KEY_KEYSTORE_PATH = "keystore.path";
@@ -46,7 +46,7 @@ public class KeystoreServiceOptions {
     private final Password keystorePassword;
     private final boolean randomPassword;
 
-    public KeystoreServiceOptions(Map<String, Object> properties, final CryptoService cryptoService) {
+    public FilesystemKeystoreServiceOptions(Map<String, Object> properties, final CryptoService cryptoService) {
         if (isNull(properties) || isNull(cryptoService)) {
             throw new IllegalArgumentException("Input parameters cannot be null!");
         }
@@ -128,7 +128,7 @@ public class KeystoreServiceOptions {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        KeystoreServiceOptions other = (KeystoreServiceOptions) obj;
+        FilesystemKeystoreServiceOptions other = (FilesystemKeystoreServiceOptions) obj;
         return Arrays.equals(keystorePassword.getPassword(), other.keystorePassword.getPassword())
                 && Objects.equals(keystorePath, other.keystorePath) && Objects.equals(pid, other.pid)
                 && randomPassword == other.randomPassword;

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/KeystoreInstance.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/KeystoreInstance.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.core.keystore;
+
+import java.security.KeyStore;
+
+interface KeystoreInstance {
+
+    public KeyStore getKeystore();
+
+    public char[] getPassword();
+}

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceImpl.java
@@ -71,14 +71,17 @@ public class PKCS11KeystoreServiceImpl extends BaseKeystoreService {
     @Override
     public void updated(Map<String, Object> properties) {
 
+        super.updated(properties);
+
         PKCS11KeystoreServiceOptions newOptions = new PKCS11KeystoreServiceOptions(properties, ownPid);
 
         if (!newOptions.equals(this.options)) {
             logger.info("Options changed...");
+
             removeProvider();
+            this.options = newOptions;
         }
 
-        super.updated(properties);
     }
 
     @Override
@@ -96,7 +99,7 @@ public class PKCS11KeystoreServiceImpl extends BaseKeystoreService {
         try {
             final KeyStore store = KeyStore.getInstance("PKCS11", currentProvider);
 
-            final char[] pin = this.options.getPin(cryptoService);
+            final char[] pin = this.options.getPin(cryptoService).orElse(null);
 
             store.load(null, pin);
 

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceImpl.java
@@ -1,0 +1,258 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.core.keystore;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.security.KeyStore;
+import java.security.KeyStore.Entry;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.CertificateException;
+import java.security.spec.AlgorithmParameterSpec;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.crypto.CryptoService;
+import org.eclipse.kura.system.SystemService;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PKCS11KeystoreServiceImpl extends BaseKeystoreService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PKCS11KeystoreServiceImpl.class);
+
+    Optional<Provider> provider = Optional.empty();
+    private PKCS11KeystoreServiceOptions options;
+
+    private CryptoService cryptoService;
+    private SystemService systemService;
+
+    public void setCryptoService(final CryptoService cryptoService) {
+        this.cryptoService = cryptoService;
+    }
+
+    public void setSystemService(final SystemService systemService) {
+        this.systemService = systemService;
+    }
+
+    @Override
+    public void activate(ComponentContext context, Map<String, Object> properties) {
+
+        super.activate(context, properties);
+
+        options = new PKCS11KeystoreServiceOptions(properties, ownPid);
+
+    }
+
+    @Override
+    public void updated(Map<String, Object> properties) {
+
+        PKCS11KeystoreServiceOptions newOptions = new PKCS11KeystoreServiceOptions(properties, ownPid);
+
+        if (!newOptions.equals(this.options)) {
+            logger.info("Options changed...");
+            removeProvider();
+        }
+
+        super.updated(properties);
+    }
+
+    @Override
+    public void deactivate() {
+
+        removeProvider();
+
+        super.deactivate();
+    }
+
+    @Override
+    protected KeystoreInstance loadKeystore() throws KuraException {
+        final Provider currentProvider = getOrRegisterProvider();
+
+        try {
+            final KeyStore store = KeyStore.getInstance("PKCS11", currentProvider);
+
+            final char[] pin = this.options.getPin(cryptoService);
+
+            store.load(null, pin);
+
+            return new KeystoreInstanceImpl(store, pin);
+
+        } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+            removeProvider();
+            logger.warn("Keystore exception", e);
+            throw new KuraException(KuraErrorCode.SECURITY_EXCEPTION);
+        }
+    }
+
+    @Override
+    protected void saveKeystore(KeystoreInstance keystore) {
+        // no need
+    }
+
+    @Override
+    public void setEntry(String alias, Entry entry) throws KuraException {
+        throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteEntry(String alias) throws KuraException {
+        throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void createKeyPair(String alias, String algorithm, AlgorithmParameterSpec algorithmParameter,
+            String signatureAlgorithm, String attributes) throws KuraException {
+        throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void createKeyPair(String alias, String algorithm, AlgorithmParameterSpec algorithmParameter,
+            String signatureAlgorithm, String attributes, SecureRandom secureRandom) throws KuraException {
+        throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void createKeyPair(String alias, String algorithm, int keySize, String signatureAlgorithm, String attributes)
+            throws KuraException {
+        throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void createKeyPair(String alias, String algorithm, int keySize, String signatureAlgorithm, String attributes,
+            SecureRandom secureRandom) throws KuraException {
+        throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    protected String getCrlStorePath() {
+        return this.options.getCrlStorePath().orElseGet(
+                () -> this.systemService.getKuraUserConfigDirectory() + "/security/pkcs11." + ownPid + ".crl");
+    }
+
+    private synchronized Provider getOrRegisterProvider() throws KuraException {
+        if (provider.isPresent()) {
+            return provider.get();
+        }
+
+        logger.info("Registering provider...");
+
+        final String config = this.options.buildSunPKCS11ProviderConfig()
+                .orElseThrow(() -> new KuraException(KuraErrorCode.CONFIGURATION_ATTRIBUTE_UNDEFINED, "library.path"));
+
+        logger.debug("PKCS11 config: {}", config);
+
+        final String javaVersion = System.getProperty("java.version");
+
+        final Provider newProvider;
+
+        if (javaVersion.startsWith("1.")) {
+            newProvider = registerProviderJava8(config);
+        } else {
+            newProvider = registerProviderJava9(config);
+        }
+
+        this.provider = Optional.of(newProvider);
+
+        logger.info("Registering provider...done");
+
+        return newProvider;
+    }
+
+    private Provider registerProviderJava8(final String config) throws KuraException {
+        try {
+            final Class<?> providerClass = Class.forName("sun.security.pkcs11.SunPKCS11");
+
+            final Constructor<?> ctor = providerClass.getConstructor(InputStream.class);
+
+            return (Provider) ctor.newInstance(new ByteArrayInputStream(config.getBytes()));
+
+        } catch (final Exception e) {
+            logger.warn("failed to load PKCS11 provider", e);
+            throw new KuraException(KuraErrorCode.SERVICE_UNAVAILABLE);
+        }
+    }
+
+    private Provider registerProviderJava9(final String config) throws KuraException {
+
+        try {
+            final Provider prototype = Security.getProvider("SunPKCS11");
+
+            final Method configure = prototype.getClass().getMethod("configure", String.class);
+
+            final File configFile = Files.createTempFile(null, null).toFile();
+
+            try {
+                try (final OutputStream out = new FileOutputStream(configFile)) {
+                    out.write(config.getBytes());
+                }
+
+                return (Provider) configure.invoke(prototype, configFile.getAbsolutePath());
+            } finally {
+                Files.deleteIfExists(configFile.toPath());
+            }
+
+        } catch (final Exception e) {
+            logger.warn("failed to load PKCS11 provider", e);
+            throw new KuraException(KuraErrorCode.SERVICE_UNAVAILABLE);
+        }
+    }
+
+    private synchronized void removeProvider() {
+        if (!provider.isPresent()) {
+            return;
+        }
+
+        logger.info("Removing provider...");
+        Security.removeProvider(provider.get().getName());
+
+        provider = Optional.empty();
+        logger.info("Removing provider...done");
+    }
+
+    private class KeystoreInstanceImpl implements KeystoreInstance {
+
+        private final KeyStore keystore;
+        private final char[] password;
+
+        KeystoreInstanceImpl(KeyStore keystore, char[] password) {
+            this.keystore = keystore;
+            this.password = password;
+        }
+
+        @Override
+        public KeyStore getKeystore() {
+            return keystore;
+        }
+
+        @Override
+        public char[] getPassword() {
+            return password;
+        }
+
+    }
+}

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceImpl.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceImpl.java
@@ -192,7 +192,11 @@ public class PKCS11KeystoreServiceImpl extends BaseKeystoreService {
 
             final Constructor<?> ctor = providerClass.getConstructor(InputStream.class);
 
-            return (Provider) ctor.newInstance(new ByteArrayInputStream(config.getBytes()));
+            final Provider newProvider = (Provider) ctor.newInstance(new ByteArrayInputStream(config.getBytes()));
+
+            Security.addProvider(newProvider);
+
+            return newProvider;
 
         } catch (final Exception e) {
             logger.warn("failed to load PKCS11 provider", e);

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceOptions.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceOptions.java
@@ -35,7 +35,7 @@ public class PKCS11KeystoreServiceOptions {
 
     private final String ownPid;
     private final Optional<String> libraryPath;
-    private final String pin;
+    private final Optional<String> pin;
     private final Optional<Integer> slot;
     private final Optional<Integer> slotListIndex;
     private final Optional<String> enabledMechanisms;
@@ -45,7 +45,7 @@ public class PKCS11KeystoreServiceOptions {
 
     public PKCS11KeystoreServiceOptions(final Map<String, Object> properties, final String ownPid) {
         this.libraryPath = PKCS11_LIBRARY_PROPERTY.getOptional(properties);
-        this.pin = PIN_PROPERTY.get(properties);
+        this.pin = PIN_PROPERTY.getOptional(properties);
         this.ownPid = ownPid;
         this.slot = SLOT_PROPERTY.getOptional(properties);
         this.slotListIndex = SLOT_LIST_INDEX_PROPERTY.getOptional(properties);
@@ -59,8 +59,12 @@ public class PKCS11KeystoreServiceOptions {
         return libraryPath;
     }
 
-    public char[] getPin(final CryptoService cryptoService) throws KuraException {
-        return cryptoService.decryptAes(pin.toCharArray());
+    public Optional<char[]> getPin(final CryptoService cryptoService) throws KuraException {
+        if (!pin.isPresent()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(cryptoService.decryptAes(pin.get().toCharArray()));
     }
 
     public String getOwnPid() {

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceOptions.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/PKCS11KeystoreServiceOptions.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.core.keystore;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.crypto.CryptoService;
+import org.eclipse.kura.util.configuration.Property;
+
+public class PKCS11KeystoreServiceOptions {
+
+    private static final Property<String> PKCS11_LIBRARY_PROPERTY = new Property<>("library.path", String.class);
+    private static final Property<String> PIN_PROPERTY = new Property<>("pin", String.class);
+    private static final Property<Integer> SLOT_PROPERTY = new Property<>("slot", Integer.class);
+    private static final Property<Integer> SLOT_LIST_INDEX_PROPERTY = new Property<>("slot.list.index", Integer.class);
+    private static final Property<String> ENABLED_MECHANISMS_PROPERTY = new Property<>("enabled.mechanisms",
+            String.class);
+    private static final Property<String> DISABLED_MECHANISMS_PROPERTY = new Property<>("disabled.mechanisms",
+            String.class);
+    private static final Property<String> ATTRIBUTES_PROPERTY = new Property<>("attributes", String.class);
+    private static final Property<String> CRL_STORE_PATH = new Property<>("crl.store.path", String.class);
+
+    private final String ownPid;
+    private final Optional<String> libraryPath;
+    private final String pin;
+    private final Optional<Integer> slot;
+    private final Optional<Integer> slotListIndex;
+    private final Optional<String> enabledMechanisms;
+    private final Optional<String> disabledMechanisms;
+    private final Optional<String> attributes;
+    private final Optional<String> crlStorePath;
+
+    public PKCS11KeystoreServiceOptions(final Map<String, Object> properties, final String ownPid) {
+        this.libraryPath = PKCS11_LIBRARY_PROPERTY.getOptional(properties);
+        this.pin = PIN_PROPERTY.get(properties);
+        this.ownPid = ownPid;
+        this.slot = SLOT_PROPERTY.getOptional(properties);
+        this.slotListIndex = SLOT_LIST_INDEX_PROPERTY.getOptional(properties);
+        this.enabledMechanisms = ENABLED_MECHANISMS_PROPERTY.getOptional(properties).filter(s -> !s.trim().isEmpty());
+        this.disabledMechanisms = DISABLED_MECHANISMS_PROPERTY.getOptional(properties).filter(s -> !s.trim().isEmpty());
+        this.attributes = ATTRIBUTES_PROPERTY.getOptional(properties).filter(s -> !s.trim().isEmpty());
+        this.crlStorePath = CRL_STORE_PATH.getOptional(properties).filter(s -> !s.trim().isEmpty());
+    }
+
+    public Optional<String> getLibraryPath() {
+        return libraryPath;
+    }
+
+    public char[] getPin(final CryptoService cryptoService) throws KuraException {
+        return cryptoService.decryptAes(pin.toCharArray());
+    }
+
+    public String getOwnPid() {
+        return ownPid;
+    }
+
+    public Optional<Integer> getSlot() {
+        return slot;
+    }
+
+    public Optional<Integer> getSlotListIndex() {
+        return slotListIndex;
+    }
+
+    public Optional<String> getEnabledMechanisms() {
+        return enabledMechanisms;
+    }
+
+    public Optional<String> getDisabledMechanisms() {
+        return disabledMechanisms;
+    }
+
+    public Optional<String> getAttributes() {
+        return attributes;
+    }
+
+    public Optional<String> getCrlStorePath() {
+        return crlStorePath;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attributes, crlStorePath, disabledMechanisms, enabledMechanisms, libraryPath, ownPid, pin,
+                slot, slotListIndex);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof PKCS11KeystoreServiceOptions)) {
+            return false;
+        }
+        PKCS11KeystoreServiceOptions other = (PKCS11KeystoreServiceOptions) obj;
+        return Objects.equals(attributes, other.attributes) && Objects.equals(crlStorePath, other.crlStorePath)
+                && Objects.equals(disabledMechanisms, other.disabledMechanisms)
+                && Objects.equals(enabledMechanisms, other.enabledMechanisms)
+                && Objects.equals(libraryPath, other.libraryPath) && Objects.equals(ownPid, other.ownPid)
+                && Objects.equals(pin, other.pin) && Objects.equals(slot, other.slot)
+                && Objects.equals(slotListIndex, other.slotListIndex);
+    }
+
+    public Optional<String> buildSunPKCS11ProviderConfig() {
+        if (!this.libraryPath.isPresent()) {
+            return Optional.empty();
+        }
+
+        final StringBuilder builder = new StringBuilder();
+
+        builder.append("library = ").append(libraryPath.get()).append('\n');
+
+        builder.append("name = kura.provider.").append(ownPid).append('\n');
+
+        if (slot.isPresent()) {
+            builder.append("slot = ").append(slot.get()).append('\n');
+        }
+
+        if (slotListIndex.isPresent()) {
+            builder.append("slotListIndex = ").append(slotListIndex.get()).append('\n');
+        }
+
+        if (enabledMechanisms.isPresent()) {
+            builder.append("enabledMechanisms = { ").append(enabledMechanisms.get()).append(" }\n");
+        }
+
+        if (disabledMechanisms.isPresent()) {
+            builder.append("disabledMechanisms = { ").append(disabledMechanisms.get()).append(" }\n");
+        }
+
+        if (attributes.isPresent()) {
+            builder.append(attributes.get());
+        }
+
+        return Optional.of(builder.toString());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/FilesystemKeystoreServiceOptionsTest.java
@@ -26,7 +26,7 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.crypto.CryptoService;
 import org.junit.Test;
 
-public class KeystoreServiceOptionsTest {
+public class FilesystemKeystoreServiceOptionsTest {
 
     private static final String CHANGEIT_PASSWORD = "changeit";
 

--- a/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/KeystoreServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/KeystoreServiceOptionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,13 +32,13 @@ public class KeystoreServiceOptionsTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullPropertiesCrypto() {
-        new KeystoreServiceOptions(null, null);
+        new FilesystemKeystoreServiceOptions(null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullCrypto() {
         Map<String, Object> properties = new HashMap<>();
-        new KeystoreServiceOptions(properties, null);
+        new FilesystemKeystoreServiceOptions(properties, null);
     }
 
     @Test
@@ -50,10 +50,12 @@ public class KeystoreServiceOptionsTest {
         when(cryptoService.decryptAes("encrypted".toCharArray())).thenReturn(CHANGEIT_PASSWORD.toCharArray());
         when(cryptoService.getKeyStorePassword(any(String.class))).thenReturn(CHANGEIT_PASSWORD.toCharArray());
 
-        KeystoreServiceOptions keystoreServiceOptions = new KeystoreServiceOptions(properties, cryptoService);
+        FilesystemKeystoreServiceOptions FilesystemKeystoreServiceOptions = new FilesystemKeystoreServiceOptions(
+                properties, cryptoService);
 
-        assertEquals("/tmp/keystore.ks", keystoreServiceOptions.getKeystorePath());
-        assertArrayEquals(CHANGEIT_PASSWORD.toCharArray(), keystoreServiceOptions.getKeystorePassword(cryptoService));
+        assertEquals("/tmp/keystore.ks", FilesystemKeystoreServiceOptions.getKeystorePath());
+        assertArrayEquals(CHANGEIT_PASSWORD.toCharArray(),
+                FilesystemKeystoreServiceOptions.getKeystorePassword(cryptoService));
     }
 
     @Test
@@ -68,10 +70,12 @@ public class KeystoreServiceOptionsTest {
         when(cryptoService.decryptAes("testPassword".toCharArray())).thenReturn("testPassword".toCharArray());
         when(cryptoService.getKeyStorePassword(any(String.class))).thenReturn("testPassword".toCharArray());
 
-        KeystoreServiceOptions keystoreServiceOptions = new KeystoreServiceOptions(properties, cryptoService);
+        FilesystemKeystoreServiceOptions FilesystemKeystoreServiceOptions = new FilesystemKeystoreServiceOptions(
+                properties, cryptoService);
 
-        assertEquals("/abc", keystoreServiceOptions.getKeystorePath());
-        assertArrayEquals("testPassword".toCharArray(), keystoreServiceOptions.getKeystorePassword(cryptoService));
+        assertEquals("/abc", FilesystemKeystoreServiceOptions.getKeystorePath());
+        assertArrayEquals("testPassword".toCharArray(),
+                FilesystemKeystoreServiceOptions.getKeystorePassword(cryptoService));
     }
 
     @Test
@@ -84,11 +88,13 @@ public class KeystoreServiceOptionsTest {
         when(cryptoService.encryptAes("testPassword".toCharArray())).thenReturn("encrypted".toCharArray());
         when(cryptoService.decryptAes("encrypted".toCharArray())).thenReturn("testPassword".toCharArray());
 
-        KeystoreServiceOptions keystoreServiceOptions1 = new KeystoreServiceOptions(properties, cryptoService);
+        FilesystemKeystoreServiceOptions FilesystemKeystoreServiceOptions1 = new FilesystemKeystoreServiceOptions(
+                properties, cryptoService);
 
-        KeystoreServiceOptions keystoreServiceOptions2 = new KeystoreServiceOptions(properties, cryptoService);
+        FilesystemKeystoreServiceOptions FilesystemKeystoreServiceOptions2 = new FilesystemKeystoreServiceOptions(
+                properties, cryptoService);
 
-        assertEquals(keystoreServiceOptions1, keystoreServiceOptions2);
+        assertEquals(FilesystemKeystoreServiceOptions1, FilesystemKeystoreServiceOptions2);
     }
 
     @Test
@@ -103,14 +109,16 @@ public class KeystoreServiceOptionsTest {
         when(cryptoService.decryptAes("encrypted".toCharArray())).thenReturn("testPassword".toCharArray());
         when(cryptoService.decryptAes("encrypted1".toCharArray())).thenReturn("testPassword1".toCharArray());
 
-        KeystoreServiceOptions keystoreServiceOptions1 = new KeystoreServiceOptions(properties, cryptoService);
+        FilesystemKeystoreServiceOptions FilesystemKeystoreServiceOptions1 = new FilesystemKeystoreServiceOptions(
+                properties, cryptoService);
 
         Map<String, Object> properties2 = new HashMap<>();
         properties2.put("keystore.path", "/abc1");
         properties2.put("keystore.password", "testPassword1");
-        KeystoreServiceOptions keystoreServiceOptions2 = new KeystoreServiceOptions(properties2, cryptoService);
+        FilesystemKeystoreServiceOptions FilesystemKeystoreServiceOptions2 = new FilesystemKeystoreServiceOptions(
+                properties2, cryptoService);
 
-        assertNotEquals(keystoreServiceOptions1, keystoreServiceOptions2);
+        assertNotEquals(FilesystemKeystoreServiceOptions1, FilesystemKeystoreServiceOptions2);
 
     }
 


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

* Added PKCS11 `KeystoreService` based on the `SunPKCS11` provider
* Kyestore access is read only for now