### PR TITLE
fix(docker): use Java8 toolchain in Docker Ubi8 build

### DIFF
--- a/kura/container/kura_ubi8/Dockerfile
+++ b/kura/container/kura_ubi8/Dockerfile
@@ -44,10 +44,6 @@ RUN mvn -B -f target-platform/pom.xml clean install -Pno-mirror $MAVEN_PROPS
 RUN mvn -B -f kura/pom.xml clean install $MAVEN_PROPS
 RUN mvn -B -f kura/distrib/pom.xml clean install $MAVEN_PROPS -Pdocker-x86_64-nn -nsu
 
-WORKDIR /
-
-RUN ls -la /kura/kura/distrib/target
-
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN true && \

--- a/kura/container/kura_ubi8/Dockerfile
+++ b/kura/container/kura_ubi8/Dockerfile
@@ -10,7 +10,7 @@ ARG KURA_COMMIT
 ARG PACKED=false
 
 RUN chmod a+x -R /usr/local/bin
-RUN dnf -y install git java-1.8.0-openjdk-devel.x86_64 maven zip
+RUN dnf -y install git java-1.8.0-openjdk-devel maven zip
 
 ENV \
   GIT_REPO=${GIT_REPO:-https://github.com/eclipse/kura.git} \

--- a/kura/container/kura_ubi8/Dockerfile
+++ b/kura/container/kura_ubi8/Dockerfile
@@ -10,12 +10,12 @@ ARG KURA_COMMIT
 ARG PACKED=false
 
 RUN chmod a+x -R /usr/local/bin
-RUN dnf -y install git java-11-openjdk-devel maven zip
+RUN dnf -y install git java-17-openjdk-devel maven zip
 
 ENV \
   GIT_REPO=${GIT_REPO:-https://github.com/eclipse/kura.git} \
   GIT_BRANCH=${GIT_BRANCH:-develop} \
-  JAVA_HOME=/usr/lib/jvm/jre-11 \
+  JAVA_HOME=/usr/lib/jvm/jre-17 \
   LAUNCHER_VERSION="1.5.800.v20200727-1323"
 
 RUN echo "$GIT_REPO / $GIT_BRANCH / $KURA_COMMIT"

--- a/kura/container/kura_ubi8/Dockerfile
+++ b/kura/container/kura_ubi8/Dockerfile
@@ -10,12 +10,12 @@ ARG KURA_COMMIT
 ARG PACKED=false
 
 RUN chmod a+x -R /usr/local/bin
-RUN dnf -y install git java-17-openjdk-devel maven zip
+RUN dnf -y install git java-1.8.0-openjdk-devel.x86_64 maven zip
 
 ENV \
   GIT_REPO=${GIT_REPO:-https://github.com/eclipse/kura.git} \
   GIT_BRANCH=${GIT_BRANCH:-develop} \
-  JAVA_HOME=/usr/lib/jvm/jre-17 \
+  JAVA_HOME=/usr/lib/jvm/jre-1.8.0 \
   LAUNCHER_VERSION="1.5.800.v20200727-1323"
 
 RUN echo "$GIT_REPO / $GIT_BRANCH / $KURA_COMMIT"


### PR DESCRIPTION
**Brief description of the PR**: This PR fixes the Ubi8-based Docker build of Kura

**Description of the solution adopted**: As of 371622f8914462231a8b36c3911f549d7d0fc865 the Docker Ubi8 build was failing with:

```
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] 'build.plugins.plugin.version' for org.eclipse.tycho.extras:tycho-p2-extras-plugin must be a valid version but is '${tycho-p2-extras-plugin.version}'. @ org.eclipse.kura:p2-repo-common:[unknown-version], /kura/target-platform/p2-repo-common/pom.xml, line 760, column 26
[ERROR] 'build.plugins.plugin.version' for org.eclipse.tycho.extras:tycho-p2-extras-plugin must be a valid version but is '${tycho-p2-extras-plugin.version}'. @ org.eclipse.kura:p2-repo-equinox_3.16.0:[unknown-version], /kura/target-platform/p2-repo-equinox_3.16.0/pom.xml, line 130, column 26
[ERROR] 'build.plugins.plugin.version' for org.eclipse.tycho.extras:tycho-p2-extras-plugin must be a valid version but is '${tycho-p2-extras-plugin.version}'. @ org.eclipse.kura:p2-repo-tests-deps:[unknown-version], /kura/target-platform/p2-repo-test-deps/pom.xml, line 125, column 26
```

This was due to the fact that the Docker Ubi8 builder image was using OpenJDK 11 which is not supported by our build. See: https://github.com/eclipse/kura/blob/develop/target-platform/pom.xml#L108-L125

```xml
        <profile>
            <id>java8</id>
            <activation>
                <jdk>1.8</jdk>
            </activation>
            <properties>
                <tycho-p2-extras-plugin.version>1.7.0</tycho-p2-extras-plugin.version>
            </properties>
        </profile>
        <profile>
            <id>java17</id>
            <activation>
                <jdk>17</jdk>
            </activation>
            <properties>
                <tycho-p2-extras-plugin.version>3.0.0</tycho-p2-extras-plugin.version>
            </properties>
        </profile>
```

Since JDK 11 was not matching any of the two profiles linked above, no profile was activated and the `${tycho-p2-extras-plugin.version}` property was not correctly set, thus the build was failing.

To fix this I installed the toolchain to the Java 8 version.

---

> **Note**: I also tried using the Java17 toolchain but it resulted in a new error on the Target Platform build, thus fell back to Java8. The error is the following:
```
Generating metadata for ..
Status ERROR: org.eclipse.equinox.p2.artifact.repository code=0 'void org.eclipse.equinox.internal.p2.repository.helpers.ChecksumProducer.<init>(java.lang.String, java.lang.String, java.lang.String)' java.lang.NoSuchMethodError: 'void org.eclipse.equinox.internal.p2.repository.helpers.ChecksumProducer.<init>(java.lang.String, java.lang.String, java.lang.String)'
Product publishing ended with the following exception:
java.lang.NoSuchMethodError: 'void org.eclipse.equinox.internal.p2.repository.helpers.ChecksumProducer.<init>(java.lang.String, java.lang.String, java.lang.String)'
    at org.eclipse.equinox.internal.p2.artifact.processors.checksum.ChecksumUtilities.calculateChecksums(ChecksumUtilities.java:124)
```

**Update**: The error was probably due to https://github.com/eclipse-tycho/tycho/issues/1814