### PR TITLE
test: fixed intermittent test failure by extending sleep time

### DIFF
--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
@@ -402,7 +402,7 @@ public class TritonServerContainerManagerTest {
 
         try {
             // Wait for monitor thread to do its job
-            Thread.sleep(10);
+            Thread.sleep(100);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             fail();


### PR DESCRIPTION
there appears not to be enough sleep time for this test to pass on the pipeline.

- I tried to implement this with a Mockito SPY and Verify + timeout, but we are waiting on an internal thread and seems very tricky to properly spy on it without messing with the API's