### PR TITLE
docs(examples): add note about error when running training script

### DIFF
--- a/kura/examples/scenarios/org.eclipse.kura.example.ai/README.md
+++ b/kura/examples/scenarios/org.eclipse.kura.example.ai/README.md
@@ -79,6 +79,18 @@ Train the model with the data provided in this repository with:
 ./train.py
 ```
 
+> **Note**: If you get the following error:
+> ```
+> TypeError: Descriptors cannot not be created directly.
+> If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
+> If you cannot immediately regenerate your protos, some other possible workarounds are:
+>
+> Downgrade the protobuf package to 3.20.x or lower.
+> Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
+> More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
+> ```
+> run the training script with: `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python ./train.py`
+
 Train script options:
 
 ```bash


### PR DESCRIPTION
When running the `train.py` script it can throw the following error.

> TypeError: Descriptors cannot not be created directly.
> If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
> If you cannot immediately regenerate your protos, some other possible workarounds are:
>  1. Downgrade the protobuf package to 3.20.x or lower.
>  2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
> 
> More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates

To fix it, one can run the script as suggested in the error:
```bash
PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python ./train.py
```
the performance penalty is acceptable for this use case.

This PR adds this information in the `example` readme file as per https://github.com/eclipse/kura/pull/4170#issuecomment-1300857405