### PR TITLE
fix: failing Ubi8-based Docker image build

### DIFF
--- a/kura/container/kura_alpine/Dockerfile
+++ b/kura/container/kura_alpine/Dockerfile
@@ -24,7 +24,7 @@ RUN echo "$GIT_REPO / $GIT_BRANCH / $KURA_COMMIT" && \
     chmod a+x -R /usr/local/bin && \
     apk update && \
     apk --no-cache add git openjdk8 maven && \
-    apk --no-cache add bash zip curl xmlstarlet gcompat && \
+    apk --no-cache add bash zip curl gcompat && \
     if [ -d /context/.git ]; then \
       mv /context /kura; \
       mv /kura/kura/container/kura_alpine /context; \

--- a/kura/container/kura_ubi8/Dockerfile
+++ b/kura/container/kura_ubi8/Dockerfile
@@ -60,7 +60,6 @@ RUN true && \
         unzip \
         gzip \
         tar \
-        xmlstarlet \
         psmisc \
         socat \
         dos2unix \


### PR DESCRIPTION
Brief description of the PR: This PR fixes the Ubi8-based Docker build of Kura

**Description of the solution adopted:** The package `xmlstarlet` was breaking the build because it was missing from the remote repo. To solve the issue it was removed from the required packages since it is not necessary anymore.

The `xmlstarlet` dependency was first introduced in https://github.com/eclipse/kura/pull/3778 with the sole purpose of disabling the Clock service in the starting snapshot (details [here](https://github.com/eclipse/kura/commit/5c2091d74f7277f7eeafda277709745d2f6deef0#diff-0012b46cf5e2c35e2387bee8539dc0df52f7291cdbca3596e2a6c1205755cb4fR99)).

With https://github.com/eclipse/kura/pull/4178 the need of `xmlstarlet` was removed because we're relying on the `docker_x86_64` installer which has its own starting snapshot for which the ClockService is already disabled (details [here](https://github.com/eclipse/kura/commit/ef505876f35efe7003c573cc5d923fdcf0ee6bbd#diff-8954ca8007020771ed14b11dcdf54a8f226eb28b8c85883670245dcb3032d983R30)).

Therefore the `xmlstarlet` dependency can be safely removed.
