### PR TITLE
fix: Prevent discarding of NetworkConfigurationService properties

### DIFF
--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -88,6 +88,7 @@ public class NetworkConfiguration {
     public NetworkConfiguration() {
         logger.debug("Created empty NetworkConfiguration");
         this.netInterfaceConfigs = new HashMap<>();
+        this.recomputeProperties = true;
     }
 
     /**
@@ -95,11 +96,11 @@ public class NetworkConfiguration {
      * set of properties
      *
      * @param properties
-     *            The properties that represent the new configuration
+     *                   The properties that represent the new configuration
      * @throws UnknownHostException
-     *             If some hostnames can not be resolved
+     *                              If some hostnames can not be resolved
      * @throws KuraException
-     *             It there is an internal error
+     *                              It there is an internal error
      */
     public NetworkConfiguration(Map<String, Object> properties) throws UnknownHostException, KuraException {
         logger.debug("Creating NetworkConfiguration from properties");
@@ -173,20 +174,20 @@ public class NetworkConfiguration {
 
         if (netInterfaceConfig == null) {
             switch (netInterfaceType) {
-            case LOOPBACK:
-                netInterfaceConfig = new LoopbackInterfaceConfigImpl(interfaceName);
-                break;
-            case ETHERNET:
-                netInterfaceConfig = new EthernetInterfaceConfigImpl(interfaceName);
-                break;
-            case WIFI:
-                netInterfaceConfig = new WifiInterfaceConfigImpl(interfaceName);
-                break;
-            case MODEM:
-                netInterfaceConfig = new ModemInterfaceConfigImpl(interfaceName);
-                break;
-            default:
-                throw new KuraException(KuraErrorCode.INVALID_PARAMETER);
+                case LOOPBACK:
+                    netInterfaceConfig = new LoopbackInterfaceConfigImpl(interfaceName);
+                    break;
+                case ETHERNET:
+                    netInterfaceConfig = new EthernetInterfaceConfigImpl(interfaceName);
+                    break;
+                case WIFI:
+                    netInterfaceConfig = new WifiInterfaceConfigImpl(interfaceName);
+                    break;
+                case MODEM:
+                    netInterfaceConfig = new ModemInterfaceConfigImpl(interfaceName);
+                    break;
+                default:
+                    throw new KuraException(KuraErrorCode.INVALID_PARAMETER);
             }
         }
 
@@ -791,72 +792,74 @@ public class NetworkConfiguration {
         NetInterfaceConfig<?> interfaceConfig = null;
 
         switch (type) {
-        case LOOPBACK:
-            interfaceConfig = new LoopbackInterfaceConfigImpl(interfaceName);
-            List<NetInterfaceAddressConfig> loopbackInterfaceAddressConfigs = new ArrayList<>();
-            NetInterfaceAddressConfigImpl netInterfaceAddressConfigImpl = new NetInterfaceAddressConfigImpl();
-            netInterfaceAddressConfigImpl.setNetConfigs(IpConfigurationInterpreter.populateConfiguration(props,
-                    interfaceName, netInterfaceAddressConfigImpl.getAddress(), interfaceConfig.isVirtual()));
-            loopbackInterfaceAddressConfigs.add(netInterfaceAddressConfigImpl);
-            ((LoopbackInterfaceConfigImpl) interfaceConfig).setNetInterfaceAddresses(loopbackInterfaceAddressConfigs);
+            case LOOPBACK:
+                interfaceConfig = new LoopbackInterfaceConfigImpl(interfaceName);
+                List<NetInterfaceAddressConfig> loopbackInterfaceAddressConfigs = new ArrayList<>();
+                NetInterfaceAddressConfigImpl netInterfaceAddressConfigImpl = new NetInterfaceAddressConfigImpl();
+                netInterfaceAddressConfigImpl.setNetConfigs(IpConfigurationInterpreter.populateConfiguration(props,
+                        interfaceName, netInterfaceAddressConfigImpl.getAddress(), interfaceConfig.isVirtual()));
+                loopbackInterfaceAddressConfigs.add(netInterfaceAddressConfigImpl);
+                ((LoopbackInterfaceConfigImpl) interfaceConfig)
+                        .setNetInterfaceAddresses(loopbackInterfaceAddressConfigs);
 
-            ((LoopbackInterfaceConfigImpl) interfaceConfig).setUsbDevice(usbDevice);
+                ((LoopbackInterfaceConfigImpl) interfaceConfig).setUsbDevice(usbDevice);
 
-            break;
-        case ETHERNET:
-            interfaceConfig = new EthernetInterfaceConfigImpl(interfaceName);
-            List<NetInterfaceAddressConfig> ethernetInterfaceAddressConfigs = new ArrayList<>();
-            netInterfaceAddressConfigImpl = new NetInterfaceAddressConfigImpl();
-            netInterfaceAddressConfigImpl.setNetConfigs(IpConfigurationInterpreter.populateConfiguration(props,
-                    interfaceName, netInterfaceAddressConfigImpl.getAddress(), interfaceConfig.isVirtual()));
-            ethernetInterfaceAddressConfigs.add(netInterfaceAddressConfigImpl);
-            ((EthernetInterfaceConfigImpl) interfaceConfig).setNetInterfaceAddresses(ethernetInterfaceAddressConfigs);
+                break;
+            case ETHERNET:
+                interfaceConfig = new EthernetInterfaceConfigImpl(interfaceName);
+                List<NetInterfaceAddressConfig> ethernetInterfaceAddressConfigs = new ArrayList<>();
+                netInterfaceAddressConfigImpl = new NetInterfaceAddressConfigImpl();
+                netInterfaceAddressConfigImpl.setNetConfigs(IpConfigurationInterpreter.populateConfiguration(props,
+                        interfaceName, netInterfaceAddressConfigImpl.getAddress(), interfaceConfig.isVirtual()));
+                ethernetInterfaceAddressConfigs.add(netInterfaceAddressConfigImpl);
+                ((EthernetInterfaceConfigImpl) interfaceConfig)
+                        .setNetInterfaceAddresses(ethernetInterfaceAddressConfigs);
 
-            ((EthernetInterfaceConfigImpl) interfaceConfig).setUsbDevice(usbDevice);
+                ((EthernetInterfaceConfigImpl) interfaceConfig).setUsbDevice(usbDevice);
 
-            break;
-        case WIFI:
-            interfaceConfig = new WifiInterfaceConfigImpl(interfaceName);
+                break;
+            case WIFI:
+                interfaceConfig = new WifiInterfaceConfigImpl(interfaceName);
 
-            List<WifiInterfaceAddressConfig> wifiInterfaceAddressConfigs = new ArrayList<>();
+                List<WifiInterfaceAddressConfig> wifiInterfaceAddressConfigs = new ArrayList<>();
 
-            WifiInterfaceAddressConfig wifiInterfaceAddressConfig = new WifiInterfaceAddressConfigImpl();
-            List<NetConfig> wifiNetConfigs = IpConfigurationInterpreter.populateConfiguration(props, interfaceName,
-                    wifiInterfaceAddressConfig.getAddress(), interfaceConfig.isVirtual());
-            wifiNetConfigs.addAll(WifiConfigurationInterpreter.populateConfiguration(props, interfaceName));
-            ((WifiInterfaceAddressConfigImpl) wifiInterfaceAddressConfig).setNetConfigs(wifiNetConfigs);
-            ((WifiInterfaceAddressConfigImpl) wifiInterfaceAddressConfig)
-                    .setMode(WifiConfigurationInterpreter.getWifiMode(props, interfaceName));
-            wifiInterfaceAddressConfigs.add(wifiInterfaceAddressConfig);
+                WifiInterfaceAddressConfig wifiInterfaceAddressConfig = new WifiInterfaceAddressConfigImpl();
+                List<NetConfig> wifiNetConfigs = IpConfigurationInterpreter.populateConfiguration(props, interfaceName,
+                        wifiInterfaceAddressConfig.getAddress(), interfaceConfig.isVirtual());
+                wifiNetConfigs.addAll(WifiConfigurationInterpreter.populateConfiguration(props, interfaceName));
+                ((WifiInterfaceAddressConfigImpl) wifiInterfaceAddressConfig).setNetConfigs(wifiNetConfigs);
+                ((WifiInterfaceAddressConfigImpl) wifiInterfaceAddressConfig)
+                        .setMode(WifiConfigurationInterpreter.getWifiMode(props, interfaceName));
+                wifiInterfaceAddressConfigs.add(wifiInterfaceAddressConfig);
 
-            ((WifiInterfaceConfigImpl) interfaceConfig).setNetInterfaceAddresses(wifiInterfaceAddressConfigs);
+                ((WifiInterfaceConfigImpl) interfaceConfig).setNetInterfaceAddresses(wifiInterfaceAddressConfigs);
 
-            ((WifiInterfaceConfigImpl) interfaceConfig).setUsbDevice(usbDevice);
+                ((WifiInterfaceConfigImpl) interfaceConfig).setUsbDevice(usbDevice);
 
-            break;
-        case MODEM:
-            interfaceConfig = new ModemInterfaceConfigImpl(interfaceName);
+                break;
+            case MODEM:
+                interfaceConfig = new ModemInterfaceConfigImpl(interfaceName);
 
-            ModemInterfaceAddressConfig modemInterfaceAddressConfig = new ModemInterfaceAddressConfigImpl();
-            List<NetConfig> modemNetConfigs = IpConfigurationInterpreter.populateConfiguration(props, interfaceName,
-                    modemInterfaceAddressConfig.getAddress(), interfaceConfig.isVirtual());
-            modemNetConfigs.addAll(ModemConfigurationInterpreter.populateConfiguration(
-                    modemInterfaceAddressConfig, props, interfaceName));
-            ((ModemInterfaceAddressConfigImpl) modemInterfaceAddressConfig).setNetConfigs(modemNetConfigs);
+                ModemInterfaceAddressConfig modemInterfaceAddressConfig = new ModemInterfaceAddressConfigImpl();
+                List<NetConfig> modemNetConfigs = IpConfigurationInterpreter.populateConfiguration(props, interfaceName,
+                        modemInterfaceAddressConfig.getAddress(), interfaceConfig.isVirtual());
+                modemNetConfigs.addAll(ModemConfigurationInterpreter.populateConfiguration(
+                        modemInterfaceAddressConfig, props, interfaceName));
+                ((ModemInterfaceAddressConfigImpl) modemInterfaceAddressConfig).setNetConfigs(modemNetConfigs);
 
-            List<ModemInterfaceAddressConfig> modemInterfaceAddressConfigs = new ArrayList<>();
-            modemInterfaceAddressConfigs.add(modemInterfaceAddressConfig);
-            ((ModemInterfaceConfigImpl) interfaceConfig).setNetInterfaceAddresses(modemInterfaceAddressConfigs);
+                List<ModemInterfaceAddressConfig> modemInterfaceAddressConfigs = new ArrayList<>();
+                modemInterfaceAddressConfigs.add(modemInterfaceAddressConfig);
+                ((ModemInterfaceConfigImpl) interfaceConfig).setNetInterfaceAddresses(modemInterfaceAddressConfigs);
 
-            ((ModemInterfaceConfigImpl) interfaceConfig).setUsbDevice(usbDevice);
+                ((ModemInterfaceConfigImpl) interfaceConfig).setUsbDevice(usbDevice);
 
-            break;
-        case UNKNOWN:
-            logger.trace("Found interface of unknown type in current configuration: {}", interfaceName);
-            return;
-        default:
-            logger.error("Unsupported type {} for interface {}", type, interfaceName);
-            return;
+                break;
+            case UNKNOWN:
+                logger.trace("Found interface of unknown type in current configuration: {}", interfaceName);
+                return;
+            default:
+                logger.error("Unsupported type {} for interface {}", type, interfaceName);
+                return;
         }
 
         this.netInterfaceConfigs.put(interfaceName, interfaceConfig);

--- a/kura/org.eclipse.kura.net.admin/OSGI-INF/networkConfigurationService.xml
+++ b/kura/org.eclipse.kura.net.admin/OSGI-INF/networkConfigurationService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+   Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
 
    This program and the accompanying materials are made
    available under the terms of the Eclipse Public License 2.0
@@ -25,5 +25,6 @@
    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
    <reference bind="setModemManagerService" cardinality="0..1" interface="org.eclipse.kura.net.admin.modem.ModemManagerService" name="ModemManagerService" policy="dynamic" unbind="unsetModemManagerService"/>
    <reference bind="setExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static" unbind="unsetExecutorService"/>
-   <reference name="CryptoService" interface="org.eclipse.kura.crypto.CryptoService" bind="setCryptoService" unbind="unsetCryptoService" cardinality="1..1" policy="static"/> 
+   <reference name="CryptoService" interface="org.eclipse.kura.crypto.CryptoService" bind="setCryptoService" unbind="unsetCryptoService" cardinality="1..1" policy="static"/>
+   <reference bind="setConfigurationService" cardinality="1..1" interface="org.eclipse.kura.configuration.ConfigurationService" name="ConfigurationService" policy="static"/> 
 </scr:component>

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
@@ -190,7 +190,7 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
             logger.debug("Got null properties...");
         } else {
             logger.debug("Props...{}", properties);
-            this.properties = properties;
+            this.properties = new HashMap<>(properties);
             updated(this.properties);
         }
     }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
@@ -349,15 +349,6 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
 
     @Override
     public synchronized ComponentConfiguration getConfiguration() throws KuraException {
-        // This method returns the network configuration properties without the current
-        // values.
-        // i.e. the ip address that should be applied to the system, but not the actual
-        // one.
-        Optional<NetworkConfiguration> networkConfiguration = getNetworkConfiguration(false);
-        if (!networkConfiguration.isPresent()) {
-            throw new KuraRuntimeException(KuraErrorCode.CONFIGURATION_ERROR,
-                    "The network component configuration cannot be retrieved");
-        }
 
         return new ComponentConfigurationImpl(PID, getDefinition(this.properties),
                 this.properties);

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
@@ -561,7 +561,8 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
 
     private Set<String> getNetworkInterfaceNamesInConfig(final Map<String, Object> properties) {
         return Optional.ofNullable(properties).map(p -> p.get(NET_INTERFACES))
-                .map(s -> COMMA.splitAsStream((String) s).collect(Collectors.toCollection(HashSet::new)))
+                .map(s -> COMMA.splitAsStream((String) s).filter(p -> !p.trim().isEmpty())
+                        .collect(Collectors.toCollection(HashSet::new)))
                 .orElseGet(HashSet::new);
     }
 

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
@@ -357,6 +357,8 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
     }
 
     private synchronized void processNetworkConfigurationChangeEvent(NetworkConfiguration newNetworkConfig) {
+        this.networkConfig = Optional.of(newNetworkConfig);
+
         if (this.modems == null || this.modems.isEmpty()) {
             return;
         }
@@ -410,7 +412,7 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
                     if (oldNetConfigs == null || !isConfigsEqual(oldNetConfigs, newNetConfigs)) {
                         logger.info("new configuration for cellular modem on usb port {} netinterface {}", usbPort,
                                 ifaceName);
-                        this.networkConfig = Optional.of(newNetworkConfig);
+
                         NetInterfaceStatus netInterfaceStatus = getNetInterfaceStatus(newNetConfigs);
                         if (pppService != null && netInterfaceStatus != NetInterfaceStatus.netIPv4StatusUnmanaged) {
                             PppState pppSt = pppService.getPppState();

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImpl.java
@@ -963,7 +963,7 @@ public class ModemMonitorServiceImpl implements ModemMonitorService, ModemManage
                         .getNetInterfaceConfig(ifaceName);
 
                 if (netInterfaceConfig == null) {
-                    networkConfig = netConfigService.getNetworkConfiguration(false);
+                    networkConfig = netConfigService.getNetworkConfiguration(true);
                     if (networkConfig.isPresent()) {
                         netInterfaceConfig = networkConfig.get().getNetInterfaceConfig(ifaceName);
                     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -334,7 +334,8 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
                             }
 
                             // The NetConfigIP4 section above should also apply for a wireless interface
-                            // Note that this section is used to configure both a station config and an access point
+                            // Note that this section is used to configure both a station config and an
+                            // access point
                             // config
                             if (netConfig instanceof WifiConfig) {
                                 logger.debug("Setting up WifiConfigIP4");
@@ -442,25 +443,25 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
                                 GwtWifiRadioMode gwtWifiRadioMode = null;
                                 if (wifiConfig.getRadioMode() != null) {
                                     switch (wifiConfig.getRadioMode()) {
-                                    case RADIO_MODE_80211a:
-                                        gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeA;
-                                        break;
-                                    case RADIO_MODE_80211b:
-                                        gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeB;
-                                        break;
-                                    case RADIO_MODE_80211g:
-                                        gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeBG;
-                                        break;
-                                    case RADIO_MODE_80211nHT20:
-                                    case RADIO_MODE_80211nHT40above:
-                                    case RADIO_MODE_80211nHT40below:
-                                        gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeBGN;
-                                        break;
-                                    case RADIO_MODE_80211_AC:
-                                        gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeANAC;
-                                        break;
-                                    default:
-                                        break;
+                                        case RADIO_MODE_80211a:
+                                            gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeA;
+                                            break;
+                                        case RADIO_MODE_80211b:
+                                            gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeB;
+                                            break;
+                                        case RADIO_MODE_80211g:
+                                            gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeBG;
+                                            break;
+                                        case RADIO_MODE_80211nHT20:
+                                        case RADIO_MODE_80211nHT40above:
+                                        case RADIO_MODE_80211nHT40below:
+                                            gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeBGN;
+                                            break;
+                                        case RADIO_MODE_80211_AC:
+                                            gwtWifiRadioMode = GwtWifiRadioMode.netWifiRadioModeANAC;
+                                            break;
+                                        default:
+                                            break;
                                     }
                                 }
                                 if (gwtWifiRadioMode != null) {
@@ -1403,7 +1404,6 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             logger.debug("mode is DHCP");
             properties.put(dhcpClient4PropName, true);
             properties.put(addressPropName, "");
-            properties.put(prefixPropName, "");
             properties.put(gatewayPropName, "");
         } else {
             logger.debug("mode is STATIC");
@@ -1422,8 +1422,6 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
                 short prefix = NetworkUtil.getNetmaskShortForm(
                         ((IP4Address) IPAddress.parseHostAddress(config.getSubnetMask())).getHostAddress());
                 properties.put(prefixPropName, prefix);
-            } else {
-                properties.put(prefixPropName, "");
             }
 
             if (config.getGateway() != null && !config.getGateway().isEmpty()) {
@@ -1820,24 +1818,24 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
         WifiRadioMode wifiRadioMode;
 
         switch (radioMode) {
-        case netWifiRadioModeA:
-            wifiRadioMode = WifiRadioMode.RADIO_MODE_80211a;
-            break;
-        case netWifiRadioModeB:
-            wifiRadioMode = WifiRadioMode.RADIO_MODE_80211b;
-            break;
-        case netWifiRadioModeBG:
-            wifiRadioMode = WifiRadioMode.RADIO_MODE_80211g;
-            break;
-        case netWifiRadioModeBGN:
-            wifiRadioMode = WifiRadioMode.RADIO_MODE_80211nHT20;
-            break;
-        case netWifiRadioModeANAC:
-            wifiRadioMode = WifiRadioMode.RADIO_MODE_80211_AC;
-            break;
+            case netWifiRadioModeA:
+                wifiRadioMode = WifiRadioMode.RADIO_MODE_80211a;
+                break;
+            case netWifiRadioModeB:
+                wifiRadioMode = WifiRadioMode.RADIO_MODE_80211b;
+                break;
+            case netWifiRadioModeBG:
+                wifiRadioMode = WifiRadioMode.RADIO_MODE_80211g;
+                break;
+            case netWifiRadioModeBGN:
+                wifiRadioMode = WifiRadioMode.RADIO_MODE_80211nHT20;
+                break;
+            case netWifiRadioModeANAC:
+                wifiRadioMode = WifiRadioMode.RADIO_MODE_80211_AC;
+                break;
 
-        default:
-            throw new GwtKuraException(GwtKuraErrorCode.ILLEGAL_ARGUMENT);
+            default:
+                throw new GwtKuraException(GwtKuraErrorCode.ILLEGAL_ARGUMENT);
         }
 
         return wifiRadioMode;

--- a/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
+++ b/kura/test/org.eclipse.kura.core.net.test/src/test/java/org/eclipse/kura/core/net/NetworkConfigurationTest.java
@@ -170,7 +170,7 @@ public class NetworkConfigurationTest {
     public void testModifiedInterfaceNames() throws NoSuchFieldException {
         NetworkConfiguration config = new NetworkConfiguration();
 
-        assertEquals(false, TestUtil.getFieldValue(config, "recomputeProperties"));
+        assertEquals(true, TestUtil.getFieldValue(config, "recomputeProperties"));
 
         List<String> modifiedInterfaceNames = new ArrayList<>();
         modifiedInterfaceNames.add("if1");
@@ -190,24 +190,24 @@ public class NetworkConfigurationTest {
     public void testModifiedInterfaceNamesNull() throws NoSuchFieldException {
         NetworkConfiguration config = new NetworkConfiguration();
 
-        assertEquals(false, TestUtil.getFieldValue(config, "recomputeProperties"));
+        assertEquals(true, TestUtil.getFieldValue(config, "recomputeProperties"));
 
         List<String> modifiedInterfaceNames = null;
         config.setModifiedInterfaceNames(modifiedInterfaceNames);
         assertNull(config.getModifiedInterfaceNames());
-        assertEquals(false, TestUtil.getFieldValue(config, "recomputeProperties"));
+        assertEquals(true, TestUtil.getFieldValue(config, "recomputeProperties"));
     }
 
     @Test
     public void testModifiedInterfaceNamesEmpty() throws NoSuchFieldException {
         NetworkConfiguration config = new NetworkConfiguration();
 
-        assertEquals(false, TestUtil.getFieldValue(config, "recomputeProperties"));
+        assertEquals(true, TestUtil.getFieldValue(config, "recomputeProperties"));
 
         List<String> modifiedInterfaceNames = new ArrayList<>();
         config.setModifiedInterfaceNames(modifiedInterfaceNames);
         assertNull(config.getModifiedInterfaceNames());
-        assertEquals(false, TestUtil.getFieldValue(config, "recomputeProperties"));
+        assertEquals(true, TestUtil.getFieldValue(config, "recomputeProperties"));
     }
 
     @Test
@@ -811,8 +811,8 @@ public class NetworkConfigurationTest {
     public void testGetConfigurationPropertiesNull() throws NoSuchFieldException {
         NetworkConfiguration config = new NetworkConfiguration();
 
-        assertEquals(false, TestUtil.getFieldValue(config, "recomputeProperties"));
-        assertNull(config.getConfigurationProperties());
+        assertEquals(true, TestUtil.getFieldValue(config, "recomputeProperties"));
+        assertNotNull(config.getConfigurationProperties());
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -36,7 +35,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.KuraRuntimeException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.metatype.AD;
 import org.eclipse.kura.configuration.metatype.OCD;
@@ -340,37 +338,6 @@ public class NetworkConfigurationServiceImplTest {
     }
 
     @Test
-    public void testGetConfigurationException() throws KuraException, NoSuchFieldException {
-        NetworkConfigurationServiceImpl svc = new NetworkConfigurationServiceImpl() {
-
-            @Override
-            protected List<String> getAllInterfaceNames() throws KuraException {
-                throw new KuraException(KuraErrorCode.CONFIGURATION_UPDATE, "test");
-            }
-        };
-
-        NetworkService networkServiceMock = mock(NetworkService.class);
-        svc.setNetworkService(networkServiceMock);
-
-        List<NetInterface<? extends NetInterfaceAddress>> interfaces = new ArrayList<>();
-        NetInterface<? extends NetInterfaceAddress> netInterface = new WifiInterfaceImpl("wlan1");
-        interfaces.add(netInterface);
-        when(networkServiceMock.getNetworkInterfaces()).thenReturn(interfaces);
-
-        UsbService usbServiceMock = mock(UsbService.class);
-        svc.setUsbService(usbServiceMock);
-
-        try {
-            svc.getConfiguration();
-            fail("Exception was expected.");
-        } catch (KuraRuntimeException e) {
-            assertEquals(KuraErrorCode.CONFIGURATION_ERROR, e.getCode());
-            assertTrue(e.getMessage().endsWith("retrieved"));
-        }
-
-    }
-
-    @Test
     public void testGetConfiguration() throws KuraException, NoSuchFieldException {
         NetworkConfigurationServiceImpl svc = new NetworkConfigurationServiceImpl() {
 
@@ -391,20 +358,20 @@ public class NetworkConfigurationServiceImplTest {
                 NetInterfaceType type;
 
                 switch (interfaceName) {
-                case "eth2":
-                    type = NetInterfaceType.ETHERNET;
-                    break;
-                case "lo":
-                    type = NetInterfaceType.LOOPBACK;
-                    break;
-                case "ppp1":
-                    type = NetInterfaceType.MODEM;
-                    break;
-                case "wlan1":
-                    type = NetInterfaceType.WIFI;
-                    break;
-                default:
-                    type = NetInterfaceType.UNKNOWN;
+                    case "eth2":
+                        type = NetInterfaceType.ETHERNET;
+                        break;
+                    case "lo":
+                        type = NetInterfaceType.LOOPBACK;
+                        break;
+                    case "ppp1":
+                        type = NetInterfaceType.MODEM;
+                        break;
+                    case "wlan1":
+                        type = NetInterfaceType.WIFI;
+                        break;
+                    default:
+                        type = NetInterfaceType.UNKNOWN;
                 }
 
                 return type;

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
@@ -404,12 +404,12 @@ public class NetworkConfigurationServiceImplTest {
         Map<String, Object> inputProperties = new HashMap<>();
         inputProperties.put("net.interfaces", "");
 
-        svc.activate(null, inputProperties);
-
         List<UsbNetDevice> usbNetDevices = new ArrayList<>();
         usbNetDevices.add(new UsbNetDevice("vendor", "product", "manufacturer", "productName", "usbBusNumber",
                 "usbDevicePath", "wlan1"));
         when(usbServiceMock.getUsbNetDevices()).thenReturn(usbNetDevices);
+
+        svc.activate(null, inputProperties);
 
         ComponentConfiguration configuration = svc.getConfiguration();
 
@@ -418,6 +418,9 @@ public class NetworkConfigurationServiceImplTest {
         Map<String, Object> properties = configuration.getConfigurationProperties();
 
         assertNotNull(properties);
+
+        System.out.println("properties: " + properties);
+
         assertEquals(83, properties.size());
         assertEquals("ETHERNET", properties.get("net.interface.eth2.type"));
         assertEquals("LOOPBACK", properties.get("net.interface.lo.type"));

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
@@ -73,6 +73,11 @@ public class NetworkConfigurationServiceImplTest {
         NetworkConfigurationServiceImpl svc = new NetworkConfigurationServiceImpl() {
 
             @Override
+            protected NetInterfaceType getNetworkType(String interfaceName) throws KuraException {
+                return guessNetworkType(interfaceName);
+            }
+
+            @Override
             protected void initVisitors() {
                 inited.set(true);
             }
@@ -106,6 +111,11 @@ public class NetworkConfigurationServiceImplTest {
     @Test
     public void testPostEvent() throws InterruptedException, NoSuchFieldException {
         NetworkConfigurationServiceImpl svc = new NetworkConfigurationServiceImpl() {
+
+            @Override
+            protected NetInterfaceType getNetworkType(String interfaceName) throws KuraException {
+                return guessNetworkType(interfaceName);
+            }
 
             @Override
             protected void initVisitors() {
@@ -257,6 +267,11 @@ public class NetworkConfigurationServiceImplTest {
         NetworkConfigurationServiceImpl svc = new NetworkConfigurationServiceImpl() {
 
             @Override
+            protected NetInterfaceType getNetworkType(String interfaceName) throws KuraException {
+                return guessNetworkType(interfaceName);
+            }
+
+            @Override
             protected void initVisitors() {
             }
 
@@ -355,26 +370,7 @@ public class NetworkConfigurationServiceImplTest {
 
             @Override
             protected NetInterfaceType getNetworkType(String interfaceName) throws KuraException {
-                NetInterfaceType type;
-
-                switch (interfaceName) {
-                    case "eth2":
-                        type = NetInterfaceType.ETHERNET;
-                        break;
-                    case "lo":
-                        type = NetInterfaceType.LOOPBACK;
-                        break;
-                    case "ppp1":
-                        type = NetInterfaceType.MODEM;
-                        break;
-                    case "wlan1":
-                        type = NetInterfaceType.WIFI;
-                        break;
-                    default:
-                        type = NetInterfaceType.UNKNOWN;
-                }
-
-                return type;
+                return guessNetworkType(interfaceName);
             }
 
             @Override
@@ -758,6 +754,22 @@ public class NetworkConfigurationServiceImplTest {
             }
         }
         assertEquals(45, adsConfigured);
+    }
+
+    private static NetInterfaceType guessNetworkType(final String interfaceName) {
+
+        if (interfaceName.startsWith("eth")) {
+            return NetInterfaceType.ETHERNET;
+        } else if (interfaceName.equals("lo")) {
+            return NetInterfaceType.LOOPBACK;
+        } else if (interfaceName.startsWith("ppp")) {
+            return NetInterfaceType.MODEM;
+        } else if (interfaceName.startsWith("wlan")) {
+            return NetInterfaceType.WIFI;
+        } else {
+            return NetInterfaceType.UNKNOWN;
+        }
+
     }
 
 }

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImplTest.java
@@ -419,8 +419,6 @@ public class NetworkConfigurationServiceImplTest {
 
         assertNotNull(properties);
 
-        System.out.println("properties: " + properties);
-
         assertEquals(83, properties.size());
         assertEquals("ETHERNET", properties.get("net.interface.eth2.type"));
         assertEquals("LOOPBACK", properties.get("net.interface.lo.type"));

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/monitor/ModemMonitorServiceImplTest.java
@@ -16,10 +16,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -85,6 +83,7 @@ import org.eclipse.kura.net.modem.ModemTechnologyType;
 import org.eclipse.kura.system.SystemService;
 import org.eclipse.kura.usb.UsbModemDevice;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 
@@ -178,7 +177,7 @@ public class ModemMonitorServiceImplTest {
         interfaceAddressConfigs.add(modemInterfaceAddressConfig);
         netInterfaceConfig.setNetInterfaceAddresses(interfaceAddressConfigs);
 
-        when(ncsMock.getNetworkConfiguration(false)).thenReturn(Optional.of(nc));
+        when(ncsMock.getNetworkConfiguration(Mockito.anyBoolean())).thenReturn(Optional.of(nc));
         svc.setNetworkConfigurationService(ncsMock);
 
         // for obtaining the available network interfaces, ppp port
@@ -353,7 +352,8 @@ public class ModemMonitorServiceImplTest {
         when(modem.getIntegratedCirquitCardId(false)).thenReturn("cardid");
         when(modem.getSignalStrength(false)).thenReturn(2);
         when(modem.isGpsSupported()).thenReturn(true);
-        // 1. for start of disabling, 2. check after being disabled, 3. log it, 4. another check before enabling it
+        // 1. for start of disabling, 2. check after being disabled, 3. log it, 4.
+        // another check before enabling it
         when(modem.isGpsEnabled()).thenReturn(true).thenReturn(false).thenReturn(false).thenReturn(false);
         when(modem.getModel()).thenReturn("testModem");
         when(modem.getAtPort()).thenReturn("usb0");
@@ -392,7 +392,8 @@ public class ModemMonitorServiceImplTest {
         when(task.isDone()).thenReturn(false);
 
         // produce a warning log...
-        when(executor.awaitTermination(anyLong(), eq(TimeUnit.SECONDS))).thenThrow(new InterruptedException("test"));
+        when(executor.awaitTermination(Mockito.anyLong(), Mockito.eq(TimeUnit.SECONDS)))
+                .thenThrow(new InterruptedException("test"));
 
         svc.deactivate();
 
@@ -640,7 +641,8 @@ public class ModemMonitorServiceImplTest {
 
     @Test
     public void testGetModemResetTimeoutMsecNull() throws Throwable {
-        // test retrieval of reset timeout from configuration where interface name is null
+        // test retrieval of reset timeout from configuration where interface name is
+        // null
 
         ModemMonitorServiceImpl svc = new ModemMonitorServiceImpl();
 
@@ -940,7 +942,7 @@ public class ModemMonitorServiceImplTest {
         NetworkConfigurationService nsCfgMock = mock(NetworkConfigurationService.class);
         NetworkConfiguration networkConfigMock = mock(NetworkConfiguration.class);
 
-        when(nsCfgMock.getNetworkConfiguration(false)).thenReturn(Optional.of(networkConfigMock));
+        when(nsCfgMock.getNetworkConfiguration(Mockito.anyBoolean())).thenReturn(Optional.of(networkConfigMock));
         svc.setNetworkConfigurationService(nsCfgMock);
 
         svc.setNetworkService(nsMock);


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

The current implementation of NetworkConfigurationService will discard properties of a configured network interface if it not connected to the system when its activate() or update() methods are called. If this happens, the network interface will be reported as "Disabled" when it is reconnected. This can cause problems expecially with USB modems.

This PR introduces the following changes:
* `NetworkConfigurationService` will no longer drop received configuration properties.
* `ModemMonitorService` will ask the `NetworkConfigurationService` to recompute the network configuration if an USB modem is connected.
