### PR TITLE
build(tests): added support for parallel builds on test module

### DIFF
--- a/kura/test/org.eclipse.kura.wire.script.filter.provider.test/pom.xml
+++ b/kura/test/org.eclipse.kura.wire.script.filter.provider.test/pom.xml
@@ -301,9 +301,14 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- parallel build config -->
+                    <parallel>classes</parallel>
+                    <useUnlimitedThreads>true</useUnlimitedThreads>
+                    <forkCount>2C</forkCount>
+                    <reuseForks>true</reuseForks>
+
                     <failIfNoTests>false</failIfNoTests>
                     <providerHint>junit4</providerHint>
-                    <useUnlimitedThreads>false</useUnlimitedThreads>
                     <argLine>
                         ${tycho.testArgLine}
                         ${tycho.surefire.testenv.args}

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -122,6 +122,12 @@
                                 <goal>test</goal>
                             </goals>
                             <configuration>
+                                <!-- parallel build config -->
+                                <parallel>classes</parallel>
+                                <useUnlimitedThreads>true</useUnlimitedThreads>
+                                <forkCount>2C</forkCount>
+                                <reuseForks>true</reuseForks>
+
                                 <argLine>${tycho.testArgLine}</argLine>
                             </configuration>
                         </execution>
@@ -133,9 +139,14 @@
                     <artifactId>tycho-surefire-plugin</artifactId>
                     <version>${tycho-version}</version>
                     <configuration>
+                        <!-- parallel build config -->
+                        <parallel>classes</parallel>
+                        <useUnlimitedThreads>true</useUnlimitedThreads>
+                        <forkCount>2C</forkCount>
+                        <reuseForks>true</reuseForks>
+
                         <failIfNoTests>false</failIfNoTests>
                         <providerHint>junit4</providerHint>
-                        <useUnlimitedThreads>false</useUnlimitedThreads>
                         <argLine>
                             ${tycho.testArgLine}
                             ${tycho.surefire.testenv.args}


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

This PR tries to enable parallel builds for the test modules.

It is possible to launch parallel tests with command:

```shell
mvn -T 32 -f kura/test/pom.xml clean install
```

Where 32 is the number of threads to assign for the build. Each module will execute the test classes concurrently and use a number of forks of `2 x nr. of cores`.

Apache Maven parallel builds: https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
