### PR TITLE
test(configuration.change.manager): add config change manager tests

### DIFF
--- a/kura/org.eclipse.kura.configuration.change.manager/src/main/java/org/eclipse/kura/configuration/change/manager/ConfigurationChangeManager.java
+++ b/kura/org.eclipse.kura.configuration.change.manager/src/main/java/org/eclipse/kura/configuration/change/manager/ConfigurationChangeManager.java
@@ -93,7 +93,7 @@ public class ConfigurationChangeManager implements ConfigurableComponent, Servic
      * Activation APIs
      */
 
-    protected void activate(final Map<String, Object> properties) throws InvalidSyntaxException {
+    public void activate(final Map<String, Object> properties) throws InvalidSyntaxException {
         logger.info("Activating ConfigurationChangeManager...");
 
         this.acceptNotifications = false;
@@ -112,9 +112,9 @@ public class ConfigurationChangeManager implements ConfigurableComponent, Servic
         this.options = new ConfigurationChangeManagerOptions(properties);
 
         if (this.options.isEnabled()) {
+            this.acceptNotifications = true;
             this.serviceTracker.open(true);
             this.serviceTracker.addServiceTrackerListener(this);
-            this.acceptNotifications = true;
         } else {
             this.acceptNotifications = false;
             this.serviceTracker.removeServiceTrackerListener(this);

--- a/kura/org.eclipse.kura.configuration.change.manager/src/main/java/org/eclipse/kura/configuration/change/manager/ConfigurationChangeManagerOptions.java
+++ b/kura/org.eclipse.kura.configuration.change.manager/src/main/java/org/eclipse/kura/configuration/change/manager/ConfigurationChangeManagerOptions.java
@@ -16,11 +16,10 @@ import java.util.Map;
 
 public class ConfigurationChangeManagerOptions {
 
-    static final String KEY_ENABLED = "enabled";
-    static final String KEY_SEND_DELAY = "send.delay";
-    static final boolean DEFAULT_ENABLED = false;
-    static final long DEFAULT_DETECTION_DELAY = 120000;
-    static final long DEFAULT_SEND_DELAY = 10;
+    public static final String KEY_ENABLED = "enabled";
+    public static final String KEY_SEND_DELAY = "send.delay";
+    public static final boolean DEFAULT_ENABLED = false;
+    public static final long DEFAULT_SEND_DELAY = 10;
 
     private final boolean enabled;
     private final long sendDelay;

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/META-INF/MANIFEST.MF
@@ -6,17 +6,19 @@ Bundle-Version: 5.3.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Fragment-Host: org.eclipse.kura.configuration.change.manager
-Import-Package: org.junit;version="4.12.0",
+Import-Package: com.google.gson;version="2.7.0",
+ junit.framework;version="4.12.0",
+ org.eclipse.kura;version="1.6.0",
+ org.eclipse.kura.cloudconnection.message;version="[1.0,2.0)",
+ org.eclipse.kura.cloudconnection.publisher;version="[1.0,2.0)",
+ org.eclipse.kura.configuration;version="[1.2,1.3)",
+ org.eclipse.kura.core.testutil.service;version="1.0.0",
+ org.junit;version="4.12.0",
  org.junit.runner;version="4.12.0",
  org.junit.runners;version="4.12.0",
  org.mockito;version="1.10.19",
  org.mockito.stubbing;version="1.10.19",
  org.osgi.framework;version="1.7",
  org.osgi.service.cm;version="1.4.0",
- org.osgi.util.tracker;version="[1.5,2.0)",
- org.eclipse.kura;version="1.6.0",
- org.eclipse.kura.cloudconnection.message;version="[1.0,2.0)",
- org.eclipse.kura.cloudconnection.publisher;version="[1.0,2.0)",
- org.eclipse.kura.configuration;version="[1.2,1.3)",
- com.google.gson;version="2.7.0"
+ org.osgi.util.tracker;version="[1.5,2.0)"
 Bundle-ClassPath: .

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/META-INF/MANIFEST.MF
@@ -1,0 +1,22 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.configuration.change.manager.test
+Bundle-SymbolicName: org.eclipse.kura.configuration.change.manager.test;singleton:=true
+Bundle-Version: 5.3.0.qualifier
+Bundle-Vendor: Eclipse Kura
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Fragment-Host: org.eclipse.kura.configuration.change.manager
+Import-Package: org.junit;version="4.12.0",
+ org.junit.runner;version="4.12.0",
+ org.junit.runners;version="4.12.0",
+ org.mockito;version="1.10.19",
+ org.mockito.stubbing;version="1.10.19",
+ org.osgi.framework;version="1.7",
+ org.osgi.service.cm;version="1.4.0",
+ org.osgi.util.tracker;version="[1.5,2.0)",
+ org.eclipse.kura;version="1.6.0",
+ org.eclipse.kura.cloudconnection.message;version="[1.0,2.0)",
+ org.eclipse.kura.cloudconnection.publisher;version="[1.0,2.0)",
+ org.eclipse.kura.configuration;version="[1.2,1.3)",
+ com.google.gson;version="2.7.0"
+Bundle-ClassPath: .

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/build.properties
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/build.properties
@@ -1,0 +1,19 @@
+#
+#  Copyright (c) 2022 Eurotech and/or its affiliates and others
+#
+#  This program and the accompanying materials are made
+#  available under the terms of the Eclipse Public License 2.0
+#  which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#   Eurotech
+#
+source.. = src/main/java
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .
+additional.bundles = slf4j.api,\
+                     org.junit,\
+                     org.apache.logging.log4j.api

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/pom.xml
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+  
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+ 
+	SPDX-License-Identifier: EPL-2.0
+	
+	Contributors:
+     Eurotech
+     
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.kura</groupId>
+        <artifactId>test</artifactId>
+        <version>5.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>org.eclipse.kura.configuration.change.manager.test</artifactId>
+    <packaging>eclipse-test-plugin</packaging>
+
+    <properties>
+        <kura.basedir>${project.basedir}/../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    </properties>
+
+    <build>
+        <plugins>
+			<plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compiletests</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+            	<groupId>org.apache.maven.plugins</groupId>
+            	<artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>target-platform-configuration</artifactId>
+            </plugin>
+		</plugins>
+    </build>
+</project>

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ComponentsServiceTrackerTest.java
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ComponentsServiceTrackerTest.java
@@ -1,0 +1,246 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.configuration.change.manager.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.kura.configuration.ConfigurationService;
+import org.eclipse.kura.configuration.change.manager.ComponentsServiceTracker;
+import org.eclipse.kura.configuration.change.manager.ServiceTrackerListener;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+public class ComponentsServiceTrackerTest {
+
+    private ComponentsServiceTracker tracker;
+    private ServiceTrackerListener listener;
+    private boolean exceptionOccurred;
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void addingServiceWithKuraPidShouldNotifyListener() throws InvalidSyntaxException {
+        givenComponentsServiceTracker();
+        givenServiceTrackerListener();
+
+        whenAddingServiceWithKuraPid("example1");
+
+        thenNoExceptionsOccurred();
+        thenListenerIsNotified("example1");
+    }
+
+    @Test
+    public void addingServiceWithServiceFactoryPidShouldNotifyListener() throws InvalidSyntaxException {
+        givenComponentsServiceTracker();
+        givenServiceTrackerListener();
+
+        whenAddingServiceWithServiceFactoryPid("example1");
+
+        thenNoExceptionsOccurred();
+        thenListenerIsNotified("example1");
+    }
+
+    @Test
+    public void addingServiceWithServicePidShouldNotifyListener() throws InvalidSyntaxException {
+        givenComponentsServiceTracker();
+        givenServiceTrackerListener();
+
+        whenAddingServiceWithServicePid("example1");
+
+        thenNoExceptionsOccurred();
+        thenListenerIsNotified("example1");
+    }
+
+    @Test
+    public void addingServiceWithWithUnknownPropertyShouldNotNotifyListener() throws InvalidSyntaxException {
+        givenComponentsServiceTracker();
+        givenServiceTrackerListener();
+
+        whenAddingServiceWithUnknownProperty();
+
+        thenNoExceptionsOccurred();
+        thenListenerIsNotNotified();
+    }
+
+    @Test
+    public void modifiedServiceShouldNotifyListener() throws InvalidSyntaxException {
+        givenComponentsServiceTracker();
+        givenServiceTrackerListener();
+
+        whenModifiedService("modified-pid");
+
+        thenNoExceptionsOccurred();
+        thenListenerIsNotified("modified-pid");
+    }
+
+    @Test
+    public void removedServiceShouldNotifyListener() throws InvalidSyntaxException {
+        givenComponentsServiceTracker();
+        givenServiceTrackerListener();
+
+        whenRemovedService("removed-pid");
+
+        thenNoExceptionsOccurred();
+        thenListenerIsNotified("removed-pid");
+    }
+
+    @Test
+    public void notRegisteredListenerShouldNotBeNotified() throws InvalidSyntaxException {
+        givenComponentsServiceTracker();
+        givenServiceTrackerListener();
+        givenRemoveServiceTrackerListener();
+
+        whenRemovedService("removed-pid2");
+
+        thenNoExceptionsOccurred();
+        thenListenerIsNotNotified();
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenComponentsServiceTracker() throws InvalidSyntaxException {
+        BundleContext mockContext = mock(BundleContext.class);
+        Filter mockFilter = mock(Filter.class);
+
+        when(mockContext.createFilter(Mockito.anyString())).thenReturn(mockFilter);
+        when(mockContext.getService(Mockito.any())).thenReturn(new Object());
+        when(mockContext.ungetService(Mockito.any())).thenReturn(true);
+        this.tracker = new ComponentsServiceTracker(mockContext);
+    }
+
+    private void givenServiceTrackerListener() {
+        this.listener = mock(ServiceTrackerListener.class);
+        this.tracker.addServiceTrackerListener(this.listener);
+    }
+
+    private void givenRemoveServiceTrackerListener() {
+        this.tracker.removeServiceTrackerListener(this.listener);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenAddingServiceWithKuraPid(String kuraPid) {
+        @SuppressWarnings("unchecked")
+        ServiceReference<Object> ref = (ServiceReference<Object>) mock(ServiceReference.class);
+        when(ref.getProperty(ConfigurationService.KURA_SERVICE_PID)).thenReturn(kuraPid);
+
+        callAddingService(ref);
+    }
+
+    private void whenAddingServiceWithServiceFactoryPid(String serviceFactoryPid) {
+        @SuppressWarnings("unchecked")
+        ServiceReference<Object> ref = (ServiceReference<Object>) mock(ServiceReference.class);
+        when(ref.getProperty(ConfigurationAdmin.SERVICE_FACTORYPID)).thenReturn(serviceFactoryPid);
+        
+        callAddingService(ref);
+    }
+
+    private void whenAddingServiceWithServicePid(String servicePid) {
+        @SuppressWarnings("unchecked")
+        ServiceReference<Object> ref = (ServiceReference<Object>) mock(ServiceReference.class);
+        when(ref.getProperty(Constants.SERVICE_PID)).thenReturn(servicePid);
+
+        callAddingService(ref);
+    }
+
+    private void whenAddingServiceWithUnknownProperty() {
+        @SuppressWarnings("unchecked")
+        ServiceReference<Object> ref = (ServiceReference<Object>) mock(ServiceReference.class);
+        when(ref.getProperty("unknwonKey")).thenReturn("unknownValue");
+
+        callAddingService(ref);
+    }
+
+    private void whenModifiedService(String kuraPid) {
+        @SuppressWarnings("unchecked")
+        ServiceReference<Object> ref = (ServiceReference<Object>) mock(ServiceReference.class);
+        when(ref.getProperty(ConfigurationService.KURA_SERVICE_PID)).thenReturn(kuraPid);
+
+        try {
+            this.tracker.modifiedService(ref, new Object());
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.exceptionOccurred = true;
+        }
+    }
+
+    private void whenRemovedService(String kuraPid) {
+        @SuppressWarnings("unchecked")
+        ServiceReference<Object> ref = (ServiceReference<Object>) mock(ServiceReference.class);
+        when(ref.getProperty(ConfigurationService.KURA_SERVICE_PID)).thenReturn(kuraPid);
+
+        try {
+            this.tracker.removedService(ref, new Object());
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.exceptionOccurred = true;
+        }
+    }
+
+    private void callAddingService(ServiceReference<Object> reference) {
+        try {
+            this.tracker.addingService(reference);
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.exceptionOccurred = true;
+        }
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenNoExceptionsOccurred() {
+        assertFalse(this.exceptionOccurred);
+    }
+
+    private void thenListenerIsNotified(String changedPid) {
+        verify(this.listener, times(1)).onConfigurationChanged(changedPid);
+    }
+
+    private void thenListenerIsNotNotified() {
+        verify(this.listener, times(0)).onConfigurationChanged(Mockito.any());
+    }
+
+    /*
+     * Utilities
+     */
+
+    @Before
+    public void cleanup() {
+        this.exceptionOccurred = false;
+    }
+
+}

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ComponentsServiceTrackerTest.java
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ComponentsServiceTrackerTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.kura.configuration.change.manager.test;
 
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -22,7 +21,6 @@ import static org.mockito.Mockito.when;
 import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.configuration.change.manager.ComponentsServiceTracker;
 import org.eclipse.kura.configuration.change.manager.ServiceTrackerListener;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.osgi.framework.BundleContext;
@@ -36,7 +34,6 @@ public class ComponentsServiceTrackerTest {
 
     private ComponentsServiceTracker tracker;
     private ServiceTrackerListener listener;
-    private boolean exceptionOccurred;
 
     /*
      * Scenarios
@@ -49,7 +46,6 @@ public class ComponentsServiceTrackerTest {
 
         whenAddingServiceWithKuraPid("example1");
 
-        thenNoExceptionsOccurred();
         thenListenerIsNotified("example1");
     }
 
@@ -60,7 +56,6 @@ public class ComponentsServiceTrackerTest {
 
         whenAddingServiceWithServiceFactoryPid("example1");
 
-        thenNoExceptionsOccurred();
         thenListenerIsNotified("example1");
     }
 
@@ -71,7 +66,6 @@ public class ComponentsServiceTrackerTest {
 
         whenAddingServiceWithServicePid("example1");
 
-        thenNoExceptionsOccurred();
         thenListenerIsNotified("example1");
     }
 
@@ -82,7 +76,6 @@ public class ComponentsServiceTrackerTest {
 
         whenAddingServiceWithUnknownProperty();
 
-        thenNoExceptionsOccurred();
         thenListenerIsNotNotified();
     }
 
@@ -93,7 +86,6 @@ public class ComponentsServiceTrackerTest {
 
         whenModifiedService("modified-pid");
 
-        thenNoExceptionsOccurred();
         thenListenerIsNotified("modified-pid");
     }
 
@@ -104,7 +96,6 @@ public class ComponentsServiceTrackerTest {
 
         whenRemovedService("removed-pid");
 
-        thenNoExceptionsOccurred();
         thenListenerIsNotified("removed-pid");
     }
 
@@ -116,7 +107,6 @@ public class ComponentsServiceTrackerTest {
 
         whenRemovedService("removed-pid2");
 
-        thenNoExceptionsOccurred();
         thenListenerIsNotNotified();
     }
 
@@ -188,12 +178,7 @@ public class ComponentsServiceTrackerTest {
         ServiceReference<Object> ref = (ServiceReference<Object>) mock(ServiceReference.class);
         when(ref.getProperty(ConfigurationService.KURA_SERVICE_PID)).thenReturn(kuraPid);
 
-        try {
-            this.tracker.modifiedService(ref, new Object());
-        } catch (Exception e) {
-            e.printStackTrace();
-            this.exceptionOccurred = true;
-        }
+        this.tracker.modifiedService(ref, new Object());
     }
 
     private void whenRemovedService(String kuraPid) {
@@ -201,30 +186,16 @@ public class ComponentsServiceTrackerTest {
         ServiceReference<Object> ref = (ServiceReference<Object>) mock(ServiceReference.class);
         when(ref.getProperty(ConfigurationService.KURA_SERVICE_PID)).thenReturn(kuraPid);
 
-        try {
-            this.tracker.removedService(ref, new Object());
-        } catch (Exception e) {
-            e.printStackTrace();
-            this.exceptionOccurred = true;
-        }
+        this.tracker.removedService(ref, new Object());
     }
 
     private void callAddingService(ServiceReference<Object> reference) {
-        try {
-            this.tracker.addingService(reference);
-        } catch (Exception e) {
-            e.printStackTrace();
-            this.exceptionOccurred = true;
-        }
+        this.tracker.addingService(reference);
     }
 
     /*
      * Then
      */
-
-    private void thenNoExceptionsOccurred() {
-        assertFalse(this.exceptionOccurred);
-    }
 
     private void thenListenerIsNotified(String changedPid) {
         verify(this.listener, times(1)).onConfigurationChanged(changedPid);
@@ -232,15 +203,6 @@ public class ComponentsServiceTrackerTest {
 
     private void thenListenerIsNotNotified() {
         verify(this.listener, times(0)).onConfigurationChanged(Mockito.any());
-    }
-
-    /*
-     * Utilities
-     */
-
-    @Before
-    public void cleanup() {
-        this.exceptionOccurred = false;
     }
 
 }

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerOptionsTest.java
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerOptionsTest.java
@@ -18,7 +18,6 @@ import static org.eclipse.kura.configuration.change.manager.ConfigurationChangeM
 import static org.eclipse.kura.configuration.change.manager.ConfigurationChangeManagerOptions.KEY_ENABLED;
 import static org.eclipse.kura.configuration.change.manager.ConfigurationChangeManagerOptions.KEY_SEND_DELAY;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +31,6 @@ public class ConfigurationChangeManagerOptionsTest {
     private Map<String, Object> properties;
     private ConfigurationChangeManagerOptions options;
     private Object returnValue;
-    private Exception exceptionOccurred;
 
     /*
      * Scenarios
@@ -45,7 +43,6 @@ public class ConfigurationChangeManagerOptionsTest {
 
         whenIsEnabled();
 
-        thenNoExceptionsOccurred();
         thenReturnValueIs(true);
     }
 
@@ -56,7 +53,6 @@ public class ConfigurationChangeManagerOptionsTest {
 
         whenIsEnabled();
 
-        thenNoExceptionsOccurred();
         thenReturnValueIs(false);
     }
 
@@ -66,7 +62,6 @@ public class ConfigurationChangeManagerOptionsTest {
 
         whenIsEnabled();
 
-        thenNoExceptionsOccurred();
         thenReturnValueIs(DEFAULT_ENABLED);
     }
 
@@ -77,7 +72,6 @@ public class ConfigurationChangeManagerOptionsTest {
 
         whenGetSendDelay();
 
-        thenNoExceptionsOccurred();
         thenReturnValueIs(1000L);
     }
 
@@ -87,7 +81,6 @@ public class ConfigurationChangeManagerOptionsTest {
 
         whenGetSendDelay();
 
-        thenNoExceptionsOccurred();
         thenReturnValueIs(DEFAULT_SEND_DELAY);
     }
 
@@ -112,28 +105,16 @@ public class ConfigurationChangeManagerOptionsTest {
      */
 
     private void whenIsEnabled() {
-        try {
-            this.returnValue = this.options.isEnabled();
-        } catch (Exception e) {
-            this.exceptionOccurred = e;
-        }
+        this.returnValue = this.options.isEnabled();
     }
 
     private void whenGetSendDelay() {
-        try {
-            this.returnValue = this.options.getSendDelay();
-        } catch (Exception e) {
-            this.exceptionOccurred = e;
-        }
+        this.returnValue = this.options.getSendDelay();
     }
 
     /*
      * Then
      */
-
-    private void thenNoExceptionsOccurred() {
-        assertNull(this.exceptionOccurred);
-    }
 
     @SuppressWarnings("unchecked")
     private <T> void thenReturnValueIs(T expectedValue) {
@@ -150,7 +131,6 @@ public class ConfigurationChangeManagerOptionsTest {
         this.properties = new HashMap<>();
         this.options = null;
         this.returnValue = null;
-        this.exceptionOccurred = null;
     }
 
 }

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerOptionsTest.java
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerOptionsTest.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+
+package org.eclipse.kura.configuration.change.manager.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.kura.configuration.change.manager.ConfigurationChangeManagerOptions;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConfigurationChangeManagerOptionsTest {
+
+    private static final String KEY_ENABLED = "enabled";
+    private static final String KEY_SEND_DELAY = "send.delay";
+    private static final boolean DEFAULT_ENABLED = false;
+    private static final long DEFAULT_SEND_DELAY = 10;
+
+    private Map<String, Object> properties;
+    private ConfigurationChangeManagerOptions options;
+    private Object returnValue;
+    private Exception exceptionOccurred;
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void shouldReturnEnabled() {
+        givenProperty(KEY_ENABLED, true);
+        givenOptionsInstatiated();
+
+        whenIsEnabled();
+
+        thenNoExceptionsOccurred();
+        thenReturnValueIs(true);
+    }
+
+    @Test
+    public void shouldReturnDisabled() {
+        givenProperty(KEY_ENABLED, false);
+        givenOptionsInstatiated();
+
+        whenIsEnabled();
+
+        thenNoExceptionsOccurred();
+        thenReturnValueIs(false);
+    }
+
+    @Test
+    public void shouldReturnDefaultEnabledValue() {
+        givenOptionsInstatiated();
+
+        whenIsEnabled();
+
+        thenNoExceptionsOccurred();
+        thenReturnValueIs(DEFAULT_ENABLED);
+    }
+
+    @Test
+    public void shouldReturnCorrectSendDelay() {
+        givenProperty(KEY_SEND_DELAY, 1000L);
+        givenOptionsInstatiated();
+
+        whenGetSendDelay();
+
+        thenNoExceptionsOccurred();
+        thenReturnValueIs(1000L);
+    }
+
+    @Test
+    public void shouldReturnDefaultSendDelay() {
+        givenOptionsInstatiated();
+
+        whenGetSendDelay();
+
+        thenNoExceptionsOccurred();
+        thenReturnValueIs(DEFAULT_SEND_DELAY);
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenProperty(String key, Object value) {
+        this.properties.put(key, value);
+    }
+
+    private void givenOptionsInstatiated() {
+        this.options = new ConfigurationChangeManagerOptions(this.properties);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenIsEnabled() {
+        try {
+            this.returnValue = this.options.isEnabled();
+        } catch (Exception e) {
+            this.exceptionOccurred = e;
+        }
+    }
+
+    private void whenGetSendDelay() {
+        try {
+            this.returnValue = this.options.getSendDelay();
+        } catch (Exception e) {
+            this.exceptionOccurred = e;
+        }
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenNoExceptionsOccurred() {
+        assertNull(this.exceptionOccurred);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> void thenReturnValueIs(T expectedValue) {
+        assertEquals(expectedValue, (T) this.returnValue);
+    }
+
+
+    /*
+     * Utility
+     */
+
+    @Before
+    public void cleanUp() {
+        this.properties = new HashMap<>();
+        this.options = null;
+        this.returnValue = null;
+        this.exceptionOccurred = null;
+    }
+
+}

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerOptionsTest.java
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerOptionsTest.java
@@ -13,6 +13,10 @@
 
 package org.eclipse.kura.configuration.change.manager.test;
 
+import static org.eclipse.kura.configuration.change.manager.ConfigurationChangeManagerOptions.DEFAULT_ENABLED;
+import static org.eclipse.kura.configuration.change.manager.ConfigurationChangeManagerOptions.DEFAULT_SEND_DELAY;
+import static org.eclipse.kura.configuration.change.manager.ConfigurationChangeManagerOptions.KEY_ENABLED;
+import static org.eclipse.kura.configuration.change.manager.ConfigurationChangeManagerOptions.KEY_SEND_DELAY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -24,11 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ConfigurationChangeManagerOptionsTest {
-
-    private static final String KEY_ENABLED = "enabled";
-    private static final String KEY_SEND_DELAY = "send.delay";
-    private static final boolean DEFAULT_ENABLED = false;
-    private static final long DEFAULT_SEND_DELAY = 10;
 
     private Map<String, Object> properties;
     private ConfigurationChangeManagerOptions options;

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerTest.java
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerTest.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.configuration.change.manager.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.kura.configuration.change.manager.ConfigurationChangeManager;
+import org.eclipse.kura.configuration.change.manager.ConfigurationChangeManagerOptions;
+import org.eclipse.kura.configuration.change.manager.test.mocks.MockCloudPublisher;
+import org.eclipse.kura.configuration.change.manager.test.mocks.MockServiceTracker;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.InvalidSyntaxException;
+
+public class ConfigurationChangeManagerTest {
+
+    private MockCloudPublisher mockPublisher = new MockCloudPublisher();
+    private MockServiceTracker mockServiceTracker = new MockServiceTracker();
+    private ConfigurationChangeManager configurationChangeManager = new ConfigurationChangeManager();
+    private boolean occurredException;
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void shouldNotPublishWhenDisabled() throws InterruptedException, ExecutionException {
+        givenConfigurationChangeManager(false, 0L);
+
+        whenConfigurationChanges("test.pid");
+
+        thenNoExceptionsOccurred();
+        thenNoMessagesPublished(0L);
+    }
+
+    @Test
+    public void shouldPublishOneMessage() throws InterruptedException, ExecutionException, TimeoutException {
+        givenConfigurationChangeManager(true, 2L);
+
+        whenConfigurationChanges("test1", "test2");
+
+        thenNoExceptionsOccurred();
+        thenMessagePublished(2L, "test1", "test2");
+    }
+
+    @Test
+    public void shouldAccumulateAndPublishOneMessages() throws InterruptedException, ExecutionException {
+        givenConfigurationChangeManager(true, 10L);
+
+        whenConfigurationChanges("pid1", "pid2", "pid3", "pid4", "pid5", "pid5");
+
+        thenNoExceptionsOccurred();
+        thenMessagePublished(10L, "pid1", "pid2", "pid3", "pid4", "pid5");
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenConfigurationChangeManager(boolean enabled, long sendDelaySec) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ConfigurationChangeManagerOptions.KEY_ENABLED, enabled);
+        properties.put(ConfigurationChangeManagerOptions.KEY_SEND_DELAY, sendDelaySec);
+
+        try {
+            this.configurationChangeManager.updated(properties);
+        } catch (NullPointerException npe) {
+            // expected NPE since the service tracker cannot be instatiated (BundleContext not available)
+        }
+    }
+
+    /*
+     * When
+     */
+
+    private void whenConfigurationChanges(String... changedPids) {
+        try {
+            for (String pid : changedPids) {
+                this.mockServiceTracker.simulateConfigChange(pid);
+            }
+        } catch (Exception e) {
+            this.occurredException = true;
+        }
+    }
+
+    private void thenNoMessagesPublished(long sendDelaySec)
+            throws InterruptedException, ExecutionException {
+        CountDownLatch waitForSendDelay = new CountDownLatch(1);
+        this.mockPublisher.addPublishCountLatch(waitForSendDelay);
+        assertFalse(waitForSendDelay.await(sendDelaySec + 5, TimeUnit.SECONDS));
+    }
+
+    private void thenMessagePublished(long sendDelaySec, String... changedPids)
+            throws InterruptedException, ExecutionException {
+        CountDownLatch waitForSendDelay = new CountDownLatch(1);
+        this.mockPublisher.addPublishCountLatch(waitForSendDelay);
+        waitForSendDelay.await(sendDelaySec + 5, TimeUnit.SECONDS);
+
+        for (String pid : changedPids) {
+            assertTrue("Not all pids have been published.", this.mockPublisher.isPidPublished(pid));
+        }
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenNoExceptionsOccurred() {
+        assertFalse(this.occurredException);
+    }
+
+    /*
+     * Utilities
+     */
+
+    @Before
+    public void cleanup() throws InvalidSyntaxException {
+        this.configurationChangeManager.setCloudPublisher(this.mockPublisher);
+        this.mockServiceTracker.setServiceTrackerListener(this.configurationChangeManager);
+        this.occurredException = false;
+    }
+
+}

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerTest.java
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/ConfigurationChangeManagerTest.java
@@ -36,7 +36,6 @@ public class ConfigurationChangeManagerTest {
     private MockCloudPublisher mockPublisher = new MockCloudPublisher();
     private MockServiceTracker mockServiceTracker = new MockServiceTracker();
     private ConfigurationChangeManager configurationChangeManager = new ConfigurationChangeManager();
-    private boolean occurredException;
 
     /*
      * Scenarios
@@ -48,7 +47,6 @@ public class ConfigurationChangeManagerTest {
 
         whenConfigurationChanges("test.pid");
 
-        thenNoExceptionsOccurred();
         thenNoMessagesPublished(0L);
     }
 
@@ -58,7 +56,6 @@ public class ConfigurationChangeManagerTest {
 
         whenConfigurationChanges("test1", "test2");
 
-        thenNoExceptionsOccurred();
         thenMessagePublished(2L, "test1", "test2");
     }
 
@@ -68,7 +65,6 @@ public class ConfigurationChangeManagerTest {
 
         whenConfigurationChanges("pid1", "pid2", "pid3", "pid4", "pid5", "pid5");
 
-        thenNoExceptionsOccurred();
         thenMessagePublished(10L, "pid1", "pid2", "pid3", "pid4", "pid5");
     }
 
@@ -97,14 +93,14 @@ public class ConfigurationChangeManagerTest {
      */
 
     private void whenConfigurationChanges(String... changedPids) {
-        try {
-            for (String pid : changedPids) {
-                this.mockServiceTracker.simulateConfigChange(pid);
-            }
-        } catch (Exception e) {
-            this.occurredException = true;
+        for (String pid : changedPids) {
+            this.mockServiceTracker.simulateConfigChange(pid);
         }
     }
+
+    /*
+     * Then
+     */
 
     private void thenNoMessagesPublished(long sendDelaySec)
             throws InterruptedException, ExecutionException {
@@ -125,14 +121,6 @@ public class ConfigurationChangeManagerTest {
     }
 
     /*
-     * Then
-     */
-
-    private void thenNoExceptionsOccurred() {
-        assertFalse(this.occurredException);
-    }
-
-    /*
      * Utilities
      */
 
@@ -140,7 +128,6 @@ public class ConfigurationChangeManagerTest {
     public void cleanup() throws InvalidSyntaxException {
         this.configurationChangeManager.setCloudPublisher(this.mockPublisher);
         this.mockServiceTracker.setServiceTrackerListener(this.configurationChangeManager);
-        this.occurredException = false;
     }
 
 }

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/mocks/MockCloudPublisher.java
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/mocks/MockCloudPublisher.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.configuration.change.manager.test.mocks;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.cloudconnection.listener.CloudConnectionListener;
+import org.eclipse.kura.cloudconnection.listener.CloudDeliveryListener;
+import org.eclipse.kura.cloudconnection.message.KuraMessage;
+import org.eclipse.kura.cloudconnection.publisher.CloudPublisher;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+public class MockCloudPublisher implements CloudPublisher {
+
+    private List<CountDownLatch> publishLatches = new LinkedList<>();
+    private List<String> publishedPids = new LinkedList<>();
+
+    public void addPublishCountLatch(CountDownLatch publishLatch) {
+        this.publishLatches.add(publishLatch);
+    }
+
+    @Override
+    public String publish(KuraMessage message) throws KuraException {
+        JsonArray array = JsonParser.parseString(new String(message.getPayload().getBody())).getAsJsonArray();
+        for (JsonElement element : array) {
+            this.publishedPids.add(element.getAsJsonObject().get("pid").getAsString());
+        }
+
+        this.publishLatches.remove(0).countDown();
+        return null;
+    }
+
+    @Override
+    public void registerCloudConnectionListener(CloudConnectionListener cloudConnectionListener) {
+        // nothing to do
+
+    }
+
+    @Override
+    public void unregisterCloudConnectionListener(CloudConnectionListener cloudConnectionListener) {
+        // nothing to do
+
+    }
+
+    @Override
+    public void registerCloudDeliveryListener(CloudDeliveryListener cloudDeliveryListener) {
+        // nothing to do
+
+    }
+
+    @Override
+    public void unregisterCloudDeliveryListener(CloudDeliveryListener cloudDeliveryListener) {
+        // nothing to do
+    }
+    
+    public synchronized boolean isPidPublished(String pid) {
+        return this.publishedPids.remove(pid);
+    }
+}

--- a/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/mocks/MockServiceTracker.java
+++ b/kura/test/org.eclipse.kura.configuration.change.manager.test/src/test/java/org/eclipse/kura/configuration/change/manager/test/mocks/MockServiceTracker.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.configuration.change.manager.test.mocks;
+
+import org.eclipse.kura.configuration.change.manager.ServiceTrackerListener;
+
+public class MockServiceTracker {
+
+    ServiceTrackerListener listener;
+
+    public void setServiceTrackerListener(ServiceTrackerListener listener) {
+        this.listener = listener;
+    }
+
+    public void simulateConfigChange(String changedPid) {
+        listener.onConfigurationChanged(changedPid);
+    }
+
+}

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -846,6 +846,7 @@
         <module>org.eclipse.kura.asset.provider.test</module>
         <module>org.eclipse.kura.asset.helper.provider.test</module>
         <module>org.eclipse.kura.camel.test</module>
+        <module>org.eclipse.kura.configuration.change.manager.test</module>
         <module>org.eclipse.kura.core.certificates.test</module>
         <module>org.eclipse.kura.core.comm.test</module>
         <module>org.eclipse.kura.core.configuration.test</module>


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds tests for the feature introduced in https://github.com/eclipse/kura/pull/4096.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** little refactor on the `configuration.change.manager` package to visibility of constants.
