### PR TITLE
build: added nashorn conditional component only on Java 8 builds, removed TODOs and refactor of some properties

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -132,10 +132,6 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>2.8</version>
                 <executions>
-                    <!--
-                        TODO: this execution can be moved in the below one once Nashorn
-                        replacement is found.
-                    -->
                     <execution>
                         <id>get-bundles-based-on-js-engine</id>
                         <phase>generate-resources</phase>
@@ -143,7 +139,7 @@
                             <goal>copy</goal>
                         </goals>
                         <configuration>
-                            <skip>${skip.js.engine.bundles}</skip>
+                            <skip>${skip.js.nashorn.engine.components}</skip>
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.eclipse.kura</groupId>
@@ -443,7 +439,7 @@
                                     <artifactId>org.eclipse.kura.wire.h2db.component.provider</artifactId>
                                     <version>${org.eclipse.kura.wire.h2db.component.provider.version}</version>
                                 </artifactItem>
-                             <artifactItem>
+                                <artifactItem>
                                     <groupId>org.eclipse.kura</groupId>
                                     <artifactId>org.eclipse.kura.wire.db.component.provider</artifactId>
                                     <version>${org.eclipse.kura.wire.db.component.provider.version}</version>
@@ -776,10 +772,6 @@
                             </target>
                         </configuration>
                     </execution>
-                    <!--
-                        TODO: this execution can be moved in the above one once Nashorn
-                        replacement is found.
-                    -->
                     <execution>
                         <id>setup-js-engine-jars</id>
                         <phase>generate-resources</phase>
@@ -787,7 +779,7 @@
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <skip>${skip.js.engine.bundles}</skip>
+                            <skip>${skip.js.nashorn.engine.components}</skip>
                             <target>
                                 <move file="target/plugins/org.eclipse.kura.wire.script.filter.provider.jar" tofile="target/plugins/org.eclipse.kura.wire.script.filter.provider_${org.eclipse.kura.wire.script.filter.provider.version}.jar" />
                                 <move file="target/plugins/org.eclipse.kura.wire.component.conditional.provider.jar" tofile="target/plugins/org.eclipse.kura.wire.component.conditional.provider_${org.eclipse.kura.wire.component.conditional.provider.version}.jar" />
@@ -1062,24 +1054,22 @@
     </dependencies>
 
     <profiles>
-        <!-- TODO: can be removed once Nashorn replacement is in place. -->
         <profile>
             <id>java8</id>
             <activation>
                 <jdk>1.8</jdk>
             </activation>
             <properties>
-                <skip.js.engine.bundles>false</skip.js.engine.bundles>
+                <skip.js.nashorn.engine.components>false</skip.js.nashorn.engine.components>
             </properties>
         </profile>
-        <!-- TODO: can be removed once Nashorn replacement is in place. -->
         <profile>
             <id>java17</id>
             <activation>
                 <jdk>17</jdk>
             </activation>
             <properties>
-                <skip.js.engine.bundles>true</skip.js.engine.bundles>
+                <skip.js.nashorn.engine.components>true</skip.js.nashorn.engine.components>
             </properties>
         </profile>
         <profile>
@@ -1968,10 +1958,6 @@
                         <artifactId>maven-antrun-plugin</artifactId>
                         <version>1.8</version>
                         <executions>
-                            <!-- 
-                                TODO: this execution can be moved in the below one once Nashorn
-                                replacement is found.
-                            -->
                             <execution>
                                 <id>prep-tp-js-engine</id>
                                 <phase>prepare-package</phase>
@@ -1979,7 +1965,7 @@
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
-                                    <skip>${skip.js.engine.bundles}</skip>
+                                    <skip>${skip.js.nashorn.engine.components}</skip>
                                     <target>
                                         <copy file="${project.build.directory}/plugins/org.eclipse.kura.wire.component.conditional.provider_${org.eclipse.kura.wire.component.conditional.provider.version}.jar" todir="${project.build.directory}/staging/target-definition/equinox_3.16.0/repository/plugins" />
                                     </target>
@@ -2316,10 +2302,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
-                            <!-- 
-                                TODO: this execution can be moved in the below one once Nashorn 
-                                replacement is found.
-                            -->
                             <execution>
                                 <id>core-dp-js-engine</id>
                                 <phase>package</phase>
@@ -2327,7 +2309,7 @@
                                     <goal>copy</goal>
                                 </goals>
                                 <configuration>
-                                    <skip>${skip.js.engine.bundles}</skip>
+                                    <skip>${skip.js.nashorn.engine.components}</skip>
                                     <artifactItems>
                                         <artifactItem>
                                             <groupId>org.eclipse.kura.feature</groupId>

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -219,6 +219,10 @@
 
         <!-- Wires bundles config -->
         <antcall target="wires-config" />
+        <available
+            file="${project.build.directory}/plugins/org.eclipse.kura.wire.component.conditional.provider_${org.eclipse.kura.wire.component.conditional.provider.version}.jar"
+            property="is.nashorn.conditional.component.present" />
+        <antcall target="wires-config-nashorn-js-engine" />
 
         <!-- Miscellaneous bundles config -->
         <antcall target="misc-config" />
@@ -725,6 +729,7 @@ fi]]>
         <antcall target="deployment-hooks-jar" />
 
         <antcall target="wires-jar" />
+        <antcall target="wires-jar-nashorn-js-engine" />
 
         <antcall target="misc-jar" />
 
@@ -1289,10 +1294,16 @@ fi]]>
                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.wire.helper.provider_${org.eclipse.kura.wire.helper.provider.version}.jar@4:start" />
             <entry key="osgi.bundles" operation="+"
                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.wire.provider_${org.eclipse.kura.wire.provider.version}.jar@4:start" />
-            <entry key="osgi.bundles" operation="+"
-                value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.wire.component.conditional.provider_${org.eclipse.kura.wire.component.conditional.provider.version}.jar@5:start" />
+            
             <entry key="osgi.bundles" operation="+"
                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.wire.component.join.provider_${org.eclipse.kura.wire.component.join.provider.version}.jar@5:start" />
+        </propertyfile>
+    </target>
+
+    <target name="wires-config-nashorn-js-engine" if="is.nashorn.conditional.component.present">
+        <propertyfile file="${project.build.directory}/${build.output.name}/config.ini">
+            <entry key="osgi.bundles" operation="+"
+                value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.wire.component.conditional.provider_${org.eclipse.kura.wire.component.conditional.provider.version}.jar@5:start" />
         </propertyfile>
     </target>
 
@@ -1393,10 +1404,15 @@ fi]]>
                 file="${project.build.directory}/plugins/org.eclipse.kura.wire.provider_${org.eclipse.kura.wire.provider.version}.jar"
                 prefix="${build.output.name}/${plugins.folder}" />
             <zipfileset
-                file="${project.build.directory}/plugins/org.eclipse.kura.wire.component.conditional.provider_${org.eclipse.kura.wire.component.conditional.provider.version}.jar"
-                prefix="${build.output.name}/${plugins.folder}" />
-            <zipfileset
                 file="${project.build.directory}/plugins/org.eclipse.kura.wire.component.join.provider_${org.eclipse.kura.wire.component.join.provider.version}.jar"
+                prefix="${build.output.name}/${plugins.folder}" />
+        </zip>
+    </target>
+
+    <target name="wires-jar-nashorn-js-engine" if="is.nashorn.conditional.component.present">
+        <zip destfile="${project.build.directory}/${build.output.name}.zip" update="true">
+            <zipfileset
+                file="${project.build.directory}/plugins/org.eclipse.kura.wire.component.conditional.provider_${org.eclipse.kura.wire.component.conditional.provider.version}.jar"
                 prefix="${build.output.name}/${plugins.folder}" />
         </zip>
     </target>

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -205,12 +205,7 @@
                 </tycho.surefire.testenv.args>
             </properties>
             <!--
-                TODO: these modules are available only on Java 8 build;
-                readd them once they are fixed also for Java 17 build.
-                
-                Nashorn removed since Java 15, need an alternative engine.
-
-                The features module need a fix on the osgi-dp plugin for
+                TODO: the features module need a fix on the osgi-dp plugin for
                 working with Tycho 3.
 
                 org.eclipse.kura-p2 is working only with Java 8, we do not


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

This PR removes some of the TODOs in the build, refactors some properties, and adds the Nashorn-based conditional component only if it was actually built (so to avoid the "missing org.eclipse.kura.wire.conditional.component.jar" warning at framework start).

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
