### PR TITLE
build: updated GraalVM dependency to mitigate CVE-2022-21476 

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -194,12 +194,12 @@ This project leverages the following third party content.
 * maven/mavencentral/org.gwtproject/gwt-user/2.10.0, Apache-2.0 AND CC0-1.0, approved, #4958
 * maven/mavencentral/org.gwtbootstrap3/gwtbootstrap3/1.0.1, Apache-2.0 AND MIT AND OFL-1.1, approved, #2020
 * maven/mavencentral/org.xerial/sqlite-jdbc/3.39.3.0, Apache-2.0 AND BSD-2-Clause AND ISC AND Artistic-2.0, approved, #3763
-* maven/mavencentral/org.graalvm.js/js/21.3.5, UPL-1.0 AND (LicenseRef-scancode-sunpro AND UPL-1.0) AND (GPL-2.0-only WITH Classpath-exception-2.0 AND UPL-1.0) AND (BSD-3-Clause AND UPL-1.0) AND (LicenseRef-scancode-x11-lucent AND MPL-2.0), restricted, #6714
+* maven/mavencentral/org.graalvm.js/js/21.3.5, UPL-1.0 AND (UPL-1.0 AND GPL-2.0-only WITH Classpath-exception-2.0) AND BSD-3-Clause AND MPL-2.0, approved, #6714
 * maven/mavencentral/org.graalvm.js/js-scriptengine/21.3.5, UPL-1.0, approved, #6715
 * maven/mavencentral/org.graalvm.js/js-launcher/21.3.5, UPL-1.0, approved, #6716
 * maven/mavencentral/org.graalvm.sdk/graal-sdk/21.3.5, UPL-1.0, approved, #6717
 * maven/mavencentral/org.graalvm.truffle/truffle-api/21.3.5, UPL-1.0, approved, #6718
-* maven/mavencentral/org.graalvm.regex/regex/21.3.5, UPL-1.0 AND (LicenseRef-scancode-unicode AND UPL-1.0), restricted, #6719
+* maven/mavencentral/org.graalvm.regex/regex/21.3.5, UPL-1.0 AND Unicode-TOU, approved, #6719
 * maven/mavencentral/org.graalvm.sdk/launcher-common/21.3.5, UPL-1.0, approved, #6720
 
 ### Additional Dependencies

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -194,13 +194,13 @@ This project leverages the following third party content.
 * maven/mavencentral/org.gwtproject/gwt-user/2.10.0, Apache-2.0 AND CC0-1.0, approved, #4958
 * maven/mavencentral/org.gwtbootstrap3/gwtbootstrap3/1.0.1, Apache-2.0 AND MIT AND OFL-1.1, approved, #2020
 * maven/mavencentral/org.xerial/sqlite-jdbc/3.39.3.0, Apache-2.0 AND BSD-2-Clause AND ISC AND Artistic-2.0, approved, #3763
-* maven/mavencentral/org.graalvm.js/js/21.3.5, , restricted, clearlydefined
-* maven/mavencentral/org.graalvm.js/js-scriptengine/21.3.5, , restricted, clearlydefined
-* maven/mavencentral/org.graalvm.js/js-launcher/21.3.5, , restricted, clearlydefined
-* maven/mavencentral/org.graalvm.sdk/graal-sdk/21.3.5, , restricted, clearlydefined
-* maven/mavencentral/org.graalvm.truffle/truffle-api/21.3.5, , restricted, clearlydefined
-* maven/mavencentral/org.graalvm.regex/regex/21.3.5, , restricted, clearlydefined
-* maven/mavencentral/org.graalvm.sdk/launcher-common/21.3.5, , restricted, clearlydefined
+* maven/mavencentral/org.graalvm.js/js/21.3.5, UPL-1.0 AND (LicenseRef-scancode-sunpro AND UPL-1.0) AND (GPL-2.0-only WITH Classpath-exception-2.0 AND UPL-1.0) AND (BSD-3-Clause AND UPL-1.0) AND (LicenseRef-scancode-x11-lucent AND MPL-2.0), restricted, #6714
+* maven/mavencentral/org.graalvm.js/js-scriptengine/21.3.5, UPL-1.0, approved, #6715
+* maven/mavencentral/org.graalvm.js/js-launcher/21.3.5, UPL-1.0, approved, #6716
+* maven/mavencentral/org.graalvm.sdk/graal-sdk/21.3.5, UPL-1.0, approved, #6717
+* maven/mavencentral/org.graalvm.truffle/truffle-api/21.3.5, UPL-1.0, approved, #6718
+* maven/mavencentral/org.graalvm.regex/regex/21.3.5, UPL-1.0 AND (LicenseRef-scancode-unicode AND UPL-1.0), restricted, #6719
+* maven/mavencentral/org.graalvm.sdk/launcher-common/21.3.5, UPL-1.0, approved, #6720
 
 ### Additional Dependencies
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -193,12 +193,14 @@ This project leverages the following third party content.
 * maven/mavencentral/com.zaxxer/HikariCP/2.7.9, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/org.gwtproject/gwt-user/2.10.0, Apache-2.0 AND CC0-1.0, approved, #4958
 * maven/mavencentral/org.gwtbootstrap3/gwtbootstrap3/1.0.1, Apache-2.0 AND MIT AND OFL-1.1, approved, #2020
-* maven/mavencentral/org.graalvm.js/js/22.0.0.2, UPL-1.0 AND (UPL-1.0 AND BSD-3-Clause) AND (UPL-1.0 AND GPL-2.0 WITH Classpath-exception-2.0) AND Unicode-TOU AND (MPL-2.0 AND X11), approved, #5271
-* maven/mavencentral/org.graalvm.js/js-scriptengine/22.0.0.2, UPL-1.0, approved, #5272
-* maven/mavencentral/org.graalvm.js/js-launcher/22.0.0.2, UPL-1.0, approved, #5273
-* maven/mavencentral/org.graalvm.sdk/graal-sdk/22.0.0.2, UPL-1.0, approved, clearlydefined
-* maven/mavencentral/org.graalvm.truffle/truffle-api/22.0.0.2, UPL-1.0, approved, #5274
 * maven/mavencentral/org.xerial/sqlite-jdbc/3.39.3.0, Apache-2.0 AND BSD-2-Clause AND ISC AND Artistic-2.0, approved, #3763
+* maven/mavencentral/org.graalvm.js/js/21.3.5, , restricted, clearlydefined
+* maven/mavencentral/org.graalvm.js/js-scriptengine/21.3.5, , restricted, clearlydefined
+* maven/mavencentral/org.graalvm.js/js-launcher/21.3.5, , restricted, clearlydefined
+* maven/mavencentral/org.graalvm.sdk/graal-sdk/21.3.5, , restricted, clearlydefined
+* maven/mavencentral/org.graalvm.truffle/truffle-api/21.3.5, , restricted, clearlydefined
+* maven/mavencentral/org.graalvm.regex/regex/21.3.5, , restricted, clearlydefined
+* maven/mavencentral/org.graalvm.sdk/launcher-common/21.3.5, , restricted, clearlydefined
 
 ### Additional Dependencies
 

--- a/kura/org.eclipse.kura.wire.script.tools/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.wire.script.tools/META-INF/MANIFEST.MF
@@ -23,4 +23,5 @@ Bundle-ClassPath: .,
  lib/js-launcher.jar,
  lib/js-scriptengine.jar,
  lib/launcher-common.jar,
- lib/truffle-api.jar
+ lib/truffle-api.jar,
+ lib/regex.jar

--- a/kura/org.eclipse.kura.wire.script.tools/build.properties
+++ b/kura/org.eclipse.kura.wire.script.tools/build.properties
@@ -8,4 +8,7 @@ bin.includes = META-INF/,\
                lib/js.jar,\
                lib/js-launcher.jar,\
                lib/js-scriptengine.jar,\
+               lib/launcher-common.jar,\
+               lib/regex.jar,\
                lib/truffle-api.jar
+               

--- a/kura/org.eclipse.kura.wire.script.tools/pom.xml
+++ b/kura/org.eclipse.kura.wire.script.tools/pom.xml
@@ -26,7 +26,7 @@
     <packaging>eclipse-plugin</packaging>
 
     <properties>
-        <graalvm.version>21.3.2</graalvm.version>
+        <graalvm.version>21.3.5</graalvm.version>
         <kura.basedir>${project.basedir}/..</kura.basedir>
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test/org.eclipse.kura.wire.script.tools.test/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
@@ -69,6 +69,16 @@
                                 <artifactItem>
                                     <groupId>org.graalvm.truffle</groupId>
                                     <artifactId>truffle-api</artifactId>
+                                    <version>${graalvm.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.graalvm.regex</groupId>
+                                    <artifactId>regex</artifactId>
+                                    <version>${graalvm.version}</version>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.graalvm.sdk</groupId>
+                                    <artifactId>launcher-common</artifactId>
                                     <version>${graalvm.version}</version>
                                 </artifactItem>
                             </artifactItems>

--- a/kura/org.eclipse.kura.wire.script.tools/pom.xml
+++ b/kura/org.eclipse.kura.wire.script.tools/pom.xml
@@ -26,7 +26,7 @@
     <packaging>eclipse-plugin</packaging>
 
     <properties>
-        <graalvm.version>22.1.0</graalvm.version>
+        <graalvm.version>21.3.2</graalvm.version>
         <kura.basedir>${project.basedir}/..</kura.basedir>
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test/org.eclipse.kura.wire.script.tools.test/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>

--- a/kura/org.eclipse.kura.wire.script.tools/pom.xml
+++ b/kura/org.eclipse.kura.wire.script.tools/pom.xml
@@ -26,7 +26,7 @@
     <packaging>eclipse-plugin</packaging>
 
     <properties>
-        <graalvm.version>22.0.0.2</graalvm.version>
+        <graalvm.version>22.1.0</graalvm.version>
         <kura.basedir>${project.basedir}/..</kura.basedir>
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test/org.eclipse.kura.wire.script.tools.test/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>


### PR DESCRIPTION
Updated GraalVM from 22.0.0.2 -> 21.3.5.
**Requires a QA before this branch can be merged! **



**Related Issue:** n/a

**Description of the solution adopted:** n/a

**Screenshots:**  n/a

**Any side note on the changes made:**  n/a
