### PR TITLE
fix(core): Fix ssl still active after change keystore in SSLServiceManager

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
 public class DataServiceImpl implements DataService, DataTransportListener, ConfigurableComponent,
         CloudConnectionStatusComponent, CriticalComponent, AutoConnectStrategy.ConnectionManager {
 
-    private static final int RECONNECTION_MIN_DELAY = 5;
+    private static final int RECONNECTION_MIN_DELAY = 1;
 
     private static final Logger logger = LoggerFactory.getLogger(DataServiceImpl.class);
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *  Red Hat Inc
@@ -99,6 +99,9 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
     private static final String TOPIC_ACCOUNT_NAME_CTX_NAME = "account-name";
     private static final String TOPIC_DEVICE_ID_CTX_NAME = "client-id";
 
+    private static final long MQTT_QUIESCE_TIMEOUT = 2;
+    private static final long MQTT_DISCONNECT_TIMEOUT = 2;
+
     private SystemService systemService;
     private SslManagerService sslManagerService;
     private CloudConnectionStatusService cloudConnectionStatusService;
@@ -140,7 +143,7 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
     public void setSslManagerService(SslManagerService sslManagerService) {
         final boolean update;
 
-        synchronized (updateLock) {
+        synchronized (this.updateLock) {
             this.sslManagerService = sslManagerService;
             update = this.clientConf != null;
         }
@@ -151,7 +154,7 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
     }
 
     public void unsetSslManagerService(SslManagerService sslManagerService) {
-        synchronized (updateLock) {
+        synchronized (this.updateLock) {
             if (sslManagerService == this.sslManagerService) {
                 this.sslManagerService = null;
             }
@@ -181,7 +184,7 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
     // ----------------------------------------------------------------
 
     protected void activate(ComponentContext componentContext, Map<String, Object> properties) {
-        synchronized (updateLock) {
+        synchronized (this.updateLock) {
             logger.info("Activating {}...", properties.get(ConfigurationService.KURA_SERVICE_PID));
 
             // We need to catch the configuration exception and activate anyway.
@@ -236,7 +239,7 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
     }
 
     public void updated(Map<String, Object> properties) {
-        synchronized (updateLock) {
+        synchronized (this.updateLock) {
             logger.info("Updating {}...", properties.get(ConfigurationService.KURA_SERVICE_PID));
 
             this.properties.clear();
@@ -281,7 +284,7 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
         // Listeners will not be notified of an invalid configuration update.
         logger.info("Building new configuration...");
 
-        synchronized (updateLock) {
+        synchronized (this.updateLock) {
             this.clientConf = buildConfiguration(this.properties);
         }
 
@@ -1035,8 +1038,8 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
 
         try {
             logger.info("Forcing client disconnect...");
-            mqttClient.disconnectForcibly();
-        } catch (MqttException e) {
+            this.mqttClient.disconnectForcibly(MQTT_QUIESCE_TIMEOUT, MQTT_DISCONNECT_TIMEOUT);
+        } catch (Exception e) {
             logger.warn("Cannot force client disconnect", e);
         }
         try {
@@ -1045,7 +1048,7 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
             this.mqttClient.setCallback(null);
             this.mqttClient.close();
             logger.info("Closed");
-        } catch (MqttException e) {
+        } catch (Exception e) {
             logger.warn("Cannot close client", e);
         } finally {
             this.mqttClient = null;

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
@@ -99,8 +99,8 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
     private static final String TOPIC_ACCOUNT_NAME_CTX_NAME = "account-name";
     private static final String TOPIC_DEVICE_ID_CTX_NAME = "client-id";
 
-    private static final long MQTT_QUIESCE_TIMEOUT = 2;
-    private static final long MQTT_DISCONNECT_TIMEOUT = 2;
+    private static final long MQTT_QUIESCE_TIMEOUT = 2000;
+    private static final long MQTT_DISCONNECT_TIMEOUT = 2000;
 
     private SystemService systemService;
     private SslManagerService sslManagerService;

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
@@ -386,7 +386,7 @@ public class DataServiceImplTest {
         }
 
         // initial checkin + 3 * authentication + (other mqtt + 3)
-        assertEquals(4, count.intValue());
+        assertEquals(8, count.intValue());
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
@@ -387,7 +387,7 @@ public class DataServiceImplTest {
         }
 
         // initial checkin + 3 * authentication + (other mqtt + 3)
-        assertEquals(8, count.intValue());
+        assertEquals(4, count.intValue());
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2017, 2023 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  ******************************************************************************/
@@ -376,8 +376,7 @@ public class DataServiceImplTest {
         cause = new MqttException(MqttException.REASON_CODE_BROKER_UNAVAILABLE);
         Throwable exc4 = new KuraConnectException(cause, "test");
         doThrow(exc1).doThrow(exc2).doThrow(exc3).doThrow(exc4)
-                .doThrow(new KuraConnectException("test ordinary exception"))
-                .when(dtsMock).connect();
+                .doThrow(new KuraConnectException("test ordinary exception")).when(dtsMock).connect();
 
         svc.activate(ctxMock, properties);
 


### PR DESCRIPTION
Now in DataServiceImpl shutdownAutoConnectStrategy is invoked org.eclipse.kura.data.transport.listener.DataTransportListener.onConfigurationUpdated(boolean).

Lowered to 4 (lesser than the minimum RECONNECTION_MIN_DELAY) the sum of timeout and quiesce time of org.eclipse.paho.client.mqttv3.MqttAsyncClient.disconnectForcibly.