### PR TITLE
feat(ai.triton.server): add Container Triton Server Service component

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerContainerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerContainerService.xml
@@ -20,8 +20,7 @@
 
         <AD id="container.image"
             name="Image name"
-            description="The image the container will be created with. The value will need to be expressed in the form registryURL/imagename in case of a custom registry.
-            Please fill the following registry credentials in case of pulling from a custom or authenticated Docker hub registry."
+            description="The image the container will be created with."
             type="String"
             cardinality="1"
             required="true"
@@ -29,7 +28,7 @@
         </AD>
 
         <AD id="container.image.tag" name="Image tag"
-            description="Describes which image version that should be pulled from the container registry."
+            description="Describes which image version that should be used for creating the container."
             type="String"
             cardinality="1"
             required="true"

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerContainerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerContainerService.xml
@@ -117,7 +117,7 @@
             required="false"
             min="1"
             max="3600"
-            default="3"
+            default="10"
             description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout, the operation will be terminated with an error.">
         </AD>
 

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerContainerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/metatype/org.eclipse.kura.ai.triton.server.TritonServerContainerService.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
+
+-->
+<MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
+    <OCD id="org.eclipse.kura.ai.triton.server.TritonServerContainerService"
+         name="Nvidia Triton Server"
+         description="Configuration for the Local Container Nvidia Triton Server">
+
+        <AD id="container.image"
+            name="Image name"
+            description="The image the container will be created with. The value will need to be expressed in the form registryURL/imagename in case of a custom registry.
+            Please fill the following registry credentials in case of pulling from a custom or authenticated Docker hub registry."
+            type="String"
+            cardinality="1"
+            required="true"
+            default="nvcr.io/nvidia/tritonserver">
+        </AD>
+
+        <AD id="container.image.tag" name="Image tag"
+            description="Describes which image version that should be pulled from the container registry."
+            type="String"
+            cardinality="1"
+            required="true"
+            default="latest">
+        </AD>
+
+        <AD id="server.ports"
+            name="Nvidia Triton Server ports"
+            type="Integer"
+            cardinality="3"
+            min="1024"
+            max="65535"
+            required="true"
+            default="4000,4001,4002"
+            description="The ports used to connect to the server for HTTP, GPRC and Metrics services.">
+        </AD>
+
+        <AD id="local.model.repository.path"
+            name="Local model repository path"
+            type="String"
+            cardinality="0"
+            required="true"
+            default=""
+            description="Specify the path on the filesystem where the models are stored.">
+       </AD>
+
+       <AD id="local.model.repository.password"
+            name="Local model decryption password"
+            type="Password"
+            cardinality="0"
+            required="false"
+            default=""
+            description="Specify the password to be used for decrypting models stored in the model repository. If none is specified, models are supposed to be plaintext.">
+       </AD>
+
+        <AD id="models"
+            name="Inference Models"
+            type="String"
+            cardinality="0"
+            required="false"
+            default=""
+            description="A comma separated list of inference model names that the server will load.">
+        </AD>
+
+        <AD id="local.backends.config"
+            name="Optional configuration for the local backends"
+            type="String"
+            cardinality="0"
+            required="false"
+            default=""
+            description="A semi-colon separated list of configuration for the backends. i.e. tensorflow,version=2;tensorflow,allow-soft-placement=false">
+        </AD>
+
+        <AD id="container.memory"
+            name="Memory"
+            description="The maximum amount of memory the container can use in bytes. Set it as a positive integer, optionally followed by a suffix of b, k, m, g, to indicate bytes, kilobytes, megabytes, or gigabytes.
+            The minimum allowed value is platform dependent (i.e. 6m). If left empty, the memory assigned to the container will be set to a default value by the native container orchestrator."
+            type="String"
+            cardinality="0"
+            required="false"
+            default="">
+        </AD>
+
+        <AD id="container.cpus"
+            name="CPUs"
+            description="Specify how many CPUs the Triton container can use. Decimal values are allowed, so if set to 1.5, the container will use at most one and a half cpu resource."
+            type="Float"
+            cardinality="0"
+            required="false"
+            default="">
+        </AD>
+
+        <AD id="container.gpus"
+            name="GPUs"
+            description="Specify how many Nvidia GPUs the Triton container can use. Allowed values are 'all' or an integer number. If there's no Nvidia GPU installed, leave the field empty."
+            type="String"
+            cardinality="1"
+            required="false"
+            default="">
+        </AD>
+
+        <AD id="timeout"
+            name="Timeout (in seconds) for time consuming tasks"
+            type="Integer"
+            cardinality="0"
+            required="false"
+            min="1"
+            max="3600"
+            default="3"
+            description="Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout, the operation will be terminated with an error.">
+        </AD>
+
+        <AD id="grpc.max.size"
+            name="Max. GRPC message size (bytes)"
+            type="Integer"
+            description="Maximum accepted input size for the GRPC calls.
+            Increase this value if the model input size is bigger than the default."
+            cardinality="0"
+            required="true"
+            default="4194304"
+            min="1">
+        </AD>
+
+    </OCD>
+    <Designate factoryPid="org.eclipse.kura.ai.triton.server.TritonServerContainerService">
+        <Object ocdref="org.eclipse.kura.ai.triton.server.TritonServerContainerService"/>
+    </Designate>
+</MetaData>

--- a/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/org.eclipse.kura.ai.triton.server.TritonServerContainerService.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/OSGI-INF/org.eclipse.kura.ai.triton.server.TritonServerContainerService.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+   Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+   This program and the accompanying materials are made
+   available under the terms of the Eclipse Public License 2.0
+   which is available at https://www.eclipse.org/legal/epl-2.0/
+
+	SPDX-License-Identifier: EPL-2.0
+
+	Contributors:
+	 Eurotech
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.ai.triton.server.TritonServerContainerService">
+   <implementation class="org.eclipse.kura.ai.triton.server.TritonServerServiceContainerImpl"/>
+   <service>
+      <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
+      <provide interface="org.eclipse.kura.ai.inference.InferenceEngineService"/>
+   </service>
+   <property name="service.pid" type="String" value="org.eclipse.kura.ai.triton.server.TritonServerContainerService"/>
+   <reference bind="setCommandExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static" />
+   <reference bind="setCryptoService" cardinality="1..1" interface="org.eclipse.kura.crypto.CryptoService" name="CryptoService" policy="static"/>
+   <reference bind="setContainerOrchestrationService" cardinality="1..1" interface="org.eclipse.kura.container.orchestration.ContainerOrchestrationService" name="ContainerOrchestrationService" policy="static"/>
+</scr:component>

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
@@ -93,7 +93,7 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
         this.commandExecutorService = executorService;
     }
 
-    public void setContainerOrchestratorService(ContainerOrchestrationService containerOrchestrationService) {
+    public void setContainerOrchestrationService(ContainerOrchestrationService containerOrchestrationService) {
         this.containerOrchestrationService = containerOrchestrationService;
     }
 

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImpl.java
@@ -1,0 +1,30 @@
+package org.eclipse.kura.ai.triton.server;
+
+import org.eclipse.kura.container.orchestration.ContainerOrchestrationService;
+import org.eclipse.kura.executor.CommandExecutorService;
+
+public class TritonServerServiceContainerImpl extends TritonServerServiceAbs {
+
+    @Override
+    TritonServerInstanceManager createInstanceManager(TritonServerServiceOptions options,
+            CommandExecutorService executorService, ContainerOrchestrationService orchestrationService,
+            String decryptionFolderPath) {
+        return new TritonServerContainerManager(options, orchestrationService, decryptionFolderPath);
+    }
+
+    @Override
+    boolean isConfigurationValid() {
+        return !isNullOrEmpty(this.options.getModelRepositoryPath()) && !isNullOrEmpty(this.options.getContainerImage())
+                && !isNullOrEmpty(this.options.getContainerImageTag());
+    }
+
+    @Override
+    boolean isModelEncryptionEnabled() {
+        return this.options.isModelEncryptionPasswordSet();
+    }
+
+    @Override
+    String getServerAddress() {
+        return "localhost";
+    }
+}

--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImpl.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImpl.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.ai.triton.server;
 
 import org.eclipse.kura.container.orchestration.ContainerOrchestrationService;

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
@@ -49,7 +49,7 @@ public class TritonServerServiceContainerImplTest extends TritonServerServiceSte
     @Test
     public void isConfigurationValidWorksWithInvalidImageTag() throws IOException {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
-        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("container.image.tag", null);
         givenPropertyWith("local.model.repository.path", "/fake-repository-path");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenTritonServerServiceContainerImpl(this.properties);

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
@@ -49,7 +49,7 @@ public class TritonServerServiceContainerImplTest extends TritonServerServiceSte
     @Test
     public void isConfigurationValidWorksWithInvalidImageTag() throws IOException {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
-        givenPropertyWith("container.image.tag", null);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", "/fake-repository-path");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenTritonServerServiceContainerImpl(this.properties);
@@ -60,7 +60,7 @@ public class TritonServerServiceContainerImplTest extends TritonServerServiceSte
     @Test
     public void isConfigurationValidWorksWithInvalidModelRepository() throws IOException {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
-        givenPropertyWith("container.image.tag", null);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", "");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenTritonServerServiceContainerImpl(this.properties);
@@ -71,8 +71,8 @@ public class TritonServerServiceContainerImplTest extends TritonServerServiceSte
     @Test
     public void isModelEncryptionEnabledWorkWithContainerConfiguration() throws IOException {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
-        givenPropertyWith("container.image.tag", null);
-        givenPropertyWith("local.model.repository.path", "");
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", "/fake-repository-path");
         givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenTritonServerServiceContainerImpl(this.properties);
 
@@ -82,9 +82,9 @@ public class TritonServerServiceContainerImplTest extends TritonServerServiceSte
     @Test
     public void isModelEncryptionEnabledWorksWhenPasswordIsSet() throws IOException {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
-        givenPropertyWith("container.image.tag", null);
-        givenPropertyWith("local.model.repository.path", "");
-        givenPropertyWith("", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", "/fake-repository-path");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
         givenPropertyWith("local.model.repository.password", "keyboards");
         givenTritonServerServiceContainerImpl(this.properties);
 

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
@@ -69,7 +69,7 @@ public class TritonServerServiceContainerImplTest extends TritonServerServiceSte
     }
 
     @Test
-    public void isModelEncryptionEnabledWorkWithContainerConfiguration() throws IOException {
+    public void isModelEncryptionEnabledWorkWhenPasswordIsNotSet() throws IOException {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", "/fake-repository-path");

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
@@ -1,0 +1,100 @@
+package org.eclipse.kura.ai.triton.server;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class TritonServerServiceContainerImplTest extends TritonServerServiceStepDefinitions {
+
+    private Map<String, Object> properties = new HashMap<>();
+
+    @Test
+    public void isConfigurationValidWorksWithContainerConfiguration() throws IOException {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", "/fake-repository-path");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenTritonServerServiceContainerImpl(this.properties);
+
+        thenIsConfigurationValidReturns(true);
+    }
+
+    @Test
+    public void isConfigurationValidWorksWithInvalidImage() throws IOException {
+        givenPropertyWith("container.image", null);
+        givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
+        givenPropertyWith("local.model.repository.path", "/fake-repository-path");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenTritonServerServiceContainerImpl(this.properties);
+
+        thenIsConfigurationValidReturns(false);
+    }
+
+    @Test
+    public void isConfigurationValidWorksWithInvalidImageTag() throws IOException {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", null);
+        givenPropertyWith("local.model.repository.path", "/fake-repository-path");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenTritonServerServiceContainerImpl(this.properties);
+
+        thenIsConfigurationValidReturns(false);
+    }
+
+    @Test
+    public void isConfigurationValidWorksWithInvalidModelRepository() throws IOException {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", null);
+        givenPropertyWith("local.model.repository.path", "");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenTritonServerServiceContainerImpl(this.properties);
+
+        thenIsConfigurationValidReturns(false);
+    }
+
+    @Test
+    public void isModelEncryptionEnabledWorkWithContainerConfiguration() throws IOException {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", null);
+        givenPropertyWith("local.model.repository.path", "");
+        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenTritonServerServiceContainerImpl(this.properties);
+
+        thenIsModelEncryptionEnabled(false);
+    }
+
+    @Test
+    public void isModelEncryptionEnabledWorksWhenPasswordIsSet() throws IOException {
+        givenPropertyWith("container.image", TRITON_IMAGE_NAME);
+        givenPropertyWith("container.image.tag", null);
+        givenPropertyWith("local.model.repository.path", "");
+        givenPropertyWith("", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("local.model.repository.password", "keyboards");
+        givenTritonServerServiceContainerImpl(this.properties);
+
+        thenIsModelEncryptionEnabled(true);
+    }
+
+    /*
+     * Given
+     */
+    private void givenPropertyWith(String name, Object value) {
+        this.properties.put(name, value);
+    }
+
+    /*
+     * Then
+     */
+    private void thenIsConfigurationValidReturns(boolean expectedValue) {
+        assertEquals(expectedValue, this.tritonServerService.isConfigurationValid());
+    }
+
+    private void thenIsModelEncryptionEnabled(boolean expectedValue) {
+        assertEquals(expectedValue, this.tritonServerService.isModelEncryptionEnabled());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerServiceContainerImplTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.ai.triton.server;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
This is the last step towards the deprecation of the current `TritonServerServiceImpl` class following #4064 

The purpose of this PR is to add the `TritonServerContainerService` Factory Components which exposes the same functionalities as the `TritonServerService` using a containerized Triton Server instance.

See UML for reference:
![image](https://user-images.githubusercontent.com/22748355/183685488-2511377f-5637-4471-8013-2b73150c9ef3.png)

Highlighted green the component available with this PR

Coming soon™ (in the upcoming PRs):
- [X] `TritonServerRemoteServiceImpl` which will expose the `TritonServerRemoteService` factory component with relative metatype
- [X] `TritonServerNativeServiceImpl` which will expose the `TritonServerNativeService` factory component with relative metatype
- [X] `TritonServerServiceOrigImpl` deprecation in favour of the new factory components
- [X] `TritonServerContainerServiceImpl` which will expose the `TritonServerContainerService` factory component with relative metatype

### Limitations:
- If the container image of the Triton server is not available on disk it won't be downloaded and an error will be logged
- If Kura is not connected to the Docker daemon an error will be logged and no further attempts to start the container will be performed
- If Kura disconnects from the Docker daemon while the Triton Server container is running, the container won't be shut down.