### PR TITLE
feat: Added connection schedule support to DataService 

### DIFF
--- a/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.kura.core;singleton:=true
 Bundle-Version: 1.3.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.kura.core.data;version="1.1.0",
+Export-Package: org.eclipse.kura.core.data;version="1.2.0",
  org.eclipse.kura.core.linux.executor;version="1.0.0",
  org.eclipse.kura.core.linux.util;version="1.2.0",
  org.eclipse.kura.core.ssl;version="1.0.0",
@@ -54,6 +54,7 @@ Import-Package: javax.crypto,
  org.osgi.service.component;version="1.2.0",
  org.osgi.service.event;version="1.4.0",
  org.osgi.util.tracker;version="1.5.0",
+ org.quartz;version="2.3.2",
  org.slf4j;version="1.6.4"
 Bundle-ClassPath: .,
  lib/org.eclipse.paho.client.mqttv3-1.2.1.k2.jar

--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -163,7 +163,31 @@
             default="1"
             min="1"
             description="The token bucket burst size."/>
-                                    
+            
+        <AD id="connection.schedule.enabled" 
+            name="Enable Connection Schedule" 
+            type="Boolean" 
+            cardinality="0" 
+            required="true" 
+            default="false"
+            description="Enables or disables the connection scheduling feature." />
+            
+        <AD id="connection.schedule.expression" 
+            name="Connection Schedule CRON Expression" 
+            type="String" 
+            cardinality="0" 
+            required="true" 
+            default="0 0 0 ? * * *"
+            description="A CRON expression that specifies the instants when the gateway should perform a connection attempt. This parameter is only used if Enable Connection Schedule is set to true. The default expression schedules a connection every day at midnight." />
+            
+         <AD id="connection.schedule.inactivity.interval.seconds" 
+            name="Connection Schedule Disconnect Inactivity Interval Seconds" 
+            type="Long" 
+            cardinality="0" 
+            required="true" 
+            default="60"
+            description="Specifies an inactivity timeout in seconds. If the timeout expires, the cloud connection will be automatically closed. This parameter is only used if Enable Connection Schedule is set to true." />
+
     </OCD>
     <Designate pid="org.eclipse.kura.data.DataService" factoryPid="org.eclipse.kura.data.DataService">
         <Object ocdref="org.eclipse.kura.data.DataService"/>

--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -186,6 +186,7 @@
             cardinality="0" 
             required="true" 
             default="60"
+            min="1"
             description="Specifies an inactivity timeout in seconds. If the timeout expires, the cloud connection will be automatically closed. This parameter is only used if Enable Connection Schedule is set to true." />
 
     </OCD>

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AlwaysConnectedStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AlwaysConnectedStrategy.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.core.data;
+
+public class AlwaysConnectedStrategy implements AutoConnectStrategy {
+
+    private final ConnectionManager connectionManager;
+
+    public AlwaysConnectedStrategy(final ConnectionManager connectionManager) {
+        this.connectionManager = connectionManager;
+        connectionManager.startConnectionTask();
+    }
+
+    @Override
+    public void onConnectionEstablished() {
+        // do nothing
+    }
+
+    @Override
+    public void onDisconnecting() {
+        // do nothing
+    }
+
+    @Override
+    public void onDisconnected() {
+        connectionManager.startConnectionTask();
+    }
+
+    @Override
+    public void onConnectionLost(Throwable cause) {
+        connectionManager.stopConnectionTask();
+        connectionManager.startConnectionTask();
+    }
+
+    @Override
+    public void onMessageArrived(String topic, byte[] payload, int qos, boolean retained) {
+        // do nothing
+    }
+
+    @Override
+    public void onMessagePublished(int messageId, String topic) {
+        // do nothing
+    }
+
+    @Override
+    public void onMessageConfirmed(int messageId, String topic) {
+        // do nothing
+    }
+
+    @Override
+    public void shutdown() {
+        connectionManager.stopConnectionTask();
+    }
+
+}

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.core.data;
+
+import org.eclipse.kura.data.listener.DataServiceListener;
+
+interface AutoConnectStrategy extends DataServiceListener {
+
+    public void shutdown();
+
+    interface ConnectionManager {
+
+        void startConnectionTask();
+
+        void stopConnectionTask();
+
+        void disconnect();
+
+        boolean hasInFlightMessages();
+
+        boolean isConnected();
+
+    }
+}

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceListenerS.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceListenerS.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -235,6 +235,10 @@ class DataServiceListenerS implements DataServiceListener {
         } else {
             logger.warn("No registered listeners. Ignoring onMessageConfirmed");
         }
+    }
+
+    public void prepend(DataServiceListener listener) {
+        this.listeners.add(0, listener);
     }
 
     public void add(DataServiceListener listener) {

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
@@ -1,0 +1,273 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.core.data;
+
+import java.util.Date;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import org.quartz.CronExpression;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ScheduleStrategy implements AutoConnectStrategy {
+
+    private static final Logger logger = LoggerFactory.getLogger(ScheduleStrategy.class);
+
+    private final ScheduledExecutorService executor;
+
+    private final CronExpression expression;
+    private final long disconnectTimeoutMs;
+    private final ConnectionManager connectionManager;
+    private final Supplier<Date> currentTimeProvider;
+    private State state;
+
+    private Optional<ScheduledFuture<?>> timeout = Optional.empty();
+
+    public ScheduleStrategy(final CronExpression expression, final long disconnectTimeoutMs,
+            final ConnectionManager connectionManager) {
+        this(expression, disconnectTimeoutMs, connectionManager, Executors.newSingleThreadScheduledExecutor(),
+                Date::new);
+    }
+
+    public ScheduleStrategy(final CronExpression expression, final long disconnectTimeoutMs,
+            final ConnectionManager connectionManager, final ScheduledExecutorService executor,
+            final Supplier<Date> currentTimeProvider) {
+        this.expression = expression;
+        this.disconnectTimeoutMs = disconnectTimeoutMs;
+        this.connectionManager = connectionManager;
+        this.state = new AwaitConnectTime();
+        this.executor = executor;
+        this.currentTimeProvider = currentTimeProvider;
+
+        updateState(State::onEnterState);
+        executor.scheduleWithFixedDelay(new TimeShiftDetector(60000), 0, 1, TimeUnit.MINUTES);
+    }
+
+    private interface State {
+        public default State onEnterState() {
+            return this;
+        }
+
+        public default State onConnectionEstablished() {
+            return this;
+        }
+
+        public default State onMessageEvent() {
+            return this;
+        }
+
+        public default State onConnectionLost() {
+            return this;
+        }
+
+        public default State onTimeout() {
+            return this;
+        }
+    }
+
+    private class AwaitConnectTime implements State {
+
+        @Override
+        public State onEnterState() {
+            connectionManager.stopConnectionTask();
+            connectionManager.disconnect();
+
+            final Date now = currentTimeProvider.get();
+
+            final Date nextTick = expression.getNextValidTimeAfter(now);
+
+            final long delay = Math.max(1, nextTick.getTime() - now.getTime());
+
+            logger.info("Connection scheduled at {} in {} ms", nextTick, delay);
+
+            rescheduleTimeout(delay);
+
+            return this;
+        }
+
+        @Override
+        public State onTimeout() {
+
+            return new AwaitConnect();
+        }
+
+    }
+
+    private class AwaitConnect implements State {
+
+        @Override
+        public State onEnterState() {
+            if (connectionManager.isConnected()) {
+                return new AwaitDisconnectTime();
+            } else {
+                connectionManager.startConnectionTask();
+                return this;
+            }
+        }
+
+        @Override
+        public State onConnectionLost() {
+            connectionManager.startConnectionTask();
+            return this;
+        }
+
+        @Override
+        public State onConnectionEstablished() {
+            return new AwaitDisconnectTime();
+        }
+
+    }
+
+    private class AwaitDisconnectTime implements State {
+
+        @Override
+        public State onEnterState() {
+            return onMessageEvent();
+        }
+
+        @Override
+        public State onConnectionLost() {
+            return new AwaitConnect();
+        }
+
+        @Override
+        public State onMessageEvent() {
+
+            rescheduleTimeout(disconnectTimeoutMs);
+
+            return this;
+        }
+
+        @Override
+        public State onTimeout() {
+            if (connectionManager.hasInFlightMessages()) {
+                return this;
+            } else {
+                return new AwaitConnectTime();
+            }
+        }
+    }
+
+    private void rescheduleTimeout(final long timeoutMs) {
+        final Optional<ScheduledFuture<?>> currentFuture = this.timeout;
+
+        if (currentFuture.isPresent()) {
+            currentFuture.get().cancel(false);
+        }
+
+        this.timeout = Optional.of(executor.schedule(() -> updateState(State::onTimeout), timeoutMs,
+                TimeUnit.MILLISECONDS));
+    }
+
+    private void updateState(final UnaryOperator<State> transition) {
+        executor.execute(() -> updateStateInternal(transition));
+    }
+
+    private void updateStateInternal(final UnaryOperator<State> transitionFunction) {
+        final Optional<ScheduledFuture<?>> currentFuture = this.timeout;
+
+        final State nextState = transitionFunction.apply(this.state);
+
+        if (nextState != this.state) {
+            logger.info("State change: {} -> {}", state.getClass().getSimpleName(),
+                    nextState.getClass().getSimpleName());
+            currentFuture.ifPresent(c -> c.cancel(false));
+
+            this.state = nextState;
+            updateStateInternal(State::onEnterState);
+        }
+    }
+
+    private class TimeShiftDetector implements Runnable {
+        private OptionalLong previousTimestamp = OptionalLong.empty();
+        private final long expectedDelay;
+
+        public TimeShiftDetector(final long expectedTickRate) {
+            this.expectedDelay = expectedTickRate;
+        }
+
+        public void run() {
+            final long now = System.currentTimeMillis();
+
+            final OptionalLong previous = this.previousTimestamp;
+
+            if (!previous.isPresent()) {
+                this.previousTimestamp = OptionalLong.of(now);
+                return;
+            }
+
+            if (now < previous.getAsLong() || Math.abs((now - previous.getAsLong()) - expectedDelay) > 60000) {
+                logger.warn("Time shift detected, reinitializing connection schedule");
+                updateState(c -> new AwaitConnectTime());
+            }
+
+            this.previousTimestamp = OptionalLong.of(now);
+
+        }
+
+    }
+
+    @Override
+    public void shutdown() {
+        executor.shutdown();
+        try {
+            executor.awaitTermination(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warn("Interrupted while waiting for executor shutdown");
+        }
+    }
+
+    @Override
+    public void onConnectionEstablished() {
+        updateState(State::onConnectionEstablished);
+    }
+
+    @Override
+    public void onDisconnecting() {
+        // no need
+    }
+
+    @Override
+    public void onDisconnected() {
+        updateState(State::onConnectionLost);
+    }
+
+    @Override
+    public void onConnectionLost(Throwable cause) {
+        updateState(State::onConnectionLost);
+    }
+
+    @Override
+    public void onMessageArrived(String topic, byte[] payload, int qos, boolean retained) {
+        // no need
+    }
+
+    @Override
+    public void onMessagePublished(int messageId, String topic) {
+        updateState(State::onMessageEvent);
+    }
+
+    @Override
+    public void onMessageConfirmed(int messageId, String topic) {
+        updateState(State::onMessageEvent);
+    }
+
+}

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
@@ -1,0 +1,227 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.core.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.kura.core.data.AutoConnectStrategy.ConnectionManager;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.quartz.CronExpression;
+
+public class ScheduleStrategyTest {
+
+    @Test
+    public void shouldScheduleFirstConnectionAttempt() {
+        givenTime("1/1/2000");
+        givenCronExpression("0/2 * * * * ?");
+
+        whenScheduleStrategyIsCreated();
+
+        thenTimeoutIsRequestedAfterMs(2000);
+    }
+
+    @Test
+    public void shouldRequestConnection() {
+        givenTime("1/1/2000");
+        givenCronExpression("0/2 * * * * ?");
+        givenScheduleStrategy();
+
+        whenTimeoutOccurs();
+
+        thenConnectionTaskIsStarted();
+    }
+
+    @Test
+    public void shouldScheduleDisconnectTimeout() {
+        givenTime("1/1/2000");
+        givenCronExpression("0/2 * * * * ?");
+        givenScheduleStrategy();
+        givenTimeout();
+
+        whenConnectionIsEstablished();
+
+        thenTimeoutIsRequestedAfterMs(60000);
+    }
+
+    @Test
+    public void shouldRequestDisconnect() {
+        givenTime("1/1/2000");
+        givenCronExpression("0/2 * * * * ?");
+        givenScheduleStrategy();
+        givenTimeout();
+        givenConnectionEstablished();
+
+        whenTimeoutOccurs();
+
+        thenDisconnectIsRequested();
+        thenConnectionTaskIsStopped();
+    }
+
+    private final ExecutorState executorState = new ExecutorState();
+    private final ConnectionManagerState connectionManagerState = new ConnectionManagerState();
+    private Date now;
+    private CronExpression expression;
+    private ScheduleStrategy strategy;
+    private long disconnectTimeoutMs = 60000;
+
+    private void givenCronExpression(String expressionString) {
+        try {
+            this.expression = new CronExpression(expressionString);
+        } catch (ParseException e) {
+            throw new IllegalStateException("failed to parse cron expression", e);
+        }
+
+    }
+
+    private void givenTime(final String time) {
+        try {
+            now = new SimpleDateFormat("dd/MM/yyyy").parse(time);
+        } catch (ParseException e) {
+            throw new IllegalStateException("failed to parse date", e);
+        }
+    }
+
+    private void givenScheduleStrategy() {
+        whenScheduleStrategyIsCreated();
+    }
+
+    private void givenTimeout() {
+        whenTimeoutOccurs();
+    }
+
+    private void givenConnectionEstablished() {
+        whenConnectionIsEstablished();
+    }
+
+    private void whenTimeoutOccurs() {
+        executorState.triggerTimeout();
+    }
+
+    private void whenScheduleStrategyIsCreated() {
+        this.strategy = new ScheduleStrategy(expression, disconnectTimeoutMs,
+                this.connectionManagerState.connectionManager,
+                this.executorState.executor, () -> this.now);
+    }
+
+    private void whenConnectionIsEstablished() {
+        this.strategy.onConnectionEstablished();
+    }
+
+    private void thenTimeoutIsRequestedAfterMs(long expectedDelay) {
+        assertEquals(expectedDelay, this.executorState.getDelay());
+    }
+
+    private void thenConnectionTaskIsStarted() {
+        try {
+            connectionManagerState.startConnectionTask.get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            fail("connection task not started");
+        }
+    }
+
+    private void thenConnectionTaskIsStopped() {
+        try {
+            connectionManagerState.stopConnectionTask.get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            fail("connection task not stopped");
+        }
+    }
+
+    private void thenDisconnectIsRequested() {
+        try {
+            connectionManagerState.disconnect.get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            fail("disconnect not requested");
+        }
+    }
+
+    private class ConnectionManagerState {
+        private ConnectionManager connectionManager = mock(ConnectionManager.class);
+        private CompletableFuture<?> startConnectionTask = new CompletableFuture<>();
+        private CompletableFuture<?> stopConnectionTask = new CompletableFuture<>();
+        private CompletableFuture<?> disconnect = new CompletableFuture<>();
+
+        ConnectionManagerState() {
+            doAnswer(i -> {
+                startConnectionTask.complete(null);
+                return null;
+            }).when(connectionManager).startConnectionTask();
+
+            doAnswer(i -> {
+                stopConnectionTask.complete(null);
+                return null;
+            }).when(connectionManager).stopConnectionTask();
+
+            doAnswer(i -> {
+                disconnect.complete(null);
+                return null;
+            }).when(connectionManager).disconnect();
+
+            when(connectionManager.isConnected()).thenReturn(false);
+        }
+    }
+
+    private class ExecutorState {
+        private ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+        private CompletableFuture<Runnable> task = new CompletableFuture<>();
+        private CompletableFuture<Long> lastDelay = new CompletableFuture<>();
+
+        public ExecutorState() {
+            Mockito.when(executor.schedule((Runnable) Mockito.any(), Mockito.anyLong(), Mockito.any()))
+                    .thenAnswer(i -> {
+
+                        this.task.complete(i.getArgumentAt(0, Runnable.class));
+                        this.lastDelay.complete(i.getArgumentAt(1, Long.class));
+
+                        return Mockito.mock(ScheduledFuture.class);
+                    });
+
+            Mockito.doAnswer(i -> {
+                i.getArgumentAt(0, Runnable.class).run();
+
+                return Mockito.mock(ScheduledFuture.class);
+            }).when(executor).execute(Mockito.any());
+        }
+
+        private void triggerTimeout() {
+            try {
+                this.task.get(30, TimeUnit.SECONDS).run();
+                this.task = new CompletableFuture<>();
+                this.lastDelay = new CompletableFuture<>();
+            } catch (Exception e) {
+                throw new IllegalStateException("timeout not set");
+            }
+        }
+
+        private long getDelay() {
+            try {
+                return lastDelay.get(30, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw new IllegalStateException("timeout not set");
+            }
+        }
+    }
+}


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Must be rebased and merged **after** #4202
