### PR TITLE
fix(linux.position): changed onLockStatusChanged listeners notification logic

### DIFF
--- a/kura/org.eclipse.kura.linux.position/src/main/java/org/eclipse/kura/linux/position/GpsDevice.java
+++ b/kura/org.eclipse.kura.linux.position/src/main/java/org/eclipse/kura/linux/position/GpsDevice.java
@@ -210,20 +210,13 @@ public class GpsDevice {
             }
 
             final boolean isLastPositionValid = GpsDevice.this.nmeaParser.isValidPosition();
+            boolean isCurrentPositionValid = false;
 
             try {
-                final boolean isValid;
-
                 synchronized (this) {
-                    isValid = GpsDevice.this.nmeaParser.parseSentence(sentence);
+                    isCurrentPositionValid = GpsDevice.this.nmeaParser.parseSentence(sentence);
                     GpsDevice.this.lastSentence = sentence;
                 }
-
-                if (isValid != isLastPositionValid && GpsDevice.this.listener != null) {
-                    GpsDevice.this.listener.onLockStatusChanged(isValid);
-                    logger.info("{}", GpsDevice.this);
-                }
-
             } catch (ParseException e) {
                 final Code code = e.getCode();
                 if (code == Code.BAD_CHECKSUM) {
@@ -235,6 +228,14 @@ public class GpsDevice {
                 }
             } catch (Exception e) {
                 logger.warn("Unexpected exception parsing NMEA sentence", e);
+            }
+
+            if (isCurrentPositionValid != isLastPositionValid && GpsDevice.this.listener != null) {
+                GpsDevice.this.listener.onLockStatusChanged(isCurrentPositionValid);
+
+                if (isCurrentPositionValid) {
+                    logger.info("{}", GpsDevice.this);
+                }
             }
         }
 

--- a/kura/org.eclipse.kura.linux.position/src/main/java/org/eclipse/kura/linux/position/PositionServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.position/src/main/java/org/eclipse/kura/linux/position/PositionServiceImpl.java
@@ -247,10 +247,10 @@ public class PositionServiceImpl
 
     private void setLock(boolean hasLock) {
         if (hasLock && !this.hasLock) {
-            logger.debug("posting PositionLockedEvent");
+            logger.info("Position locked.");
             this.eventAdmin.postEvent(new PositionLockedEvent(Collections.emptyMap()));
         } else if (!hasLock && this.hasLock) {
-            logger.debug("posting PositionLostEvent");
+            logger.info("Position fix lost.");
             this.eventAdmin.postEvent(new PositionLostEvent(Collections.emptyMap()));
         }
         this.hasLock = hasLock;


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

`onLockStatusChanged` was never called when an exception occurred. Using a serial provider, a parsing exception is an indicator of position fix loss.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
