### PR TITLE
ci: update meaning of `deprecate` commit type

### DIFF
--- a/.github/release_notes_template/template.hbs
+++ b/.github/release_notes_template/template.hbs
@@ -41,7 +41,7 @@ Bug Fixes:
 {{! Deprecated APIs/components section }}
 {{#ifContainsType commits type='deprecate'}}
 
-Deprecated:
+Deprecated APIs/components:
   {{#commits}}
     {{#ifCommitType . type='deprecate'}}
   * {{firstLetters hash number='10'}} - {{{commitDescription .}}} ({{authorName}})

--- a/.github/release_notes_template/template.hbs
+++ b/.github/release_notes_template/template.hbs
@@ -38,10 +38,10 @@ Bug Fixes:
     {{/ifCommitType}}
   {{/commits}}
 {{/ifContainsType}}
-{{! Deprecated APIs section }}
+{{! Deprecated components section }}
 {{#ifContainsType commits type='deprecate'}}
 
-Deprecated APIs:
+Deprecated:
   {{#commits}}
     {{#ifCommitType . type='deprecate'}}
   * {{firstLetters hash number='10'}} - {{{commitDescription .}}} ({{authorName}})

--- a/.github/release_notes_template/template.hbs
+++ b/.github/release_notes_template/template.hbs
@@ -38,7 +38,7 @@ Bug Fixes:
     {{/ifCommitType}}
   {{/commits}}
 {{/ifContainsType}}
-{{! Deprecated components section }}
+{{! Deprecated APIs/components section }}
 {{#ifContainsType commits type='deprecate'}}
 
 Deprecated:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ Types other than `feat` and `fix` MAY be used in your commit messages and mu
 - `ci`: Changes to our CI configuration files and scripts
 - `revert`: Reverts a previous commit
 - `perf`: A code change that improves performance
-- `deprecate`: An API deprecation. Use the summary field to provide the API which was deprecated (eg: `deprecate: org.eclipse.kura.position.PositionService`)
+- `deprecate`: An API/component deprecation. Use the summary field to provide the API/component which was deprecated (eg: `deprecate: org.eclipse.kura.position.PositionService`)
 
 ### Scope
 


### PR DESCRIPTION
**Brief description of the PR.**: Update the meaning of the `deprecate` commit type for a more general use.


**Description of the solution adopted:** Up until now the `deprecate` commit type was underused due to the specificity we decided to give it. 

With this PR we want to generalise the use of the `deprecate` commit type such that it won't be used only for APIs deprecations.

The motivation is that by using the `refactor` commit type for deprecating components we're not giving them the required importance (in the release notes these commits will be hidden in the changelog section). This PR updates the Release notes template and the documentation for supporting the new meaning of the `deprecate` commit type.
