### PR TITLE
ci: Release Notes automation information improvements

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -56,5 +56,5 @@ jobs:
       with:
         title: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
         commit-message: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
-        body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.version }} version release notes"
+        body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
         branch-suffix: short-commit-hash

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -56,5 +56,5 @@ jobs:
       with:
         title: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
         commit-message: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
-        body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
+        body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.version }} version release notes since commit `${{ github.event.inputs.starting_commit }}` (non-inclusive)"
         branch-suffix: short-commit-hash

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -10,7 +10,7 @@ on:
           required: true
         starting_commit:
           type: string
-          description: Commit from which to start generating the release notes
+          description: Commit from which to start generating the release notes (non-inclusive)
           required: true
 
 jobs:


### PR DESCRIPTION
With this PR:
- I added a note in the description of the workflow about the fact that the starting commit is *non-inclusive*
![MicrosoftTeams-image (4)](https://user-images.githubusercontent.com/22748355/203342019-9d006fda-f63d-43a1-a5eb-11c784d59437.png)
- The generated PR description will now contain the commit used as starting point for the release notes generation.
![MicrosoftTeams-image (5)](https://user-images.githubusercontent.com/22748355/203342210-905a4eb1-4b13-4938-a779-384e18ce766f.png)
