### PR TITLE
fix: issue when instantiating a wire component with the same name as a deleted one

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
@@ -117,7 +117,10 @@ public class Configurations {
 
     public void deleteConfiguration(String pid) {
         this.allActivePids.remove(pid);
-        this.currentConfigurations.remove(pid);
+
+        if (!WIRE_ASSET_PID.equals(this.currentConfigurations.get(pid).getConfiguration().getFactoryId())) {
+            this.currentConfigurations.remove(pid);
+        }
     }
 
     public void setChannelDescriptiors(List<GwtConfigComponent> descriptors) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/configuration/Configurations.java
@@ -117,6 +117,7 @@ public class Configurations {
 
     public void deleteConfiguration(String pid) {
         this.allActivePids.remove(pid);
+        this.currentConfigurations.remove(pid);
     }
 
     public void setChannelDescriptiors(List<GwtConfigComponent> descriptors) {


### PR DESCRIPTION
**Brief description of the PR.** Fix bug in wire component instantiation with same name.

**Description of the solution adopted:** Before this PR it was not possible to delete a wire component and recreate it in with the same name before saving the wire graph. See attached video. Probably affects all component types except Wire Assets.

https://user-images.githubusercontent.com/22748355/209096817-1d73baab-30ae-406b-b8da-84684cb475a9.mov

This PR fixes the issue.