### PR TITLE
deprecate: org.eclipse.kura.wire.script.filter.provider

### DIFF
--- a/kura/org.eclipse.kura.wire.script.filter.provider/OSGI-INF/metatype/org.eclipse.kura.wire.ScriptFilter.xml
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/OSGI-INF/metatype/org.eclipse.kura.wire.ScriptFilter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,9 @@
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kura.wire.ScriptFilter" 
-         name="Javascript Filter" 
-         description="A wire component that provides scripting functionalities in JavaScript.">
+         name="Javascript Filter (deprecated)" 
+         description="A wire component that provides scripting functionalities in JavaScript.
+            Deprecated component, available only if running on JRE with Nashorn (Java < 15).">
 
         <AD id="script"
             name="script"

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/OutputWireRecordListWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/OutputWireRecordListWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/OutputWireRecordListWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/OutputWireRecordListWrapper.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.eclipse.kura.wire.WireRecord;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0
  */
 @Deprecated

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/OutputWireRecordListWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/OutputWireRecordListWrapper.java
@@ -19,6 +19,11 @@ import java.util.List;
 
 import org.eclipse.kura.wire.WireRecord;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0
+ */
+@Deprecated
 public class OutputWireRecordListWrapper {
 
     private List<WireRecord> records;

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/ScriptFilter.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/ScriptFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/ScriptFilter.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/ScriptFilter.java
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
 import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0, use
  *             {@link org.eclipse.kura.wire.script.tools.filter.component.FilterComponent}
  */

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/ScriptFilter.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/ScriptFilter.java
@@ -44,6 +44,12 @@ import org.slf4j.LoggerFactory;
 
 import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0, use
+ *             {@link org.eclipse.kura.wire.script.tools.filter.component.FilterComponent}
+ */
+@Deprecated
 public class ScriptFilter implements WireEmitter, WireReceiver, ConfigurableComponent {
 
     private static final Logger logger = LoggerFactory.getLogger(ScriptFilter.class);

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireEnvelopeWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireEnvelopeWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireEnvelopeWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireEnvelopeWrapper.java
@@ -13,7 +13,6 @@
 package org.eclipse.kura.wire.script.filter.provider;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0
  */
 @Deprecated

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireEnvelopeWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireEnvelopeWrapper.java
@@ -12,6 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kura.wire.script.filter.provider;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0
+ */
+@Deprecated
 public class WireEnvelopeWrapper {
 
     @SuppressWarnings("checkstyle:visibilityModifier")

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordListWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordListWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordListWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordListWrapper.java
@@ -18,6 +18,11 @@ import org.eclipse.kura.wire.WireRecord;
 
 import jdk.nashorn.api.scripting.AbstractJSObject;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0
+ */
+@Deprecated
 class WireRecordListWrapper extends AbstractJSObject {
 
     private static final String LENGTH_PROP_NAME = "length";

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordListWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordListWrapper.java
@@ -19,7 +19,6 @@ import org.eclipse.kura.wire.WireRecord;
 import jdk.nashorn.api.scripting.AbstractJSObject;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0
  */
 @Deprecated

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordWrapper.java
@@ -24,7 +24,6 @@ import org.eclipse.kura.type.TypedValue;
 import jdk.nashorn.api.scripting.AbstractJSObject;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0
  */
 @Deprecated

--- a/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordWrapper.java
+++ b/kura/org.eclipse.kura.wire.script.filter.provider/src/main/java/org/eclipse/kura/wire/script/filter/provider/WireRecordWrapper.java
@@ -23,6 +23,11 @@ import org.eclipse.kura.type.TypedValue;
 
 import jdk.nashorn.api.scripting.AbstractJSObject;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0
+ */
+@Deprecated
 class WireRecordWrapper extends AbstractJSObject {
 
     Map<String, TypedValue<?>> properties;


### PR DESCRIPTION
This PR deprecated the component `org.eclipse.kura.wire.script.filter.provider` because it is not working on Java 17. The component can be replaced with `org.eclipse.kura.wire.script.tools.filter.component.FilterComponent`.

**Related Issue:** N/A.

**Description of the solution adopted:** Besides adding the annotation to the classes of the package, the **metatype** has been modified to inform the user that the component is deprecated.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
