### PR TITLE
refactor(ai.triton.server): add TritonServerContainerManager implementation

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManager.java
@@ -99,7 +99,7 @@ public class TritonServerContainerManager implements TritonServerInstanceManager
             String containerID = this.containerOrchestrationService.startContainer(containerConfiguration);
             logger.info("Nvidia Triton Container started. Container ID: {}", containerID);
         } catch (KuraException | InterruptedException e) {
-            logger.info("Nvidia Triton Container not started. {}", e);
+            logger.info("Nvidia Triton Container not started.", e);
         }
     }
 

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManager.java
@@ -1,0 +1,256 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.ai.triton.server;
+
+import static java.util.Objects.nonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.container.orchestration.ContainerConfiguration;
+import org.eclipse.kura.container.orchestration.ContainerConfiguration.ContainerConfigurationBuilder;
+import org.eclipse.kura.container.orchestration.ContainerInstanceDescriptor;
+import org.eclipse.kura.container.orchestration.ContainerNetworkConfiguration.ContainerNetworkConfigurationBuilder;
+import org.eclipse.kura.container.orchestration.ContainerOrchestrationService;
+import org.eclipse.kura.container.orchestration.ContainerState;
+import org.eclipse.kura.container.orchestration.ImageConfiguration.ImageConfigurationBuilder;
+import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TritonServerContainerManager implements TritonServerInstanceManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(TritonServerContainerManager.class);
+
+    private static final int MONITOR_PERIOD = 30;
+    private static final String TRITON_CONTAINER_NAME = "tritonserver-kura";
+    private static final String TRITON_LOGGING_TYPE = "DEFAULT";
+    private static final String TRITON_INTERNAL_MODEL_REPO = "/models";
+    private static final boolean TRITON_FRAMEWORK_MANAGED = true;
+    private static final List<Integer> TRITON_INTERNAL_PORTS = Arrays.asList(8000, 8001, 8002);
+
+    private TritonServerServiceOptions options;
+    private ContainerOrchestrationService containerOrchestrationService;
+    private String decryptionFolderPath;
+
+    private ScheduledExecutorService scheduledExecutorService;
+    private ScheduledFuture<?> scheduledFuture;
+
+    protected TritonServerContainerManager(TritonServerServiceOptions options,
+            ContainerOrchestrationService containerOrchestrationService, String decryptionFolderPath) {
+        this.options = options;
+        this.containerOrchestrationService = containerOrchestrationService;
+        this.decryptionFolderPath = decryptionFolderPath;
+        this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @Override
+    public void start() {
+        if (!isImageAvailable()) {
+            logger.error("Docker image not available on disk. Aborting....");
+            return;
+        }
+        startContainerServerMonitor();
+    }
+
+    @Override
+    public void stop() {
+        stopLocalServerMonitor();
+        stopScheduledExecutor();
+    }
+
+    @Override
+    public void kill() {
+        killLocalServerMonitor();
+        stopScheduledExecutor();
+    }
+
+    private void startContainerServerMonitor() {
+        this.scheduledFuture = this.scheduledExecutorService.scheduleAtFixedRate(() -> {
+            Thread.currentThread().setName(getClass().getSimpleName());
+            if (!isServerRunning()) {
+                startLocalServer();
+            }
+        }, 0, MONITOR_PERIOD, TimeUnit.SECONDS);
+    }
+
+    private void startLocalServer() {
+        ContainerConfiguration containerConfiguration = createContainerConfiguration();
+        try {
+            String containerID = this.containerOrchestrationService.startContainer(containerConfiguration);
+            logger.info("Nvidia Triton Container started. Container ID: {}", containerID);
+        } catch (KuraException | InterruptedException e) {
+            logger.info("Nvidia Triton Container not started. {}", e);
+        }
+    }
+
+    private void stopLocalServerMonitor() {
+        stopMonitor();
+        stopLocalServer();
+    }
+
+    private void killLocalServerMonitor() {
+        stopMonitor();
+        killLocalServer();
+    }
+
+    private void stopMonitor() {
+        if (nonNull(this.scheduledFuture)) {
+            this.scheduledFuture.cancel(true);
+            while (!this.scheduledFuture.isDone()) {
+                sleepFor(500);
+            }
+        }
+    }
+
+    private synchronized void stopLocalServer() {
+        try {
+            String containerID = getContainerID();
+            this.containerOrchestrationService.stopContainer(containerID);
+            this.containerOrchestrationService.deleteContainer(containerID);
+        } catch (KuraException e) {
+            logger.error("Can't stop container. Caused by", e);
+        }
+    }
+
+    private synchronized void killLocalServer() {
+        stopLocalServer();
+    }
+
+    private void stopScheduledExecutor() {
+        if (this.scheduledExecutorService != null) {
+            this.scheduledExecutorService.shutdown();
+            while (!this.scheduledExecutorService.isTerminated()) {
+                sleepFor(500);
+            }
+            this.scheduledExecutorService = null;
+        }
+    }
+
+    @Override
+    public boolean isServerRunning() {
+        try {
+            final Optional<ContainerInstanceDescriptor> existingInstance = this.containerOrchestrationService
+                    .listContainerDescriptors().stream().filter(c -> c.getContainerName().equals(TRITON_CONTAINER_NAME))
+                    .findAny();
+
+            if (!existingInstance.isPresent()) {
+                return false;
+            }
+
+            ContainerInstanceDescriptor descr = existingInstance.get();
+            return descr.getContainerState() == ContainerState.ACTIVE
+                    || descr.getContainerState() == ContainerState.STARTING;
+        } catch (IllegalStateException e) {
+            logger.error("Cannot retrieve container status information", e);
+            return false;
+        }
+    }
+
+    private boolean isImageAvailable() {
+        List<ImageInstanceDescriptor> existingImage;
+
+        try {
+            existingImage = this.containerOrchestrationService.listImageInstanceDescriptors();
+        } catch (IllegalStateException e) {
+            logger.error("Cannot retrieve container image status information", e);
+            return false;
+        }
+
+        for (ImageInstanceDescriptor imageDescriptor : existingImage) {
+            if (imageDescriptor.getImageName().equals(this.options.getContainerImage())
+                    && imageDescriptor.getImageTag().equals(this.options.getContainerImageTag())) {
+                return true;
+            }
+
+        }
+
+        return false;
+    }
+
+    private String getContainerID() throws KuraException {
+        final Optional<ContainerInstanceDescriptor> existingInstance = this.containerOrchestrationService
+                .listContainerDescriptors().stream().filter(c -> c.getContainerName().equals(TRITON_CONTAINER_NAME))
+                .findAny();
+
+        if (!existingInstance.isPresent()) {
+            throw new KuraException(KuraErrorCode.NOT_FOUND, "Can't find Kura-managed Triton server container");
+        }
+
+        ContainerInstanceDescriptor descr = existingInstance.get();
+        return descr.getContainerId();
+    }
+
+    private static void sleepFor(long timeout) {
+        try {
+            Thread.sleep(timeout);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug(e.getMessage(), e);
+        }
+    }
+
+    private ContainerConfiguration createContainerConfiguration() {
+
+        ImageConfigurationBuilder imageConfigBuilder = new ImageConfigurationBuilder();
+        imageConfigBuilder.setImageName(this.options.getContainerImage());
+        imageConfigBuilder.setImageTag(this.options.getContainerImageTag());
+        imageConfigBuilder.setRegistryCredentials(Optional.empty());
+
+        ContainerNetworkConfigurationBuilder networkConfigurationBuilder = new ContainerNetworkConfigurationBuilder();
+        networkConfigurationBuilder.setNetworkMode(Optional.empty());
+
+        ContainerConfigurationBuilder builder = new ContainerConfigurationBuilder();
+
+        builder.setImageConfiguration(imageConfigBuilder.build());
+        builder.setContainerNetowrkConfiguration(networkConfigurationBuilder.build());
+
+        builder.setContainerName(TRITON_CONTAINER_NAME);
+        builder.setFrameworkManaged(TRITON_FRAMEWORK_MANAGED);
+        builder.setLoggingType(TRITON_LOGGING_TYPE);
+        builder.setInternalPorts(TRITON_INTERNAL_PORTS);
+        builder.setExternalPorts(
+                Arrays.asList(this.options.getHttpPort(), this.options.getGrpcPort(), this.options.getMetricsPort()));
+
+        builder.setMemory(this.options.getContainerMemory());
+        builder.setCpus(this.options.getContainerCpus());
+        builder.setGpus(this.options.getContainerGpus());
+
+        if (this.options.isModelEncryptionPasswordSet()) {
+            builder.setVolumes(Collections.singletonMap(this.decryptionFolderPath, TRITON_INTERNAL_MODEL_REPO));
+        } else {
+            builder.setVolumes(
+                    Collections.singletonMap(this.options.getModelRepositoryPath(), TRITON_INTERNAL_MODEL_REPO));
+        }
+
+        List<String> entrypointOverride = new ArrayList<>();
+        entrypointOverride.add("tritonserver");
+        entrypointOverride.add("--model-repository=" + TRITON_INTERNAL_MODEL_REPO);
+        entrypointOverride.add("--model-control-mode=explicit");
+        if (!this.options.getBackendsConfigs().isEmpty()) {
+            this.options.getBackendsConfigs().forEach(config -> entrypointOverride.add("--backend-config=" + config));
+        }
+        builder.setEntryPoint(entrypointOverride);
+
+        return builder.build();
+    }
+}

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManager.java
@@ -98,7 +98,10 @@ public class TritonServerContainerManager implements TritonServerInstanceManager
         try {
             String containerID = this.containerOrchestrationService.startContainer(containerConfiguration);
             logger.info("Nvidia Triton Container started. Container ID: {}", containerID);
-        } catch (KuraException | InterruptedException e) {
+        } catch (InterruptedException e) {
+            logger.info("Nvidia Triton Container start interrupted.", e);
+            Thread.currentThread().interrupt();
+        } catch (KuraException e) {
             logger.info("Nvidia Triton Container not started.", e);
         }
     }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
@@ -118,6 +118,23 @@ public class TritonServerContainerManagerTest {
     }
 
     @Test
+    public void stopMethodShouldWorkWhenNotRunning() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonContainerIsNotRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStopIsCalled();
+
+        thenContainerOrchestrationStopContainerWasNotCalled();
+        thenContainerOrchestrationDeleteContainerWasNotCalled();
+    }
+
+    @Test
     public void killMethodShouldWork() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
@@ -369,6 +386,24 @@ public class TritonServerContainerManagerTest {
         try {
             verify(this.orc, never()).startContainer((ContainerConfiguration) any(Object.class));
         } catch (KuraException | InterruptedException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    private void thenContainerOrchestrationStopContainerWasNotCalled() {
+        try {
+            verify(this.orc, never()).stopContainer(any(String.class));
+        } catch (KuraException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    private void thenContainerOrchestrationDeleteContainerWasNotCalled() {
+        try {
+            verify(this.orc, never()).deleteContainer(any(String.class));
+        } catch (KuraException e) {
             e.printStackTrace();
             fail();
         }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
@@ -217,6 +217,24 @@ public class TritonServerContainerManagerTest {
     }
 
     @Test
+    public void startMethodShouldWorkWhenAlreadyRunning() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonImageIsAvailable();
+        givenTritonContainerIsRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenContainerOrchestrationStartContainerWasNotCalled();
+    }
+
+    @Test
     public void containerManagerShouldUseDecryptionFolderIfPasswordIsSet() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
@@ -152,6 +152,23 @@ public class TritonServerContainerManagerTest {
     }
 
     @Test
+    public void startMethodShouldWorkWhenOrchestratorNotConnected() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenOrchestratorIsNotConnected();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenContainerOrchestrationStartContainerWasNotCalled();
+    }
+
+    @Test
     public void startMethodShouldWorkIfImageIsNotAvailable() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
@@ -1,0 +1,428 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.ai.triton.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.container.orchestration.ContainerConfiguration;
+import org.eclipse.kura.container.orchestration.ContainerInstanceDescriptor;
+import org.eclipse.kura.container.orchestration.ContainerOrchestrationService;
+import org.eclipse.kura.container.orchestration.ContainerState;
+import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+public class TritonServerContainerManagerTest {
+
+    private static final String TRITON_IMAGE_NAME = "tritonserver";
+    private static final String TRITON_IMAGE_TAG = "latest";
+    private static final String TRITON_INTERNAL_MODEL_REPO = "/models";
+    private static final String MOCK_DECRYPT_FOLDER = "testDecryptionFolder";
+    private static final String TRITON_CONTAINER_NAME = "tritonserver-kura";
+    private static final String TRITON_CONTAINER_ID = "tritonserver-kura-ID";
+    private static final String TRITON_REPOSITORY_PATH = "/path/to/repository";
+
+    private Map<String, Object> properties = new HashMap<>();
+    private TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
+
+    private ContainerOrchestrationService orc;
+    private TritonServerContainerManager manager;
+
+    @Captor
+    ArgumentCaptor<ContainerConfiguration> configurationCaptor = ArgumentCaptor.forClass(ContainerConfiguration.class);
+    private ContainerConfiguration capturedContainerConfig;
+
+    @Test
+    public void isServerRunningWorksWhenNotRunning() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonContainerIsNotRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        thenServerIsRunningReturns(false);
+    }
+
+    @Test
+    public void isServerRunningWorksWhenRunning() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonContainerIsRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        thenServerIsRunningReturns(true);
+    }
+
+    @Test
+    public void isServerRunningWorksWhenOrchestratorNotConnected() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenOrchestratorIsNotConnected();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        thenServerIsRunningReturns(false);
+    }
+
+    @Test
+    public void stopMethodShouldWork() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonContainerIsRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStopIsCalled();
+
+        thenContainerOrchestrationStopContainerWasCalledWith(TRITON_CONTAINER_ID);
+        thenContainerOrchestrationDeleteContainerWasCalledWith(TRITON_CONTAINER_ID);
+    }
+
+    @Test
+    public void killMethodShouldWork() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonContainerIsRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenKillIsCalled();
+
+        thenContainerOrchestrationStopContainerWasCalledWith(TRITON_CONTAINER_ID);
+        thenContainerOrchestrationDeleteContainerWasCalledWith(TRITON_CONTAINER_ID);
+    }
+
+    @Test
+    public void startMethodShouldWorkIfImageIsNotAvailable() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonImageIsNotAvailable();
+        givenTritonContainerIsNotRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenContainerOrchestrationStartContainerWasNotCalled();
+    }
+
+    @Test
+    public void startMethodShouldWorkIfImageIsAvailable() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonImageIsAvailable();
+        givenTritonContainerIsNotRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenContainerOrchestrationStartContainerWasCalled();
+        thenContainerConfigurationIsFrameworkManaged(true);
+        thenContainerConfigurationPortsEquals(Arrays.asList(4000, 4001, 4002));
+        thenContainerConfigurationImageEquals(TRITON_IMAGE_NAME);
+        thenContainerConfigurationImageTagEquals(TRITON_IMAGE_TAG);
+        thenContainerConfigurationNameEquals(TRITON_CONTAINER_NAME);
+        thenContainerConfigurationVolumesEquals(
+                Collections.singletonMap(TRITON_REPOSITORY_PATH, TRITON_INTERNAL_MODEL_REPO));
+        thenContainerConfigurationEntrypointOverrideContains("--model-control-mode=explicit");
+
+        thenContainerConfigurationMemoryIsPresent(false);
+        thenContainerConfigurationCpusIsPresent(false);
+        thenContainerConfigurationGpusIsPresent(false);
+    }
+
+    @Test
+    public void containerManagerShouldUseDecryptionFolderIfPasswordIsSet() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
+        givenPropertyWith("local.model.repository.password", "hutini");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonImageIsAvailable();
+        givenTritonContainerIsNotRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenContainerOrchestrationStartContainerWasCalled();
+        thenContainerConfigurationVolumesEquals(
+                Collections.singletonMap(MOCK_DECRYPT_FOLDER, TRITON_INTERNAL_MODEL_REPO));
+    }
+
+    @Test
+    public void containerDeviceRuntimeOptionsAreCorrectlySet() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("container.memory", "7g");
+        givenPropertyWith("container.cpus", 1.5F);
+        givenPropertyWith("container.gpus", "all");
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonImageIsAvailable();
+        givenTritonContainerIsNotRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenContainerOrchestrationStartContainerWasCalled();
+
+        thenContainerConfigurationMemoryIsPresent(true);
+        thenContainerConfigurationMemoryEquals(7516192768L);
+
+        thenContainerConfigurationCpusIsPresent(true);
+        thenContainerConfigurationCpusEquals(1.5F);
+
+        thenContainerConfigurationGpusIsPresent(true);
+        thenContainerConfigurationGpusEquals("all");
+    }
+
+    @Test
+    public void containerBackendConfigOptionsAreCorrectlySet() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("local.backends.config", "testConfiguration");
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonImageIsAvailable();
+        givenTritonContainerIsNotRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenContainerOrchestrationStartContainerWasCalled();
+        thenContainerConfigurationIsFrameworkManaged(true);
+        thenContainerConfigurationPortsEquals(Arrays.asList(4000, 4001, 4002));
+        thenContainerConfigurationImageEquals(TRITON_IMAGE_NAME);
+        thenContainerConfigurationEntrypointOverrideContains("--backend-config=testConfiguration");
+    }
+
+    /*
+     * Given
+     */
+    private void givenPropertyWith(String name, Object value) {
+        this.properties.put(name, value);
+    }
+
+    private void givenServiceOptionsBuiltWith(Map<String, Object> properties) {
+        this.options = new TritonServerServiceOptions(properties);
+    }
+
+    private void givenMockContainerOrchestrationService() {
+        this.orc = mock(ContainerOrchestrationService.class);
+    }
+
+    private void givenTritonImageIsAvailable() {
+        ImageInstanceDescriptor imageDescriptor = mock(ImageInstanceDescriptor.class);
+        when(imageDescriptor.getImageName()).thenReturn(TRITON_IMAGE_NAME);
+        when(imageDescriptor.getImageTag()).thenReturn(TRITON_IMAGE_TAG);
+
+        when(this.orc.listImageInstanceDescriptors()).thenReturn(Arrays.asList(imageDescriptor));
+    }
+
+    private void givenTritonImageIsNotAvailable() {
+        when(this.orc.listImageInstanceDescriptors()).thenReturn(Arrays.asList());
+    }
+
+    private void givenOrchestratorIsNotConnected() {
+        when(this.orc.listImageInstanceDescriptors()).thenThrow(new IllegalStateException());
+    }
+
+    private void givenTritonContainerIsRunning() {
+        ContainerInstanceDescriptor runningContainer = mock(ContainerInstanceDescriptor.class);
+        when(runningContainer.getContainerName()).thenReturn(TRITON_CONTAINER_NAME);
+        when(runningContainer.getContainerId()).thenReturn(TRITON_CONTAINER_ID);
+        when(runningContainer.getContainerState()).thenReturn(ContainerState.ACTIVE);
+        when(runningContainer.getContainerImage()).thenReturn(TRITON_IMAGE_NAME);
+        when(runningContainer.getContainerImageTag()).thenReturn(TRITON_IMAGE_TAG);
+
+        when(this.orc.listContainerDescriptors()).thenReturn(Arrays.asList(runningContainer));
+    }
+
+    private void givenTritonContainerIsNotRunning() {
+        when(this.orc.listContainerDescriptors()).thenReturn(Arrays.asList());
+    }
+
+    private void givenLocalManagerBuiltWith(TritonServerServiceOptions options, ContainerOrchestrationService orc,
+            String decryptionFolder) {
+        this.manager = new TritonServerContainerManager(options, orc, decryptionFolder);
+    }
+
+    /*
+     * When
+     */
+    private void whenKillIsCalled() {
+        this.manager.kill();
+    }
+
+    private void whenStopIsCalled() {
+        this.manager.stop();
+    }
+
+    private void whenStartIsCalled() {
+        this.manager.start();
+
+        try {
+            // Wait for monitor thread to do its job
+            Thread.sleep(10);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            fail();
+        }
+    }
+
+    /*
+     * Then
+     */
+    private void thenServerIsRunningReturns(boolean expectedState) {
+        assertEquals(expectedState, this.manager.isServerRunning());
+    }
+
+    private void thenContainerOrchestrationStopContainerWasCalledWith(String containerID) {
+        try {
+            verify(this.orc, times(1)).stopContainer(containerID);
+        } catch (KuraException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    private void thenContainerOrchestrationDeleteContainerWasCalledWith(String containerID) {
+        try {
+            verify(this.orc, times(1)).deleteContainer(containerID);
+        } catch (KuraException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    private void thenContainerOrchestrationStartContainerWasCalled() {
+        try {
+            verify(this.orc, times(1)).startContainer(configurationCaptor.capture());
+            this.capturedContainerConfig = configurationCaptor.getValue();
+        } catch (KuraException | InterruptedException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    private void thenContainerOrchestrationStartContainerWasNotCalled() {
+        try {
+            verify(this.orc, never()).startContainer((ContainerConfiguration) any(Object.class));
+        } catch (KuraException | InterruptedException e) {
+            e.printStackTrace();
+            fail();
+        }
+    }
+
+    private void thenContainerConfigurationImageEquals(String expectedImage) {
+        assertEquals(expectedImage, this.capturedContainerConfig.getContainerImage());
+    }
+
+    private void thenContainerConfigurationImageTagEquals(String expectedImageTag) {
+        assertEquals(expectedImageTag, this.capturedContainerConfig.getContainerImageTag());
+    }
+
+    private void thenContainerConfigurationNameEquals(String expectedContainerName) {
+        assertEquals(expectedContainerName, this.capturedContainerConfig.getContainerName());
+    }
+
+    private void thenContainerConfigurationPortsEquals(List<Integer> expectedPorts) {
+        assertEquals(expectedPorts, this.capturedContainerConfig.getContainerPortsExternal());
+    }
+
+    private void thenContainerConfigurationVolumesEquals(Map<String, String> expectedVolumes) {
+        assertEquals(expectedVolumes, this.capturedContainerConfig.getContainerVolumes());
+    }
+
+    private void thenContainerConfigurationMemoryIsPresent(boolean expectedResult) {
+        assertEquals(expectedResult, this.capturedContainerConfig.getMemory().isPresent());
+    }
+
+    private void thenContainerConfigurationMemoryEquals(Long expectedMemory) {
+        assertEquals(expectedMemory, this.capturedContainerConfig.getMemory().get());
+    }
+
+    private void thenContainerConfigurationCpusIsPresent(boolean expectedResult) {
+        assertEquals(expectedResult, this.capturedContainerConfig.getCpus().isPresent());
+    }
+
+    private void thenContainerConfigurationCpusEquals(Float expectedCpus) {
+        assertEquals(expectedCpus, this.capturedContainerConfig.getCpus().get());
+    }
+
+    private void thenContainerConfigurationGpusIsPresent(boolean expectedResult) {
+        assertEquals(expectedResult, this.capturedContainerConfig.getGpus().isPresent());
+    }
+
+    private void thenContainerConfigurationGpusEquals(String expectedGpus) {
+        assertEquals(expectedGpus, this.capturedContainerConfig.getGpus().get());
+    }
+
+    private void thenContainerConfigurationIsFrameworkManaged(boolean expectedResult) {
+        assertEquals(expectedResult, this.capturedContainerConfig.isFrameworkManaged());
+    }
+
+    private void thenContainerConfigurationEntrypointOverrideContains(String expectedString) {
+        assertTrue(this.capturedContainerConfig.getEntryPoint().contains(expectedString));
+    }
+}

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
@@ -187,6 +187,24 @@ public class TritonServerContainerManagerTest {
     }
 
     @Test
+    public void startMethodShouldWorkIfImageIsAvailableWithDifferentTag() {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenServiceOptionsBuiltWith(properties);
+
+        givenMockContainerOrchestrationService();
+        givenTritonImageWithDifferentTagIsAvailable();
+        givenTritonContainerIsNotRunning();
+        givenLocalManagerBuiltWith(this.options, this.orc, MOCK_DECRYPT_FOLDER);
+
+        whenStartIsCalled();
+
+        thenContainerOrchestrationStartContainerWasNotCalled();
+    }
+
+    @Test
     public void startMethodShouldWorkIfImageIsAvailable() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
@@ -327,6 +345,14 @@ public class TritonServerContainerManagerTest {
         ImageInstanceDescriptor imageDescriptor = mock(ImageInstanceDescriptor.class);
         when(imageDescriptor.getImageName()).thenReturn(TRITON_IMAGE_NAME);
         when(imageDescriptor.getImageTag()).thenReturn(TRITON_IMAGE_TAG);
+
+        when(this.orc.listImageInstanceDescriptors()).thenReturn(Arrays.asList(imageDescriptor));
+    }
+
+    private void givenTritonImageWithDifferentTagIsAvailable() {
+        ImageInstanceDescriptor imageDescriptor = mock(ImageInstanceDescriptor.class);
+        when(imageDescriptor.getImageName()).thenReturn(TRITON_IMAGE_NAME);
+        when(imageDescriptor.getImageTag()).thenReturn("py3-min");
 
         when(this.orc.listImageInstanceDescriptors()).thenReturn(Arrays.asList(imageDescriptor));
     }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
@@ -319,6 +319,7 @@ public class TritonServerContainerManagerTest {
 
     private void givenOrchestratorIsNotConnected() {
         when(this.orc.listImageInstanceDescriptors()).thenThrow(new IllegalStateException());
+        when(this.orc.listContainerDescriptors()).thenThrow(new IllegalStateException());
     }
 
     private void givenTritonContainerIsRunning() {


### PR DESCRIPTION
This PR adds the new `TritonServerContainerManager` class required by the upcoming Triton Server Service component. This class is responsible for managing the lifecycle of the Triton container.

This element is responsible for:
- Starting the Triton container
- Configuring the container mapping volumes, ports and setting the correct entrypoint override
- Stopping the Triton container
- Checking whether it's running

> ⚠️ At this point this class **won't handle the Triton container image download** nor **the connection/disconnection between Kura and the Docker daemon**.

As of this PR, this class is not used by any component. It will be once the Triton Server Container Service will be added to the codebase.

![image](https://user-images.githubusercontent.com/22748355/183579842-eb07ad51-bf06-4c01-896b-484c9e856325.png)
Highlighted green the component available with this PR
Highlighted red the upcoming components

This PR is a requirement for the upcoming Container Triton Server Service component discussed in https://github.com/eclipse/kura/pull/4064