### PR TITLE
feat(container.orchestrator): adding support for container restart on failure

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
@@ -51,6 +51,7 @@ public class ContainerConfiguration {
     private ImageConfiguration imageConfig;
     private ContainerNetworkConfiguration networkConfiguration;
     private List<String> entryPoint;
+    private Boolean containerRestartOnFailure = false;
 
     private ContainerConfiguration() {
     }
@@ -223,6 +224,16 @@ public class ContainerConfiguration {
     public List<String> getEntryPoint() {
         return this.entryPoint;
     }
+    
+    /**
+     * Returns boolean which determines if container will restart on failure
+     * 
+     * @return
+     * @since 2.5
+     */
+    public boolean getRestartOnFailure() {
+        return this.containerRestartOnFailure;
+    }
 
     /**
      * Creates a builder for creating a new {@link ContainerConfiguration} instance.
@@ -279,6 +290,7 @@ public class ContainerConfiguration {
         private ImageConfigurationBuilder imageConfigBuilder = new ImageConfiguration.ImageConfigurationBuilder();
         private ContainerNetworkConfigurationBuilder networkConfigurationBuilder = new ContainerNetworkConfigurationBuilder();
         private List<String> entryPoint = new LinkedList<>();
+        private Boolean containerRestartOnFailure = false;
 
         public ContainerConfigurationBuilder setContainerName(String serviceName) {
             this.containerName = serviceName;
@@ -381,6 +393,16 @@ public class ContainerConfiguration {
             this.imageConfigBuilder.setImageDownloadTimeoutSeconds(imageConfig.getimageDownloadTimeoutSeconds());
             return this;
         }
+        
+        /**
+         * Set if container will restart on failure
+         * 
+         * @since 2.5
+         */
+        public ContainerConfigurationBuilder setRestartOnFailure(boolean containerRestartOnFailure) {
+            this.containerRestartOnFailure = containerRestartOnFailure;
+            return this;
+        }
 
         public ContainerConfiguration build() {
             ContainerConfiguration result = new ContainerConfiguration();
@@ -398,6 +420,7 @@ public class ContainerConfiguration {
             result.imageConfig = this.imageConfigBuilder.build();
             result.networkConfiguration = this.networkConfigurationBuilder.build();
             result.entryPoint = requireNonNull(this.entryPoint, "Container EntryPoint list must not be null");
+            result.containerRestartOnFailure = this.containerRestartOnFailure;
 
             return result;
         }

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -61,6 +61,7 @@ import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Ports.Binding;
 import com.github.dockerjava.api.model.PullResponseItem;
 import com.github.dockerjava.api.model.Volume;
+import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
@@ -448,6 +449,10 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
             commandBuilder = containerEnviromentVariablesHandler(containerDescription, commandBuilder);
 
             commandBuilder = containerEntrypointHandler(containerDescription, commandBuilder);
+            
+            if (containerDescription.getRestartOnFailure()) {
+                commandBuilder = commandBuilder.withRestartPolicy(RestartPolicy.unlessStoppedRestart());                
+            }
 
             // Host Configuration Related
             configuration = containerVolumeMangamentHandler(containerDescription, configuration);

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -139,6 +139,9 @@
             description="Used to pass logger parameters to a container's logging driver. Example: max-buffer-size=4m, labels=location." type="String" cardinality="1"
             required="false" default="" />
 
+        <AD id="container.restart.onfailure" name="Restart Container On Failire" type="Boolean" cardinality="1" required="true" default="false"
+            description="Automatically restart the container when it has failed.">
+        </AD>
     </OCD>
     <Designate pid="org.eclipse.kura.container.provider.ContainerInstance"
         factoryPid="org.eclipse.kura.container.provider.ContainerInstance">

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
@@ -57,6 +57,7 @@ public class ContainerInstanceOptions {
             500);
     private static final Property<String> CONTAINER_NETWORKING_MODE = new Property<>("container.networkMode", "");
     private static final Property<String> CONTAINER_ENTRY_POINT = new Property<>("container.entrypoint", "");
+    private static final Property<Boolean> CONTAINER_RESTART_FAILURE = new Property<>("container.restart.onfailure", false);
 
     private final boolean enabled;
     private final String image;
@@ -79,6 +80,7 @@ public class ContainerInstanceOptions {
     private final int imageDownloadTimeout;
     private final Optional<String> containerNetworkingMode;
     private final List<String> containerEntryPoint;
+    private final boolean restartOnFailure;
 
     public ContainerInstanceOptions(final Map<String, Object> properties) {
         if (isNull(properties)) {
@@ -106,6 +108,7 @@ public class ContainerInstanceOptions {
         this.imageDownloadTimeout = IMAGES_DOWNLOAD_TIMEOUT.get(properties);
         this.containerNetworkingMode = CONTAINER_NETWORKING_MODE.getOptional(properties);
         this.containerEntryPoint = parseStringListSplitByComma(CONTAINER_ENTRY_POINT.get(properties));
+        this.restartOnFailure = CONTAINER_RESTART_FAILURE.get(properties);
     }
 
     private Map<String, String> parseVolume(String volumeString) {
@@ -228,6 +231,10 @@ public class ContainerInstanceOptions {
     public String getLoggingType() {
         return this.containerLoggerType;
     }
+    
+    public boolean getRestartOnFailure() {
+        return this.restartOnFailure;
+    }
 
     public Map<String, String> getLoggerParameters() {
         return this.containerLoggingParameters;
@@ -272,7 +279,7 @@ public class ContainerInstanceOptions {
                 .setVolumes(getContainerVolumeList()).setPrivilegedMode(this.privilegedMode)
                 .setDeviceList(getContainerDeviceList()).setFrameworkManaged(true).setLoggingType(getLoggingType())
                 .setContainerNetowrkConfiguration(buildContainerNetworkConfig())
-                .setLoggerParameters(getLoggerParameters()).setEntryPoint(getEntryPoint()).build();
+                .setLoggerParameters(getLoggerParameters()).setEntryPoint(getEntryPoint()).setRestartOnFailure(getRestartOnFailure()).build();
     }
 
     private List<Integer> parsePortString(String ports) {


### PR DESCRIPTION
…failure

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
