### PR TITLE
fix: web UI bug where invalid component could not be deleted.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
@@ -150,8 +150,7 @@ public class Configurations {
     public List<String> getInvalidConfigurationPids() {
         final List<String> result = new ArrayList<>();
         for (Entry<String, HasConfiguration> entry : this.currentConfigurations.entrySet()) {
-            // Check if the item is invalid and if it is active (not queued for deletion).
-            if (!entry.getValue().isValid() && this.allActivePids.contains(entry.getKey())) {
+            if (!entry.getValue().isValid()) {
                 result.add(entry.getKey());
             }
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
@@ -150,7 +150,8 @@ public class Configurations {
     public List<String> getInvalidConfigurationPids() {
         final List<String> result = new ArrayList<>();
         for (Entry<String, HasConfiguration> entry : this.currentConfigurations.entrySet()) {
-            if (!entry.getValue().isValid()) {
+            // Check if the item is invalid and if it is active (not queued for deletion).
+            if (!entry.getValue().isValid() && this.allActivePids.contains(entry.getKey())) {
                 result.add(entry.getKey());
             }
         }


### PR DESCRIPTION
**Related Issue:** https://github.com/eclipse/kura/issues/4305

**Description of the solution adopted:**  Web UI throws an error when you try to apply a wire graph with an invalid component. the issue is this error is present when trying to delete this wire graph as well.
check if the invalid component is going to be deleted (not active),  before adding It to the list of invalid components so the error is not thrown. 

**Screenshots:** n/a

**Any side note on the changes made:** n/a
