### PR TITLE
deprecate: org.eclipse.kura.wire.component.conditional.provider

### DIFF
--- a/kura/org.eclipse.kura.wire.component.conditional.provider/OSGI-INF/metatype/org.eclipse.kura.wire.Conditional.xml
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/OSGI-INF/metatype/org.eclipse.kura.wire.Conditional.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -15,8 +15,9 @@
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
     <OCD id="org.eclipse.kura.wire.Conditional"
-         name="Conditional"
-         description="A wire component that allows to forward the received envelopes to different ports depending on a boolean condition">
+         name="Conditional (deprecated)"
+         description="A wire component that allows to forward the received envelopes to different ports depending on a boolean condition.
+         Deprecated component, available only if running on JRE with Nashorn (Java < 15).">
 
          <AD id="condition"
             name="condition"

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/Conditional.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/Conditional.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,7 +47,11 @@ import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
 /**
  * The Class Conditional is a specific Wire Component to apply a condition
  * on the received {@link WireEnvelope}
+ * 
+ * @deprecated as of Kura 5.3.0, use
+ *             {@link org.eclipse.kura.wire.script.tools.conditional.component.ConditionalComponent}
  */
+@Deprecated
 public final class Conditional implements WireReceiver, WireEmitter, ConfigurableComponent {
 
     private static final Logger logger = LoggerFactory.getLogger(Conditional.class);

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/ConditionalOptions.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/ConditionalOptions.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import javax.script.ScriptException;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0
  */
 @Deprecated

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/ConditionalOptions.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/ConditionalOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,11 @@ import java.util.Map;
 
 import javax.script.ScriptException;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0
+ */
+@Deprecated
 public class ConditionalOptions {
 
     private static final String CONDITION_PROPERTY_KEY = "condition";

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/ImmutableJSObject.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/ImmutableJSObject.java
@@ -16,7 +16,6 @@ package org.eclipse.kura.internal.wire.conditional;
 import jdk.nashorn.api.scripting.AbstractJSObject;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0
  */
 @Deprecated

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/ImmutableJSObject.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/ImmutableJSObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,11 @@ package org.eclipse.kura.internal.wire.conditional;
 
 import jdk.nashorn.api.scripting.AbstractJSObject;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0
+ */
+@Deprecated
 public class ImmutableJSObject extends AbstractJSObject {
 
     private static final String READ_ONLY_ERROR_MESSAGE = "This object is read-only";

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireEnvelopeWrapper.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireEnvelopeWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,11 @@
 
 package org.eclipse.kura.internal.wire.conditional;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0
+ */
+@Deprecated
 public class WireEnvelopeWrapper {
 
     @SuppressWarnings("checkstyle:visibilityModifier")

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireEnvelopeWrapper.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireEnvelopeWrapper.java
@@ -14,7 +14,6 @@
 package org.eclipse.kura.internal.wire.conditional;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0
  */
 @Deprecated

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireRecordListWrapper.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireRecordListWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,11 @@ import java.util.List;
 
 import org.eclipse.kura.wire.WireRecord;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0
+ */
+@Deprecated
 class WireRecordListWrapper extends ImmutableJSObject {
 
     private static final String LENGTH_PROP_NAME = "length";

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireRecordListWrapper.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireRecordListWrapper.java
@@ -17,7 +17,6 @@ import java.util.List;
 import org.eclipse.kura.wire.WireRecord;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0
  */
 @Deprecated

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireRecordWrapper.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireRecordWrapper.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import org.eclipse.kura.type.TypedValue;
 
 /**
- * 
  * @deprecated as of Kura 5.3.0
  */
 @Deprecated

--- a/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireRecordWrapper.java
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/src/main/java/org/eclipse/kura/internal/wire/conditional/WireRecordWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2022 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,11 @@ import java.util.Set;
 
 import org.eclipse.kura.type.TypedValue;
 
+/**
+ * 
+ * @deprecated as of Kura 5.3.0
+ */
+@Deprecated
 class WireRecordWrapper extends ImmutableJSObject {
 
     Map<String, TypedValue<?>> properties;


### PR DESCRIPTION
This PR deprecated the component `org.eclipse.kura.wire.component.conditional.provider` because it is not working on Java 17. The component can be replaced with `org.eclipse.kura.wire.script.tools.conditional.component.ConditionalComponent`.

**Related Issue:** N/A.

**Description of the solution adopted:** Besides adding the annotation to the classes of the package, the **metatype** has been modified to inform the user that the component is deprecated.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
