### PR TITLE
fix: network configuration not updating on Jetson Nano

### DIFF
--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
@@ -65,9 +65,6 @@
             <esf:property name="net.interface.eth0.config.dhcpServer4.defaultLeaseTime" array="false" encrypted="false" type="Integer">
                 <esf:value>7200</esf:value>
             </esf:property>
-            <esf:property name="modified.interface.names" array="false" encrypted="false" type="String">
-                <esf:value></esf:value>
-            </esf:property>
             <esf:property name="net.interface.lo.config.ip4.address" array="false" encrypted="false" type="String">
                 <esf:value>127.0.0.1</esf:value>
             </esf:property>


### PR DESCRIPTION
On 5.2.1_RC1 I encountered issues in changing the network interface configurations: the `/etc/network/interfaces` file was never updated.

The issue was caused by the fact that the `modified.interface.names` property was persisted in the snapshot_0 of the Jetson Nano and, since the addition of the new behaviour with [PR4218](https://github.com/eclipse/kura/pull/4218), it was never correctly computed and thus prevented the `/etc/network/interfaces` file write.

This meant that the [getModifiedNetInterfaceConfigs](https://github.com/eclipse/kura/blob/fabe1e8a3901fb6d9d319ffe5bb30c1b3b171814/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java#L411) always returned a list with an empty string which meant that the [IfcfgConfigWriter](https://github.com/eclipse/kura/blob/fabe1e8a3901fb6d9d319ffe5bb30c1b3b171814/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/visitor/linux/IfcfgConfigWriter.java#L55) never wrote the configuration.

By removing the property from the initial snapshot Kura behaves as expected.

**Note**: please port this PR to the `release-5.2.0` maintenance branch
