### PR TITLE
ci: add Lint PR workflow for release-5.1.0 branch

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,32 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            docs
+            refactor
+            test
+            style
+            chore
+            build
+            ci
+            revert
+            perf
+            deprecate
+          requireScope: false


### PR DESCRIPTION
Since we decided to backport the release notes automation workflow on the `release-5.1.0` branch, I added the workflow responsible for parsing the PR titles and enforcing the Conventional Commit specification.

**Note**: this workflow is already updated with the latest changes brought by https://github.com/eclipse/kura/pull/4263