### PR TITLE
fix: asset page refreshes after deletion

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/DriversAndAssetsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/DriversAndAssetsUi.java
@@ -174,6 +174,7 @@ public class DriversAndAssetsUi extends Composite implements DriversAndAssetsLis
         DriversAndAssetsRPC.deleteFactoryConfiguration(pid, result -> {
             this.configurations.deleteConfiguration(pid);
             this.driverAndAssetsListUi.refresh();
+            this.refresh();
         });
     }
 


### PR DESCRIPTION
**Brief description of the PR:** Fix bug in driver UI where deleting Asset/Driver does not remove item until page refresh

**Description of the solution adopted:** Before this PR, when deleting an Asset/Driver in the UI the item was not removed until page refresh. This PR fixes the issue.

Steps for reproduction:

- install driver dp (for example: com.eurotech.modbus.driver)
- go to drivers add add install driver (it can happen that driver is not visible immediately  so refresh the page)
- create an asset based on created driver
- remove asset

→ asset is still visible on the list

Video of the old behaviour:

https://user-images.githubusercontent.com/22748355/209102626-0471ccb9-3d5c-40c5-971a-d6925409e159.mov
