### PR TITLE
docs: Updated gpus field in contaniner docs

### DIFF
--- a/_posts/builtin/2022-02-23-container-orchestration-provider.md
+++ b/_posts/builtin/2022-02-23-container-orchestration-provider.md
@@ -70,7 +70,7 @@ Containers may be configured using the following fields:
 
  - **CPUs (optional)** - This value specifies how many CPUs a container can use. Decimal values are allowed, so if set to 1.5, the container will use at most one and a half cpu resource.
 
-- **GPUs (optional)** - This field configures how many Nvidia GPUs a container can use. Allowed values are 'all' or an integer number.
+- **GPUs (optional)** - This field configures how many Nvidia GPUs a container can use. Allowed values are 'all' or an integer number. If there's no Nvidia GPU installed, leave it empty. The Nvidia Container Toolkit must be installed on the system to correctly configure the service, otherwise the container will not start.
 
 - **Volume Mount (optional)** - This field accepts a comma-separated list of system-to-container file mounts. This allows for the container to access files on the host machine.
   


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Updated gpu field explanation in the container orchestrator service doc.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>