### PR TITLE
build(deb-installers): added jre 17 as alternative dependencies

### DIFF
--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate, 
- openjdk-8-jre-headless, cron
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
@@ -5,7 +5,8 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate, 
- openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
+ openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate, 
- openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
@@ -5,7 +5,8 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate, 
- openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
+ openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate, 
- openjdk-8-jre-headless | temurin-8-jdk, cron
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate, 
- openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
@@ -8,7 +8,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown,
- openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk, 
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, 
  dmidecode, cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
@@ -7,7 +7,8 @@ Depends: hostapd, isc-dhcp-server, iw,
  ethtool, telnet, bluez-hcidump, 
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
- ifupdown, openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, 
+ ifupdown,
+ openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk, 
  dmidecode, cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
@@ -7,7 +7,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  ethtool, telnet, bluez-hcidump, 
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
- ifupdown, openjdk-8-jre-headless | temurin-8-jdk, 
+ ifupdown, openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, 
  dmidecode, cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
@@ -4,7 +4,8 @@ Section: misc
 Priority: low
 Depends: dos2unix, unzip, telnet, 
  bluez-hcidump, chrony, ntpdate, 
- openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
+ openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
@@ -4,7 +4,7 @@ Section: misc
 Priority: low
 Depends: dos2unix, unzip, telnet, 
  bluez-hcidump, chrony, ntpdate, 
- openjdk-8-jre-headless | temurin-8-jdk, cron
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
@@ -4,7 +4,7 @@ Section: misc
 Priority: low
 Depends: dos2unix, unzip, telnet, 
  bluez-hcidump, chrony, ntpdate, 
- openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
@@ -7,7 +7,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  ethtool, telnet, ifupdown, 
  net-tools, iptables, chrony, 
  dmidecode, ntpdate,
- openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk, 
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, 
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
@@ -6,7 +6,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  dos2unix, bind9, unzip, 
  ethtool, telnet, ifupdown, 
  net-tools, iptables, chrony, 
- dmidecode, ntpdate, openjdk-8-jre-headless | temurin-8-jdk, 
+ dmidecode, ntpdate, openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, 
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
@@ -6,7 +6,8 @@ Depends: hostapd, isc-dhcp-server, iw,
  dos2unix, bind9, unzip, 
  ethtool, telnet, ifupdown, 
  net-tools, iptables, chrony, 
- dmidecode, ntpdate, openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, 
+ dmidecode, ntpdate,
+ openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk, 
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/raspberry-pi-arm64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-arm64-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, telnet, 
  bluez-hcidump, bluez, chrony, 
  ntpdate, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/raspberry-pi-arm64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-arm64-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, telnet, 
  bluez-hcidump, bluez, chrony, 
  ntpdate, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | temurin-8-jdk, cron
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-arm64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-arm64-nn/deb/control/control
@@ -5,7 +5,8 @@ Priority: low
 Depends: dos2unix, unzip, telnet, 
  bluez-hcidump, bluez, chrony, 
  ntpdate, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
+ openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-arm64/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-arm64/deb/control/control
@@ -8,7 +8,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
  dmidecode, cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/raspberry-pi-arm64/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-arm64/deb/control/control
@@ -8,7 +8,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | temurin-8-jdk, dmidecode, cron
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, dmidecode, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-arm64/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-arm64/deb/control/control
@@ -8,7 +8,8 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, dmidecode, cron
+ openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ dmidecode, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-armhf-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-armhf-nn/deb/control/control
@@ -6,7 +6,7 @@ Depends: hostapd, dos2unix, bind9,
  unzip, ethtool, telnet, 
  bluez-hcidump, bluez, chrony, 
  ntpdate, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/raspberry-pi-armhf-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-armhf-nn/deb/control/control
@@ -6,7 +6,8 @@ Depends: hostapd, dos2unix, bind9,
  unzip, ethtool, telnet, 
  bluez-hcidump, bluez, chrony, 
  ntpdate, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
+ openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-armhf-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-armhf-nn/deb/control/control
@@ -6,7 +6,7 @@ Depends: hostapd, dos2unix, bind9,
  unzip, ethtool, telnet, 
  bluez-hcidump, bluez, chrony, 
  ntpdate, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | temurin-8-jdk, cron
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-armhf/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-armhf/deb/control/control
@@ -8,7 +8,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | temurin-8-jdk, cron
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/raspberry-pi-armhf/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-armhf/deb/control/control
@@ -8,7 +8,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
  cron
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/raspberry-pi-armhf/deb/control/control
+++ b/kura/distrib/src/main/resources/raspberry-pi-armhf/deb/control/control
@@ -8,7 +8,8 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate, 
  ifupdown, pi-bluetooth, rpi.gpio-common, 
- openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk, cron
+ openjdk-8-jre-headless | openjdk-8-jre | temurin-8-jdk | openjdk-17-jre-headless | openjdk-17-jre | temurin-17-jdk,
+ cron
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

Since Java 17 is now supported, the DEB installers now have Java 17 jre packages as alternative debian dependencies.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
