### PR TITLE
fix: restrict Nashorn components to supported jre

### DIFF
--- a/kura/org.eclipse.kura.wire.component.conditional.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Import-Package: javax.script,
  org.osgi.service.component;version="1.2.0",
  org.osgi.service.wireadmin;version="1.0.1",
  org.slf4j;version="1.6.4"
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+Require-Capability: osgi.ee;filter:="(& (&(osgi.ee=JavaSE)(version=1.8)) (!(&(osgi.ee=JavaSE)(version>=15))) )"
 Eclipse-BuddyPolicy: ext
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/kura/org.eclipse.kura.wire.script.filter.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Kura Wires Script Filter Provider
 Bundle-SymbolicName: org.eclipse.kura.wire.script.filter.provider
 Bundle-Version: 1.3.0.qualifier
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+Require-Capability: osgi.ee;filter:="(& (&(osgi.ee=JavaSE)(version=1.8)) (!(&(osgi.ee=JavaSE)(version>=15))) )"
 Import-Package: javax.script,
  org.eclipse.kura.configuration;version="[1.1,2.0)",
  org.eclipse.kura.type;version="[1.0,2.0)",

--- a/kura/test/org.eclipse.kura.wire.script.filter.provider.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.wire.script.filter.provider.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: org.eclipse.kura.wire.script.filter.provider.test
 Bundle-SymbolicName: org.eclipse.kura.wire.script.filter.provider.test;singleton:=true
 Bundle-Version: 5.3.0.qualifier
 Bundle-Vendor: Eclipse Kura
-Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+Require-Capability: osgi.ee;filter:="(& (&(osgi.ee=JavaSE)(version=1.8)) (!(&(osgi.ee=JavaSE)(version>=15))) )"
 Bundle-ActivationPolicy: lazy
 Fragment-Host: org.eclipse.kura.wire.script.filter.provider
 Import-Package: org.eclipse.kura;version="[1.0,2.0)",


### PR DESCRIPTION
This PR restricts the `wire.script.filter.provider` and the `wire.component.conditional.provider` to run only on JRE < 15 since they are using Nashorn JS Engine internal classes.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
