### PR TITLE
ci: remove deprecated `set-output` command

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -26,10 +26,5 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
-
       - name: Deploy with mike
-        run: mike deploy --push ${{ steps.extract_branch.outputs.branch }}
+        run: mike deploy --push ${GITHUB_REF#refs/heads/}


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

With this PR there's no need to use the `set-output` command anymore.