### PR TITLE
fix(web2): non-clickable dialogs in login page after GWT upgrade

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/login/LoginUi.ui.xml
@@ -1,17 +1,17 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 
-<!-- 
-    
+<!--
+
     Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
-  
+
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
- 
+
 	SPDX-License-Identifier: EPL-2.0
-	
+
 	Contributors:
-     Eurotech 
+     Eurotech
 
 -->
 
@@ -25,30 +25,33 @@
 	<ui:with field="msgs"
 		type="org.eclipse.kura.web.client.messages.Messages" />
 
-	<b:Container fluid="true" addStyleNames="login-background">
+    <g:HTMLPanel>
+        <b:Container fluid="true" addStyleNames="login-background">
 
-<g:FormPanel ui:field="loginForm">
-		<b:Modal ui:field="loginDialog" title="Login" closable="false"
-			fade="false" dataBackdrop="FALSE" addStyleNames="login-form" visible="false">
-			
-			<b:ModalBody ui:field="loginModalBody">
-						<b.html:Paragraph text="{msgs.loginWebUiAccessNotEnabled}" ui:field="noAuthMethodsWarning" />
-						<b:FormGroup ui:field="authenticationMethodGroup" visible="false">
-                            <b:FormLabel for="authenticationMethod" text="Authentication Method"/>
-                            <g:FlowPanel>
-                                <b:ListBox ui:field="authenticationMethod" b:id="authenticationMethod">
-                                </b:ListBox>
-                            </g:FlowPanel>
-                        </b:FormGroup>
-			</b:ModalBody>
-			<b:ModalFooter>
-				<b:SubmitButton text="Login" b:id="login-button" ui:field="loginButton" visible="false"/>
-			</b:ModalFooter>
-		
-				
-		</b:Modal>
-		</g:FormPanel>
-        
+            <g:FormPanel ui:field="loginForm">
+                <b:Modal ui:field="loginDialog" title="Login" closable="false"
+                    fade="false" dataBackdrop="FALSE" addStyleNames="login-form" visible="false">
+
+                    <b:ModalBody ui:field="loginModalBody">
+                                <b.html:Paragraph text="{msgs.loginWebUiAccessNotEnabled}" ui:field="noAuthMethodsWarning" />
+                                <b:FormGroup ui:field="authenticationMethodGroup" visible="false">
+                                    <b:FormLabel for="authenticationMethod" text="Authentication Method"/>
+                                    <g:FlowPanel>
+                                        <b:ListBox ui:field="authenticationMethod" b:id="authenticationMethod">
+                                        </b:ListBox>
+                                    </g:FlowPanel>
+                                </b:FormGroup>
+                    </b:ModalBody>
+                    <b:ModalFooter>
+                        <b:SubmitButton text="Login" b:id="login-button" ui:field="loginButton" visible="false"/>
+                    </b:ModalFooter>
+
+
+                </b:Modal>
+            </g:FormPanel>
+
+        </b:Container>
+
         <b:Modal closable="false" fade="true" dataBackdrop="STATIC"
             dataKeyboard="true" ui:field="accessBannerModal"
             b:id="accessBannerModal">
@@ -65,7 +68,7 @@
             </b:ModalFooter>
         </b:Modal>
 
+        <kura:AlertDialog ui:field="alertDialog" />
 
-		<kura:AlertDialog ui:field="alertDialog" />
-	</b:Container>
+    </g:HTMLPanel>
 </ui:UiBinder>


### PR DESCRIPTION
**Brief description of the PR.**: After updating GWT the dialogs in the login page (i.e. the Access Banner and the Alert Dialog) were covered by the backdrop and could not be dismissed. This PR fixes the issue.

**Description of the solution adopted:** After updating GWT in the Java 17 https://github.com/eclipse/kura/pull/4206 PR the dialogs in the login page were covered by the backdrop and rendered unclickable.

![kura_530](https://user-images.githubusercontent.com/22748355/208066563-d6818773-c1c6-4216-b5c4-3d2cec823ef2.png)

The issue and its solution are described in [this Stack Overflow post](https://stackoverflow.com/questions/20983110/bootstrap-modal-sitting-behind-backdrop).

Following the suggestion in the first answer I wrapped all the login UI elements inside a `<g:HTMLPanel>` (since the `UiBinder` expect to have only *one* child element) and moved the `Modal` and `AlertDialog` outside the main `Container` element. This seems to fix the issue.

![image](https://user-images.githubusercontent.com/22748355/208067372-20dd6a6b-234b-409e-9d9d-15dcbdaf3dfa.png)

> **Note**: Since I was already there I fixed the indentation of the `xml` file.

## Testing

The fix was tested on the Kura user workspace on my workstation.

- **Test 1**: Go to Security -> Web Console -> Enable banner. At logout the banner should be clickabe and not covered by the backdrop.
- **Test 2**: At login use wrong password. The alert dialog should be clickable and not covered by the backdrop.

## Additional notes

A similar issue was reported for the "Identities" UI but I wasn't able to reproduce. I'm waiting for more details before setting this PR as ready for review.