### PR TITLE
fix: Improved handling of floating point values in KuraPayload JSON encoding

### DIFF
--- a/kura/org.eclipse.kura.json.marshaller.unmarshaller.provider/src/main/java/org/eclipse/kura/internal/json/marshaller/unmarshaller/message/CloudPayloadJsonEncoder.java
+++ b/kura/org.eclipse.kura.json.marshaller.unmarshaller.provider/src/main/java/org/eclipse/kura/internal/json/marshaller/unmarshaller/message/CloudPayloadJsonEncoder.java
@@ -147,7 +147,9 @@ public class CloudPayloadJsonEncoder {
     }
 
     private static void encodePositionDouble(final JsonObject object, final String metric, final Double value) {
-        encodeDoubleProperty(object, metric, value, "discarding non finite double metric: position.{}={}");
+        if (value != null) {
+            encodeDoubleProperty(object, metric, value, "discarding non finite double metric: position.{}={}");
+        }
     }
 
     private static void encodeTimestamp(KuraPayload kuraPayload, JsonObject json) {

--- a/kura/test/org.eclipse.kura.json.marshaller.unmarshaller.provider.test/src/test/java/org/eclipse/kura/internal/json/marshaller/unmarshaller/message/test/CloudPayloadJsonEncoderTest.java
+++ b/kura/test/org.eclipse.kura.json.marshaller.unmarshaller.provider.test/src/test/java/org/eclipse/kura/internal/json/marshaller/unmarshaller/message/test/CloudPayloadJsonEncoderTest.java
@@ -201,6 +201,28 @@ public class CloudPayloadJsonEncoderTest {
     }
 
     @Test
+    public void shouldEncodeEmptyPosition() {
+        KuraPayload payload = new KuraPayload();
+        KuraPosition position = new KuraPosition();
+
+        payload.setPosition(position);
+
+        String result = CloudPayloadJsonEncoder.marshal(payload);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        KuraPayload decodedPayload = CloudPayloadJsonDecoder.buildFromString(result);
+
+        assertNull(decodedPayload.getPosition().getAltitude());
+        assertNull(decodedPayload.getPosition().getHeading());
+        assertNull(decodedPayload.getPosition().getLatitude());
+        assertNull(decodedPayload.getPosition().getLongitude());
+        assertNull(decodedPayload.getPosition().getPrecision());
+        assertNull(decodedPayload.getPosition().getSpeed());
+    }
+
+    @Test
     public void testToJsonKuraPayloadOnlyTimestamp() {
         KuraPayload payload = new KuraPayload();
         payload.setTimestamp(new Date());

--- a/kura/test/org.eclipse.kura.json.marshaller.unmarshaller.provider.test/src/test/java/org/eclipse/kura/internal/json/marshaller/unmarshaller/message/test/CloudPayloadJsonEncoderTest.java
+++ b/kura/test/org.eclipse.kura.json.marshaller.unmarshaller.provider.test/src/test/java/org/eclipse/kura/internal/json/marshaller/unmarshaller/message/test/CloudPayloadJsonEncoderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -53,6 +53,151 @@ public class CloudPayloadJsonEncoderTest {
         assertEquals(payload.getBody(), decodedPayload.getBody());
         assertEquals(payload.getTimestamp(), decodedPayload.getTimestamp());
         assertEquals(payload.metrics(), decodedPayload.metrics());
+    }
+
+    @Test
+    public void shouldDiscardNonFiniteFloatMetrics() {
+        KuraPayload payload = new KuraPayload();
+
+        payload.addMetric("positive.infinity", Float.POSITIVE_INFINITY);
+        payload.addMetric("negative.infinity", Float.NEGATIVE_INFINITY);
+        payload.addMetric("nan", Float.NaN);
+        payload.addMetric("foo", "bar");
+
+        String result = CloudPayloadJsonEncoder.marshal(payload);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        KuraPayload decodedPayload = CloudPayloadJsonDecoder.buildFromString(result);
+
+        assertEquals(payload.getPosition(), decodedPayload.getPosition());
+        assertEquals(payload.getBody(), decodedPayload.getBody());
+        assertEquals(payload.getTimestamp(), decodedPayload.getTimestamp());
+
+        assertNull(decodedPayload.metrics().get("positive.infinity"));
+        assertNull(decodedPayload.metrics().get("negative.infinity"));
+        assertNull(decodedPayload.metrics().get("nan"));
+        assertEquals("bar", decodedPayload.getMetric("foo"));
+    }
+
+    @Test
+    public void shouldDiscardPositiveInfinityInPositionFields() {
+        KuraPayload payload = new KuraPayload();
+        KuraPosition position = new KuraPosition();
+
+        position.setAltitude(Double.POSITIVE_INFINITY);
+        position.setHeading(Double.POSITIVE_INFINITY);
+        position.setLatitude(Double.POSITIVE_INFINITY);
+        position.setLongitude(Double.POSITIVE_INFINITY);
+        position.setPrecision(Double.POSITIVE_INFINITY);
+        position.setSpeed(Double.POSITIVE_INFINITY);
+        position.setSatellites(40);
+
+        payload.setPosition(position);
+
+        String result = CloudPayloadJsonEncoder.marshal(payload);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        KuraPayload decodedPayload = CloudPayloadJsonDecoder.buildFromString(result);
+
+        assertNull(decodedPayload.getPosition().getAltitude());
+        assertNull(decodedPayload.getPosition().getHeading());
+        assertNull(decodedPayload.getPosition().getLatitude());
+        assertNull(decodedPayload.getPosition().getLongitude());
+        assertNull(decodedPayload.getPosition().getPrecision());
+        assertNull(decodedPayload.getPosition().getSpeed());
+        assertEquals(40, (int) decodedPayload.getPosition().getSatellites());
+    }
+
+    @Test
+    public void shouldDiscardNegativeInfinityInPositionFields() {
+        KuraPayload payload = new KuraPayload();
+        KuraPosition position = new KuraPosition();
+
+        position.setAltitude(Double.NEGATIVE_INFINITY);
+        position.setHeading(Double.NEGATIVE_INFINITY);
+        position.setLatitude(Double.NEGATIVE_INFINITY);
+        position.setLongitude(Double.NEGATIVE_INFINITY);
+        position.setPrecision(Double.NEGATIVE_INFINITY);
+        position.setSpeed(Double.NEGATIVE_INFINITY);
+        position.setSatellites(40);
+
+        payload.setPosition(position);
+
+        String result = CloudPayloadJsonEncoder.marshal(payload);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        KuraPayload decodedPayload = CloudPayloadJsonDecoder.buildFromString(result);
+
+        assertNull(decodedPayload.getPosition().getAltitude());
+        assertNull(decodedPayload.getPosition().getHeading());
+        assertNull(decodedPayload.getPosition().getLatitude());
+        assertNull(decodedPayload.getPosition().getLongitude());
+        assertNull(decodedPayload.getPosition().getPrecision());
+        assertNull(decodedPayload.getPosition().getSpeed());
+        assertEquals(40, (int) decodedPayload.getPosition().getSatellites());
+    }
+
+    @Test
+    public void shouldDiscardNaNInfinityInPositionFields() {
+        KuraPayload payload = new KuraPayload();
+        KuraPosition position = new KuraPosition();
+
+        position.setAltitude(Double.NaN);
+        position.setHeading(Double.NaN);
+        position.setLatitude(Double.NaN);
+        position.setLongitude(Double.NaN);
+        position.setPrecision(Double.NaN);
+        position.setSpeed(Double.NaN);
+        position.setSatellites(40);
+
+        payload.setPosition(position);
+
+        String result = CloudPayloadJsonEncoder.marshal(payload);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        KuraPayload decodedPayload = CloudPayloadJsonDecoder.buildFromString(result);
+
+        assertNull(decodedPayload.getPosition().getAltitude());
+        assertNull(decodedPayload.getPosition().getHeading());
+        assertNull(decodedPayload.getPosition().getLatitude());
+        assertNull(decodedPayload.getPosition().getLongitude());
+        assertNull(decodedPayload.getPosition().getPrecision());
+        assertNull(decodedPayload.getPosition().getSpeed());
+        assertEquals(40, (int) decodedPayload.getPosition().getSatellites());
+    }
+
+    @Test
+    public void shoyldDiscardNonFiniteDoubleMetrics() {
+        KuraPayload payload = new KuraPayload();
+
+        payload.addMetric("positive.infinity", Double.POSITIVE_INFINITY);
+        payload.addMetric("negative.infinity", Double.NEGATIVE_INFINITY);
+        payload.addMetric("nan", Double.NaN);
+        payload.addMetric("foo", "bar");
+
+        String result = CloudPayloadJsonEncoder.marshal(payload);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        KuraPayload decodedPayload = CloudPayloadJsonDecoder.buildFromString(result);
+
+        assertEquals(payload.getPosition(), decodedPayload.getPosition());
+        assertEquals(payload.getBody(), decodedPayload.getBody());
+        assertEquals(payload.getTimestamp(), decodedPayload.getTimestamp());
+
+        assertNull(decodedPayload.metrics().get("positive.infinity"));
+        assertNull(decodedPayload.metrics().get("negative.infinity"));
+        assertNull(decodedPayload.metrics().get("nan"));
+        assertEquals("bar", decodedPayload.getMetric("foo"));
     }
 
     @Test
@@ -119,7 +264,7 @@ public class CloudPayloadJsonEncoderTest {
 
         assertNotNull(result);
         assertFalse(result.isEmpty());
-        
+
         KuraPayload decodedPayload = CloudPayloadJsonDecoder.buildFromString(result);
 
         assertEquals(payload.getTimestamp(), decodedPayload.getTimestamp());


### PR DESCRIPTION
…load JSON serialization

Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

* Infinite and NaN metrics and position fields are now ignored instead of causing the entire message to be dropped
