### PR TITLE
fix(core.configuration): default values of metatype are always splitted in array before parsing [backport 5.2.0]

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/metatype/Tad.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/metatype/Tad.java
@@ -343,10 +343,13 @@ public class Tad implements AD {
 
     /**
      * Sets the value of the default property.
+     * Commas ',' need to be escaped with '\' if not intended to separate
+     * elements of the array.
      *
      * @param value
      *            allowed object is
-     *            {@link String }
+     *            {@link String }.
+     *            If cardinality = n > 1 is specified, then must contain at most n String elements separated by ','.
      *
      */
     public void setDefault(String value) {

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
@@ -360,16 +360,10 @@ public class ComponentUtil {
         Object[] objectValues = null;
         Scalar type = attrDef.getType();
         if (type != null) {
-
-            // split the default value in separate string
-            // if cardinality is greater than 0 or abs(1)
-            String[] defaultValues = new String[] { defaultValue };
-            int cardinality = attrDef.getCardinality();
-            if (cardinality != 0 && cardinality != 1 && cardinality != -1) {
-                defaultValues = StringUtil.splitValues(defaultValue);
-            }
+            String[] defaultValues = StringUtil.splitValues(defaultValue);
 
             // convert string values into object values
+            int cardinality = attrDef.getCardinality();
             objectValues = getObjectValue(type, defaultValues, ctx);
             if (objectValues != null && (cardinality == 0 || cardinality == 1 || cardinality == -1)) {
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -364,7 +364,7 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
         tad.setId(FirewallConfiguration.OPEN_PORTS_PROP_NAME);
         tad.setName(FirewallConfiguration.OPEN_PORTS_PROP_NAME);
         tad.setType(Tscalar.STRING);
-        tad.setCardinality(1);
+        tad.setCardinality(0);
         tad.setRequired(true);
         tad.setDefault(FirewallConfiguration.DFLT_OPEN_PORTS_VALUE);
         tad.setDescription(NetworkAdminConfigurationMessages.getMessage(NetworkAdminConfiguration.PLATFORM_INTERFACES));
@@ -374,7 +374,7 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
         tad.setId(FirewallConfiguration.PORT_FORWARDING_PROP_NAME);
         tad.setName(FirewallConfiguration.PORT_FORWARDING_PROP_NAME);
         tad.setType(Tscalar.STRING);
-        tad.setCardinality(1);
+        tad.setCardinality(0);
         tad.setRequired(true);
         tad.setDefault(FirewallConfiguration.DFLT_PORT_FORWARDING_VALUE);
         tad.setDescription(NetworkAdminConfigurationMessages.getMessage(NetworkAdminConfiguration.PLATFORM_INTERFACES));
@@ -384,7 +384,7 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
         tad.setId(FirewallConfiguration.NAT_PROP_NAME);
         tad.setName(FirewallConfiguration.NAT_PROP_NAME);
         tad.setType(Tscalar.STRING);
-        tad.setCardinality(1);
+        tad.setCardinality(0);
         tad.setRequired(true);
         tad.setDefault(FirewallConfiguration.DFLT_NAT_VALUE);
         tad.setDescription(NetworkAdminConfigurationMessages.getMessage(NetworkAdminConfiguration.PLATFORM_INTERFACES));

--- a/kura/org.eclipse.kura.wire.provider/OSGI-INF/metatype/org.eclipse.kura.wire.graph.WireGraphService.xml
+++ b/kura/org.eclipse.kura.wire.provider/OSGI-INF/metatype/org.eclipse.kura.wire.graph.WireGraphService.xml
@@ -23,7 +23,7 @@
             type="String"
             cardinality="0"
             required="true"
-            default="{&quot;components&quot;:[],&quot;wires&quot;:[]}"
+            default="{&quot;components&quot;:[]\,&quot;wires&quot;:[]}"
             description="The default wire graph JSON">
         </AD>
     </OCD>


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Backport for PR https://github.com/eclipse/kura/pull/4128.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
