### PR TITLE
fix(ai.triton.server): Added grpc channel termination waiting

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerServiceAbs.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.eclipse.kura.KuraException;
@@ -142,6 +143,15 @@ public abstract class TritonServerServiceAbs implements InferenceEngineService, 
         logger.info("Deactivate TritonServerService...");
         stopManagedInstance();
         this.grpcChannel.shutdownNow();
+        try {
+            boolean isTerminated = this.grpcChannel.awaitTermination(5, TimeUnit.SECONDS);
+            if (!isTerminated) {
+                logger.warn("Unable to terminate grpc channel gracefully");
+            }
+        } catch (InterruptedException e) {
+            logger.warn("Unable to terminate grpc channel gracefully", e);
+            Thread.currentThread().interrupt();
+        }
     }
 
     private void startManagedInstance() {


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Added grpc channel termination waiting with with a 5 seconds time limit.
