### PR TITLE
feat: add Temurin JDK as alternative JVM in .deb dependencies

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate, 
- openjdk-8-jre-headless, cron
+ openjdk-8-jre-headless | temurin-8-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
@@ -7,7 +7,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  ethtool, telnet, bluez-hcidump, 
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
- ifupdown, openjdk-8-jre-headless, 
+ ifupdown, openjdk-8-jre-headless | temurin-8-jdk, 
  dmidecode, cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
@@ -4,7 +4,7 @@ Section: misc
 Priority: low
 Depends: dos2unix, unzip, telnet, 
  bluez-hcidump, chrony, ntpdate, 
- openjdk-8-jre-headless, cron
+ openjdk-8-jre-headless | temurin-8-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
@@ -6,7 +6,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  dos2unix, bind9, unzip, 
  ethtool, telnet, ifupdown, 
  net-tools, iptables, chrony, 
- dmidecode, ntpdate, openjdk-8-jre-headless, 
+ dmidecode, ntpdate, openjdk-8-jre-headless | temurin-8-jdk, 
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/raspberry-pi-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-nn/deb/control/control
@@ -6,7 +6,7 @@ Depends: hostapd, dos2unix, bind9,
  unzip, ethtool, telnet, 
  bluez-hcidump, bluez, chrony, 
  ntpdate, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless, cron
+ openjdk-8-jre-headless | temurin-8-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, telnet, 
  bluez-hcidump, bluez, chrony, 
  ntpdate, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless, cron
+ openjdk-8-jre-headless | temurin-8-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-ubuntu-20/deb/control/control
@@ -8,7 +8,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless, dmidecode, cron
+ openjdk-8-jre-headless | temurin-8-jdk, dmidecode, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi/deb/control/control
@@ -8,7 +8,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless, cron
+ openjdk-8-jre-headless | temurin-8-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer


### PR DESCRIPTION
As per title: added [Temurin JDK](https://adoptium.net/en-GB/) as an alternative JVM in all the .deb package installers.