### PR TITLE
refactor(core.deployment): add writeConfigurationFile method

### DIFF
--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -442,21 +442,8 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         oldDeployedPackages.putAll(deployedPackages);
         deployedPackages.setProperty(packageName, packageUrl);
 
-        if (this.dpaConfPath == null) {
-            logger.warn("Configuration file not specified");
-            return;
-        }
-
-        if (oldDeployedPackages.equals(deployedPackages)) {
-            return;
-        }
-
-        try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
-            deployedPackages.store(fos, null);
-            fos.flush();
-            fos.getFD().sync();
-        } catch (IOException e) {
-            logger.error("Error writing package configuration file", e);
+        if (!oldDeployedPackages.equals(deployedPackages)) {
+            writeConfigurationFile(this.dpaConfPath, deployedPackages);
         }
     }
 
@@ -466,16 +453,18 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         oldDeployedPackages.putAll(deployedPackages);
         deployedPackages.remove(packageName);
 
-        if (this.dpaConfPath == null) {
+        if (!oldDeployedPackages.equals(deployedPackages)) {
+            writeConfigurationFile(this.dpaConfPath, deployedPackages);
+        }
+    }
+
+    private static void writeConfigurationFile(String dpaConfPath, Properties deployedPackages) {
+        if (dpaConfPath == null) {
             logger.warn("Configuration file not specified");
             return;
         }
 
-        if (oldDeployedPackages.equals(deployedPackages)) {
-            return;
-        }
-
-        try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
+        try (FileOutputStream fos = new FileOutputStream(dpaConfPath)) {
             deployedPackages.store(fos, null);
             fos.flush();
             fos.getFD().sync();

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -443,7 +443,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         deployedPackages.setProperty(packageName, packageUrl);
 
         if (!oldDeployedPackages.equals(deployedPackages)) {
-            writeConfigurationFile(this.dpaConfPath, deployedPackages);
+            writeDPAPropertiesFile(this.dpaConfPath, deployedPackages);
         }
     }
 
@@ -454,11 +454,11 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         deployedPackages.remove(packageName);
 
         if (!oldDeployedPackages.equals(deployedPackages)) {
-            writeConfigurationFile(this.dpaConfPath, deployedPackages);
+            writeDPAPropertiesFile(this.dpaConfPath, deployedPackages);
         }
     }
 
-    private static void writeConfigurationFile(String dpaConfPath, Properties deployedPackages) {
+    private static void writeDPAPropertiesFile(String dpaConfPath, Properties deployedPackages) {
         if (dpaConfPath == null) {
             logger.warn("Configuration file not specified");
             return;

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -456,7 +456,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         }
     }
 
-    private void writeDPAPropertiesFile(String dpaConfPath, Properties deployedPackages) {
+    private static void writeDPAPropertiesFile(String dpaConfPath, Properties deployedPackages) {
         try (FileOutputStream fos = new FileOutputStream(dpaConfPath)) {
             deployedPackages.store(fos, null);
             fos.flush();

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -348,12 +348,10 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
 
     protected Properties readDeployedPackages() {
         Properties deployedPackages = new Properties();
-        if (this.dpaConfPath != null) {
-            try (FileReader fr = new FileReader(this.dpaConfPath)) {
-                deployedPackages.load(fr);
-            } catch (IOException e) {
-                logger.error("Exception loading deployment packages configuration file", e);
-            }
+        try (FileReader fr = new FileReader(this.dpaConfPath)) {
+            deployedPackages.load(fr);
+        } catch (IOException e) {
+            logger.error("Exception loading deployment packages configuration file", e);
         }
         return deployedPackages;
     }

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -459,11 +459,6 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
     }
 
     private void writeDPAPropertiesFile(String dpaConfPath, Properties deployedPackages) {
-        if (dpaConfPath == null) {
-            logger.warn("Configuration file not specified");
-            return;
-        }
-
         try (FileOutputStream fos = new FileOutputStream(dpaConfPath)) {
             deployedPackages.store(fos, null);
             fos.flush();

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -458,7 +458,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         }
     }
 
-    private static void writeDPAPropertiesFile(String dpaConfPath, Properties deployedPackages) {
+    private void writeDPAPropertiesFile(String dpaConfPath, Properties deployedPackages) {
         if (dpaConfPath == null) {
             logger.warn("Configuration file not specified");
             return;

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -441,7 +441,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         deployedPackages.setProperty(packageName, packageUrl);
 
         if (!oldDeployedPackages.equals(deployedPackages)) {
-            writeDPAPropertiesFile(this.dpaConfPath, deployedPackages);
+            writeDPAPropertiesFile(deployedPackages);
         }
     }
 
@@ -452,12 +452,12 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         deployedPackages.remove(packageName);
 
         if (!oldDeployedPackages.equals(deployedPackages)) {
-            writeDPAPropertiesFile(this.dpaConfPath, deployedPackages);
+            writeDPAPropertiesFile(deployedPackages);
         }
     }
 
-    private static void writeDPAPropertiesFile(String dpaConfPath, Properties deployedPackages) {
-        try (FileOutputStream fos = new FileOutputStream(dpaConfPath)) {
+    private void writeDPAPropertiesFile(Properties deployedPackages) {
+        try (FileOutputStream fos = new FileOutputStream(this.dpaConfPath)) {
             deployedPackages.store(fos, null);
             fos.flush();
             fos.getFD().sync();


### PR DESCRIPTION
**Brief description of the PR**: This PR refactors the recent changes in the `deployment.agent` package to adhere to Sonar code quality suggestions.

**Related Issue:** This PR fixes/closes https://github.com/eclipse/kura/pull/4016

**Description of the solution adopted:** Extracted duplicated code in the newly added `writeDPAPropertiesFile` static method.
