### PR TITLE
fix(container.orchestrator): replaced deprecated call on containerRestartOnFailure

### DIFF
--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -454,14 +454,14 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
 
             commandBuilder = containerEntrypointHandler(containerDescription, commandBuilder);
 
-            if (containerDescription.getRestartOnFailure()) {
-                commandBuilder = commandBuilder.withRestartPolicy(RestartPolicy.unlessStoppedRestart());
-            }
-
             // Host Configuration Related
             configuration = containerVolumeMangamentHandler(containerDescription, configuration);
 
             configuration = containerDevicesHandler(containerDescription, configuration);
+            
+            if (containerDescription.getRestartOnFailure()) {
+                configuration = configuration.withRestartPolicy(RestartPolicy.unlessStoppedRestart());
+            }
 
             configuration = containerPortManagementHandler(containerDescription, configuration);
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
