### PR TITLE
fix: Moved message store capacity management to DataService

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/message/store/provider/MessageStore.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/message/store/provider/MessageStore.java
@@ -36,11 +36,6 @@ public interface MessageStore {
      * Inserts a new message in the store. The implementation must set the value of
      * the <code>createdOn</code> message parameter to the current time.
      * <br>
-     * This method must throw a {@link KuraStoreException} if the number of messages
-     * in the store is greater or equal than the value of the <code>capacity</code>
-     * parameter that has been provided to the
-     * {@link MessageStoreProvider#openMessageStore(String, int)} call that created
-     * this store.
      * 
      * @param topic    the value of the <code>topic</code> parameter.
      * @param payload  topic the value of the <code>payload</code> parameter.
@@ -118,6 +113,16 @@ public interface MessageStore {
     public Optional<StoredMessage> get(int msgId) throws KuraStoreException;
 
     /**
+     * Returns the number of messages currently in the store.
+     * This should include all messages, regardless of the value of their
+     * parameters.
+     * 
+     * @return the message count.
+     * @throws KuraStoreException
+     */
+    public int getMessageCount() throws KuraStoreException;
+
+    /**
      * Returns the list of messages whose <code>publishedOn</code> parameter is not
      * set.
      * <br>
@@ -179,7 +184,7 @@ public interface MessageStore {
      * <ul>
      * <li>The value of the <code>QoS</code> parameter is greater than 0.</li>
      * <li>The <code>publishedOn</code> parameter is set.</li>
-     * <li>The <code>publishedOn</code> parameter is not set.</li>
+     * <li>The <code>confirmedOn</code> parameter is not set.</li>
      * </ul>
      * 
      * @throws KuraStoreException

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/message/store/provider/MessageStoreProvider.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/message/store/provider/MessageStoreProvider.java
@@ -27,10 +27,9 @@ public interface MessageStoreProvider {
     /**
      * Opens or creates a {@link MessageStore} instance with the given name.
      * 
-     * @param name     the store name.
-     * @param capacity the maximum message count that is possible to store.
-     * @return
+     * @param name the store name.
+     * @return the opened {@link MessageStore}
      * @throws KuraStoreException
      */
-    public MessageStore openMessageStore(String name, int capacity) throws KuraStoreException;
+    public MessageStore openMessageStore(String name) throws KuraStoreException;
 }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/store/MessageStoreState.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/store/MessageStoreState.java
@@ -61,8 +61,7 @@ public class MessageStoreState {
             return this.messageStore.get();
         }
 
-        final MessageStore result = this.messageStoreProvider.openMessageStore(this.options.getKuraServicePid(),
-                this.options.getStoreCapacity());
+        final MessageStore result = this.messageStoreProvider.openMessageStore(this.options.getKuraServicePid());
 
         this.messageStore = Optional.of(result);
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/db/H2DbServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/db/H2DbServiceImpl.java
@@ -612,9 +612,9 @@ public class H2DbServiceImpl
     }
 
     @Override
-    public MessageStore openMessageStore(String name, int capacity) throws KuraStoreException {
+    public MessageStore openMessageStore(String name) throws KuraStoreException {
 
-        return new H2DbMessageStoreImpl(this, name, capacity);
+        return new H2DbMessageStoreImpl(this, name);
     }
 
     @Override

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
@@ -84,7 +84,7 @@ public class DataServiceImplTest {
         // the actual invocation
         svc.setMessageStoreProvider(messageStoreProviderMock);
 
-        verify(messageStoreProviderMock, times(1)).openMessageStore("foo", capacity);
+        verify(messageStoreProviderMock, times(1)).openMessageStore("foo");
 
         Map<DataTransportToken, Integer> ifMsgs = (Map<DataTransportToken, Integer>) TestUtil.getFieldValue(svc,
                 "inFlightMsgIds");
@@ -560,7 +560,7 @@ public class DataServiceImplTest {
             List<StoredMessage> inFlight,
             List<StoredMessage> dropped) throws KuraStoreException {
 
-        when(messageStoreProviderMock.openMessageStore(Mockito.any(), Mockito.anyInt()))
+        when(messageStoreProviderMock.openMessageStore(Mockito.any()))
                 .thenReturn(messageStoreMock);
 
         when(messageStoreMock.getUnpublishedMessages()).thenReturn(unpublished);

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/store/DbDataStoreStorageTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/store/DbDataStoreStorageTest.java
@@ -58,7 +58,7 @@ public class DbDataStoreStorageTest {
     @Test
     public void shouldStoreNullPayload() {
         givenNullPayload();
-        givenDbDataStore(10000, 10000, 10);
+        givenDbDataStore(10000, 10000);
 
         whenStore(TOPIC, this.payload, QOS2, true, PRIORITY_LOW);
 
@@ -69,7 +69,7 @@ public class DbDataStoreStorageTest {
     @Test
     public void shouldStoreSmallPayload() {
         givenSmallPayload();
-        givenDbDataStore(10000, 10000, 10);
+        givenDbDataStore(10000, 10000);
 
         whenStore(TOPIC, this.payload, QOS2, true, PRIORITY_LOW);
 
@@ -80,7 +80,7 @@ public class DbDataStoreStorageTest {
     @Test
     public void shouldStoreLargePayload() {
         givenLargePayload();
-        givenDbDataStore(10000, 10000, 10);
+        givenDbDataStore(10000, 10000);
 
         whenStore(TOPIC, this.payload, QOS2, true, PRIORITY_LOW);
 
@@ -89,41 +89,9 @@ public class DbDataStoreStorageTest {
     }
 
     @Test
-    public void highPriorityMessagesStoredEvenWhenCapacityExceeded() {
-        givenSmallPayload();
-        givenDbDataStore(10000, 10000, 0);
-
-        whenStore(TOPIC, this.payload, QOS2, true, PRIORITY_HIGH);
-
-        thenNoExceptionsOccurred();
-        thenStoredMessageIs(TOPIC, this.payload, QOS2, true, PRIORITY_HIGH);
-    }
-
-    @Test
-    public void mediumPriorityMessagesStoredEvenWhenCapacityExceeded() {
-        givenSmallPayload();
-        givenDbDataStore(10000, 10000, 0);
-
-        whenStore(TOPIC, this.payload, QOS2, true, PRIORITY_MEDIUM);
-
-        thenNoExceptionsOccurred();
-        thenStoredMessageIs(TOPIC, this.payload, QOS2, true, PRIORITY_MEDIUM);
-    }
-
-    @Test
-    public void lowPriorityMessagesAreNotStoredWhenCapacityExceeded() {
-        givenSmallPayload();
-        givenDbDataStore(10000, 10000, 0);
-
-        whenStore(TOPIC, this.payload, QOS2, true, PRIORITY_LOW);
-
-        thenStoreCapacityExceededException();
-    }
-
-    @Test
     public void idsAreResetIfOverflown() {
         givenSmallPayload();
-        givenDbDataStore(H2_MAX_ID_VALUE, H2_MAX_ID_VALUE, H2_MAX_ID_VALUE);
+        givenDbDataStore(H2_MAX_ID_VALUE, H2_MAX_ID_VALUE);
 
         whenOverflowingIds();
 
@@ -134,7 +102,7 @@ public class DbDataStoreStorageTest {
     @Test
     public void storeWithPriority0ShouldUpdateDbEvenIfDbIsFull() {
         givenSmallPayload();
-        givenDbDataStore(H2_MAX_ID_VALUE, H2_MAX_ID_VALUE, 0);
+        givenDbDataStore(H2_MAX_ID_VALUE, H2_MAX_ID_VALUE);
 
         whenStore(TOPIC, this.payload, QOS0, true, PRIORITY_HIGH);
 
@@ -144,7 +112,7 @@ public class DbDataStoreStorageTest {
     @Test
     public void storeWithPriority1ShouldUpdateDbEvenIfDbIsFull() {
         givenSmallPayload();
-        givenDbDataStore(H2_MAX_ID_VALUE, H2_MAX_ID_VALUE, 0);
+        givenDbDataStore(H2_MAX_ID_VALUE, H2_MAX_ID_VALUE);
 
         whenStore(TOPIC, this.payload, QOS1, true, PRIORITY_MEDIUM);
 
@@ -177,11 +145,11 @@ public class DbDataStoreStorageTest {
         }
     }
 
-    private void givenDbDataStore(int houseKeeperInterval, int purgeAge, int capacity) {
+    private void givenDbDataStore(int houseKeeperInterval, int purgeAge) {
         H2DbService h2Service = new MockH2DbService();
 
         try {
-            this.dataStore = new H2DbMessageStoreImpl(h2Service, TABLE_NAME, capacity);
+            this.dataStore = new H2DbMessageStoreImpl(h2Service, TABLE_NAME);
         } catch (KuraStoreException e) {
             this.occurredException = e;
         }


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

* Moves the responsibility to manage the message store capacity from the MessageStore implementation to the DataService
* Fixed typo in Javadoc
