### PR TITLE
fix(util.wire.store): ignore case when comparing column names during record insertion

### DIFF
--- a/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/wire/store/SqlWireRecordStoreHelper.java
+++ b/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/wire/store/SqlWireRecordStoreHelper.java
@@ -146,7 +146,7 @@ public class SqlWireRecordStoreHelper {
 
         final String sqlColName = sanitizer.apply(name);
 
-        if (!columnTypes.containsKey(name)) {
+        if (!columnTypes.containsKey(name) && !columnTypes.containsKey(name.toLowerCase())) {
 
             logger.debug("creating new column: {} {}", name, expectedType.get());
             execute(c, MessageFormat.format(queries.getSqlAddColumn(), sqlColName,

--- a/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/wire/store/SqlWireRecordStoreHelper.java
+++ b/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/wire/store/SqlWireRecordStoreHelper.java
@@ -155,7 +155,7 @@ public class SqlWireRecordStoreHelper {
         } else {
             final Optional<String> columnType = Optional.ofNullable(columnTypes.get(name));
 
-            if (!expectedType.equals(columnType)) {
+            if (columnType.isPresent() && !expectedType.get().equalsIgnoreCase(columnType.get())) {
 
                 logger.debug("changing column type: {} {}", name, expectedType.get());
 

--- a/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/wire/store/SqlWireRecordStoreHelper.java
+++ b/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/wire/store/SqlWireRecordStoreHelper.java
@@ -146,7 +146,7 @@ public class SqlWireRecordStoreHelper {
 
         final String sqlColName = sanitizer.apply(name);
 
-        if (!columnTypes.containsKey(name) && !columnTypes.containsKey(name.toLowerCase())) {
+        if (!columnTypes.containsKey(name)) {
 
             logger.debug("creating new column: {} {}", name, expectedType.get());
             execute(c, MessageFormat.format(queries.getSqlAddColumn(), sqlColName,
@@ -155,7 +155,7 @@ public class SqlWireRecordStoreHelper {
         } else {
             final Optional<String> columnType = Optional.ofNullable(columnTypes.get(name));
 
-            if (columnType.isPresent() && !expectedType.get().equalsIgnoreCase(columnType.get())) {
+            if (!expectedType.equals(columnType)) {
 
                 logger.debug("changing column type: {} {}", name, expectedType.get());
 

--- a/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/wire/store/SqlWireRecordStoreHelper.java
+++ b/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/wire/store/SqlWireRecordStoreHelper.java
@@ -146,18 +146,19 @@ public class SqlWireRecordStoreHelper {
 
         final String sqlColName = sanitizer.apply(name);
 
-        if (!columnTypes.containsKey(name)) {
+        if (!columnTypes.containsKey(sqlColName)) {
 
-            logger.debug("creating new column: {} {}", name, expectedType.get());
+            logger.debug("creating new column: {} {}", sqlColName, expectedType.get());
             execute(c, MessageFormat.format(queries.getSqlAddColumn(), sqlColName,
                     expectedType.get()));
 
         } else {
-            final Optional<String> columnType = Optional.ofNullable(columnTypes.get(name));
+            final Optional<String> columnType = Optional.ofNullable(columnTypes.get(sqlColName));
 
-            if (!expectedType.equals(columnType)) {
+            if (!expectedType.equals(columnType) && columnType.isPresent()) {
 
-                logger.debug("changing column type: {} {}", name, expectedType.get());
+                logger.debug("changing column {} type from {} to {}", sqlColName, columnType.get(),
+                        expectedType.get());
 
                 execute(c, MessageFormat.format(queries.getSqlDropColumn(), sqlColName));
                 execute(c, MessageFormat.format(queries.getSqlAddColumn(), sqlColName,


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
