### PR TITLE
fix(container.provider): Fixed empty gpus field in container provider

### DIFF
--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -100,17 +100,17 @@
         <AD id="container.memory" name="Memory"
             description="The maximum amount of memory the container can use in bytes. Set it as a positive integer, optionally followed by a suffix of b, k, m, g, to indicate bytes, kilobytes, megabytes, or gigabytes. 
             The minimum allowed value is platform dependent (i.e. 6m). If left empty, the memory assigned to the container will be set to a default value by the native container orchestrator."
-            type="String" cardinality="1"
+            type="String" cardinality="0"
             required="false" default="" />
             
         <AD id="container.cpus" name="CPUs"
             description="Specify how many CPUs a container can use. Decimal values are allowed, so if set to 1.5, the container will use at most one and a half cpu resource."
-            type="Float" cardinality="1"
+            type="Float" cardinality="0"
             required="false" default="" />
 
         <AD id="container.gpus" name="GPUs"
             description="Specify how many Nvidia GPUs a container can use. Allowed values are 'all' or an integer number."
-            type="String" cardinality="1"
+            type="String" cardinality="0"
             required="false" default="" />
                         
         <AD id="container.volume" name="Volume Mount"

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -109,8 +109,8 @@
             required="false" default="" />
 
         <AD id="container.gpus" name="GPUs"
-            description="Specify how many Nvidia GPUs a container can use. Allowed values are 'all' or an integer number."
-            type="String" cardinality="0"
+            description="Specify how many Nvidia GPUs a container can use. Allowed values are 'all' or an integer number. If there's no Nvidia GPU installed, leave the field empty."
+            type="String" cardinality="1"
             required="false" default="" />
                         
         <AD id="container.volume" name="Volume Mount"

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
@@ -118,7 +118,7 @@ public class ContainerInstanceOptions {
         this.restartOnFailure = CONTAINER_RESTART_FAILURE.get(properties);
         this.containerMemory = parseMemoryString(CONTAINER_MEMORY.getOptional(properties));
         this.containerCpus = CONTAINER_CPUS.getOptional(properties);
-        this.containerGpus = CONTAINER_GPUS.getOptional(properties);
+        this.containerGpus = parseGpusString(CONTAINER_GPUS.getOptional(properties));
     }
 
     private Map<String, String> parseVolume(String volumeString) {
@@ -209,6 +209,14 @@ public class ContainerInstanceOptions {
             return Optional.of(result);
         } else {
             return Optional.empty();
+        }
+    }
+
+    private Optional<String> parseGpusString(Optional<String> gpus) {
+        if (gpus.isPresent() && gpus.get().isEmpty()) {
+            return Optional.empty();
+        } else {
+            return gpus;
         }
     }
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds a check for empty gpus field in the container instance configuration.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>