### PR TITLE
fix: Fixed SSLManager service truststore unset method

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
@@ -137,7 +137,7 @@ public class SslManagerServiceImpl implements SslManagerService, ConfigurableCom
     }
 
     public void unsetTruststoreKeystoreService(KeystoreService keystoreService) {
-        if (this.keystoreService == truststoreKeystoreService) {
+        if (this.truststoreKeystoreService == keystoreService) {
 
             this.truststoreKeystoreService = null;
             this.truststoreKeystoreServicePid = Optional.empty();


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Fixed issue with SSLManagerService unset method