### PR TITLE
fix: Filter out modified.interface.names property

### DIFF
--- a/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
+++ b/kura/org.eclipse.kura.core.net/src/main/java/org/eclipse/kura/core/net/NetworkConfiguration.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.regex.Pattern;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
@@ -79,6 +80,7 @@ public class NetworkConfiguration {
     private static final String SECURITY_TYPE = ".securityType";
     private static final String NET_INTERFACE = "net.interface.";
     private static final String NET_INTERFACES = "net.interfaces";
+    private static final Pattern COMMA = Pattern.compile(",");
 
     private final Map<String, NetInterfaceConfig<? extends NetInterfaceAddressConfig>> netInterfaceConfigs;
     private Map<String, Object> properties;
@@ -139,9 +141,8 @@ public class NetworkConfiguration {
         this.modifiedInterfaceNames = new ArrayList<>();
         String modifiedInterfaces = (String) properties.get("modified.interface.names");
         if (modifiedInterfaces != null) {
-            for (String interfaceName : modifiedInterfaces.split(",")) {
-                this.modifiedInterfaceNames.add(interfaceName);
-            }
+            COMMA.splitAsStream(modifiedInterfaces).filter(s -> !s.trim().isEmpty())
+                    .forEach(this.modifiedInterfaceNames::add);
         }
 
         this.recomputeProperties = true;

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
@@ -92,6 +92,7 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
     private static final String CONFIG_AUTOCONNECT = ".config.autoconnect";
     private static final String CONFIG_MTU = ".config.mtu";
     private static final String NET_INTERFACES = "net.interfaces";
+    private static final String MODIFIED_INTERFACE_NAMES = "modified.interface.names";
     private static final String MODEM_PORT_REGEX = "^\\d+-\\d+";
     private static final Pattern PPP_INTERFACE = Pattern.compile("ppp[0-9]+");
     private static final Pattern COMMA = Pattern.compile(",");
@@ -196,7 +197,7 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
             logger.debug("Got null properties...");
         } else {
             logger.debug("Props...{}", properties);
-            this.properties = new HashMap<>(properties);
+            this.properties = discardModifiedNetworkInterfaces(new HashMap<>(properties));
             updated(this.properties);
         }
     }
@@ -279,6 +280,8 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
             updateCurrentNetworkConfiguration();
 
             this.eventAdmin.postEvent(new NetworkConfigurationChangeEvent(modifiedProps));
+
+            this.properties = discardModifiedNetworkInterfaces(this.properties);
 
             if (changed) {
                 this.configurationService.snapshot();
@@ -747,6 +750,16 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
             getWifiInfraDefinition(objectFactory, tocd, ifaceName);
             getWifiMasterDefinition(objectFactory, tocd, ifaceName);
         }
+    }
+
+    private static Map<String, Object> discardModifiedNetworkInterfaces(final Map<String, Object> properties) {
+        if (!properties.containsKey(MODIFIED_INTERFACE_NAMES)) {
+            return properties;
+        }
+
+        final Map<String, Object> result = new HashMap<>(properties);
+        result.remove(MODIFIED_INTERFACE_NAMES);
+        return result;
     }
 
     private void getWifiMasterDefinition(ObjectFactory objectFactory, Tocd tocd, String ifaceName) {

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
@@ -253,7 +253,7 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
         try {
             final Map<String, Object> newProperties = migrateModemConfigs(receivedProperties);
             logger.debug("new properties - updating");
-            logger.debug("modified.interface.names: {}", newProperties.get("modified.interface.names"));
+            logger.debug("modified.interface.names: {}", newProperties.get(MODIFIED_INTERFACE_NAMES));
 
             Map<String, Object> modifiedProps = new HashMap<>(newProperties);
 


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

* Prevents the `modified.interface.names` property from being stored to / loaded from snapshot
