### PR TITLE
build: updated gson to 2.9.0

### DIFF
--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -56,7 +56,7 @@ com.eclipsesource.jaxrs.publisher.version=5.3.1.201602281253
 com.eclipsesource.jaxrs.provider.gson.version=2.3.0.201602281253
 com.eclipsesource.jaxrs.provider.security.version=2.2.0.201602281253
 com.eclipsesource.jaxrs.provider.multipart.version=2.2.0.201602281253
-com.google.gson.version=2.7.0.v20170129-0911
+com.google.gson.version=2.9.0
 bluez-dbus-osgi.version=0.1.4
 
 commons-beanutils.version=1.9.3

--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -337,8 +337,8 @@
                                     <version>${com.eclipsesource.jaxrs.provider.multipart.version}</version>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>org.eclipse.kura</groupId>
-                                    <artifactId>com.google.gson</artifactId>
+                                    <groupId>com.google.code.gson</groupId>
+                                    <artifactId>gson</artifactId>
                                     <version>${com.google.gson.version}</version>
                                 </artifactItem>
                                 <artifactItem>
@@ -596,7 +596,7 @@
                                 <move file="target/source/plugins/com.eclipsesource.jaxrs.provider.gson.jar" tofile="target/source/plugins/com.eclipsesource.jaxrs.provider.gson_${com.eclipsesource.jaxrs.provider.gson.version}.jar"/>
                                 <move file="target/source/plugins/com.eclipsesource.jaxrs.provider.security.jar" tofile="target/source/plugins/com.eclipsesource.jaxrs.provider.security_${com.eclipsesource.jaxrs.provider.security.version}.jar"/>
                                 <move file="target/source/plugins/com.eclipsesource.jaxrs.provider.multipart.jar" tofile="target/source/plugins/com.eclipsesource.jaxrs.provider.multipart_${com.eclipsesource.jaxrs.provider.multipart.version}.jar"/>
-                                <move file="target/source/plugins/com.google.gson.jar" tofile="target/source/plugins/com.google.gson_${com.google.gson.version}.jar"/>
+                                <move file="target/source/plugins/gson.jar" tofile="target/source/plugins/com.google.gson_${com.google.gson.version}.jar"/>
                                 <move file="target/source/plugins/jakarta.xml.bind-api.jar" tofile="target/source/plugins/jakarta.xml.bind-api_${jakarta.xml.bind-api.version}.jar"/>
                                 <move file="target/source/plugins/jakarta.activation-api.jar" tofile="target/source/plugins/jakarta.activation-api_${jakarta.activation-api.version}.jar"/>
                                 <move file="target/source/plugins/jakarta.xml.ws-api.jar" tofile="target/source/plugins/jakarta.xml.ws-api_${jakarta.xml.ws-api.version}.jar"/>


### PR DESCRIPTION
Signed-off-by: MMaiero <matteo.maiero@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).


```
echo "maven/mavencentral/com.google.code.gson/gson/2.9.0" | java -jar /Users/matteo.maiero/Downloads/org.eclipse.dash.licenses-0.0.1-20220729.055040-500.jar -      
[main] INFO Querying Eclipse Foundation for license data for 1 items.
[main] INFO Found 1 items.
[main] INFO Vetted license information was found for all content. No further investigation is required.
```