### PR TITLE
deprecate(container.orchestrator): deprecated set&getPortsExternal&Internal in ContainerConfiguration & ContainerInstanceDescriptor

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
@@ -90,7 +90,11 @@ public class ContainerConfiguration {
     }
 
     /**
-     * Returns the list of external ports that will be mapped to the given container
+     * @deprecated please use {@link getContainerPorts} as it includes the network
+     *             protocol with the port mapping.
+     * 
+     *             Returns the list of external ports that will be mapped to the
+     *             given container.
      *
      * @return
      */
@@ -103,7 +107,11 @@ public class ContainerConfiguration {
     }
 
     /**
-     * Returns the list of internal ports that will be mapped to the given container
+     * @deprecated please use {@link getContainerPorts} as it includes the network
+     *             protocol with the port mapping.
+     * 
+     *             Returns the list of internal ports that will be mapped to the
+     *             given container
      *
      * @return
      */
@@ -237,7 +245,8 @@ public class ContainerConfiguration {
     }
 
     /**
-     * Returns a List<String> of container entry points. An empty list can be returned if no entrypoints are specified.
+     * Returns a List<String> of container entry points. An empty list can be
+     * returned if no entrypoints are specified.
      *
      * @return
      * @since 2.4
@@ -360,7 +369,8 @@ public class ContainerConfiguration {
         }
 
         /**
-         * Set a list of {@link ContainerPort}, to express which ports to expose and what protocol to use.
+         * Set a list of {@link ContainerPort}, to express which ports to expose and
+         * what protocol to use.
          * 
          * @since 2.5
          */
@@ -370,9 +380,14 @@ public class ContainerConfiguration {
         }
 
         /**
-         * Accepts a list<Integer> of ports to be exposed. Assumes all ports are TCP. To use other Internet protocols
-         * please see the {@link setContainerPorts} method. Ensure that the number of elements in this list is the same
-         * as the number of elements set with {@link setInternalPorts}.
+         * @deprecated please use {@link setContainerPorts} as it allows for network
+         *             protocol to be specified in a port mapping.
+         * 
+         *             Accepts a list<Integer> of ports to be exposed. Assumes all ports
+         *             are TCP. To use other Internet protocols
+         *             please see the {@link setContainerPorts} method. Ensure that the
+         *             number of elements in this list is the same
+         *             as the number of elements set with {@link setInternalPorts}.
          * 
          */
         public ContainerConfigurationBuilder setExternalPorts(List<Integer> containerPortsExternal) {
@@ -381,10 +396,16 @@ public class ContainerConfiguration {
         }
 
         /**
-         * Accepts a list<Integer> of ports to be open internally within the container. Assumes all ports are TCP. To
-         * use other Internet protocols please see the {@link setContainerPorts} method.
-         * Ensure that the number of elements in this list is the same as the
-         * number of elements set with {@link setExternalPorts}.
+         * @deprecated please use {@link setContainerPorts} as it allows for network
+         *             protocol to be specified in a port mapping.
+         * 
+         *             Accepts a list<Integer> of ports to be open internally within the
+         *             container. Assumes all ports are TCP. To
+         *             use other Internet protocols please see the
+         *             {@link setContainerPorts} method.
+         *             Ensure that the number of elements in this list is the same as
+         *             the
+         *             number of elements set with {@link setExternalPorts}.
          * 
          */
         public ContainerConfigurationBuilder setInternalPorts(List<Integer> containerPortsInternal) {

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
@@ -90,14 +90,15 @@ public class ContainerConfiguration {
     }
 
     /**
-     * @deprecated please use {@link getContainerPorts} as it includes the network
-     *             protocol with the port mapping.
-     * 
-     *             Returns the list of external ports that will be mapped to the
-     *             given container.
+     * Returns the list of external ports that will be mapped to the
+     * given container.
      *
      * @return
+     *
+     * @deprecated since 2.5. Please use {@link getContainerPorts} as it includes the network
+     *             protocol with the port mapping.
      */
+    @Deprecated
     public List<Integer> getContainerPortsExternal() {
         List<Integer> portList = new LinkedList<>();
         for (ContainerPort port : this.containerPorts) {
@@ -107,14 +108,15 @@ public class ContainerConfiguration {
     }
 
     /**
-     * @deprecated please use {@link getContainerPorts} as it includes the network
-     *             protocol with the port mapping.
-     * 
-     *             Returns the list of internal ports that will be mapped to the
-     *             given container
+     * Returns the list of internal ports that will be mapped to the
+     * given container
      *
      * @return
+     *
+     * @deprecated since 2.5. Please use {@link getContainerPorts} as it includes the network
+     *             protocol with the port mapping.
      */
+    @Deprecated
     public List<Integer> getContainerPortsInternal() {
         List<Integer> portList = new LinkedList<>();
         for (ContainerPort port : this.containerPorts) {
@@ -257,7 +259,7 @@ public class ContainerConfiguration {
 
     /**
      * Returns boolean which determines if container will restart on failure
-     * 
+     *
      * @return
      * @since 2.4
      */
@@ -317,7 +319,7 @@ public class ContainerConfiguration {
         if (this == obj) {
             return true;
         }
-        if ((obj == null) || (getClass() != obj.getClass())) {
+        if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
         ContainerConfiguration other = (ContainerConfiguration) obj;
@@ -371,7 +373,7 @@ public class ContainerConfiguration {
         /**
          * Set a list of {@link ContainerPort}, to express which ports to expose and
          * what protocol to use.
-         * 
+         *
          * @since 2.5
          */
         public ContainerConfigurationBuilder setContainerPorts(List<ContainerPort> containerPorts) {
@@ -380,34 +382,34 @@ public class ContainerConfiguration {
         }
 
         /**
-         * @deprecated please use {@link setContainerPorts} as it allows for network
+         * Accepts a list<Integer> of ports to be exposed. Assumes all ports
+         * are TCP. To use other Internet protocols
+         * please see the {@link setContainerPorts} method. Ensure that the
+         * number of elements in this list is the same
+         * as the number of elements set with {@link setInternalPorts}.
+         *
+         * @deprecated since 2.5. Please use {@link setContainerPorts} as it allows for network
          *             protocol to be specified in a port mapping.
-         * 
-         *             Accepts a list<Integer> of ports to be exposed. Assumes all ports
-         *             are TCP. To use other Internet protocols
-         *             please see the {@link setContainerPorts} method. Ensure that the
-         *             number of elements in this list is the same
-         *             as the number of elements set with {@link setInternalPorts}.
-         * 
          */
+        @Deprecated
         public ContainerConfigurationBuilder setExternalPorts(List<Integer> containerPortsExternal) {
             this.containerPortsExternal = new ArrayList<>(containerPortsExternal);
             return this;
         }
 
         /**
-         * @deprecated please use {@link setContainerPorts} as it allows for network
+         * Accepts a list<Integer> of ports to be open internally within the
+         * container. Assumes all ports are TCP. To
+         * use other Internet protocols please see the
+         * {@link setContainerPorts} method.
+         * Ensure that the number of elements in this list is the same as
+         * the number of elements set with {@link setExternalPorts}.
+         *
+         * @deprecated since 2.5. Please use {@link setContainerPorts} as it allows for network
          *             protocol to be specified in a port mapping.
-         * 
-         *             Accepts a list<Integer> of ports to be open internally within the
-         *             container. Assumes all ports are TCP. To
-         *             use other Internet protocols please see the
-         *             {@link setContainerPorts} method.
-         *             Ensure that the number of elements in this list is the same as
-         *             the
-         *             number of elements set with {@link setExternalPorts}.
-         * 
+         *
          */
+        @Deprecated
         public ContainerConfigurationBuilder setInternalPorts(List<Integer> containerPortsInternal) {
             this.containerPortsInternal = new ArrayList<>(containerPortsInternal);
             return this;
@@ -497,7 +499,7 @@ public class ContainerConfiguration {
 
         /**
          * Set if container will restart on failure
-         * 
+         *
          * @since 2.4
          */
         public ContainerConfigurationBuilder setRestartOnFailure(boolean containerRestartOnFailure) {

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.eclipse.kura.container.orchestration.ContainerNetworkConfiguration.ContainerNetworkConfigurationBuilder;
 import org.eclipse.kura.container.orchestration.ImageConfiguration.ImageConfigurationBuilder;
@@ -100,11 +101,7 @@ public class ContainerConfiguration {
      */
     @Deprecated
     public List<Integer> getContainerPortsExternal() {
-        List<Integer> portList = new LinkedList<>();
-        for (ContainerPort port : this.containerPorts) {
-            portList.add(port.getExternalPort());
-        }
-        return portList;
+        return this.containerPorts.stream().map(ContainerPort::getExternalPort).collect(Collectors.toList());
     }
 
     /**
@@ -118,11 +115,7 @@ public class ContainerConfiguration {
      */
     @Deprecated
     public List<Integer> getContainerPortsInternal() {
-        List<Integer> portList = new LinkedList<>();
-        for (ContainerPort port : this.containerPorts) {
-            portList.add(port.getInternalPort());
-        }
-        return portList;
+        return this.containerPorts.stream().map(ContainerPort::getInternalPort).collect(Collectors.toList());
     }
 
     /**

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerInstanceDescriptor.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerInstanceDescriptor.java
@@ -15,9 +15,9 @@ package org.eclipse.kura.container.orchestration;
 
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -120,11 +120,7 @@ public class ContainerInstanceDescriptor {
      */
     @Deprecated
     public List<Integer> getContainerPortsExternal() {
-        List<Integer> portList = new LinkedList<>();
-        for (ContainerPort port : this.containerPorts) {
-            portList.add(port.getExternalPort());
-        }
-        return portList;
+        return this.containerPorts.stream().map(ContainerPort::getExternalPort).collect(Collectors.toList());
     }
 
     /**
@@ -139,11 +135,7 @@ public class ContainerInstanceDescriptor {
      */
     @Deprecated
     public List<Integer> getContainerPortsInternal() {
-        List<Integer> portList = new LinkedList<>();
-        for (ContainerPort port : this.containerPorts) {
-            portList.add(port.getInternalPort());
-        }
-        return portList;
+        return this.containerPorts.stream().map(ContainerPort::getInternalPort).collect(Collectors.toList());
     }
 
     @Override

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerInstanceDescriptor.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerInstanceDescriptor.java
@@ -22,7 +22,8 @@ import java.util.Objects;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * Object which represents a instantiated container. Used to track created containers.
+ * Object which represents a instantiated container. Used to track created
+ * containers.
  *
  * @noimplement This interface is not intended to be implemented by clients.
  * @since 2.3
@@ -52,9 +53,11 @@ public class ContainerInstanceDescriptor {
     }
 
     /**
-     * The method will provide information if the container is or not managed by the framework
+     * The method will provide information if the container is or not managed by the
+     * framework
      *
-     * @return <code>true</code> if the framework manages the container. <code>false</code> otherwise
+     * @return <code>true</code> if the framework manages the container.
+     *         <code>false</code> otherwise
      */
     public boolean isFrameworkManaged() {
         return this.isFrameworkManaged;
@@ -107,7 +110,11 @@ public class ContainerInstanceDescriptor {
     }
 
     /**
-     * Returns the list of external ports that will be mapped to the given container
+     * @deprecated please use {@link getContainerPorts} as it includes the network
+     *             protocol with the port mapping.
+     * 
+     *             Returns the list of external ports that will be mapped to the
+     *             given container
      *
      * @return
      */
@@ -120,7 +127,11 @@ public class ContainerInstanceDescriptor {
     }
 
     /**
-     * Returns the list of internal ports that will be mapped to the given container
+     * @deprecated please use {@link getContainerPorts} as it includes the network
+     *             protocol with the port mapping.
+     * 
+     *             Returns the list of internal ports that will be mapped to the
+     *             given container
      *
      * @return
      */
@@ -156,7 +167,8 @@ public class ContainerInstanceDescriptor {
     }
 
     /**
-     * Creates a builder for creating a new {@link ContainerInstanceDescriptor} instance.
+     * Creates a builder for creating a new {@link ContainerInstanceDescriptor}
+     * instance.
      *
      * @return the builder.
      */
@@ -203,7 +215,8 @@ public class ContainerInstanceDescriptor {
 
         /**
          * 
-         * Set a list of container ports, to express which ports to expose and what protocol to use.
+         * Set a list of container ports, to express which ports to expose and what
+         * protocol to use.
          * 
          * @since 2.5
          */
@@ -213,9 +226,15 @@ public class ContainerInstanceDescriptor {
         }
 
         /**
-         * Accepts a list<Integer> of ports to be exposed. Assumes all ports are TCP. To use other Internet protocols
-         * please see the {@link setContainerPorts} method. Ensure that the number of elements in this list is the same
-         * as the number of elements set with {@link setInternalPorts}.
+         * @deprecated please use {@link setContainerPorts} as it allows for network
+         *             protocol to be specified in a port mapping.
+         * 
+         * 
+         *             Accepts a list<Integer> of ports to be exposed. Assumes all ports
+         *             are TCP. To use other Internet protocols
+         *             please see the {@link setContainerPorts} method. Ensure that the
+         *             number of elements in this list is the same
+         *             as the number of elements set with {@link setInternalPorts}.
          * 
          */
         public ContainerInstanceDescriptorBuilder setExternalPorts(List<Integer> containerPortsExternal) {
@@ -224,10 +243,17 @@ public class ContainerInstanceDescriptor {
         }
 
         /**
-         * Accepts a list<Integer> of ports to be open internally within the container. Assumes all ports are TCP. To
-         * use other Internet protocols please see the {@link setContainerPorts} method.
-         * Ensure that the number of elements in this list is the same as the
-         * number of elements set with {@link setExternalPorts}.
+         * @deprecated please use {@link setContainerPorts} as it allows for network
+         *             protocol to be specified in a port mapping.
+         * 
+         *             Accepts a list<Integer> of ports to be open internally within the
+         *             container.
+         *             Assumes all ports are TCP. To
+         *             use other Internet protocols please see the
+         *             {@link setContainerPorts} method.
+         *             Ensure that the number of elements in this list is the same as
+         *             the
+         *             number of elements set with {@link setExternalPorts}.
          * 
          */
         public ContainerInstanceDescriptorBuilder setInternalPorts(List<Integer> containerPortsInternal) {

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerInstanceDescriptor.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerInstanceDescriptor.java
@@ -110,14 +110,15 @@ public class ContainerInstanceDescriptor {
     }
 
     /**
-     * @deprecated please use {@link getContainerPorts} as it includes the network
-     *             protocol with the port mapping.
-     * 
-     *             Returns the list of external ports that will be mapped to the
-     *             given container
+     * Returns the list of external ports that will be mapped to the
+     * given container
      *
      * @return
+     *
+     * @deprecated please use {@link getContainerPorts} as it includes the network
+     *             protocol with the port mapping.
      */
+    @Deprecated
     public List<Integer> getContainerPortsExternal() {
         List<Integer> portList = new LinkedList<>();
         for (ContainerPort port : this.containerPorts) {
@@ -127,14 +128,16 @@ public class ContainerInstanceDescriptor {
     }
 
     /**
-     * @deprecated please use {@link getContainerPorts} as it includes the network
-     *             protocol with the port mapping.
-     * 
-     *             Returns the list of internal ports that will be mapped to the
-     *             given container
+     * Returns the list of internal ports that will be mapped to the
+     * given container
      *
      * @return
+     *
+     * @deprecated please use {@link getContainerPorts} as it includes the network
+     *             protocol with the port mapping.
+     *
      */
+    @Deprecated
     public List<Integer> getContainerPortsInternal() {
         List<Integer> portList = new LinkedList<>();
         for (ContainerPort port : this.containerPorts) {
@@ -214,10 +217,10 @@ public class ContainerInstanceDescriptor {
         }
 
         /**
-         * 
+         *
          * Set a list of container ports, to express which ports to expose and what
          * protocol to use.
-         * 
+         *
          * @since 2.5
          */
         public ContainerInstanceDescriptorBuilder setContainerPorts(List<ContainerPort> containerPorts) {
@@ -226,36 +229,36 @@ public class ContainerInstanceDescriptor {
         }
 
         /**
+         * Accepts a list<Integer> of ports to be exposed. Assumes all ports
+         * are TCP. To use other Internet protocols
+         * please see the {@link setContainerPorts} method. Ensure that the
+         * number of elements in this list is the same
+         * as the number of elements set with {@link setInternalPorts}.
+         *
          * @deprecated please use {@link setContainerPorts} as it allows for network
          *             protocol to be specified in a port mapping.
-         * 
-         * 
-         *             Accepts a list<Integer> of ports to be exposed. Assumes all ports
-         *             are TCP. To use other Internet protocols
-         *             please see the {@link setContainerPorts} method. Ensure that the
-         *             number of elements in this list is the same
-         *             as the number of elements set with {@link setInternalPorts}.
-         * 
+         *
          */
+        @Deprecated
         public ContainerInstanceDescriptorBuilder setExternalPorts(List<Integer> containerPortsExternal) {
             this.containerPortsExternal = new ArrayList<>(containerPortsExternal);
             return this;
         }
 
         /**
+         * Accepts a list<Integer> of ports to be open internally within the
+         * container.
+         * Assumes all ports are TCP. To
+         * use other Internet protocols please see the
+         * {@link setContainerPorts} method.
+         * Ensure that the number of elements in this list is the same as
+         * the number of elements set with {@link setExternalPorts}.
+         *
          * @deprecated please use {@link setContainerPorts} as it allows for network
          *             protocol to be specified in a port mapping.
-         * 
-         *             Accepts a list<Integer> of ports to be open internally within the
-         *             container.
-         *             Assumes all ports are TCP. To
-         *             use other Internet protocols please see the
-         *             {@link setContainerPorts} method.
-         *             Ensure that the number of elements in this list is the same as
-         *             the
-         *             number of elements set with {@link setExternalPorts}.
-         * 
+         *
          */
+        @Deprecated
         public ContainerInstanceDescriptorBuilder setInternalPorts(List<Integer> containerPortsInternal) {
             this.containerPortsInternal = new ArrayList<>(containerPortsInternal);
             return this;


### PR DESCRIPTION

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to inderstand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
