### PR TITLE
chore: fix Oomph installer Sonarlint plugin repo url

### DIFF
--- a/kura/setups/kura.setup
+++ b/kura/setups/kura.setup
@@ -90,7 +90,7 @@
     <repository
         url="http://update.eclemma.org/"/>
     <repository
-        url="http://eclipse.sonarlint.org/"/>
+        url="https://eclipse-uc.sonarlint.org/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <setupTask


### PR DESCRIPTION
Brief description of the PR: Oomph installer fix for Sonarlint plugin repository URL.

**Related Issue:** This PR fixes/closes #4171 
