### PR TITLE
refactor(linux.clock): Increased log level for step event not found in Chrony Sync Provider

### DIFF
--- a/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ChronyClockSyncProvider.java
+++ b/kura/org.eclipse.kura.linux.clock/src/main/java/org/eclipse/kura/linux/clock/ChronyClockSyncProvider.java
@@ -213,7 +213,7 @@ public class ChronyClockSyncProvider implements ClockSyncProvider {
                 logger.debug("No new clock stepping event");
             }
         } else {
-            logger.info("Chrony stepping not found in system journal (may be not requested). {}",
+            logger.debug("Chrony stepping not found in system journal (may be not requested). {}",
                     journalClockUpdateRead.getErrorStream());
         }
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Increased log level for step event not found in Chrony Sync Provider
