### PR TITLE
fix(core): disabling connect auto on startup in data service terminates active cloud connection

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -989,7 +989,6 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
 
     @Override
     public void stopConnectionTask() {
-        disconnect();
         stopConnectionMonitorTask();
     }
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
@@ -686,7 +686,7 @@ public class MqttDataTransport implements DataTransportService, MqttCallback, Co
     @Override
     public void onConfigurationUpdated() {
 
-        // The SSL service was update, build a new socket connection and close the current SSL client session
+        // The SSL service was updated, build a new socket connection and close the current SSL client session
         if (this.mqttClient != null && isSSL(this.mqttClient.getServerURI())) {
             closeMqttClient();
         }


### PR DESCRIPTION
Fixes a bug where auto-connect is enabled when there is an active connection to a cloud service and then updated to 'disabled', and the cloud connection disconnects.

**Related Issue:** n/a

**Description of the solution adopted:**  removed the disconnect method call when trying to disable the auto-connect strategy.

**Screenshots:** n/a

**Any side note on the changes made:** n/a
