### PR TITLE
build: Added hikaricp 2.7.9

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -188,6 +188,7 @@ This project leverages the following third party content.
 * maven/mavencentral/org.usb4java/usb4java-javax/1.2.0, MIT, approved, #3090
 * maven/mavencentral/org.usb4java/usb4java/1.2.0, MIT, approved, #3089
 * maven/mavencentral/org.apache.servicemix.bundles/org.apache.servicemix.bundles.c3p0/0.9.5.5_1, Apache-2.0, approved, #3761
+* maven/mavencentral/com.zaxxer/HikariCP/2.7.9, Apache-2.0, approved, clearlydefined
 
 ### Additional Dependencies
 

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -983,6 +983,8 @@ fi]]>
                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/com.eurotech.gpsd4java_${com.eurotech.gpsd4java.version}.jar@3" />
             <entry key="osgi.bundles" operation="+"
                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.apache.servicemix.bundles.c3p0_${org.apache.servicemix.bundles.c3p0.version}.jar@3" />
+            <entry key="osgi.bundles" operation="+"
+                value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/com.zaxxer.HikariCP_${hikaricp.version}.jar@3" />
         </propertyfile>
     </target>
 

--- a/kura/distrib/src/main/resources/common/Kura_Emulator.launch
+++ b/kura/distrib/src/main/resources/common/Kura_Emulator.launch
@@ -173,6 +173,7 @@
         <setEntry value="slf4j.api@default:default"/>
         <setEntry value="usb4java-javax@default:default"/>
         <setEntry value="org.apache.servicemix.bundles.c3p0@default:default"/>
+        <setEntry value="com.zaxxer.HikariCP@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.kura.demo.heater@default:default"/>

--- a/kura/emulator/org.eclipse.kura.emulator/src/main/resources/Kura_Emulator.launch
+++ b/kura/emulator/org.eclipse.kura.emulator/src/main/resources/Kura_Emulator.launch
@@ -169,6 +169,7 @@
         <setEntry value="slf4j.api@default:default"/>
         <setEntry value="usb4java-javax@default:default"/>
         <setEntry value="org.apache.servicemix.bundles.c3p0@default:default"/>
+        <setEntry value="com.zaxxer.HikariCP@default:default"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
         <setEntry value="org.eclipse.kura.demo.heater@default:default"/>

--- a/kura/setups/launchers/Eclipse Kura Emulator.launch
+++ b/kura/setups/launchers/Eclipse Kura Emulator.launch
@@ -161,6 +161,7 @@
 <setEntry value="org.eclipse.kura.wire.script.filter.provider@default:default"/>
 <setEntry value="org.eclipse.kura.xml.marshaller.unmarshaller.provider@2:default"/>
 <setEntry value="org.apache.servicemix.bundles.c3p0@default:default"/>
+<setEntry value="com.zaxxer.HikariCP@default:default"/>
 </setAttribute>
 <booleanAttribute key="show_selected_only" value="false"/>
 <stringAttribute key="timestamp" value="1449054439069"/>

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -87,6 +87,7 @@ com.eurotech.gpsd4java.version=1.0.0
 libsocket-can-osgi.version=1.1.0-SNAPSHOT
 
 org.apache.servicemix.bundles.c3p0.version=0.9.5.5_1
+hikaricp.version=2.7.9
 
 #target platform equinox versions
 javax.servlet.version=3.1.0.v201410161800

--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -606,6 +606,11 @@
                                     <artifactId>org.apache.servicemix.bundles.c3p0</artifactId>
                                     <version>${org.apache.servicemix.bundles.c3p0.version}</version>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>com.zaxxer</groupId>
+                                    <artifactId>HikariCP</artifactId>
+                                    <version>${hikaricp.version}</version>
+                                </artifactItem>
                             </artifactItems>
                             <stripVersion>true</stripVersion>
                             <outputDirectory>${project.basedir}/target/source/plugins</outputDirectory>
@@ -716,6 +721,7 @@
                                 <move file="target/source/plugins/bcpg-jdk18on.jar" tofile="target/source/plugins/bcpg_${org.bouncycastle.version}.jar"/>
                                 <move file="target/source/plugins/gpsd4java.jar" tofile="target/source/plugins/com.eurotech.gpsd4java_${com.eurotech.gpsd4java.version}.jar"/>
                                 <move file="target/source/plugins/org.apache.servicemix.bundles.c3p0.jar" tofile="target/source/plugins/org.apache.servicemix.bundles.c3p0_${org.apache.servicemix.bundles.c3p0.version}.jar"/>
+                                <move file="target/source/plugins/HikariCP.jar" tofile="target/source/plugins/HikariCP_${hikaricp.version}.jar"/>
                             </tasks>
                         </configuration>
                     </execution>


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Adds a prerequisite dependency for moving the quartz bundle to the target platform.

Must be rebased and merged **after** #4198

```
echo "maven/mavencentral/com.zaxxer/HikariCP/2.7.9" | java -jar ./org.eclipse.dash.licenses-0.0.1-20220524.055036-435.jar -
[main] INFO Querying Eclipse Foundation for license data for 1 items.
[main] INFO Found 0 items.
[main] INFO Querying ClearlyDefined for license data for 1 items.
[main] INFO Found 1 items.
[main] INFO Vetted license information was found for all content. No further investigation is required.
```