### PR TITLE
fix(log.filesystem.provider): prevent EOF ending incomplete lines and refactor of parser

### DIFF
--- a/kura/org.eclipse.kura.log.filesystem.provider/src/main/java/org/eclipse/kura/log/filesystem/provider/FilesystemLogProvider.java
+++ b/kura/org.eclipse.kura.log.filesystem.provider/src/main/java/org/eclipse/kura/log/filesystem/provider/FilesystemLogProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2022 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -164,8 +164,8 @@ public class FilesystemLogProvider implements ConfigurableComponent, LogProvider
         private synchronized void notifyListeners(String message, String stacktrace) {
             if (message != null) {
                 for (LogListener listener : FilesystemLogProvider.this.registeredListeners) {
-                    LogEntry entry = KuraLogLineParser.createLogEntry(message, FilesystemLogProvider.this.filePath,
-                            stacktrace);
+                    LogEntry entry = new KuraLogLineParser(message, FilesystemLogProvider.this.filePath, stacktrace)
+                            .createLogEntry();
                     listener.newLogEntry(entry);
                 }
             }

--- a/kura/org.eclipse.kura.log.filesystem.provider/src/main/java/org/eclipse/kura/log/filesystem/provider/KuraLogLineParser.java
+++ b/kura/org.eclipse.kura.log.filesystem.provider/src/main/java/org/eclipse/kura/log/filesystem/provider/KuraLogLineParser.java
@@ -57,7 +57,7 @@ public final class KuraLogLineParser {
         this.stacktrace = stacktrace;
     }
 
-    public static LogEntry createLogEntry(String message, String filepath, String stacktrace) {
+    public static synchronized LogEntry createLogEntry(String message, String filepath, String stacktrace) {
         instance = new KuraLogLineParser(message, filepath, stacktrace);
 
         if (filepath.contains("kura.log")) {

--- a/kura/test/org.eclipse.kura.log.filesystem.provider.test/src/test/java/org/eclipse/kura/log/filesystem/provider/KuraLogLineParserTest.java
+++ b/kura/test/org.eclipse.kura.log.filesystem.provider.test/src/test/java/org/eclipse/kura/log/filesystem/provider/KuraLogLineParserTest.java
@@ -158,7 +158,7 @@ public class KuraLogLineParserTest {
 
     private void whenParseLogLine() {
         this.parsedLogEntry = null;
-        this.parsedLogEntry = KuraLogLineParser.createLogEntry(this.logLine, this.filePath, this.stacktrace);
+        this.parsedLogEntry = new KuraLogLineParser(this.logLine, this.filePath, this.stacktrace).createLogEntry();
     }
 
     /*


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

The log files that we are reading can be written character by character. This could mislead the reader thread if the line has not been completely written, since once EOF is detected the [RandomAccessFile.readLine()](https://docs.oracle.com/javase/7/docs/api/java/io/RandomAccessFile.html#readLine()) returns the line read up to that point. On the next iteration, the read resumes from that point resulting in an unexpected start of line, thus causing a parse exception. As an example, consider the following case:

*First read, line not completely written by log4j but `readLine` called:*
```
2022-09-07T11:47:23,901 [qtp24668432-131] INFO  o.e.k.w.s.s.WiresBlinkServlet - unregiEOF
```
*Second read, resumes from the last read character and causes exception:*
```
stered
```

Sometimes parsing exceptions arise from the `log.filesystem.provider` component (https://github.com/eclipse/kura/issues/4133). This is due to the `KuraLogLineParser` which is implemented as a singleton but is concurrently accessed by all the instances of `FilesystemLogProvider`s.

**Related Issue:** [Error parsing Kura log timestamp](https://github.com/eclipse/kura/issues/4133).

**Description of the solution adopted:** Added a utility method to read lines until a new line is encountered. It stores a pointer to the last character read that is not an `EOF` so that we an `EOF` is encountered it can resume the reading and finish the line.

`KuraLogLineParser` has been refactored to not be a singleton.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.