### PR TITLE
fix: wire can be instantiated again after being deleted

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
@@ -116,7 +116,6 @@ public class Configurations {
     }
 
     public void deleteConfiguration(String pid) {
-        // this.currentConfigurations.remove(pid);
         this.allActivePids.remove(pid);
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
@@ -116,7 +116,7 @@ public class Configurations {
     }
 
     public void deleteConfiguration(String pid) {
-        this.currentConfigurations.remove(pid);
+        // this.currentConfigurations.remove(pid);
         this.allActivePids.remove(pid);
     }
 


### PR DESCRIPTION
Signed-off-by: Gregory Ivo <gregorybivo@gmail.com>

Fixes the bug demonstrated by @mattdibi  where when you delete a dirty wireAsset, it cannot be re-instantiated until you reset/reload the wire graph.

**Related Issue:** N/A

**Description of the solution adopted:** N/A

**Screenshots:** N/A

**Any side note on the changes made:** Removed a line responsible for this issue.  When deleted, the object would be removed from the list of all assets, when it should have been only removed from the list of configured assets.
