### PR TITLE
fix: Removed internal usage of ConnectionInfo

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/NetworkServiceImpl.java
@@ -54,7 +54,6 @@ import org.eclipse.kura.linux.net.util.IScanTool;
 import org.eclipse.kura.linux.net.util.LinuxIfconfig;
 import org.eclipse.kura.linux.net.util.LinuxNetworkUtil;
 import org.eclipse.kura.linux.net.util.ScanTool;
-import org.eclipse.kura.net.ConnectionInfo;
 import org.eclipse.kura.net.IPAddress;
 import org.eclipse.kura.net.NetInterface;
 import org.eclipse.kura.net.NetInterfaceAddress;
@@ -755,7 +754,6 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
             throws KuraException {
         List<NetInterfaceAddress> netInterfaceAddresses = new ArrayList<>();
         if (isUp) {
-            ConnectionInfo conInfo = new ConnectionInfoImpl(interfaceName);
             NetInterfaceAddressImpl netInterfaceAddress = new NetInterfaceAddressImpl();
             try {
                 LinuxIfconfig ifconfig = this.linuxNetworkUtil.getInterfaceConfiguration(interfaceName);
@@ -770,8 +768,6 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
                         Optional<IPAddress> gatewayAddress = this.linuxNetworkUtil.getGatewayIpAddress(interfaceName);
                         if (gatewayAddress.isPresent()) {
                             netInterfaceAddress.setGateway(gatewayAddress.get());
-                        } else {
-                            netInterfaceAddress.setGateway(conInfo.getGateway());
                         }
                         netInterfaceAddress.setDnsServers(new ArrayList<>(LinuxDns.getInstance().getDnServers()));
                         netInterfaceAddresses.add(netInterfaceAddress);
@@ -788,7 +784,6 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
             throws KuraException {
         List<WifiInterfaceAddress> wifiInterfaceAddresses = new ArrayList<>();
         if (isUp) {
-            ConnectionInfo conInfo = new ConnectionInfoImpl(interfaceName);
             WifiInterfaceAddressImpl wifiInterfaceAddress = new WifiInterfaceAddressImpl();
             wifiInterfaceAddresses.add(wifiInterfaceAddress);
             try {
@@ -802,8 +797,6 @@ public class NetworkServiceImpl implements NetworkService, EventHandler {
                     Optional<IPAddress> gatewayAddress = this.linuxNetworkUtil.getGatewayIpAddress(interfaceName);
                     if (gatewayAddress.isPresent()) {
                         wifiInterfaceAddress.setGateway(gatewayAddress.get());
-                    } else {
-                        wifiInterfaceAddress.setGateway(conInfo.getGateway());
                     }
                     wifiInterfaceAddress.setDnsServers(new ArrayList<>(LinuxDns.getInstance().getDnServers()));
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/InterfaceStateBuilder.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/InterfaceStateBuilder.java
@@ -15,11 +15,9 @@ package org.eclipse.kura.net.admin.monitor;
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.executor.CommandExecutorService;
-import org.eclipse.kura.linux.net.ConnectionInfoImpl;
 import org.eclipse.kura.linux.net.util.LinuxNetworkUtil;
 import org.eclipse.kura.linux.net.wifi.HostapdManager;
 import org.eclipse.kura.linux.net.wifi.WpaSupplicantManager;
-import org.eclipse.kura.net.ConnectionInfo;
 import org.eclipse.kura.net.IPAddress;
 import org.eclipse.kura.net.NetInterfaceType;
 import org.eclipse.kura.net.wifi.WifiMode;
@@ -125,8 +123,7 @@ public class InterfaceStateBuilder {
             this.link = this.linuxNetworkUtil.isLinkUp(this.type, this.interfaceName);
             logger.debug("InterfaceState() :: {} - link?={}", this.interfaceName, this.link);
             logger.debug("InterfaceState() :: {} - up?={}", this.interfaceName, this.up);
-            ConnectionInfo connInfo = new ConnectionInfoImpl(this.interfaceName);
-            this.ipAddress = connInfo.getIpAddress();
+            this.ipAddress = getCurrentIpAddress(interfaceName);
             this.carrierChanges = this.linuxNetworkUtil.getCarrierChanges(this.interfaceName);
         }
         return new InterfaceState(this.interfaceName, this.up, this.link, this.ipAddress, this.carrierChanges);
@@ -141,8 +138,7 @@ public class InterfaceStateBuilder {
         this.link = this.linuxNetworkUtil.isLinkUp(NetInterfaceType.WIFI, this.interfaceName);
         logger.debug("InterfaceState() :: {} - link?={}", this.interfaceName, this.link);
         logger.debug("InterfaceState() :: {} - up?={}", this.interfaceName, this.up);
-        ConnectionInfo connInfo = new ConnectionInfoImpl(this.interfaceName);
-        this.ipAddress = connInfo.getIpAddress();
+        this.ipAddress = getCurrentIpAddress(interfaceName);
         setWifiLinkState(this.interfaceName, this.wifiMode);
         this.carrierChanges = this.linuxNetworkUtil.getCarrierChanges(this.interfaceName);
         return new WifiInterfaceState(this.interfaceName, this.up, this.link, this.ipAddress, this.carrierChanges);
@@ -169,6 +165,21 @@ public class InterfaceStateBuilder {
                     this.link = false;
                 }
             }
+        }
+    }
+
+    private IPAddress getCurrentIpAddress(final String interfaceName) {
+        try {
+            final String currentIpAddress = this.linuxNetworkUtil.getCurrentIpAddress(interfaceName);
+
+            if (ipAddress != null) {
+                return IPAddress.parseHostAddress(currentIpAddress);
+            } else {
+                return null;
+            }
+        } catch (final Exception e) {
+            logger.warn("Cannot obtain current IP address", e);
+            return null;
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Kura currently installs the `/etc/network/if-up.d/ifup-local` script that populates the `/tmp/.kura` with some `coninfo` files that contain some information about network interface state (DNS, GATEWAY, IP address).
Kura pareses these files using the `ConnectionInfo` APIs, that is currently used for determining the current gateway for an interface.
These files are regenerated when an interface is brought up using the `ifup` command, for interfaces configured using DHCP by Kura, this happens only once on boot. If a DHCP interface is reconfigured at runtime, the information contained in the `coninfo` files can become outdated.

This PR attempts to remove the internal usage of the `coninfo` files to reduce the risk of inconsistencies. The `coninfo` file generation and related APIs are kept.

