### PR TITLE
fix(core): Fixed abnormal size of file-based database.

### DIFF
--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.core.db.H2DbService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.core.db.H2DbService.xml
@@ -70,7 +70,17 @@
             default="10"
             min="1"
             description="The H2DbService manages connections using a connection pool. This parameter defines the maximum number of connections for the pool"/>
+
+        <AD id="db.max.compact.time" 
+            name="Maximum compact time"
+            type="Integer" 
+            cardinality="0" 
+            required="true" 
+            default="120000" 
+            min="0"
+            description="The maximum time allowed to perform database defragmentation." />
         </OCD>
+
     <Designate pid="org.eclipse.kura.core.db.H2DbService" factoryPid="org.eclipse.kura.core.db.H2DbService">
         <Object ocdref="org.eclipse.kura.core.db.H2DbService"/>
     </Designate>

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/db/H2DbServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/db/H2DbServiceImpl.java
@@ -448,13 +448,17 @@ public class H2DbServiceImpl implements H2DbService, ConfigurableComponent {
 
         this.dataSource = new JdbcDataSource();
 
-        this.dataSource.setURL(configuration.getDbUrl());
+        this.dataSource.setURL(withMaxCompactTime(configuration.getMaxCompactTime(), configuration.getDbUrl()));
         this.dataSource.setUser(configuration.getUser());
         this.dataSource.setPassword(password);
 
         this.connectionPool = JdbcConnectionPool.create(this.dataSource);
 
         openDatabase(configuration, true);
+    }
+
+    private String withMaxCompactTime(Integer maxCompactTime, String dbUrl) {
+        return dbUrl.concat(";MAX_COMPACT_TIME=").concat(maxCompactTime.toString());
     }
 
     private void openDatabase(H2DbServiceOptions configuration, boolean deleteDbOnError) {
@@ -574,7 +578,7 @@ public class H2DbServiceImpl implements H2DbService, ConfigurableComponent {
             try {
                 conn = H2DbServiceImpl.this.dataSource.getConnection();
                 stmt = conn.createStatement();
-                stmt.execute("SHUTDOWN DEFRAG");
+                stmt.execute("SHUTDOWN");
             } finally {
                 close(stmt);
                 close(conn);

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/db/H2DbServiceOptions.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/db/H2DbServiceOptions.java
@@ -27,10 +27,12 @@ class H2DbServiceOptions {
     private static final Property<Integer> DEFRAG_INTERVAL_MINUTES_PROP = new Property<>("db.defrag.interval.minutes",
             20);
     private static final Property<Integer> CONNECTION_POOL_MAX_SIZE = new Property<>("db.connection.pool.max.size", 10);
+    private static final Property<Integer> MAX_COMPACT_TIME = new Property<>("db.max.compact.time", 120000);
 
     private static final Pattern FILE_LOG_LEVEL_PATTERN = generatePatternForProperty("trace_level_file");
     private static final Pattern USER_PATTERN = generatePatternForProperty("user");
     private static final Pattern PASSWORD_PATTERN = generatePatternForProperty("password");
+    private static final Pattern MAX_COMPACT_TIME_PATTERN = generatePatternForProperty("max_compact_time");
 
     private static final Pattern JDBC_URL_PARSE_PATTERN = Pattern.compile("jdbc:([^:]+):(([^:]+):)?([^;]*)(;.*)?");
 
@@ -40,6 +42,7 @@ class H2DbServiceOptions {
     private final long checkpointIntervalSeconds;
     private final long defragIntervalMinutes;
     private final int maxConnectionPoolSize;
+    private final int maxCompactTime;
 
     private boolean isInMemory;
     private boolean isFileBased;
@@ -57,11 +60,13 @@ class H2DbServiceOptions {
         this.checkpointIntervalSeconds = CHECKPOINT_INTERVAL_SECONDS_PROP.get(properties);
         this.defragIntervalMinutes = DEFRAG_INTERVAL_MINUTES_PROP.get(properties);
         this.maxConnectionPoolSize = CONNECTION_POOL_MAX_SIZE.get(properties);
+        this.maxCompactTime = MAX_COMPACT_TIME.get(properties);
 
         String dbUrlProp = CONNECTOR_URL_PROP.get(properties);
 
         dbUrlProp = USER_PATTERN.matcher(dbUrlProp).replaceAll("");
         dbUrlProp = PASSWORD_PATTERN.matcher(dbUrlProp).replaceAll("");
+        dbUrlProp = MAX_COMPACT_TIME_PATTERN.matcher(dbUrlProp).replaceAll("");
 
         this.dbUrl = dbUrlProp;
         computeUrlParts();
@@ -180,6 +185,10 @@ class H2DbServiceOptions {
 
     public int getConnectionPoolMaxSize() {
         return this.maxConnectionPoolSize;
+    }
+
+    public int getMaxCompactTime() {
+        return maxCompactTime;
     }
 
     public boolean isFileBasedLogLevelSpecified() {

--- a/target-platform/p2-repo-equinox_3.16.0/pom.xml
+++ b/target-platform/p2-repo-equinox_3.16.0/pom.xml
@@ -152,9 +152,7 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${project.build.directory}/download" />
-                                <!--
-                                    - direct mirror link: http://www.eclipse.org/downloads/download.php?file=/equinox/drops/R-Neon.1-201609071200/equinox-SDK-Neon.1.zip&amp;r=1
-                                -->
+
                                 <get src="${equinox.download.url}" dest="${project.build.directory}/download/equinox.zip"
                                     usetimestamp="true" />
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

**Description:** Now SHUTDOWN is used to defragment the database instead of SHUTDOWN DEFRAG, since setting the value of MAX_COMPACT_TIME allows the system to perform compaction for a maximum time specified by the value. 
The previous solution did not work because of a bug in H2.

**Related Issue:** This PR fixes/closes {#4234}

