### PR TITLE
docs(camel.xml): added JS init code support warning in metatype

### DIFF
--- a/kura/org.eclipse.kura.camel.xml/OSGI-INF/metatype/org.eclipse.kura.camel.xml.XmlRouterComponent.xml
+++ b/kura/org.eclipse.kura.camel.xml/OSGI-INF/metatype/org.eclipse.kura.camel.xml.XmlRouterComponent.xml
@@ -43,11 +43,11 @@
             />
 
         <AD id="initCode"
-            name="JavaScript init code"
+            name="JavaScript init code (Java 8 only)"
             type="String"
             cardinality="1"
             required="false"
-            description="JavaScript code which is called when the router is initialized first. The camel context is available in the variable 'camelContext'.|TextArea"/>
+            description="JavaScript code which is called when the router is initialized first. The camel context is available in the variable 'camelContext'. This feature only works on JRE with Nashorn (Java &lt; 15).|TextArea"/>
 
         <AD id="disableJmx"
             name="Disable JMX"

--- a/kura/org.eclipse.kura.camel.xml/OSGI-INF/metatype/org.eclipse.kura.camel.xml.XmlRouterComponent.xml
+++ b/kura/org.eclipse.kura.camel.xml/OSGI-INF/metatype/org.eclipse.kura.camel.xml.XmlRouterComponent.xml
@@ -47,7 +47,7 @@
             type="String"
             cardinality="1"
             required="false"
-            description="JavaScript code which is called when the router is initialized first. The camel context is available in the variable 'camelContext'. This feature only works on JRE with Nashorn (Java &lt; 15).|TextArea"/>
+            description="JavaScript code which is called when the router is initialized first. The camel context is available in the variable 'camelContext'. Warning: this feature only works on JRE with Nashorn (Java &lt; 15).|TextArea"/>
 
         <AD id="disableJmx"
             name="Disable JMX"


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

If running on Java > 15 the *JavaScript init code* feature will not work. This PR adds a warning on the metatype to inform the user on the supported JREs.

**Related Issue:** https://github.com/eclipse/kura/issues/4301.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
