### PR TITLE
feat(wire.CloudPublisher): Set as body a property removing it from metrics

### DIFF
--- a/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.CloudPublisher.xml
+++ b/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.CloudPublisher.xml
@@ -54,7 +54,7 @@
             cardinality="0"
             required="true"
             default="false"
-            description="If Set body from envelope property is not an empty value, the publisher will remove from the message metrics the property added in the message body.">
+            description="Set true to remove the metric that is sent as body of the message.">
         </AD>
     </OCD>
     

--- a/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.CloudPublisher.xml
+++ b/kura/org.eclipse.kura.wire.component.provider/OSGI-INF/metatype/org.eclipse.kura.wire.CloudPublisher.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2023 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -46,6 +46,15 @@
             required="false"
             default=""
             description="If set to a non empty value, the publisher will set the message body to the value of the provided STRING or BYTE_ARRAY metric.">
+        </AD>
+        
+        <AD id="remove.body.from.metrics"
+            name="Remove body envelope property from metrics"
+            type="Boolean"
+            cardinality="0"
+            required="true"
+            default="false"
+            description="If Set body from envelope property is not an empty value, the publisher will remove from the message metrics the property added in the message body.">
         </AD>
     </OCD>
     

--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisher.java
@@ -21,12 +21,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherOptions.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -32,6 +32,7 @@ final class CloudPublisherOptions {
 
     private static final String CONF_POSITION = "publish.position";
     private static final String CONF_BODY_PROPERTY = "set.body.from.property";
+    private static final String CONF_REMOVE_BODY_PROPERTY = "remove.body.from.metrics";
 
     private final Map<String, Object> properties;
 
@@ -39,7 +40,7 @@ final class CloudPublisherOptions {
      * Instantiates a new cloud publisher options.
      *
      * @param properties
-     *            the properties
+     *                       the properties
      */
     CloudPublisherOptions(final Map<String, Object> properties) {
         requireNonNull(properties, "Properties cannot be null");
@@ -81,5 +82,10 @@ final class CloudPublisherOptions {
         }
 
         return Optional.of(property);
+    }
+
+    Boolean getRemoveBodyPropertyFromMetrics() {
+        final Object propertyRaw = this.properties.get(CONF_REMOVE_BODY_PROPERTY);
+        return (Boolean) propertyRaw;
     }
 }

--- a/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherOptions.java
+++ b/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/publisher/CloudPublisherOptions.java
@@ -40,7 +40,7 @@ final class CloudPublisherOptions {
      * Instantiates a new cloud publisher options.
      *
      * @param properties
-     *                       the properties
+     *            the properties
      */
     CloudPublisherOptions(final Map<String, Object> properties) {
         requireNonNull(properties, "Properties cannot be null");
@@ -84,8 +84,7 @@ final class CloudPublisherOptions {
         return Optional.of(property);
     }
 
-    Boolean getRemoveBodyPropertyFromMetrics() {
-        final Object propertyRaw = this.properties.get(CONF_REMOVE_BODY_PROPERTY);
-        return (Boolean) propertyRaw;
+    boolean getRemoveBodyPropertyFromMetrics() {
+        return (boolean) this.properties.getOrDefault(CONF_REMOVE_BODY_PROPERTY, false);
     }
 }


### PR DESCRIPTION
Added "remove.body.from.metrics" boolean property in the component metatype.
If set to True and the "set a property as body" is not empty, remove the property from the KuraPayload metrics and KuraMessage properties.
The default value is false and preserve the current behaviour.

Added the test cases and refactor the CloudPublisherTest class with scenarios.

**Related Issue:** This PR fixes the issue #4292 

