### PR TITLE
docs: removed tabs navigation to avoid menu overflow

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,8 +140,6 @@ theme:
   features:
     - navigation.instant
     - navigation.tracking
-    - navigation.tabs # enable the navigation tabs in the header
-    - navigation.tabs.sticky # navigation tabs will lock below the header and always remain visible when scrolling down
     - navigation.top # enable the back-to-top button
     - announce.dismiss # enable custom announcements, they will dismiss by scrolling down
 


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR removes the tabs navigation since with many items the menu overflows and hides the last sections.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
