### PR TITLE
fix: Modules java.lang and java.util are not available with the jvm 17.

### DIFF
--- a/kura/container/kura_alpine/bin/start-kura
+++ b/kura/container/kura_alpine/bin/start-kura
@@ -2,6 +2,16 @@
 
 set -e
 
+#get java version
+JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+JAVA_VERSION_NUM=$(echo "$JAVA_VERSION" | awk -F. '{printf("%03d%03d",$1,$2);}')
+
+OPEN_MODULE_OPTIONS=''
+
+if [ $JAVA_VERSION_NUM -gt 001008 ] ; then
+        OPEN_MODULE_OPTIONS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"
+fi
+
 mkdir -p /tmp/.kura/configuration
 cp "${KURA_DIR}/framework/config.ini" /tmp/.kura/configuration/
 
@@ -11,6 +21,7 @@ JAVA_INT_OPTS="$JAVA_INT_OPTS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMem
 
 JAVA_INT_OPTS="$JAVA_INT_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/kura-heapdump.hprof"
 JAVA_INT_OPTS="$JAVA_INT_OPTS -XX:ErrorFile=/var/log/kura-error.log"
+JAVA_INT_OPTS="$JAVA_INT_OPTS \"${OPEN_MODULE_OPTIONS}\""
 JAVA_INT_OPTS="$JAVA_INT_OPTS --add-modules=ALL-SYSTEM"
 
 JAVA_INT_OPTS="$JAVA_INT_OPTS -Dkura.os.version=centos"

--- a/kura/container/kura_ubi8/bin/start-kura
+++ b/kura/container/kura_ubi8/bin/start-kura
@@ -2,6 +2,16 @@
 
 set -e
 
+#get java version
+JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+JAVA_VERSION_NUM=$(echo "$JAVA_VERSION" | awk -F. '{printf("%03d%03d",$1,$2);}')
+
+OPEN_MODULE_OPTIONS=''
+
+if [ $JAVA_VERSION_NUM -gt 001008 ] ; then
+        OPEN_MODULE_OPTIONS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"
+fi
+
 mkdir -p /tmp/.kura/configuration
 cp "${KURA_DIR}/framework/config.ini" /tmp/.kura/configuration/
 
@@ -11,6 +21,7 @@ JAVA_INT_OPTS="$JAVA_INT_OPTS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMem
 
 JAVA_INT_OPTS="$JAVA_INT_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/kura-heapdump.hprof"
 JAVA_INT_OPTS="$JAVA_INT_OPTS -XX:ErrorFile=/var/log/kura-error.log"
+JAVA_INT_OPTS="$JAVA_INT_OPTS \"${OPEN_MODULE_OPTIONS}\""
 JAVA_INT_OPTS="$JAVA_INT_OPTS --add-modules=ALL-SYSTEM"
 
 JAVA_INT_OPTS="$JAVA_INT_OPTS -Dkura.os.version=ubi8"

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -299,11 +299,22 @@ cp ${DIR}/framework/config.ini /tmp/.kura/configuration/
 
 KURA_RUNNING=`ps ax | grep java | grep "org.eclipse.equinox"`
 
+#get java version
+JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+JAVA_VERSION_NUM=$(echo "$JAVA_VERSION" | awk -F. '{printf("%03d%03d",$1,$2);}')
+
+OPEN_MODULE_OPTIONS=''
+
+if [ $JAVA_VERSION_NUM -gt 001008 ] ; then
+        OPEN_MODULE_OPTIONS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"
+fi
+
 if [ -z "$KURA_RUNNING" ] ; then
         exec java -Xms${kura.mem.size} -Xmx${kura.mem.size} \
         -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/kura-heapdump.hprof \
         -XX:ErrorFile=/var/log/kura-error.log \
         -XX:+IgnoreUnrecognizedVMOptions \
+        ${OPEN_MODULE_OPTIONS} \
         --add-modules=ALL-SYSTEM \
         -Dkura.os.version=${kura.os.version} \
         -Dkura.arch=${kura.arch} \
@@ -341,6 +352,16 @@ cp ${DIR}/framework/config.ini /tmp/.kura/configuration/
 
 KURA_RUNNING=`ps ax | grep java | grep "org.eclipse.equinox"`
 
+#get java version
+JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+JAVA_VERSION_NUM=$(echo "$JAVA_VERSION" | awk -F. '{printf("%03d%03d",$1,$2);}')
+
+OPEN_MODULE_OPTIONS=''
+
+if [ $JAVA_VERSION_NUM -gt 001008 ] ; then
+        OPEN_MODULE_OPTIONS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"
+fi
+
 if [ -z "$KURA_RUNNING" ] ; then
         exec java -Xms${kura.mem.size} -Xmx${kura.mem.size} \
         -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -Xloggc:/var/log/kura-gc.log \
@@ -348,6 +369,7 @@ if [ -z "$KURA_RUNNING" ] ; then
         -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/kura-heapdump.hprof \
         -XX:ErrorFile=/var/log/kura-error.log \
         -XX:+IgnoreUnrecognizedVMOptions \
+        ${OPEN_MODULE_OPTIONS} \
         --add-modules=ALL-SYSTEM \
         -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=8000,suspend=n \
         -Dkura.os.version=${kura.os.version} \
@@ -387,11 +409,22 @@ cp ${DIR}/framework/config.ini /tmp/.kura/configuration/
 
 KURA_RUNNING=`ps ax | grep java | grep "org.eclipse.equinox"`
 
+#get java version
+JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+JAVA_VERSION_NUM=$(echo "$JAVA_VERSION" | awk -F. '{printf("%03d%03d",$1,$2);}')
+
+OPEN_MODULE_OPTIONS=''
+
+if [ $JAVA_VERSION_NUM -gt 001008 ] ; then
+        OPEN_MODULE_OPTIONS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"
+fi
+
 if [ -z "$KURA_RUNNING" ] ; then
   nohup java -Xms${kura.mem.size} -Xmx${kura.mem.size} \
         -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/log/kura-heapdump.hprof \
         -XX:ErrorFile=/var/log/kura-error.log \
         -XX:+IgnoreUnrecognizedVMOptions \
+        ${OPEN_MODULE_OPTIONS} \
         --add-modules=ALL-SYSTEM \
         -Dkura.os.version=${kura.os.version} \
         -Dkura.arch=${kura.arch} \


### PR DESCRIPTION
Added "--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"
to jvm launch options if version is greater than 8.
