### PR TITLE
chore: added dash-licenses-snapshots plugin repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ bin/
 +# IntelliJ Idea
 .idea/
 *.iml
+maven.deps
+DEPENDENCIES

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -184,6 +184,16 @@
         </snapshotRepository>
     </distributionManagement>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>dash-licenses-snapshots</id>
+            <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
+
     <profiles>
         <profile>
             <id>default</id>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -107,6 +107,16 @@
             </properties>
         </profile>
     </profiles>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>dash-licenses-snapshots</id>
+            <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
     
     <build>
         <plugins>


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds the `dash-licenses-snapshots` plugins repository to support the Maven plugin for the [Eclipse Dash License Tool](https://github.com/eclipse/dash-licenses).

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
