### PR TITLE
docs: add "Apache Camel Integration" section

### DIFF
--- a/docs/cloud-platform/apache-camel-integration/kura-camel-app.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel-app.md
@@ -1,0 +1,327 @@
+---
+layout: page
+title:  "Apache Camel™ as application"
+categories: [camel]
+---
+
+# Camel as Kura application
+
+As of 2.1.0 Kura provides a set of different ways to implement an application backed by Camel:
+
+ * Simple XML route configuration
+ * Custom XML route configuration
+ * Custom Java DSL definition
+
+## Kura cloud endpoint
+
+Kura provides a special "Kura cloud endpoint" which allows to publish
+or subscribe to the Kura Cloud API. The default component name for this
+component is `kura-cloud` but it may be overridden in the following use cases.
+
+The default component will only be registered once the default Kura Cloud API is
+registered with OSGi. This instance is registered with the OSGi property `kura.service.pid=org.eclipse.kura.cloud.CloudService`.
+
+If you want to publish to a different cloud service instance you can either manually
+register a new instance of this endpoint, or e.g. use a functionality like
+the Simple XML router provides: also see [selecting a cloud service](#selecting-a-cloud-service).
+
+### Endpoint URI
+
+The URI syntax of the endpoint is (assuming the default component name): `kura-cloud:appid/topic`.
+Where `appid` is the application ID registered with the Cloud API and `topic` is the topic to use.
+
+The following URI parameters are supported by the endpoint:
+
+<table>
+<thead><tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+<tbody>
+
+<tr>
+  <td><code>applicationId</code></td>
+  <td>String</td>
+  <td><em>From URI path</em></td>
+  <td>The application ID used with the Cloud API</td>
+</tr>
+
+<tr>
+  <td><code>topic</code></td>
+  <td>String</td>
+  <td><em>From URI path</em></td>
+  <td>The default topic name to publish/subscribe to when no header value is specified</td>
+</tr>
+
+<tr>
+  <td><code>qos</code></td>
+  <td>Integer</td>
+  <td>0</td>
+  <td>The QoS value when publishing to MQTT</td>
+</tr>
+
+<tr>
+  <td><code>retain</code></td>
+  <td>Boolean</td>
+  <td>false</td>
+  <td>The default retain flag when publishing to MQTT</td>
+</tr>
+
+<tr>
+  <td><code>priority</code></td>
+  <td>Integer</td>
+  <td>5</td>
+  <td>The default priority value</td>
+</tr>
+
+<tr>
+  <td><code>control</code></td>
+  <td>Boolean</td>
+  <td>false</td>
+  <td>Whether to publish/subscribe on the control or data topic hierarchy</td>
+</tr>
+
+<tr>
+  <td><code>deviceId</code></td>
+  <td>String</td>
+  <td><em>empty</em></td>
+  <td>The default device ID when publishing/subscribing to control topics</td>
+</tr>
+
+</tbody>
+</table>
+
+The following header fields are supported. If a value is not set when publishing it is taken from the endpoint configuration:
+
+<table>
+<thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead>
+<tbody>
+
+<tr>
+  <td><code>CamelKuraCloudService.topic</code></td>
+  <td>String</td>
+  <td>The name of the topic to publish to or from which the message was received</td>
+</tr>
+
+<tr>
+  <td><code>CamelKuraCloudService.qos</code></td>
+  <td>Integer</td>
+  <td>The QoS to use when publishing to MQTT</td>
+</tr>
+
+<tr>
+  <td><code>CamelKuraCloudService.retain</code></td>
+  <td>Boolean</td>
+  <td>The value of the retain flag when publishing to MQTT</td>
+</tr>
+
+<tr>
+  <td><code>CamelKuraCloudService.control</code></td>
+  <td>Boolean</td>
+  <td>Whether to publish/subscribe on the control or data topic hierarchy</td>
+</tr>
+
+<tr>
+  <td><code>CamelKuraCloudService.deviceId</code></td>
+  <td>String</td>
+  <td>The device ID when publishing to control topics</td>
+</tr>
+
+</tbody>
+</table>
+
+### Cloud to cloud messaging
+
+As already described, header values override the endpoint settings. This allows for a finer grained
+control with Camel messaging. However this can cause unexpected behavior when two Cloud API endpoints
+are bridged. Camel can received from a Cloud endpoint but also publish to it. Now it is possible to
+write Camel routes with exchange messages, receiving from one Cloud API, pushing to another.
+
+    -------------------             -------------------
+    | Cloud Service A |    <--->    | Cloud Service B |
+    -------------------             -------------------
+
+Which could result in a Camel route XML like:
+
+    <route id="bridgeLocalToRemote">
+      <from uri="local-cloud:sensor/sensor1" />
+      <to   uri="upstream-cloud:gateway1/all-sensors" />
+    </route>
+
+However the Consumer (from) would set the topic header value with the topic name it received the message
+from. And the Producer (to) would get its topic from the URI overriden by that header value.
+
+In order to fix this behavior the header field has to be cleared before publishing:
+
+    <route id="bridgeLocalToRemote">
+      <from uri="local-cloud:sensor/sensor1" />
+      <removeHeaders pattern="CamelKuraCloudService.topic"/>
+      <to   uri="upstream-cloud:gateway1/all-sensors" />
+    </route>
+
+## Simple XML routes
+
+Eclipse Kura 2.1.0 introduces a new "out-of-the-box" component which
+allows to configure a set of XML based routes. The component is called "Camel XML router"
+and can be configured with a simple set of XML routes.
+
+The following example logs all messages received on the topic `foo/bar` to a logger named
+`MESSAGE_FROM_CLOUD`:
+
+    <routes xmlns="http://camel.apache.org/schema/spring">
+      <route id="cloudConsumer">
+        <from uri="kura-cloud:foo/bar"/>
+        <to uri="log:MESSAGE_FROM_CLOUD"/>
+      </route>
+    </routes>
+
+But it is also possible to generate data and push to upstream to the cloud service:
+
+    <route id="route1">
+      <from uri="timer:foo"/>
+      <setBody>
+        <method ref="payloadFactory" method="create('random',${random(10)})"/>
+      </setBody>
+      <bean ref="payloadFactory" method="append('foo','bar')"/>
+      <to uri="stream:out"/>
+      <to uri="kura-cloud:myapp/test"/>
+    </route>
+
+This example to run a timer named "foo" every second. It uses the "Payload Factory" bean,
+which is pre-registered, to create a new payload structure and then append a second elemen
+to it.
+
+The output is first sent to a logger and then to the cloud source.
+
+### Defining dependencies on components
+
+It is possible to use the Web UI to define a list of Camel components which must be present in
+order for this configuration to work. For example if the routes make use of the "milo-server"
+adapter for providing OPC UA support then "milo-server" can be added and the setup will wait for
+this component to be registered with OSGi before the Camel context gets started.
+
+The field contains a list of comma separated component names: e.g. `milo-server, timer, log`
+
+### Selecting a cloud service
+
+It is also possible to define a map of cloud services which will be available for upstream connectivity.
+This makes use of Kura's "multi cloud client" feature. CloudService instances will get mapped from either
+a Kura Service PID (`kura.service.pid`, as shown in the Web UI) or a full OSGi filter. The string is
+a comma seperated, `key=value` string, where the key is the name of the Camel cloud the instance will be
+registered as and the value is the Kura service PID or the OSGi filter string.
+
+For example: `cloud=org.eclipse.kura.cloud.CloudService, cloud-2=foobar`
+
+## Custom Camel routers
+
+If a standard XML route configuration is not enough then it is possible to use XML routes
+in combination with a custom OSGi bundle or a Java DSL based Camel approach.
+For this to work a Kura development setup is required, please see [Getting started](kura-setup.html)
+for more information.
+
+The implementation of such Camel components follow the standard Kura guides for developing components,
+like, for example, the `ConfigurableComponent` pattern. This section only describes the Camel
+specifics.
+
+Of course it is also possible to follow a very simple approach and directly use the Camel OSGi
+functionalities like `org.apache.camel.core.osgi.OsgiDefaultCamelContext`.
+
+{% include note.html message="Kura currently doesn't support the OSGi Blueprint approach" %}
+
+Kura support for Camel is split up in two layers. There is a more basic support, which helps
+in running a raw Camel router. This is `CamelRunner` which is located in the
+package `org.eclipse.kura.camel.router`. And then there are a few abstract basic components
+in the package `org.eclipse.kura.camel.component` which help in creating Kura components based
+on Camel.
+
+## Camel components
+
+The base classes in `org.eclipse.kura.camel.component` are intended to help creating new OSGi DS
+components base on Camel.
+
+### XML based component
+
+For an XML based approach which can be configured through the Kura `ConfigurationService` the base
+class `AbstractXmlCamelComponent` can be used. The constructor expectes the name of a property
+which will contain the Camel XML router information when it gets configured through the configuration
+service. It will automatically parse and apply the Camel routes.
+
+The method `void beforeStart(CamelContext camelContext)` may be used in order to configure
+the Camel context before it gets started.
+
+Every time the routes get updated using the `modified(Map<String, Object>)` method, the route XML
+will be re-parsed and routes will be added, removed or updated according to the new XML.
+
+### Java DSL based component
+
+In order to create a Java DSL based router setup the base class `AbstractJavaCamelComponent` may
+be used, which implements and `RouteBuilder` class, a simple setup might look like:
+
+    import org.eclipse.kura.camel.component.AbstractJavaCamelComponent;
+
+    class MyRouter extends AbstractJavaCamelComponent {
+       public void configure() throws Exception {
+          from("direct:test")
+             .to("mock:test");
+       }
+    }
+
+### Using the CamelRunner
+
+The `CamelRunner` class is not derived from any OSGi or Kura base class and can be used
+in scenarios where more flexibility is required. It allows to define a set of pre-requisites
+for the Camel context. It is for example possible to define a dependency on a Kura cloud service
+instance and a Camel component provider. Once the runner is started it will listen for OSGi
+services resolving those dependencies and then starting up the Camel context.
+
+The following example shows how to set up a Camel context using the `CamelRunner`:
+
+    // create a new camel Builder
+
+    Builder builder = new CamelRunner.Builder();
+
+    // add service dependency
+
+    builder.cloudService("kura.service.pid", "my.cloud.service.pid");
+
+    // add Camel component dependency to 'milo-server'
+
+    builder.requireComponent("milo-server");
+
+    CamelRunner runner = builder.build();
+
+    // set routes
+
+    runner.setRoutes ( new RouteBuilder() {
+      public void configure() throws Exception {
+        from("direct:test")
+          .to("mock:test");
+      }
+    } );
+
+    // set routes
+
+    runner.start ();
+
+It is also possible to later update routes with a call to `setRoutes`:
+
+    // maybe update routes at a later time
+
+    runner.setRoutes ( /* different routes */ );
+
+# Examples
+
+The following examples can help in getting started.
+
+## Kura Camel example publisher
+
+The Camel example publisher (`org.eclipse.kura.example.camel.publisher`) can be used as an reference for starting.
+The final OSGi bundle can be dropped into a Kura application an be started. It allows to configure dynamically
+during runtime and is capable of switching CloudService instances dynamically.
+
+## Kura Camel quickstart
+
+The Camel quickstart project (`org.eclipse.kura.example.camel.quickstart`) shows two components, Java and XML based,
+working together. The bundle can also be dropped into Kura for testing.
+
+## Kura Camel aggregation
+
+The Camel quickstart project (`org.eclipse.kura.example.camel.aggregation`) shows a simple data aggregation pattern
+with Camel by processing data and publishing the result.

--- a/docs/cloud-platform/apache-camel-integration/kura-camel-app.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel-app.md
@@ -1,9 +1,3 @@
----
-layout: page
-title:  "Apache Camel™ as application"
-categories: [camel]
----
-
 # Camel as Kura application
 
 As of 2.1.0 Kura provides a set of different ways to implement an application backed by Camel:
@@ -14,21 +8,15 @@ As of 2.1.0 Kura provides a set of different ways to implement an application ba
 
 ## Kura cloud endpoint
 
-Kura provides a special "Kura cloud endpoint" which allows to publish
-or subscribe to the Kura Cloud API. The default component name for this
-component is `kura-cloud` but it may be overridden in the following use cases.
+Kura provides a special "Kura cloud endpoint" which allows to publish or subscribe to the Kura Cloud API. The default component name for this component is `kura-cloud` but it may be overridden in the following use cases.
 
-The default component will only be registered once the default Kura Cloud API is
-registered with OSGi. This instance is registered with the OSGi property `kura.service.pid=org.eclipse.kura.cloud.CloudService`.
+The default component will only be registered once the default Kura Cloud API is registered with OSGi. This instance is registered with the OSGi property `kura.service.pid=org.eclipse.kura.cloud.CloudService`.
 
-If you want to publish to a different cloud service instance you can either manually
-register a new instance of this endpoint, or e.g. use a functionality like
-the Simple XML router provides: also see [selecting a cloud service](#selecting-a-cloud-service).
+If you want to publish to a different cloud service instance you can either manually register a new instance of this endpoint, or e.g. use a functionality like the Simple XML router provides: also see [selecting a cloud service](#selecting-a-cloud-service).
 
 ### Endpoint URI
 
-The URI syntax of the endpoint is (assuming the default component name): `kura-cloud:appid/topic`.
-Where `appid` is the application ID registered with the Cloud API and `topic` is the topic to use.
+The URI syntax of the endpoint is (assuming the default component name): `kura-cloud:appid/topic`. Where `appid` is the application ID registered with the Cloud API and `topic` is the topic to use.
 
 The following URI parameters are supported by the endpoint:
 
@@ -129,199 +117,174 @@ The following header fields are supported. If a value is not set when publishing
 
 ### Cloud to cloud messaging
 
-As already described, header values override the endpoint settings. This allows for a finer grained
-control with Camel messaging. However this can cause unexpected behavior when two Cloud API endpoints
-are bridged. Camel can received from a Cloud endpoint but also publish to it. Now it is possible to
-write Camel routes with exchange messages, receiving from one Cloud API, pushing to another.
+As already described, header values override the endpoint settings. This allows for a finer grained control with Camel messaging. However this can cause unexpected behavior when two Cloud API endpoints are bridged. Camel can received from a Cloud endpoint but also publish to it. Now it is possible to write Camel routes with exchange messages, receiving from one Cloud API, pushing to another.
 
-    -------------------             -------------------
-    | Cloud Service A |    <--->    | Cloud Service B |
-    -------------------             -------------------
+```
+-------------------             -------------------
+| Cloud Service A |    <--->    | Cloud Service B |
+-------------------             -------------------
+```
 
 Which could result in a Camel route XML like:
 
-    <route id="bridgeLocalToRemote">
-      <from uri="local-cloud:sensor/sensor1" />
-      <to   uri="upstream-cloud:gateway1/all-sensors" />
-    </route>
+```xml
+<route id="bridgeLocalToRemote">
+  <from uri="local-cloud:sensor/sensor1" />
+  <to   uri="upstream-cloud:gateway1/all-sensors" />
+</route>
+```
 
 However the Consumer (from) would set the topic header value with the topic name it received the message
 from. And the Producer (to) would get its topic from the URI overriden by that header value.
 
 In order to fix this behavior the header field has to be cleared before publishing:
 
-    <route id="bridgeLocalToRemote">
-      <from uri="local-cloud:sensor/sensor1" />
-      <removeHeaders pattern="CamelKuraCloudService.topic"/>
-      <to   uri="upstream-cloud:gateway1/all-sensors" />
-    </route>
+```xml
+<route id="bridgeLocalToRemote">
+  <from uri="local-cloud:sensor/sensor1" />
+  <removeHeaders pattern="CamelKuraCloudService.topic"/>
+  <to   uri="upstream-cloud:gateway1/all-sensors" />
+</route>
+```
 
 ## Simple XML routes
 
-Eclipse Kura 2.1.0 introduces a new "out-of-the-box" component which
-allows to configure a set of XML based routes. The component is called "Camel XML router"
-and can be configured with a simple set of XML routes.
+Eclipse Kura 2.1.0 introduces a new "out-of-the-box" component which allows to configure a set of XML based routes. The component is called "Camel XML router" and can be configured with a simple set of XML routes.
 
-The following example logs all messages received on the topic `foo/bar` to a logger named
-`MESSAGE_FROM_CLOUD`:
+The following example logs all messages received on the topic `foo/bar` to a logger named `MESSAGE_FROM_CLOUD`:
 
-    <routes xmlns="http://camel.apache.org/schema/spring">
-      <route id="cloudConsumer">
-        <from uri="kura-cloud:foo/bar"/>
-        <to uri="log:MESSAGE_FROM_CLOUD"/>
-      </route>
-    </routes>
+```xml
+<routes xmlns="http://camel.apache.org/schema/spring">
+  <route id="cloudConsumer">
+    <from uri="kura-cloud:foo/bar"/>
+    <to uri="log:MESSAGE_FROM_CLOUD"/>
+  </route>
+</routes>
+```
 
 But it is also possible to generate data and push to upstream to the cloud service:
 
-    <route id="route1">
-      <from uri="timer:foo"/>
-      <setBody>
-        <method ref="payloadFactory" method="create('random',${random(10)})"/>
-      </setBody>
-      <bean ref="payloadFactory" method="append('foo','bar')"/>
-      <to uri="stream:out"/>
-      <to uri="kura-cloud:myapp/test"/>
-    </route>
+```xml
+<route id="route1">
+  <from uri="timer:foo"/>
+  <setBody>
+    <method ref="payloadFactory" method="create('random',${random(10)})"/>
+  </setBody>
+  <bean ref="payloadFactory" method="append('foo','bar')"/>
+  <to uri="stream:out"/>
+  <to uri="kura-cloud:myapp/test"/>
+</route>
+```
 
-This example to run a timer named "foo" every second. It uses the "Payload Factory" bean,
-which is pre-registered, to create a new payload structure and then append a second elemen
-to it.
+This example to run a timer named "foo" every second. It uses the "Payload Factory" bean, which is pre-registered, to create a new payload structure and then append a second element to it.
 
 The output is first sent to a logger and then to the cloud source.
 
 ### Defining dependencies on components
 
-It is possible to use the Web UI to define a list of Camel components which must be present in
-order for this configuration to work. For example if the routes make use of the "milo-server"
-adapter for providing OPC UA support then "milo-server" can be added and the setup will wait for
-this component to be registered with OSGi before the Camel context gets started.
+It is possible to use the Web UI to define a list of Camel components which must be present in order for this configuration to work. For example if the routes make use of the "milo-server" adapter for providing OPC UA support then "milo-server" can be added and the setup will wait for this component to be registered with OSGi before the Camel context gets started.
 
 The field contains a list of comma separated component names: e.g. `milo-server, timer, log`
 
 ### Selecting a cloud service
 
-It is also possible to define a map of cloud services which will be available for upstream connectivity.
-This makes use of Kura's "multi cloud client" feature. CloudService instances will get mapped from either
-a Kura Service PID (`kura.service.pid`, as shown in the Web UI) or a full OSGi filter. The string is
-a comma seperated, `key=value` string, where the key is the name of the Camel cloud the instance will be
-registered as and the value is the Kura service PID or the OSGi filter string.
+It is also possible to define a map of cloud services which will be available for upstream connectivity. This makes use of Kura's "multi cloud client" feature. CloudService instances will get mapped from either a Kura Service PID (`kura.service.pid`, as shown in the Web UI) or a full OSGi filter. The string is a comma seperated, `key=value` string, where the key is the name of the Camel cloud the instance will be registered as and the value is the Kura service PID or the OSGi filter string.
 
 For example: `cloud=org.eclipse.kura.cloud.CloudService, cloud-2=foobar`
 
 ## Custom Camel routers
 
-If a standard XML route configuration is not enough then it is possible to use XML routes
-in combination with a custom OSGi bundle or a Java DSL based Camel approach.
-For this to work a Kura development setup is required, please see [Getting started](kura-setup.html)
-for more information.
+If a standard XML route configuration is not enough then it is possible to use XML routes in combination with a custom OSGi bundle or a Java DSL based Camel approach. For this to work a Kura development setup is required, please see [Getting started](kura-setup.html) for more information.
 
-The implementation of such Camel components follow the standard Kura guides for developing components,
-like, for example, the `ConfigurableComponent` pattern. This section only describes the Camel
-specifics.
+The implementation of such Camel components follow the standard Kura guides for developing components, like, for example, the `ConfigurableComponent` pattern. This section only describes the Camel specifics.
 
-Of course it is also possible to follow a very simple approach and directly use the Camel OSGi
-functionalities like `org.apache.camel.core.osgi.OsgiDefaultCamelContext`.
+Of course it is also possible to follow a very simple approach and directly use the Camel OSGi functionalities like `org.apache.camel.core.osgi.OsgiDefaultCamelContext`.
 
-{% include note.html message="Kura currently doesn't support the OSGi Blueprint approach" %}
+!!! note
+    Kura currently doesn't support the OSGi Blueprint approach
 
-Kura support for Camel is split up in two layers. There is a more basic support, which helps
-in running a raw Camel router. This is `CamelRunner` which is located in the
-package `org.eclipse.kura.camel.router`. And then there are a few abstract basic components
-in the package `org.eclipse.kura.camel.component` which help in creating Kura components based
-on Camel.
+Kura support for Camel is split up in two layers. There is a more basic support, which helps in running a raw Camel router. This is `CamelRunner` which is located in the package `org.eclipse.kura.camel.router`. And then there are a few abstract basic components in the package `org.eclipse.kura.camel.component` which help in creating Kura components based on Camel.
 
 ## Camel components
 
-The base classes in `org.eclipse.kura.camel.component` are intended to help creating new OSGi DS
-components base on Camel.
+The base classes in `org.eclipse.kura.camel.component` are intended to help creating new OSGi DS components base on Camel.
 
 ### XML based component
 
-For an XML based approach which can be configured through the Kura `ConfigurationService` the base
-class `AbstractXmlCamelComponent` can be used. The constructor expectes the name of a property
-which will contain the Camel XML router information when it gets configured through the configuration
-service. It will automatically parse and apply the Camel routes.
+For an XML based approach which can be configured through the Kura `ConfigurationService` the base class `AbstractXmlCamelComponent` can be used. The constructor expectes the name of a property which will contain the Camel XML router information when it gets configured through the configuration service. It will automatically parse and apply the Camel routes.
 
-The method `void beforeStart(CamelContext camelContext)` may be used in order to configure
-the Camel context before it gets started.
+The method `void beforeStart(CamelContext camelContext)` may be used in order to configure the Camel context before it gets started.
 
-Every time the routes get updated using the `modified(Map<String, Object>)` method, the route XML
-will be re-parsed and routes will be added, removed or updated according to the new XML.
+Every time the routes get updated using the `modified(Map<String, Object>)` method, the route XML will be re-parsed and routes will be added, removed or updated according to the new XML.
 
 ### Java DSL based component
 
-In order to create a Java DSL based router setup the base class `AbstractJavaCamelComponent` may
-be used, which implements and `RouteBuilder` class, a simple setup might look like:
+In order to create a Java DSL based router setup the base class `AbstractJavaCamelComponent` may be used, which implements and `RouteBuilder` class, a simple setup might look like:
 
-    import org.eclipse.kura.camel.component.AbstractJavaCamelComponent;
+```java
+import org.eclipse.kura.camel.component.AbstractJavaCamelComponent;
 
-    class MyRouter extends AbstractJavaCamelComponent {
-       public void configure() throws Exception {
-          from("direct:test")
-             .to("mock:test");
-       }
-    }
+class MyRouter extends AbstractJavaCamelComponent {
+   public void configure() throws Exception {
+      from("direct:test")
+         .to("mock:test");
+   }
+}
+```
 
 ### Using the CamelRunner
 
-The `CamelRunner` class is not derived from any OSGi or Kura base class and can be used
-in scenarios where more flexibility is required. It allows to define a set of pre-requisites
-for the Camel context. It is for example possible to define a dependency on a Kura cloud service
-instance and a Camel component provider. Once the runner is started it will listen for OSGi
-services resolving those dependencies and then starting up the Camel context.
+The `CamelRunner` class is not derived from any OSGi or Kura base class and can be used in scenarios where more flexibility is required. It allows to define a set of pre-requisites for the Camel context. It is for example possible to define a dependency on a Kura cloud service instance and a Camel component provider. Once the runner is started it will listen for OSGi services resolving those dependencies and then starting up the Camel context. The following example shows how to set up a Camel context using the `CamelRunner`:
 
-The following example shows how to set up a Camel context using the `CamelRunner`:
+```java
+// create a new camel Builder
 
-    // create a new camel Builder
+Builder builder = new CamelRunner.Builder();
 
-    Builder builder = new CamelRunner.Builder();
+// add service dependency
 
-    // add service dependency
+builder.cloudService("kura.service.pid", "my.cloud.service.pid");
 
-    builder.cloudService("kura.service.pid", "my.cloud.service.pid");
+// add Camel component dependency to 'milo-server'
 
-    // add Camel component dependency to 'milo-server'
+builder.requireComponent("milo-server");
 
-    builder.requireComponent("milo-server");
+CamelRunner runner = builder.build();
 
-    CamelRunner runner = builder.build();
+// set routes
 
-    // set routes
+runner.setRoutes ( new RouteBuilder() {
+  public void configure() throws Exception {
+    from("direct:test")
+      .to("mock:test");
+  }
+} );
 
-    runner.setRoutes ( new RouteBuilder() {
-      public void configure() throws Exception {
-        from("direct:test")
-          .to("mock:test");
-      }
-    } );
+// set routes
 
-    // set routes
-
-    runner.start ();
+runner.start ();
+```
 
 It is also possible to later update routes with a call to `setRoutes`:
 
-    // maybe update routes at a later time
+```java
+// maybe update routes at a later time
 
-    runner.setRoutes ( /* different routes */ );
+runner.setRoutes ( /* different routes */ );
+```
 
-# Examples
+## Examples
 
 The following examples can help in getting started.
 
-## Kura Camel example publisher
+### Kura Camel example publisher
 
-The Camel example publisher (`org.eclipse.kura.example.camel.publisher`) can be used as an reference for starting.
-The final OSGi bundle can be dropped into a Kura application an be started. It allows to configure dynamically
-during runtime and is capable of switching CloudService instances dynamically.
+The Camel example publisher (`org.eclipse.kura.example.camel.publisher`) can be used as an reference for starting. The final OSGi bundle can be dropped into a Kura application an be started. It allows to configure dynamically during runtime and is capable of switching CloudService instances dynamically.
 
-## Kura Camel quickstart
+### Kura Camel quickstart
 
-The Camel quickstart project (`org.eclipse.kura.example.camel.quickstart`) shows two components, Java and XML based,
-working together. The bundle can also be dropped into Kura for testing.
+The Camel quickstart project (`org.eclipse.kura.example.camel.quickstart`) shows two components, Java and XML based, working together. The bundle can also be dropped into Kura for testing.
 
-## Kura Camel aggregation
+### Kura Camel aggregation
 
-The Camel quickstart project (`org.eclipse.kura.example.camel.aggregation`) shows a simple data aggregation pattern
-with Camel by processing data and publishing the result.
+The Camel quickstart project (`org.eclipse.kura.example.camel.aggregation`) shows a simple data aggregation pattern with Camel by processing data and publishing the result.

--- a/docs/cloud-platform/apache-camel-integration/kura-camel-app.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel-app.md
@@ -20,100 +20,25 @@ The URI syntax of the endpoint is (assuming the default component name): `kura-c
 
 The following URI parameters are supported by the endpoint:
 
-<table>
-<thead><tr><th>Name</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
-<tbody>
-
-<tr>
-  <td><code>applicationId</code></td>
-  <td>String</td>
-  <td><em>From URI path</em></td>
-  <td>The application ID used with the Cloud API</td>
-</tr>
-
-<tr>
-  <td><code>topic</code></td>
-  <td>String</td>
-  <td><em>From URI path</em></td>
-  <td>The default topic name to publish/subscribe to when no header value is specified</td>
-</tr>
-
-<tr>
-  <td><code>qos</code></td>
-  <td>Integer</td>
-  <td>0</td>
-  <td>The QoS value when publishing to MQTT</td>
-</tr>
-
-<tr>
-  <td><code>retain</code></td>
-  <td>Boolean</td>
-  <td>false</td>
-  <td>The default retain flag when publishing to MQTT</td>
-</tr>
-
-<tr>
-  <td><code>priority</code></td>
-  <td>Integer</td>
-  <td>5</td>
-  <td>The default priority value</td>
-</tr>
-
-<tr>
-  <td><code>control</code></td>
-  <td>Boolean</td>
-  <td>false</td>
-  <td>Whether to publish/subscribe on the control or data topic hierarchy</td>
-</tr>
-
-<tr>
-  <td><code>deviceId</code></td>
-  <td>String</td>
-  <td><em>empty</em></td>
-  <td>The default device ID when publishing/subscribing to control topics</td>
-</tr>
-
-</tbody>
-</table>
+| Name            | Type    | Default         | Description                                                                      |
+|-----------------|---------|-----------------|----------------------------------------------------------------------------------|
+| `applicationId` | String  | _From URI path_ | The application ID used with the Cloud API                                       |
+| `topic`         | String  | _From URI path_ | The default topic name to publish/subscribe to when no header value is specified |
+| `qos`           | Integer | 0               | The QoS value when publishing to MQTT                                            |
+| `retain`        | Boolean | false           | The default retain flag when publishing to MQTT                                  |
+| `priority`      | Integer | 5               | The default priority value                                                       |
+| `control`       | Boolean | false           | Whether to publish/subscribe on the control or data topic hierarchy              |
+| `deviceId`      | String  | empty           | The default device ID when publishing/subscribing to control topics              |
 
 The following header fields are supported. If a value is not set when publishing it is taken from the endpoint configuration:
 
-<table>
-<thead><tr><th>Name</th><th>Type</th><th>Description</th></tr></thead>
-<tbody>
-
-<tr>
-  <td><code>CamelKuraCloudService.topic</code></td>
-  <td>String</td>
-  <td>The name of the topic to publish to or from which the message was received</td>
-</tr>
-
-<tr>
-  <td><code>CamelKuraCloudService.qos</code></td>
-  <td>Integer</td>
-  <td>The QoS to use when publishing to MQTT</td>
-</tr>
-
-<tr>
-  <td><code>CamelKuraCloudService.retain</code></td>
-  <td>Boolean</td>
-  <td>The value of the retain flag when publishing to MQTT</td>
-</tr>
-
-<tr>
-  <td><code>CamelKuraCloudService.control</code></td>
-  <td>Boolean</td>
-  <td>Whether to publish/subscribe on the control or data topic hierarchy</td>
-</tr>
-
-<tr>
-  <td><code>CamelKuraCloudService.deviceId</code></td>
-  <td>String</td>
-  <td>The device ID when publishing to control topics</td>
-</tr>
-
-</tbody>
-</table>
+| Name                             | Type    | Description                                                                |
+|----------------------------------|---------|----------------------------------------------------------------------------|
+| `CamelKuraCloudService.topic`    | String  | The name of the topic to publish to or from which the message was received |
+| `CamelKuraCloudService.qos`      | Integer | The QoS to use when publishing to MQTT                                     |
+| `CamelKuraCloudService.retain`   | Boolean | The value of the retain flag when publishing to MQTT                       |
+| `CamelKuraCloudService.control`  | Boolean | Whether to publish/subscribe on the control or data topic hierarchy        |
+| `CamelKuraCloudService.deviceId` | String  | The device ID when publishing to control topics                            |
 
 ### Cloud to cloud messaging
 

--- a/docs/cloud-platform/apache-camel-integration/kura-camel-app.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel-app.md
@@ -1,4 +1,4 @@
-# Camel as Kura application
+# Apache Camel&trade; as a Kura application
 
 As of 2.1.0 Kura provides a set of different ways to implement an application backed by Camel:
 

--- a/docs/cloud-platform/apache-camel-integration/kura-camel-cloud.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel-cloud.md
@@ -1,0 +1,46 @@
+---
+layout: page
+title:  "Apache Camel™ Cloud Service"
+categories: [camel]
+---
+
+# Camel as Kura cloud service
+
+The default way to create a new cloud service instance backed by Camel is to use the new Web UI
+for cloud services. A new cloud service instance of the type `org.eclipse.kura.camel.cloud.factory.CamelFactory`
+has to be created. In addition to that a set of Camel routes have to be provided.
+
+The interface with the Kura application is the Camel `vm` component. Information set "upstream" from the Kura application
+can be received by the Camel cloud service instance of the following endpoint `vm:camel:example`. Where `camel` is the
+application id and `example` is the topic.
+
+The following code snippet writes out all of the Kura payload structure received on this topic to the logger system:
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <routes xmlns="http://camel.apache.org/schema/spring">
+
+      <route id="camel-example-topic">
+        <from uri="vm:camel:example"/>
+        <split>
+          <simple>${body.metrics().entrySet()}</simple>
+          <setHeader headerName="item">
+            <simple>${body.key()}</simple>
+          </setHeader>
+          <setBody>
+            <simple>${body.value()}</simple>
+          </setBody>
+          <toD uri="log:kura.data.${header.item}"/>
+        </split>
+      </route>
+
+    </routes>
+
+The snippet splits up the incoming KuraPayload structure and creates a logger called `kura.data.<metric>` for each
+metric and writes out the actual value to it. The output in the log file should look like:
+
+    2016-11-14 16:14:34,539 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.intValue - Exchange[ExchangePattern: InOnly, BodyType: Long, Body: 19]
+    2016-11-14 16:14:34,566 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.doubleValue - Exchange[ExchangePattern: InOnly, BodyType: Double, Body: 10.226808617581144]
+    2016-11-14 16:14:35,575 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.intValue - Exchange[ExchangePattern: InOnly, BodyType: Long, Body: 19]
+    2016-11-14 16:14:35,602 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.doubleValue - Exchange[ExchangePattern: InOnly, BodyType: Double, Body: 10.27218775669447]
+    2016-11-14 16:14:36,539 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.intValue - Exchange[ExchangePattern: InOnly, BodyType: Long, Body: 19]
+    2016-11-14 16:14:36,567 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.doubleValue - Exchange[ExchangePattern: InOnly, BodyType: Double, Body: 10.314456684208022]

--- a/docs/cloud-platform/apache-camel-integration/kura-camel-cloud.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel-cloud.md
@@ -1,4 +1,4 @@
-# Camel as Kura cloud service
+# Apache Camel&trade; as a Kura cloud service
 
 The default way to create a new cloud service instance backed by Camel is to use the new Web UI for cloud services. A new cloud service instance of the type `org.eclipse.kura.camel.cloud.factory.CamelFactory` has to be created. In addition to that a set of Camel routes have to be provided.
 

--- a/docs/cloud-platform/apache-camel-integration/kura-camel-cloud.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel-cloud.md
@@ -1,46 +1,39 @@
----
-layout: page
-title:  "Apache Camel™ Cloud Service"
-categories: [camel]
----
-
 # Camel as Kura cloud service
 
-The default way to create a new cloud service instance backed by Camel is to use the new Web UI
-for cloud services. A new cloud service instance of the type `org.eclipse.kura.camel.cloud.factory.CamelFactory`
-has to be created. In addition to that a set of Camel routes have to be provided.
+The default way to create a new cloud service instance backed by Camel is to use the new Web UI for cloud services. A new cloud service instance of the type `org.eclipse.kura.camel.cloud.factory.CamelFactory` has to be created. In addition to that a set of Camel routes have to be provided.
 
-The interface with the Kura application is the Camel `vm` component. Information set "upstream" from the Kura application
-can be received by the Camel cloud service instance of the following endpoint `vm:camel:example`. Where `camel` is the
-application id and `example` is the topic.
+The interface with the Kura application is the Camel `vm` component. Information set "upstream" from the Kura application can be received by the Camel cloud service instance of the following endpoint `vm:camel:example`. Where `camel` is the application id and `example` is the topic.
 
 The following code snippet writes out all of the Kura payload structure received on this topic to the logger system:
 
-    <?xml version="1.0" encoding="UTF-8"?>
-    <routes xmlns="http://camel.apache.org/schema/spring">
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://camel.apache.org/schema/spring">
 
-      <route id="camel-example-topic">
-        <from uri="vm:camel:example"/>
-        <split>
-          <simple>${body.metrics().entrySet()}</simple>
-          <setHeader headerName="item">
-            <simple>${body.key()}</simple>
-          </setHeader>
-          <setBody>
-            <simple>${body.value()}</simple>
-          </setBody>
-          <toD uri="log:kura.data.${header.item}"/>
-        </split>
-      </route>
+  <route id="camel-example-topic">
+    <from uri="vm:camel:example"/>
+    <split>
+      <simple>${body.metrics().entrySet()}</simple>
+      <setHeader headerName="item">
+        <simple>${body.key()}</simple>
+      </setHeader>
+      <setBody>
+        <simple>${body.value()}</simple>
+      </setBody>
+      <toD uri="log:kura.data.${header.item}"/>
+    </split>
+  </route>
 
-    </routes>
+</routes>
+```
 
-The snippet splits up the incoming KuraPayload structure and creates a logger called `kura.data.<metric>` for each
-metric and writes out the actual value to it. The output in the log file should look like:
+The snippet splits up the incoming KuraPayload structure and creates a logger called `kura.data.<metric>` for each metric and writes out the actual value to it. The output in the log file should look like:
 
-    2016-11-14 16:14:34,539 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.intValue - Exchange[ExchangePattern: InOnly, BodyType: Long, Body: 19]
-    2016-11-14 16:14:34,566 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.doubleValue - Exchange[ExchangePattern: InOnly, BodyType: Double, Body: 10.226808617581144]
-    2016-11-14 16:14:35,575 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.intValue - Exchange[ExchangePattern: InOnly, BodyType: Long, Body: 19]
-    2016-11-14 16:14:35,602 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.doubleValue - Exchange[ExchangePattern: InOnly, BodyType: Double, Body: 10.27218775669447]
-    2016-11-14 16:14:36,539 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.intValue - Exchange[ExchangePattern: InOnly, BodyType: Long, Body: 19]
-    2016-11-14 16:14:36,567 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.doubleValue - Exchange[ExchangePattern: InOnly, BodyType: Double, Body: 10.314456684208022]
+```
+2016-11-14 16:14:34,539 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.intValue - Exchange[ExchangePattern: InOnly, BodyType: Long, Body: 19]
+2016-11-14 16:14:34,566 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.doubleValue - Exchange[ExchangePattern: InOnly, BodyType: Double, Body: 10.226808617581144]
+2016-11-14 16:14:35,575 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.intValue - Exchange[ExchangePattern: InOnly, BodyType: Long, Body: 19]
+2016-11-14 16:14:35,602 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.doubleValue - Exchange[ExchangePattern: InOnly, BodyType: Double, Body: 10.27218775669447]
+2016-11-14 16:14:36,539 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.intValue - Exchange[ExchangePattern: InOnly, BodyType: Long, Body: 19]
+2016-11-14 16:14:36,567 [Camel (camel-10) thread #18 - vm://camel:example] INFO  k.d.doubleValue - Exchange[ExchangePattern: InOnly, BodyType: Double, Body: 10.314456684208022]
+```

--- a/docs/cloud-platform/apache-camel-integration/kura-camel.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel.md
@@ -1,0 +1,34 @@
+---
+layout: page
+title:  "Apache Camel™ integration"
+categories: [camel]
+---
+
+# Kura Camel overview
+
+{% include note.html message="This document describes the Camel integration for Kura 2.1.0" %}
+
+Kura provides two main integration points for Camel:
+
+ * Camel as a Kura application
+ * Camel as a Kura cloud service
+
+The first allows one to configure Camel to provide data and receive commands from any CloudService instance
+which is configured in Kura. For example the default CloudService instance which is backed by MQTT.
+
+The second approach allows one to create a custom CloudService implementation and route data coming from other
+Kura applications with the routes provided by this Camel context.
+
+## Deploying additional Camel components
+
+Kura comes with the following Camel components pre-installed:
+
+* camel-core
+* camel-core-osgi
+* camel-stream
+
+If additional Camel components are required, they can be installed using
+deployment packages (DP), as common with Kura.
+
+There are pre-packaged DPs available for e.g. AMQP, OPC UA, MQTT and other
+Camel components outside of the Kura project.

--- a/docs/cloud-platform/apache-camel-integration/kura-camel.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel.md
@@ -1,12 +1,7 @@
----
-layout: page
-title:  "Apache Camel™ integration"
-categories: [camel]
----
-
 # Kura Camel overview
 
-{% include note.html message="This document describes the Camel integration for Kura 2.1.0" %}
+!!! note
+    This document describes the Camel integration for Kura 2.1.0
 
 Kura provides two main integration points for Camel:
 
@@ -23,12 +18,10 @@ Kura applications with the routes provided by this Camel context.
 
 Kura comes with the following Camel components pre-installed:
 
-* camel-core
-* camel-core-osgi
-* camel-stream
+* `camel-core`
+* `camel-core-osgi`
+* `camel-stream`
 
-If additional Camel components are required, they can be installed using
-deployment packages (DP), as common with Kura.
+If additional Camel components are required, they can be installed using deployment packages (DP), as common with Kura.
 
-There are pre-packaged DPs available for e.g. AMQP, OPC UA, MQTT and other
-Camel components outside of the Kura project.
+There are pre-packaged DPs available for e.g. AMQP, OPC UA, MQTT and other Camel components outside of the Kura project.

--- a/docs/cloud-platform/apache-camel-integration/kura-camel.md
+++ b/docs/cloud-platform/apache-camel-integration/kura-camel.md
@@ -1,4 +1,4 @@
-# Kura Camel overview
+# Apache Camel&trade; integration overview
 
 !!! note
     This document describes the Camel integration for Kura 2.1.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,10 @@ nav:
       - Azure IoT Hub&trade; platform: cloud-platform/kura-azure.md
       - Eclipse Kapua&trade; platform: cloud-platform/kura-kapua.md
       - Eclipse Hono&trade; platform: cloud-platform/kura-hono.md
+      - Apache Camel&trade; Integration:
+        - Apache Camel&trade; as application: cloud-platform/apache-camel-integration/kura-camel-app.md
+        - Apache Camel&trade; Cloud Service: cloud-platform/apache-camel-integration/kura-camel-cloud.md
+        - Apache Camel&trade; integration: cloud-platform/apache-camel-integration/kura-camel.md
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,9 +68,9 @@ nav:
       - Eclipse Kapua&trade; platform: cloud-platform/kura-kapua.md
       - Eclipse Hono&trade; platform: cloud-platform/kura-hono.md
       - Apache Camel&trade; Integration:
+        - Apache Camel&trade; integration: cloud-platform/apache-camel-integration/kura-camel.md
         - Apache Camel&trade; as application: cloud-platform/apache-camel-integration/kura-camel-app.md
         - Apache Camel&trade; Cloud Service: cloud-platform/apache-camel-integration/kura-camel-cloud.md
-        - Apache Camel&trade; integration: cloud-platform/apache-camel-integration/kura-camel.md
 
 theme:
   name: material


### PR DESCRIPTION
Add "Apache Camel Integration" section under the "Cloud Platform Connections" section. This is a simple port of the original documentation.