### PR TITLE
feat: high-prority messages cause re-connect

### DIFF
--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -180,6 +180,22 @@
             default="0 0 0 ? * * *"
             description="A CRON expression that specifies the instants when the gateway should perform a connection attempt. This parameter is only used if Enable Connection Schedule is set to true. The default expression schedules a connection every day at midnight." />
             
+        <AD id="connection.schedule.priority.override.enable" 
+            name="Allow priority message to force connection beyond schedule" 
+            type="Boolean" 
+            cardinality="0" 
+            required="true" 
+            default="false"
+            description="Allows messages beyond a specified priority to force a connection and be sent regardless of connection schedule." />
+            
+        <AD id="connection.schedule.priority.override.threshold" 
+            name="Force message prority threshold" 
+            type="Integer" 
+            cardinality="0" 
+            required="true" 
+            default="1"
+            description="A message with a priority of equal or lessthen than this threshold will automatically re-connect and send regardless of the connection schedule." />
+            
          <AD id="connection.schedule.inactivity.interval.seconds" 
             name="Connection Schedule Disconnect Inactivity Interval Seconds" 
             type="Long" 

--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -181,7 +181,7 @@
             description="A CRON expression that specifies the instants when the gateway should perform a connection attempt. This parameter is only used if Enable Connection Schedule is set to true. The default expression schedules a connection every day at midnight." />
             
         <AD id="connection.schedule.priority.override.enable" 
-            name="Allow priority message to force connection beyond schedule" 
+            name="Allow priority message to overide connection schedule" 
             type="Boolean" 
             cardinality="0" 
             required="true" 
@@ -189,12 +189,12 @@
             description="Allows messages beyond a specified priority to force a connection and be sent regardless of connection schedule." />
             
         <AD id="connection.schedule.priority.override.threshold" 
-            name="Force message prority threshold" 
+            name="Message schedule priority override threshold" 
             type="Integer" 
             cardinality="0" 
             required="true" 
             default="1"
-            description="A message with a priority of equal or lessthen than this threshold will automatically re-connect and send regardless of the connection schedule." />
+            description="A message with a priority equal to or less than this threshold will cause the framework to automatically re-connect and send regardless of the connection schedule." />
             
          <AD id="connection.schedule.inactivity.interval.seconds" 
             name="Connection Schedule Disconnect Inactivity Interval Seconds" 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AlwaysConnectedStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AlwaysConnectedStrategy.java
@@ -63,9 +63,8 @@ public class AlwaysConnectedStrategy implements AutoConnectStrategy {
     }
 
     @Override
-    public void onPublishRequested() {
+    public void onPublishRequested(String topic, byte[] payload, int qos, boolean retain, int priority) {
         // do nothing
-
     }
 
 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AlwaysConnectedStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AlwaysConnectedStrategy.java
@@ -62,4 +62,10 @@ public class AlwaysConnectedStrategy implements AutoConnectStrategy {
         connectionManager.stopConnectionTask();
     }
 
+    @Override
+    public void onPublish() {
+        // do nothing
+
+    }
+
 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AlwaysConnectedStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AlwaysConnectedStrategy.java
@@ -63,7 +63,7 @@ public class AlwaysConnectedStrategy implements AutoConnectStrategy {
     }
 
     @Override
-    public void onPublish() {
+    public void onPublishRequested() {
         // do nothing
 
     }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
@@ -18,7 +18,7 @@ interface AutoConnectStrategy extends DataServiceListener {
 
     public void shutdown();
 
-    public void onPublishRequested();
+    public void onPublishRequested(String topic, byte[] payload, int qos, boolean retain, int priority);
 
     interface ConnectionManager {
 
@@ -27,8 +27,6 @@ interface AutoConnectStrategy extends DataServiceListener {
         void stopConnectionTask();
 
         void disconnect();
-
-        DataMessage getNextMessage();
 
         boolean hasInFlightMessages();
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
@@ -18,6 +18,8 @@ interface AutoConnectStrategy extends DataServiceListener {
 
     public void shutdown();
 
+    public void onPublish();
+
     interface ConnectionManager {
 
         void startConnectionTask();
@@ -25,6 +27,8 @@ interface AutoConnectStrategy extends DataServiceListener {
         void stopConnectionTask();
 
         void disconnect();
+
+        DataMessage getNextMessage();
 
         boolean hasInFlightMessages();
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
@@ -28,6 +28,8 @@ interface AutoConnectStrategy extends DataServiceListener {
 
         void disconnect();
 
+        DataMessage getNextMessage();
+
         boolean hasInFlightMessages();
 
         boolean isConnected();

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/AutoConnectStrategy.java
@@ -18,7 +18,7 @@ interface AutoConnectStrategy extends DataServiceListener {
 
     public void shutdown();
 
-    public void onPublish();
+    public void onPublishRequested();
 
     interface ConnectionManager {
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -529,7 +529,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
     public int publish(String topic, byte[] payload, int qos, boolean retain, int priority) throws KuraStoreException {
 
         if (this.autoConnectStrategy.isPresent()) {
-            this.autoConnectStrategy.get().onPublishRequested();
+            this.autoConnectStrategy.get().onPublishRequested(topic, payload, qos, retain, priority);
         }
 
         logger.info("Storing message on topic: {}, priority: {}", topic, priority);
@@ -949,14 +949,4 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
         return !inFlightMsgIds.isEmpty();
     }
 
-    @Override
-    public DataMessage getNextMessage() {
-        DataMessage message = null;
-        try {
-            message = DataServiceImpl.this.store.getNextMessage();
-        } catch (Exception e) {
-            logger.error("Probably an unrecoverable exception", e);
-        }
-        return message;
-    }
 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -529,7 +529,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
     public int publish(String topic, byte[] payload, int qos, boolean retain, int priority) throws KuraStoreException {
 
         if (this.autoConnectStrategy.isPresent()) {
-            this.autoConnectStrategy.get().onPublish();
+            this.autoConnectStrategy.get().onPublishRequested();
         }
 
         logger.info("Storing message on topic: {}, priority: {}", topic, priority);

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -585,10 +585,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
         if (!this.dataServiceOptions.isConnectionScheduleEnabled() || !schedule.isPresent()) {
             strategy = new AlwaysConnectedStrategy(this);
         } else {
-            strategy = new ScheduleStrategy(schedule.get(),
-                    this.dataServiceOptions.getConnectionScheduleDisconnectDelay() * 1000, this,
-                    this.dataServiceOptions.isConnectionSchedulePriorityOverrideEnabled(),
-                    this.dataServiceOptions.getConnectionSchedulePriorityOverridePriority());
+            strategy = new ScheduleStrategy(schedule.get(), this.dataServiceOptions, this);
         }
 
         this.autoConnectStrategy = Optional.of(strategy);

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -949,4 +949,15 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
         return !inFlightMsgIds.isEmpty();
     }
 
+    @Override
+    public DataMessage getNextMessage() {
+        DataMessage message = null;
+        try {
+            message = DataServiceImpl.this.store.getNextMessage();
+        } catch (Exception e) {
+            logger.error("Probably an unrecoverable exception", e);
+        }
+        return message;
+    }
+
 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
@@ -48,6 +48,8 @@ public class DataServiceOptions {
     private static final String CONNECTION_SCHEDULE_ENABLED = "connection.schedule.enabled";
     private static final String CONNECTION_SCHECULE_EXPRESSION = "connection.schedule.expression";
     private static final String CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS = "connection.schedule.inactivity.interval.seconds";
+    private static final String CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE = "connection.schedule.priority.override.enable";
+    private static final String CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD = "connection.schedule.priority.override.threshold";
 
     private static final boolean AUTOCONNECT_PROP_DEFAULT = false;
     private static final int CONNECT_DELAY_DEFAULT = 60;
@@ -67,6 +69,8 @@ public class DataServiceOptions {
     private static final int RECOVERY_MAX_FAILURES_DEFAULT = 10;
     private static final boolean CONNECTION_SCHEDULE_ENABLED_DEFAULT = false;
     private static final long CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS_DEFAULT = 60;
+    private static final boolean CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE_DEFAULT = false;
+    private static final int CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD_DEFAULT = 1;
 
     private static final int CONNECT_CRITICAL_COMPONENT_TIMEOUT_MULTIPLIER = 5000;
 
@@ -186,5 +190,18 @@ public class DataServiceOptions {
     long getConnectionScheduleDisconnectDelay() {
         return (long) this.properties.getOrDefault(CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS,
                 CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS_DEFAULT);
+    }
+
+    Boolean isConnectionSchedulePriorityOverrideEnabled() {
+        return (Boolean) this.properties.getOrDefault(CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE,
+                CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE_DEFAULT) && isConnectionScheduleEnabled()
+                && getConnectionScheduleExpression().isPresent();
+    }
+
+    int getConnectionSchedulePriorityOverridePriority() {
+
+        return (Integer) this.properties.getOrDefault(CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD,
+                CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD_DEFAULT);
+
     }
 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
@@ -276,7 +276,7 @@ public class ScheduleStrategy implements AutoConnectStrategy {
     }
 
     @Override
-    public void onPublish() {
+    public void onPublishRequested() {
         DataMessage tempDataMessage = this.connectionManager.getNextMessage();
 
         if (tempDataMessage == null) {

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
@@ -294,7 +294,7 @@ public class ScheduleStrategy implements AutoConnectStrategy {
 
     @Override
     public void onPublishRequested(String topic, byte[] payload, int qos, boolean retain, int priority) {
-        this.updateState(State::onPublish(topic, payload, qos, retain, priority));
+        this.updateState(c -> this.state.onPublish(topic, payload, qos, retain, priority));
     }
 
 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
@@ -93,6 +93,8 @@ public class ScheduleStrategy implements AutoConnectStrategy {
 
     private class AwaitConnectTime implements State {
 
+        boolean isSeccondMessage = false;
+
         @Override
         public State onEnterState() {
             connectionManager.stopConnectionTask();
@@ -122,10 +124,12 @@ public class ScheduleStrategy implements AutoConnectStrategy {
 
             if (isConnectionSchedulePriorityOverrideEnabled
                     && priority <= getConnectionSchedulePriorityOverridePriority
-                    && !connectionManager.isConnected()) {
+                    && !connectionManager.isConnected() && isSeccondMessage) {
                 logger.info("Initiating Connection to send message with a high priority.");
 
                 return new AwaitConnect();
+            } else {
+                isSeccondMessage = true;
             }
             return this;
         }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/ScheduleStrategy.java
@@ -65,6 +65,23 @@ public class ScheduleStrategy implements AutoConnectStrategy {
         executor.scheduleWithFixedDelay(new TimeShiftDetector(60000), 0, 1, TimeUnit.MINUTES);
     }
 
+    public ScheduleStrategy(final CronExpression expression, final long disconnectTimeoutMs,
+            final ConnectionManager connectionManager, final ScheduledExecutorService executor,
+            final Supplier<Date> currentTimeProvider, boolean isConnectionSchedulePriorityOverrideEnabled,
+            int getConnectionSchedulePriorityOverridePriority) {
+        this.expression = expression;
+        this.disconnectTimeoutMs = disconnectTimeoutMs;
+        this.connectionManager = connectionManager;
+        this.state = new AwaitConnectTime();
+        this.executor = executor;
+        this.currentTimeProvider = currentTimeProvider;
+        this.isConnectionSchedulePriorityOverrideEnabled = isConnectionSchedulePriorityOverrideEnabled;
+        this.getConnectionSchedulePriorityOverridePriority = getConnectionSchedulePriorityOverridePriority;
+
+        updateState(State::onEnterState);
+        executor.scheduleWithFixedDelay(new TimeShiftDetector(60000), 0, 1, TimeUnit.MINUTES);
+    }
+
     private interface State {
         public default State onEnterState() {
             return this;

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceOptionsTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.kura.core.data;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -35,6 +36,7 @@ public class DataServiceOptionsTest {
         givenPropertiesThatEnableOverrideSchedule();
         whenDataServiceOptionsIsCreated();
         thenConnectionScheduleEnabled();
+        thenCheckpriorityEquals(3);
     }
 
     @Test
@@ -42,6 +44,7 @@ public class DataServiceOptionsTest {
         givenPropertiesThatDisableOverrideSchedule();
         whenDataServiceOptionsIsCreated();
         thenConnectionScheduleDisabled();
+        thenCheckpriorityEquals(3);
     }
 
     /*
@@ -70,10 +73,9 @@ public class DataServiceOptionsTest {
 
         properties.put("connection.schedule.priority.override.enable", false);
         properties.put("connection.schedule.priority.override.threshold", 3);
-        properties.put("connect.auto-on-startup", true);
+        properties.put("connect.auto-on-startup", false);
         properties.put("connection.schedule.inactivity.interval.seconds", 2);
         properties.put("connection.schedule.enabled", false);
-        properties.put("connection.schedule.expression", "0 0 0 ? * * *");
     }
 
     /*
@@ -93,6 +95,10 @@ public class DataServiceOptionsTest {
 
     private void thenConnectionScheduleDisabled() {
         assertFalse(this.dataServiceOptions.isConnectionSchedulePriorityOverrideEnabled());
+    }
+
+    private void thenCheckpriorityEquals(int priority) {
+        assertEquals(this.dataServiceOptions.getConnectionSchedulePriorityOverridePriority(), priority);
     }
 
 }

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceOptionsTest.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+
+package org.eclipse.kura.core.data;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class DataServiceOptionsTest {
+
+    private DataServiceOptions dataServiceOptions;
+    Map<String, Object> properties;
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void shouldReturnTrueToPriorityOverrideEnabled() {
+        givenPropertiesThatEnableOverrideSchedule();
+        whenDataServiceOptionsIsCreated();
+        thenConnectionScheduleEnabled();
+    }
+
+    @Test
+    public void shouldReturnTrueToPriorityOverrideDisabled() {
+        givenPropertiesThatDisableOverrideSchedule();
+        whenDataServiceOptionsIsCreated();
+        thenConnectionScheduleDisabled();
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenPropertiesThatEnableOverrideSchedule() {
+        // Create DataServiceOptions
+        properties = new HashMap<>();
+
+        properties.put("connection.schedule.priority.override.enable", true);
+        properties.put("connection.schedule.priority.override.threshold", 3);
+        properties.put("connect.auto-on-startup", true);
+        properties.put("connection.schedule.inactivity.interval.seconds", 2);
+        properties.put("connection.schedule.enabled", true);
+        properties.put("connection.schedule.expression", "0 0 0 ? * * *");
+    }
+
+    private void givenPropertiesThatDisableOverrideSchedule() {
+        // Create DataServiceOptions
+        properties = new HashMap<>();
+
+        properties.put("connection.schedule.priority.override.enable", false);
+        properties.put("connection.schedule.priority.override.threshold", 3);
+        properties.put("connect.auto-on-startup", true);
+        properties.put("connection.schedule.inactivity.interval.seconds", 2);
+        properties.put("connection.schedule.enabled", false);
+        properties.put("connection.schedule.expression", "0 0 0 ? * * *");
+    }
+
+    /*
+     * When
+     */
+
+    private void whenDataServiceOptionsIsCreated() {
+        this.dataServiceOptions = new DataServiceOptions(properties);
+    }
+
+    /*
+     * Then
+     */
+    private void thenConnectionScheduleEnabled() {
+        assertTrue(this.dataServiceOptions.isConnectionSchedulePriorityOverrideEnabled());
+    }
+
+    private void thenConnectionScheduleDisabled() {
+        assertFalse(this.dataServiceOptions.isConnectionSchedulePriorityOverrideEnabled());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceOptionsTest.java
@@ -20,9 +20,74 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.kura.db.H2DbService;
 import org.junit.Test;
 
 public class DataServiceOptionsTest {
+
+    private static final String AUTOCONNECT_PROP_NAME = "connect.auto-on-startup";
+    private static final String CONNECT_DELAY_PROP_NAME = "connect.retry-interval";
+    private static final String DISCONNECT_DELAY_PROP_NAME = "disconnect.quiesce-timeout";
+    private static final String STORE_DB_SERVICE_INSTANCE_PROP_NAME = "store.db.service.pid";
+    private static final String STORE_HOUSEKEEPER_INTERVAL_PROP_NAME = "store.housekeeper-interval";
+    private static final String STORE_PURGE_AGE_PROP_NAME = "store.purge-age";
+    private static final String STORE_CAPACITY_PROP_NAME = "store.capacity";
+    private static final String REPUBLISH_IN_FLIGHT_MSGS_PROP_NAME = "in-flight-messages.republish-on-new-session";
+    private static final String MAX_IN_FLIGHT_MSGS_PROP_NAME = "in-flight-messages.max-number";
+    private static final String IN_FLIGHT_MSGS_CONGESTION_TIMEOUT_PROP_NAME = "in-flight-messages.congestion-timeout";
+    private static final String RATE_LIMIT_ENABLE_PROP_NAME = "enable.rate.limit";
+    private static final String RATE_LIMIT_AVERAGE_RATE_PROP_NAME = "rate.limit.average";
+    private static final String RATE_LIMIT_TIME_UNIT_PROP_NAME = "rate.limit.time.unit";
+    private static final String RATE_LIMIT_BURST_SIZE_PROP_NAME = "rate.limit.burst.size";
+    private static final String RECOVERY_ENABLE_PROP_NAME = "enable.recovery.on.connection.failure";
+    private static final String RECOVERY_MAX_FAILURES_PROP_NAME = "connection.recovery.max.failures";
+    private static final String CONNECTION_SCHEDULE_ENABLED = "connection.schedule.enabled";
+    private static final String CONNECTION_SCHECULE_EXPRESSION = "connection.schedule.expression";
+    private static final String CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS = "connection.schedule.inactivity.interval.seconds";
+    private static final String CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE = "connection.schedule.priority.override.enable";
+    private static final String CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD = "connection.schedule.priority.override.threshold";
+
+    private static final boolean AUTOCONNECT_PROP_DEFAULT = false;
+    private static final int CONNECT_DELAY_DEFAULT = 60;
+    private static final int DISCONNECT_DELAY_DEFAULT = 10;
+    private static final String DB_SERVICE_INSTANCE_DEFAULT = H2DbService.DEFAULT_INSTANCE_PID;
+    private static final int STORE_HOUSEKEEPER_INTERVAL_DEFAULT = 900;
+    private static final int STORE_PURGE_AGE_DEFAULT = 60;
+    private static final int STORE_CAPACITY_DEFAULT = 10000;
+    private static final boolean REPUBLISH_IN_FLIGHT_MSGS_DEFAULT = true;
+    private static final int MAX_IN_FLIGHT_MSGS_DEFAULT = 9;
+    private static final int IN_FLIGHT_MSGS_CONGESTION_TIMEOUT_DEFAULT = 0;
+    private static final boolean RATE_LIMIT_ENABLE_DEFAULT = true;
+    private static final int RATE_LIMIT_AVERAGE_RATE_DEFAULT = 1;
+    private static final int RATE_LIMIT_BURST_SIZE_DEFAULT = 1;
+    private static final boolean RECOVERY_ENABLE_DEFAULT = true;
+    private static final int RECOVERY_MAX_FAILURES_DEFAULT = 10;
+    private static final boolean CONNECTION_SCHEDULE_ENABLED_DEFAULT = false;
+    private static final boolean CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE_DEFAULT = false;
+    private static final int CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD_DEFAULT = 1;
+
+    private static final boolean AUTOCONNECT_PROP_CHANGED = true;
+    private static final int CONNECT_DELAY_CHANGED = 65;
+    private static final int DISCONNECT_DELAY_CHANGED = 15;
+    private static final String DB_SERVICE_INSTANCE_CHANGED = H2DbService.DEFAULT_INSTANCE_PID;
+    private static final int STORE_HOUSEKEEPER_INTERVAL_CHANGED = 950;
+    private static final int STORE_PURGE_AGE_CHANGED = 65;
+    private static final int STORE_CAPACITY_CHANGED = 10050;
+    private static final boolean REPUBLISH_IN_FLIGHT_MSGS_CHANGED = true;
+    private static final int MAX_IN_FLIGHT_MSGS_CHANGED = 5;
+    private static final int IN_FLIGHT_MSGS_CONGESTION_TIMEOUT_CHANGED = 1;
+    private static final boolean RATE_LIMIT_ENABLE_CHANGED = false;
+    private static final int RATE_LIMIT_AVERAGE_RATE_CHANGED = 2;
+    private static final int RATE_LIMIT_BURST_SIZE_CHANGED = 2;
+    private static final boolean RECOVERY_ENABLE_CHANGED = false;
+    private static final int RECOVERY_MAX_FAILURES_CHANGED = 15;
+    private static final boolean CONNECTION_SCHEDULE_ENABLED_CHANGED = true;
+    private static final boolean CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE_CHANGED = true;
+    private static final int CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD_CHANGED = 2;
+
+    private static final int CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS_CHANGED = 5;
+    private static final String RATE_LIMIT_TIME_UNIT_PROP_NAME_CHANGED = "MILLISECONDS";
+    private static final String CONNECTION_SCHECULE_EXPRESSION_CHANGED = "0 0 0 ? * * *";
 
     private DataServiceOptions dataServiceOptions;
     Map<String, Object> properties;
@@ -30,6 +95,22 @@ public class DataServiceOptionsTest {
     /*
      * Scenarios
      */
+
+    @Test
+    public void shouldReturnDefaultsTest() {
+        givenEmptyProperties();
+        whenDataServiceOptionsIsCreated();
+        thenCheckIfAllDefaultsAreSet();
+
+    }
+
+    @Test
+    public void shouldReturnChangedTest() {
+        givenFullChangedProperties();
+        whenDataServiceOptionsIsCreated();
+        thenCheckIfAllChangesAreSet();
+
+    }
 
     @Test
     public void shouldReturnTrueToPriorityOverrideEnabled() {
@@ -78,6 +159,41 @@ public class DataServiceOptionsTest {
         properties.put("connection.schedule.enabled", false);
     }
 
+    private void givenEmptyProperties() {
+        // Create DataServiceOptions
+        properties = new HashMap<>();
+    }
+
+    private void givenFullChangedProperties() {
+        // Create DataServiceOptions
+        properties = new HashMap<>();
+
+        properties.put(AUTOCONNECT_PROP_NAME, AUTOCONNECT_PROP_CHANGED);
+        properties.put(CONNECT_DELAY_PROP_NAME, CONNECT_DELAY_CHANGED);
+        properties.put(DISCONNECT_DELAY_PROP_NAME, DISCONNECT_DELAY_CHANGED);
+        properties.put(STORE_DB_SERVICE_INSTANCE_PROP_NAME, DB_SERVICE_INSTANCE_CHANGED);
+        properties.put(STORE_HOUSEKEEPER_INTERVAL_PROP_NAME, STORE_HOUSEKEEPER_INTERVAL_CHANGED);
+        properties.put(STORE_PURGE_AGE_PROP_NAME, STORE_PURGE_AGE_CHANGED);
+        properties.put(STORE_CAPACITY_PROP_NAME, STORE_CAPACITY_CHANGED);
+        properties.put(REPUBLISH_IN_FLIGHT_MSGS_PROP_NAME, REPUBLISH_IN_FLIGHT_MSGS_CHANGED);
+        properties.put(MAX_IN_FLIGHT_MSGS_PROP_NAME, MAX_IN_FLIGHT_MSGS_CHANGED);
+        properties.put(IN_FLIGHT_MSGS_CONGESTION_TIMEOUT_PROP_NAME, IN_FLIGHT_MSGS_CONGESTION_TIMEOUT_CHANGED);
+        properties.put(RATE_LIMIT_ENABLE_PROP_NAME, RATE_LIMIT_ENABLE_CHANGED);
+        properties.put(RATE_LIMIT_AVERAGE_RATE_PROP_NAME, RATE_LIMIT_AVERAGE_RATE_CHANGED);
+        properties.put(RATE_LIMIT_TIME_UNIT_PROP_NAME, RATE_LIMIT_TIME_UNIT_PROP_NAME_CHANGED);
+        properties.put(RATE_LIMIT_BURST_SIZE_PROP_NAME, RATE_LIMIT_BURST_SIZE_CHANGED);
+        properties.put(RECOVERY_ENABLE_PROP_NAME, RECOVERY_ENABLE_CHANGED);
+        properties.put(RECOVERY_MAX_FAILURES_PROP_NAME, RECOVERY_MAX_FAILURES_CHANGED);
+        properties.put(CONNECTION_SCHEDULE_ENABLED, CONNECTION_SCHEDULE_ENABLED_CHANGED);
+        properties.put(CONNECTION_SCHECULE_EXPRESSION, CONNECTION_SCHECULE_EXPRESSION_CHANGED);
+        properties.put(CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS,
+                CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS_CHANGED);
+        properties.put(CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE,
+                CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE_CHANGED);
+        properties.put(CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD,
+                CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD_CHANGED);
+    }
+
     /*
      * When
      */
@@ -101,4 +217,53 @@ public class DataServiceOptionsTest {
         assertEquals(this.dataServiceOptions.getConnectionSchedulePriorityOverridePriority(), priority);
     }
 
+    private void thenCheckIfAllDefaultsAreSet() {
+
+        assertEquals(AUTOCONNECT_PROP_DEFAULT, this.dataServiceOptions.isAutoConnect());
+        assertEquals(CONNECT_DELAY_DEFAULT, this.dataServiceOptions.getConnectDelay());
+        assertEquals(DISCONNECT_DELAY_DEFAULT, this.dataServiceOptions.getDisconnectDelay());
+        assertEquals(DB_SERVICE_INSTANCE_DEFAULT, this.dataServiceOptions.getDbServiceInstancePid());
+        assertEquals(STORE_HOUSEKEEPER_INTERVAL_DEFAULT, this.dataServiceOptions.getStoreHousekeeperInterval());
+        assertEquals(STORE_PURGE_AGE_DEFAULT, this.dataServiceOptions.getStorePurgeAge());
+        assertEquals(STORE_CAPACITY_DEFAULT, this.dataServiceOptions.getStoreCapacity());
+        assertEquals(REPUBLISH_IN_FLIGHT_MSGS_DEFAULT, this.dataServiceOptions.isPublishInFlightMessages());
+        assertEquals(MAX_IN_FLIGHT_MSGS_DEFAULT, this.dataServiceOptions.getMaxInFlightMessages());
+        assertEquals(IN_FLIGHT_MSGS_CONGESTION_TIMEOUT_DEFAULT,
+                this.dataServiceOptions.getInFlightMessagesCongestionTimeout());
+        assertEquals(RATE_LIMIT_ENABLE_DEFAULT, this.dataServiceOptions.isRateLimitEnabled());
+        assertEquals(RATE_LIMIT_AVERAGE_RATE_DEFAULT, this.dataServiceOptions.getRateLimitAverageRate());
+        assertEquals(RATE_LIMIT_BURST_SIZE_DEFAULT, this.dataServiceOptions.getRateLimitBurstSize());
+        assertEquals(RECOVERY_ENABLE_DEFAULT, this.dataServiceOptions.isConnectionRecoveryEnabled());
+        assertEquals(RECOVERY_MAX_FAILURES_DEFAULT, this.dataServiceOptions.getRecoveryMaximumAllowedFailures());
+        assertEquals(CONNECTION_SCHEDULE_ENABLED_DEFAULT, this.dataServiceOptions.isConnectionScheduleEnabled());
+        assertEquals(CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE_DEFAULT,
+                this.dataServiceOptions.isConnectionSchedulePriorityOverrideEnabled());
+        assertEquals(CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD_DEFAULT,
+                this.dataServiceOptions.getConnectionSchedulePriorityOverridePriority());
+    }
+
+    private void thenCheckIfAllChangesAreSet() {
+
+        assertEquals(AUTOCONNECT_PROP_CHANGED, this.dataServiceOptions.isAutoConnect());
+        assertEquals(CONNECT_DELAY_CHANGED, this.dataServiceOptions.getConnectDelay());
+        assertEquals(DISCONNECT_DELAY_CHANGED, this.dataServiceOptions.getDisconnectDelay());
+        assertEquals(DB_SERVICE_INSTANCE_CHANGED, this.dataServiceOptions.getDbServiceInstancePid());
+        assertEquals(STORE_HOUSEKEEPER_INTERVAL_CHANGED, this.dataServiceOptions.getStoreHousekeeperInterval());
+        assertEquals(STORE_PURGE_AGE_CHANGED, this.dataServiceOptions.getStorePurgeAge());
+        assertEquals(STORE_CAPACITY_CHANGED, this.dataServiceOptions.getStoreCapacity());
+        assertEquals(REPUBLISH_IN_FLIGHT_MSGS_CHANGED, this.dataServiceOptions.isPublishInFlightMessages());
+        assertEquals(MAX_IN_FLIGHT_MSGS_CHANGED, this.dataServiceOptions.getMaxInFlightMessages());
+        assertEquals(IN_FLIGHT_MSGS_CONGESTION_TIMEOUT_CHANGED,
+                this.dataServiceOptions.getInFlightMessagesCongestionTimeout());
+        assertEquals(RATE_LIMIT_ENABLE_CHANGED, this.dataServiceOptions.isRateLimitEnabled());
+        assertEquals(RATE_LIMIT_AVERAGE_RATE_CHANGED, this.dataServiceOptions.getRateLimitAverageRate());
+        assertEquals(RATE_LIMIT_BURST_SIZE_CHANGED, this.dataServiceOptions.getRateLimitBurstSize());
+        assertEquals(RECOVERY_ENABLE_CHANGED, this.dataServiceOptions.isConnectionRecoveryEnabled());
+        assertEquals(RECOVERY_MAX_FAILURES_CHANGED, this.dataServiceOptions.getRecoveryMaximumAllowedFailures());
+        assertEquals(CONNECTION_SCHEDULE_ENABLED_CHANGED, this.dataServiceOptions.isConnectionScheduleEnabled());
+        assertEquals(CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE_CHANGED,
+                this.dataServiceOptions.isConnectionSchedulePriorityOverrideEnabled());
+        assertEquals(CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD_CHANGED,
+                this.dataServiceOptions.getConnectionSchedulePriorityOverridePriority());
+    }
 }

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
@@ -92,6 +92,8 @@ public class ScheduleStrategyTest {
         givenScheduleStrategy();
         givenTimeout();
 
+        whenScheduleStrategyIsCreatedWithAlternativeConstructor();
+
         whenMessageIsSent();
 
         thenConnectionTaskIsNotStarted();
@@ -157,6 +159,23 @@ public class ScheduleStrategyTest {
         this.strategy = new ScheduleStrategy(expression, disconnectTimeoutMs,
                 this.connectionManagerState.connectionManager,
                 this.executorState.executor, () -> this.now, this.dataServiceOptions);
+    }
+
+    private void whenScheduleStrategyIsCreatedWithAlternativeConstructor() {
+
+        // Create DataServiceOptions
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("connection.schedule.priority.override.enable", true);
+        properties.put("connection.schedule.priority.override.threshold", 3);
+        properties.put("connect.auto-on-startup", true);
+        properties.put("connection.schedule.inactivity.interval.seconds", disconnectTimeoutMs);
+        properties.put("connection.schedule.enabled", true);
+        properties.put("connection.schedule.expression", expression.toString());
+
+        this.dataServiceOptions = new DataServiceOptions(properties);
+
+        this.strategy = new ScheduleStrategy(this.expression, this.dataServiceOptions,
+                this.connectionManagerState.connectionManager);
     }
 
     private void whenConnectionIsEstablished() {

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
@@ -198,7 +198,7 @@ public class ScheduleStrategyTest {
         properties.put("connection.schedule.inactivity.interval.seconds", disconnectTimeoutMs);
         properties.put("connection.schedule.enabled", true);
         properties.put("connection.schedule.expression", expression.toString());
-        properties.put("connection.schedule.inactivity.interval.seconds", 1);
+        properties.put("connection.schedule.inactivity.interval.seconds", (long) 1);
 
         this.dataServiceOptions = new DataServiceOptions(properties);
 

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
@@ -148,6 +148,7 @@ public class ScheduleStrategyTest {
         properties.put("connection.schedule.priority.override.enable", true);
         properties.put("connection.schedule.priority.override.threshold", 3);
         properties.put("connect.auto-on-startup", true);
+        properties.put("connection.schedule.inactivity.interval.seconds", disconnectTimeoutMs);
 
         this.dataServiceOptions = new DataServiceOptions(properties);
 
@@ -165,7 +166,7 @@ public class ScheduleStrategyTest {
     }
 
     private void whenPriorityMessageIsSent() {
-        this.strategy.onPublishRequested("test/topic", null, 0, false, 70);
+        this.strategy.onPublishRequested("test/topic", null, 0, false, 0);
     }
 
     private void thenTimeoutIsRequestedAfterMs(long expectedDelay) {

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
@@ -149,6 +149,8 @@ public class ScheduleStrategyTest {
         properties.put("connection.schedule.priority.override.threshold", 3);
         properties.put("connect.auto-on-startup", true);
         properties.put("connection.schedule.inactivity.interval.seconds", disconnectTimeoutMs);
+        properties.put("connection.schedule.enabled", true);
+        properties.put("connection.schedule.expression", expression.toString());
 
         this.dataServiceOptions = new DataServiceOptions(properties);
 

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.when;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -33,6 +35,8 @@ import org.mockito.Mockito;
 import org.quartz.CronExpression;
 
 public class ScheduleStrategyTest {
+
+    private DataServiceOptions dataServiceOptions;
 
     @Test
     public void shouldScheduleFirstConnectionAttempt() {
@@ -138,9 +142,18 @@ public class ScheduleStrategyTest {
     }
 
     private void whenScheduleStrategyIsCreated() {
+
+        // Create DataServiceOptions
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("connection.schedule.priority.override.enable", true);
+        properties.put("connection.schedule.priority.override.threshold", 3);
+        properties.put("connect.auto-on-startup", true);
+
+        this.dataServiceOptions = new DataServiceOptions(properties);
+
         this.strategy = new ScheduleStrategy(expression, disconnectTimeoutMs,
                 this.connectionManagerState.connectionManager,
-                this.executorState.executor, () -> this.now, true, 3);
+                this.executorState.executor, () -> this.now, this.dataServiceOptions);
     }
 
     private void whenConnectionIsEstablished() {

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
@@ -102,6 +102,33 @@ public class ScheduleStrategyTest {
 
         thenConnectionTaskIsStarted();
     }
+    
+    @Test
+    public void shouldReconnectIfMessageIsSentDuringDisconnect() {
+        givenTime("1/1/2000");
+        givenCronExpression("0/2 * * * * ?");
+        givenScheduleStrategy();
+        givenTimeout();
+        
+        whenScheduleStrategyIsCreatedWithAlternativeConstructor();
+        
+        whenMessageIsSent();
+        
+        thenConnectionTaskIsNotStarted();
+        
+        whenPriorityMessageIsSent();
+        
+        thenConnectionTaskIsStarted();
+        
+        //Create Minor Delay
+        whenMessageIsSent();
+        whenMessageIsSent();
+        whenMessageIsSent();
+        
+        whenPriorityMessageIsSent();
+        
+        thenConnectionTaskIsStarted();
+    }
 
     private final ExecutorState executorState = new ExecutorState();
     private final ConnectionManagerState connectionManagerState = new ConnectionManagerState();
@@ -171,6 +198,7 @@ public class ScheduleStrategyTest {
         properties.put("connection.schedule.inactivity.interval.seconds", disconnectTimeoutMs);
         properties.put("connection.schedule.enabled", true);
         properties.put("connection.schedule.expression", expression.toString());
+        properties.put("connection.schedule.inactivity.interval.seconds", 1);
 
         this.dataServiceOptions = new DataServiceOptions(properties);
 

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/ScheduleStrategyTest.java
@@ -82,7 +82,7 @@ public class ScheduleStrategyTest {
     }
 
     @Test
-    public void shouldForceRecconectOutsideOfSchedule() {
+    public void shouldForceReconnectOutsideOfSchedule() {
         givenTime("1/1/2000");
         givenCronExpression("0/2 * * * * ?");
         givenScheduleStrategy();


### PR DESCRIPTION
DataService will initiate a re-connect when a priority message is sent. When using the Schedule strategy. 

**Related Issue:** N/A

**Description of the solution adopted:**N/A

**Screenshots:** N/A

**Any side note on the changes made:** N/A
