### PR TITLE
build(libsocket-can-osgi): Updated version of libsocket-can

### DIFF
--- a/target-platform/org.eclipse.kura.libsocket-can-osgi/pom.xml
+++ b/target-platform/org.eclipse.kura.libsocket-can-osgi/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.eurotech</groupId>
             <artifactId>libsocket-can-java</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR updates the version of the native libsocket-can dependency to 1.0.1.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>