### PR TITLE
refactor(event.publisher): removed fragment dependency, reorganized constants

### DIFF
--- a/kura/org.eclipse.kura.event.publisher/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.event.publisher/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Vendor: EUROTECH
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
-Fragment-Host: org.eclipse.kura.core.cloud;bundle-version="[1.2.0,2.0.0)"
 Import-Package: org.eclipse.kura;version="[1.0,2.0)",
  org.eclipse.kura.cloudconnection;version="[1.0,2.0)",
  org.eclipse.kura.cloudconnection.listener;version="[1.0,2.0)",

--- a/kura/org.eclipse.kura.event.publisher/src/main/java/org/eclipse/kura/event/publisher/EventPublisherConstants.java
+++ b/kura/org.eclipse.kura.event.publisher/src/main/java/org/eclipse/kura/event/publisher/EventPublisherConstants.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.event.publisher;
+
+
+public final class EventPublisherConstants {
+
+    private EventPublisherConstants() {
+    }
+
+    public static final String TOPIC_ACCOUNT_TOKEN = "#account-name";
+    public static final String TOPIC_CLIENT_ID_TOKEN = "#client-id";
+    public static final String TOPIC_SEPARATOR = "/";
+    public static final String CONTROL = "CONTROL";
+    public static final String FULL_TOPIC = "FULL_TOPIC";
+    public static final String PRIORITY = "PRIORITY";
+    public static final String QOS = "QOS";
+    public static final String RETAIN = "RETAIN";
+
+}

--- a/kura/org.eclipse.kura.event.publisher/src/main/java/org/eclipse/kura/event/publisher/EventPublisherOptions.java
+++ b/kura/org.eclipse.kura.event.publisher/src/main/java/org/eclipse/kura/event/publisher/EventPublisherOptions.java
@@ -16,25 +16,24 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.kura.cloudconnection.CloudConnectionConstants;
-import org.eclipse.kura.core.cloud.CloudServiceOptions;
 import org.eclipse.kura.util.configuration.Property;
 
 public class EventPublisherOptions {
     
-    protected static final String TOPIC_PREFIX_PROP_NAME = "topic.prefix";
-    protected static final String TOPIC_PROP_NAME = "topic";
-    protected static final String QOS_PROP_NAME = "qos";
-    protected static final String RETAIN_PROP_NAME = "retain";
-    protected static final String PRIORITY_PROP_NAME = "priority";
+    public static final String TOPIC_PREFIX_PROP_NAME = "topic.prefix";
+    public static final String TOPIC_PROP_NAME = "topic";
+    public static final String QOS_PROP_NAME = "qos";
+    public static final String RETAIN_PROP_NAME = "retain";
+    public static final String PRIORITY_PROP_NAME = "priority";
 
-    protected static final String DEFAULT_TOPIC = "EVENT_TOPIC";
-    protected static final int DEFAULT_QOS = 0;
-    protected static final boolean DEFAULT_RETAIN = false;
-    protected static final int DEFAULT_PRIORITY = 7;
+    public static final String DEFAULT_TOPIC = "EVENT_TOPIC";
+    public static final int DEFAULT_QOS = 0;
+    public static final boolean DEFAULT_RETAIN = false;
+    public static final int DEFAULT_PRIORITY = 7;
+    public static final String DEFAULT_ENDPOINT_PID = "org.eclipse.kura.cloud.CloudService";
 
     private static final Property<String> PROPERTY_CLOUD_SERVICE_PID = new Property<>(
-            CloudConnectionConstants.CLOUD_ENDPOINT_SERVICE_PID_PROP_NAME.value(),
-            "org.eclipse.kura.cloud.CloudService");
+            CloudConnectionConstants.CLOUD_ENDPOINT_SERVICE_PID_PROP_NAME.value(), DEFAULT_ENDPOINT_PID);
     private static final Property<String> PROPERTY_TOPIC_PREFIX = new Property<>(TOPIC_PREFIX_PROP_NAME, String.class);
     private static final Property<String> PROPERTY_TOPIC = new Property<>(TOPIC_PROP_NAME, DEFAULT_TOPIC);
     private static final Property<Integer> PROPERTY_QOS = new Property<>(QOS_PROP_NAME, DEFAULT_QOS);
@@ -91,11 +90,11 @@ public class EventPublisherOptions {
 
     private String removeTopicSeparatorsFromExtremes(String input) {
         String result = new String(input);
-        if (result.startsWith(CloudServiceOptions.getTopicSeparator())) {
+        if (result.startsWith(EventPublisherConstants.TOPIC_SEPARATOR)) {
             result = result.substring(1);
         }
 
-        if (result.endsWith(CloudServiceOptions.getTopicSeparator())) {
+        if (result.endsWith(EventPublisherConstants.TOPIC_SEPARATOR)) {
             result = result.substring(0, result.length() - 1);
         }
 


### PR DESCRIPTION
…loud connection constants

Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR is a simple refactor to make the `event.publisher` use **only** Kura APIs.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
