### PR TITLE
fix(net.admin): Fixed cellular interface name in nat rules

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/FirewallAutoNatConfigWriter.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/FirewallAutoNatConfigWriter.java
@@ -21,6 +21,7 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.net.AbstractNetInterface;
 import org.eclipse.kura.core.net.NetworkConfiguration;
 import org.eclipse.kura.core.net.NetworkConfigurationVisitor;
+import org.eclipse.kura.core.net.modem.ModemInterfaceConfigImpl;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.linux.net.iptables.LinuxFirewall;
 import org.eclipse.kura.linux.net.iptables.NATRule;
@@ -74,7 +75,7 @@ public class FirewallAutoNatConfigWriter implements NetworkConfigurationVisitor 
             // get relevant interfaces
             for (NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig : networkConfig
                     .getNetInterfaceConfigs()) {
-                String interfaceName = netInterfaceConfig.getName();
+                String interfaceName = getInterfaceName(netInterfaceConfig);
                 NetInterfaceStatus status = NetInterfaceStatus.netIPv4StatusUnknown;
                 boolean isNat = false;
 
@@ -109,5 +110,13 @@ public class FirewallAutoNatConfigWriter implements NetworkConfigurationVisitor 
         }
 
         return natConfigs;
+    }
+
+    private String getInterfaceName(NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig) {
+        if (netInterfaceConfig instanceof ModemInterfaceConfigImpl) {
+            return "ppp" + ((ModemInterfaceConfigImpl) netInterfaceConfig).getPppNum();
+        } else {
+            return netInterfaceConfig.getName();
+        }
     }
 }


### PR DESCRIPTION

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR fixes the cellular interface names in nat rules.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** When a internet connection is shared between a cellular connection and a wifi or ethernet one, some nat rules are added to the firewall. In these rules, the ppp interface name was wrong: it uses the usb path instead of the ppp name. This PR fixes this wrong behavior.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>