### PR TITLE
ci: fix backport job permissions for forks

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled


### PR DESCRIPTION
If a pull request is made from a fork, jobs triggered by the `pull_request` trigger will not have access to a `GITHUB_TOKEN` that has write access. In contrast, jobs triggered by the `pull_request_target` trigger will always have access to a `GITHUB_TOKEN` that has write access, even if the pull request is made from a fork.

This was the cause of recente backport job failures. This PR should fix the issue.
