### PR TITLE
fix: Fixed SSLManager service truststore unset method (#4118) [backport release-5.2.0]

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/ssl/SslManagerServiceImpl.java
@@ -137,7 +137,7 @@ public class SslManagerServiceImpl implements SslManagerService, ConfigurableCom
     }
 
     public void unsetTruststoreKeystoreService(KeystoreService keystoreService) {
-        if (this.keystoreService == truststoreKeystoreService) {
+        if (this.truststoreKeystoreService == keystoreService) {
 
             this.truststoreKeystoreService = null;
             this.truststoreKeystoreServicePid = Optional.empty();


### PR DESCRIPTION
* fix: Fixed SSLManager service truststore unset method

Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

* test: Added test for truststore unset

Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
