### PR TITLE
fix(core.configuration): Fixed getDefaultValue method in ComponentUtil

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
@@ -353,7 +353,7 @@ public class ComponentUtil {
         // then split it by comma-separate list
         // keeping in mind the possible escape sequence "\,"
         String defaultValue = attrDef.getDefault();
-        if (defaultValue == null) {
+        if (defaultValue == null || defaultValue.isEmpty()) {
             return null;
         }
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR fixes a check in the `ComponentUtil` class

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** The `getDefaultValue` method in the `ComponentUtil` class now check also if the parameter is empty.

**Any side note on the changes made:** With this modification the rest calls for getting the default configuration of `SelfConfiguringComponents` don't return the default values that are empty. This is alligned with the behavior of the same calls for `ConfigurableComponent`s.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>