### PR TITLE
fix(core.data.store): allow storing null payloads

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/store/DbDataStore.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/store/DbDataStore.java
@@ -342,12 +342,16 @@ public class DbDataStore implements DataStore {
                 pstmt.setInt(6, -1);                                                // publishedMessageId
                 pstmt.setTimestamp(7, null);                                        // confirmedOn
 
-                if (payload.length < PAYLOAD_BYTE_SIZE_THRESHOLD) {
-                    pstmt.setBytes(8, payload);                                     // smallPayload
+                // smallPayload (=8) vs. largePayload (=9)
+                if (payload == null) {
+                    pstmt.setNull(8, Types.VARBINARY);
+                    pstmt.setNull(9, Types.BLOB);
+                } else if (payload.length < PAYLOAD_BYTE_SIZE_THRESHOLD) {
+                    pstmt.setBytes(8, payload);
                     pstmt.setNull(9, Types.BLOB);
                 } else {
                     pstmt.setNull(8, Types.VARBINARY);
-                    pstmt.setBinaryStream(9, new ByteArrayInputStream(payload), payload.length);    // largePayload
+                    pstmt.setBinaryStream(9, new ByteArrayInputStream(payload), payload.length);
                 }
 
                 pstmt.setInt(10, priority);                                         // priority

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/store/DbDataStore.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/store/DbDataStore.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kura.core.data.store;
 
+import static java.util.Objects.isNull;
+
 import java.io.ByteArrayInputStream;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -343,10 +345,7 @@ public class DbDataStore implements DataStore {
                 pstmt.setTimestamp(7, null);                                        // confirmedOn
 
                 // smallPayload (=8) vs. largePayload (=9)
-                if (payload == null) {
-                    pstmt.setNull(8, Types.VARBINARY);
-                    pstmt.setNull(9, Types.BLOB);
-                } else if (payload.length < PAYLOAD_BYTE_SIZE_THRESHOLD) {
+                if (isNull(payload) || payload.length < PAYLOAD_BYTE_SIZE_THRESHOLD) {
                     pstmt.setBytes(8, payload);
                     pstmt.setNull(9, Types.BLOB);
                 } else {

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/store/DbDataStoreStorageTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/store/DbDataStoreStorageTest.java
@@ -51,6 +51,17 @@ public class DbDataStoreStorageTest {
     /*
      * Scenarios
      */
+    
+    @Test
+    public void shouldStoreNullPayload() {
+        givenNullPayload();
+        givenDbDataStore(10000, 10000, 10);
+        
+        whenStore(TOPIC, this.payload, QOS2, true, PRIORITY_LOW);
+        
+        thenNoExceptionsOccurred();
+        thenStoredMessageIs(TOPIC, this.payload, QOS2, true, PRIORITY_LOW);
+    }
 
     @Test
     public void shouldStoreSmallPayload() {
@@ -144,6 +155,10 @@ public class DbDataStoreStorageTest {
     /*
      * Given
      */
+    
+    private void givenNullPayload() {
+        this.payload = null;
+    }
 
     private void givenSmallPayload() {
         this.payload = new byte[200];


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR allows the `DbDataStore` to store null payloads.

**Related Issue:** This PR fixes/closes https://github.com/eclipse/kura/issues/4246.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
