### PR TITLE
fix: NPE on some properties, allowed status properties for unconfigured interfaces

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -51,7 +51,7 @@ public class GwtNetworkServiceImpl {
             List<GwtNetInterfaceConfig> result = new LinkedList<>();
             for (String ifname : status.getNetInterfaces()) {
                 GwtNetInterfaceConfig gwtConfig = configuration.getGwtNetInterfaceConfig(ifname);
-                status.fillWithStatusProperties(gwtConfig);
+                status.fillWithStatusProperties(ifname, gwtConfig);
 
                 logger.debug("GWT Network Configuration for interface {}:\n{}\n", ifname, gwtConfig.getProperties());
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -20,7 +20,6 @@ import org.eclipse.kura.net.wifi.WifiBgscanModule;
 import org.eclipse.kura.web.server.net2.utils.EnumsParser;
 import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetIfConfigMode;
-import org.eclipse.kura.web.shared.model.GwtNetIfStatus;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetRouterMode;
 import org.eclipse.kura.web.shared.model.GwtWifiBgscanModule;
@@ -50,19 +49,13 @@ public class GwtNetInterfaceConfigBuilder {
     }
 
     public GwtNetInterfaceConfig build() {
-        if (this.properties.getNetworkInterfaces().contains(ifname)) {
-            setCommonProperties();
-            setIpv4Properties();
-            setIpv4DhcpClientProperties();
-            setIpv4DhcpServerProperties();
-            setRouterMode();
-            setWifiProperties();
-            setModemProperties();
-        } else {
-            this.gwtConfig.setStatus(GwtNetIfStatus.netIPv4StatusDisabled.name());
-            this.gwtConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
-            this.gwtConfig.setRouterMode(GwtNetRouterMode.netRouterOff.name());
-        }
+        setCommonProperties();
+        setIpv4Properties();
+        setIpv4DhcpClientProperties();
+        setIpv4DhcpServerProperties();
+        setRouterMode();
+        setWifiProperties();
+        setModemProperties();
 
         return this.gwtConfig;
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -50,9 +50,8 @@ public class GwtNetInterfaceConfigBuilder {
     }
 
     public GwtNetInterfaceConfig build() {
-        setCommonProperties();
-
         if (this.properties.getNetworkInterfaces().contains(ifname)) {
+            setCommonProperties();
             setIpv4Properties();
             setIpv4DhcpClientProperties();
             setIpv4DhcpServerProperties();
@@ -61,6 +60,8 @@ public class GwtNetInterfaceConfigBuilder {
             setModemProperties();
         } else {
             this.gwtConfig.setStatus(GwtNetIfStatus.netIPv4StatusDisabled.name());
+            this.gwtConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
+            this.gwtConfig.setRouterMode(GwtNetRouterMode.netRouterOff.name());
         }
 
         return this.gwtConfig;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -70,7 +70,7 @@ public class NetworkConfigurationServiceProperties {
     private static final String NET_INTERFACE_CONFIG_NAT_ENABLED = "net.interface.%s.config.nat.enabled";
 
     public Optional<String> getType(String ifname) {
-        return Optional.of((String) this.properties.get(String.format(NET_INTERFACE_TYPE, ifname)));
+        return Optional.ofNullable((String) this.properties.get(String.format(NET_INTERFACE_TYPE, ifname)));
     }
 
     public void setType(String ifname, String type) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -244,7 +244,8 @@ public class NetworkConfigurationServiceProperties {
     private static final String NET_INTERFACE_CONFIG_DHCP_CLIENT_ENABLED = "net.interface.%s.config.dhcpClient4.enabled";
 
     public boolean getDhcpClient4Enabled(String ifname) {
-        return (boolean) this.properties.get(String.format(NET_INTERFACE_CONFIG_DHCP_CLIENT_ENABLED, ifname));
+        return (boolean) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_DHCP_CLIENT_ENABLED, ifname),
+                true);
     }
 
     public void setDhcpClient4Enabled(String ifname, boolean isDhcpClientEnabled) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -50,9 +50,10 @@ public class NetworkStatusServiceAdapter {
         return this.networkStatusService.getInterfaceNames();
     }
 
-    public Optional<GwtNetInterfaceConfig> fillWithStatusProperties(GwtNetInterfaceConfig gwtConfigToUpdate) {
-        NetInterface<NetInterfaceAddress> networkInterface = this.networkStatusService
-                .getNetworkStatus(gwtConfigToUpdate.getName());
+    public Optional<GwtNetInterfaceConfig> fillWithStatusProperties(String ifname,
+            GwtNetInterfaceConfig gwtConfigToUpdate) {
+
+        NetInterface<NetInterfaceAddress> networkInterface = this.networkStatusService.getNetworkStatus(ifname);
 
         if (networkInterface != null) {
             setCommonStateProperties(gwtConfigToUpdate, networkInterface);
@@ -63,6 +64,8 @@ public class NetworkStatusServiceAdapter {
 
             return Optional.of(gwtConfigToUpdate);
         }
+
+        logger.debug("No status information retrieved for interface '{}'.", ifname);
 
         return Optional.empty();
     }


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

This PR fixes the NPE when retrieving a nullable property.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
