### PR TITLE
refactor(net.admin): Removed useless debug messages

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkAdminServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkAdminServiceImpl.java
@@ -270,9 +270,7 @@ public class NetworkAdminServiceImpl implements NetworkAdminService, EventHandle
     public List<NetConfig> getNetworkInterfaceConfigs(String interfaceName, boolean recompute) throws KuraException {
 
         List<NetConfig> netConfigs = new ArrayList<>();
-        long started = System.currentTimeMillis();
         NetworkConfiguration networkConfig = getNetworkConfigurationInternal(recompute);
-        logger.info("GetNetworkConfiguration1 {}", (System.currentTimeMillis() - started));
         if (interfaceName != null && networkConfig != null) {
             try {
                 logger.debug("Getting networkInterfaceConfigs for {}", interfaceName);


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR removes an old message used for debug purposes.

Signed-off-by: pierantoniomerlino <pierantonio.merlino@eurotech.com>