### PR TITLE
feat(web.server.net2): added list of all WiFi channel frequencies

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImplFacade.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImplFacade.java
@@ -180,7 +180,7 @@ public class GwtNetworkServiceImplFacade extends OsgiRemoteServiceServlet implem
 
         if (isNet2()) {
             // TODO
-            return new ArrayList<>();
+            return org.eclipse.kura.web.server.net2.GwtNetworkServiceImpl.findFrequencies(interfaceName, radioMode);
         } else {
             return org.eclipse.kura.web.server.net.GwtNetworkServiceImpl.findFrequencies(interfaceName, radioMode);
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImplFacade.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImplFacade.java
@@ -179,7 +179,6 @@ public class GwtNetworkServiceImplFacade extends OsgiRemoteServiceServlet implem
         checkXSRFToken(xsrfToken);
 
         if (isNet2()) {
-            // TODO
             return org.eclipse.kura.web.server.net2.GwtNetworkServiceImpl.findFrequencies(interfaceName, radioMode);
         } else {
             return org.eclipse.kura.web.server.net.GwtNetworkServiceImpl.findFrequencies(interfaceName, radioMode);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -31,6 +31,8 @@ import org.eclipse.kura.web.shared.model.GwtFirewallNatEntry;
 import org.eclipse.kura.web.shared.model.GwtFirewallOpenPortEntry;
 import org.eclipse.kura.web.shared.model.GwtFirewallPortForwardEntry;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
+import org.eclipse.kura.web.shared.model.GwtWifiChannelFrequency;
+import org.eclipse.kura.web.shared.model.GwtWifiRadioMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,5 +179,30 @@ public class GwtNetworkServiceImpl {
         } catch (KuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
+    }
+
+    public static List<GwtWifiChannelFrequency> findFrequencies(String interfaceName, GwtWifiRadioMode radioMode) {
+        List<GwtWifiChannelFrequency> result = new ArrayList<>();
+
+        final int startFreq_5GHz = 5000;
+        final int[] channels_5GHz = { 7, 8, 9, 10, 11, 12, 16, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58,
+                60, 62, 64, 68, 96, 100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126, 128, 132, 134,
+                136, 138, 140, 142, 144, 149, 151, 153, 155, 157, 159, 161, 163, 165, 167, 169, 171, 173, 175, 177,
+                180, 182, 184, 187, 188, 189, 192, 196 };
+
+        final int startFreq_2_4GHz = 2408;
+        final int[] channels_2_4GHz = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 };
+
+        for (int channelNumber : channels_2_4GHz) {
+            final int channelCenterFrequency = startFreq_2_4GHz + 5 * channelNumber - 1;
+            result.add(new GwtWifiChannelFrequency(channelNumber, channelCenterFrequency));
+        }
+
+        for (int channelNumber : channels_5GHz) {
+            final int channelCenterFrequency = startFreq_5GHz + 5 * channelNumber;
+            result.add(new GwtWifiChannelFrequency(channelNumber, channelCenterFrequency));
+        }
+
+        return result;
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -54,9 +54,6 @@ public class GwtNetworkServiceImpl {
             for (String ifname : status.getNetInterfaces()) {
                 GwtNetInterfaceConfig gwtConfig = configuration.getGwtNetInterfaceConfig(ifname);
                 status.fillWithStatusProperties(ifname, gwtConfig);
-
-                logger.debug("GWT Network Configuration for interface {}:\n{}\n", ifname, gwtConfig.getProperties());
-
                 result.add(gwtConfig);
             }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kura.web.server.net2.configuration;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -154,7 +156,11 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setDriver(this.properties.getWifiMasterDriver(this.ifname));
         gwtWifiConfig.setIgnoreSSID(this.properties.getWifiMasterIgnoreSsid(this.ifname));
         gwtWifiConfig.setPassword(new String(this.properties.getWifiMasterPassphrase(this.ifname).getPassword()));
-        gwtWifiConfig.setChannels(this.properties.getWifiMasterChannel(this.ifname));
+        
+        List<Integer> channel = new ArrayList<>();
+        channel.add(this.properties.getWifiMasterChannel(this.ifname));
+        gwtWifiConfig.setChannels(channel);
+
         gwtWifiConfig.setWirelessMode(
                 EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMasterMode(this.ifname)));
         gwtWifiConfig.setSecurity(
@@ -188,7 +194,11 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setDriver(this.properties.getWifiInfraDriver(this.ifname));
         gwtWifiConfig.setIgnoreSSID(this.properties.getWifiInfraIgnoreSsid(this.ifname));
         gwtWifiConfig.setPassword(new String(this.properties.getWifiInfraPassphrase(this.ifname).getPassword()));
-        gwtWifiConfig.setChannels(this.properties.getWifiInfraChannel(this.ifname));
+
+        List<Integer> channel = new ArrayList<>();
+        channel.add(this.properties.getWifiInfraChannel(this.ifname));
+        gwtWifiConfig.setChannels(channel);
+
         gwtWifiConfig
                 .setWirelessMode(EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiInfraMode(this.ifname)));
         gwtWifiConfig

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kura.web.server.net2.configuration;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -156,10 +154,7 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setDriver(this.properties.getWifiMasterDriver(this.ifname));
         gwtWifiConfig.setIgnoreSSID(this.properties.getWifiMasterIgnoreSsid(this.ifname));
         gwtWifiConfig.setPassword(new String(this.properties.getWifiMasterPassphrase(this.ifname).getPassword()));
-        
-        List<Integer> channel = new ArrayList<>();
-        channel.add(this.properties.getWifiMasterChannel(this.ifname));
-        gwtWifiConfig.setChannels(channel);
+        gwtWifiConfig.setChannels(this.properties.getWifiMasterChannel(this.ifname));
 
         gwtWifiConfig.setWirelessMode(
                 EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMasterMode(this.ifname)));
@@ -194,10 +189,7 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setDriver(this.properties.getWifiInfraDriver(this.ifname));
         gwtWifiConfig.setIgnoreSSID(this.properties.getWifiInfraIgnoreSsid(this.ifname));
         gwtWifiConfig.setPassword(new String(this.properties.getWifiInfraPassphrase(this.ifname).getPassword()));
-
-        List<Integer> channel = new ArrayList<>();
-        channel.add(this.properties.getWifiInfraChannel(this.ifname));
-        gwtWifiConfig.setChannels(channel);
+        gwtWifiConfig.setChannels(this.properties.getWifiInfraChannel(this.ifname));
 
         gwtWifiConfig
                 .setWirelessMode(EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiInfraMode(this.ifname)));

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
@@ -20,6 +20,8 @@ import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.web.server.util.ServiceLocator;
 import org.eclipse.kura.web.shared.GwtKuraException;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Adapter to retrieve NetworkConfigurationService properties and
@@ -29,7 +31,7 @@ import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 public class NetworkConfigurationServiceAdapter {
 
     private static final String NETWORK_CONFIGURATION_SERVICE_PID = "org.eclipse.kura.net.admin.NetworkConfigurationService";
-
+    private static final Logger logger = LoggerFactory.getLogger(NetworkConfigurationServiceAdapter.class);
 
     private final ConfigurationService configurationService;
     private final Map<String, Object> netConfServProperties;
@@ -48,7 +50,13 @@ public class NetworkConfigurationServiceAdapter {
      *         NetworkConfigurationService
      */
     public GwtNetInterfaceConfig getGwtNetInterfaceConfig(String ifname) {
-        return new GwtNetInterfaceConfigBuilder(this.netConfServProperties).forInterface(ifname).build();
+        GwtNetInterfaceConfig gwtConfig = new GwtNetInterfaceConfigBuilder(this.netConfServProperties)
+                .forInterface(ifname).build();
+
+        logger.debug("Created GWT Network Configuration for interface {}:\n\n{}\n\n", ifname,
+                gwtConfig.getProperties());
+
+        return gwtConfig;
     }
 
     /**
@@ -62,6 +70,8 @@ public class NetworkConfigurationServiceAdapter {
         NetworkConfigurationServicePropertiesBuilder builder = new NetworkConfigurationServicePropertiesBuilder(
                 gwtConfig);
         Map<String, Object> newProperties = builder.build();
+
+        logger.debug("Updating '{}' with properties:\n\n{}\n\n", NETWORK_CONFIGURATION_SERVICE_PID, newProperties);
 
         this.configurationService.updateConfiguration(NETWORK_CONFIGURATION_SERVICE_PID, newProperties);
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kura.web.server.net2.configuration;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -312,14 +311,14 @@ public class NetworkConfigurationServiceProperties {
         this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_MODE, ifname), mode);
     }
 
-    public List<Integer> getWifiMasterChannel(String ifname) {
-        return channelsAsIntegersList(
-                (String) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_CHANNEL, ifname),
-                        ""));
+    public int getWifiMasterChannel(String ifname) {
+        String intString = (String) this.properties
+                .getOrDefault(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_CHANNEL, ifname), 1);
+        return Integer.parseInt(intString);
     }
 
-    public void setWifiMasterChannel(String ifname, List<Integer> channels) {
-        this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_CHANNEL, ifname), channels);
+    public void setWifiMasterChannel(String ifname, int channel) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_CHANNEL, ifname), channel);
     }
 
     public Optional<String> getWifiMasterRadioMode(String ifname) {
@@ -389,14 +388,14 @@ public class NetworkConfigurationServiceProperties {
         this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_SSID, ifname), ssid);
     }
 
-    public List<Integer> getWifiInfraChannel(String ifname) {
-        return channelsAsIntegersList(
-                (String) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_CHANNEL, ifname),
-                        ""));
+    public int getWifiInfraChannel(String ifname) {
+        String intString = (String) this.properties
+                .getOrDefault(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_CHANNEL, ifname), 1);
+        return Integer.parseInt(intString);
     }
 
-    public void setWifiInfraChannel(String ifname, List<Integer> channels) {
-        this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_CHANNEL, ifname), channels);
+    public void setWifiInfraChannel(String ifname, int channel) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_CHANNEL, ifname), channel);
     }
 
     public Optional<String> getWifiInfraBgscan(String ifname) {
@@ -752,24 +751,6 @@ public class NetworkConfigurationServiceProperties {
         }
 
         return Optional.empty();
-    }
-
-    private List<Integer> channelsAsIntegersList(String channelValue) {
-        List<Integer> channels = new ArrayList<>();
-
-        String[] split = channelValue.split(" ");
-
-        for (String channel : split) {
-            if (!channel.trim().isEmpty()) {
-                try {
-                    channels.add(Integer.parseInt(channel.trim()));
-                } catch (NumberFormatException e) {
-                    logger.error("Error parsing channel property '" + channelValue + "'", e);
-                }
-            }
-        }
-
-        return channels;
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kura.web.server.net2.configuration;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -311,14 +312,14 @@ public class NetworkConfigurationServiceProperties {
         this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_MODE, ifname), mode);
     }
 
-    public int getWifiMasterChannel(String ifname) {
-        String intString = (String) this.properties
-                .getOrDefault(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_CHANNEL, ifname), 1);
-        return Integer.parseInt(intString);
+    public List<Integer> getWifiMasterChannel(String ifname) {
+        return channelsStringAsIntList((String) this.properties
+                .getOrDefault(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_CHANNEL, ifname), ""));
     }
 
-    public void setWifiMasterChannel(String ifname, int channel) {
-        this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_CHANNEL, ifname), channel);
+    public void setWifiMasterChannel(String ifname, List<Integer> channels) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_MASTER_CHANNEL, ifname),
+                intListAsChannelsString(channels));
     }
 
     public Optional<String> getWifiMasterRadioMode(String ifname) {
@@ -388,14 +389,14 @@ public class NetworkConfigurationServiceProperties {
         this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_SSID, ifname), ssid);
     }
 
-    public int getWifiInfraChannel(String ifname) {
-        String intString = (String) this.properties
-                .getOrDefault(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_CHANNEL, ifname), 1);
-        return Integer.parseInt(intString);
+    public List<Integer> getWifiInfraChannel(String ifname) {
+        return channelsStringAsIntList((String) this.properties
+                .getOrDefault(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_CHANNEL, ifname), ""));
     }
 
-    public void setWifiInfraChannel(String ifname, int channel) {
-        this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_CHANNEL, ifname), channel);
+    public void setWifiInfraChannel(String ifname, List<Integer> channels) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_WIFI_INFRA_CHANNEL, ifname),
+                intListAsChannelsString(channels));
     }
 
     public Optional<String> getWifiInfraBgscan(String ifname) {
@@ -751,6 +752,35 @@ public class NetworkConfigurationServiceProperties {
         }
 
         return Optional.empty();
+    }
+
+    private List<Integer> channelsStringAsIntList(String channelValue) {
+        List<Integer> channels = new ArrayList<>();
+
+        String[] split = channelValue.split(" ");
+
+        for (String channel : split) {
+            if (!channel.trim().isEmpty()) {
+                try {
+                    channels.add(Integer.parseInt(channel.trim()));
+                } catch (NumberFormatException e) {
+                    logger.error("Error parsing channel property '" + channelValue + "'", e);
+                }
+            }
+        }
+
+        return channels;
+    }
+
+    private String intListAsChannelsString(List<Integer> channels) {
+        StringBuilder result = new StringBuilder();
+
+        for (int channel : channels) {
+            result.append(channel);
+            result.append(" ");
+        }
+
+        return result.toString().trim();
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -118,7 +118,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
         this.properties.setWifiMasterDriver(this.ifname, gwtWifiConfig.getDriver());
         this.properties.setWifiMasterIgnoreSsid(this.ifname, gwtWifiConfig.ignoreSSID());
         this.properties.setWifiMasterPassphrase(this.ifname, gwtWifiConfig.getPassword());
-        this.properties.setWifiMasterChannel(this.ifname, gwtWifiConfig.getChannels());
+        this.properties.setWifiMasterChannel(this.ifname, gwtWifiConfig.getChannels().get(0));
 
         this.properties.setWifiMasterMode(this.ifname,
                 EnumsParser.getWifiMode(Optional.ofNullable(gwtWifiConfig.getWirelessMode())));
@@ -143,7 +143,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
         this.properties.setWifiInfraDriver(this.ifname, gwtWifiConfig.getDriver());
         this.properties.setWifiInfraIgnoreSsid(this.ifname, gwtWifiConfig.ignoreSSID());
         this.properties.setWifiInfraPassphrase(this.ifname, gwtWifiConfig.getPassword());
-        this.properties.setWifiInfraChannel(this.ifname, gwtWifiConfig.getChannels());
+        this.properties.setWifiInfraChannel(this.ifname, gwtWifiConfig.getChannels().get(0));
 
         this.properties.setWifiInfraMode(this.ifname,
                 EnumsParser.getWifiMode(Optional.ofNullable(gwtWifiConfig.getWirelessMode())));

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -131,8 +131,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
         this.properties.setWifiMasterSecurityType(this.ifname,
                 EnumsParser.getWifiSecurity(Optional.ofNullable(gwtWifiConfig.getSecurity())));
         this.properties.setWifiMasterPairwiseCiphers(this.ifname,
-                Optional.ofNullable(gwtWifiConfig.getPairwiseCiphers()));
-        this.properties.setWifiMasterGroupCiphers(this.ifname, Optional.ofNullable(gwtWifiConfig.getGroupCiphers()));
+                EnumsParser.getWifiCiphers(Optional.ofNullable(gwtWifiConfig.getPairwiseCiphers())));
+        this.properties.setWifiMasterGroupCiphers(this.ifname,
+                EnumsParser.getWifiCiphers(Optional.ofNullable(gwtWifiConfig.getGroupCiphers())));
 
         // wifi master specific properties
         this.properties.setWifiMasterRadioMode(this.ifname,
@@ -156,8 +157,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
         this.properties.setWifiInfraSecurityType(this.ifname,
                 EnumsParser.getWifiSecurity(Optional.ofNullable(gwtWifiConfig.getSecurity())));
         this.properties.setWifiInfraPairwiseCiphers(this.ifname,
-                Optional.ofNullable(gwtWifiConfig.getPairwiseCiphers()));
-        this.properties.setWifiInfraGroupCiphers(this.ifname, Optional.ofNullable(gwtWifiConfig.getGroupCiphers()));
+                EnumsParser.getWifiCiphers(Optional.ofNullable(gwtWifiConfig.getPairwiseCiphers())));
+        this.properties.setWifiInfraGroupCiphers(this.ifname,
+                EnumsParser.getWifiCiphers(Optional.ofNullable(gwtWifiConfig.getGroupCiphers())));
 
         // wifi infra specific properties
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -96,15 +96,21 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
     private void setWifiProperties() {
         if (this.gwtConfig instanceof GwtWifiNetInterfaceConfig) {
-            String wifiMode = EnumsParser
-                    .getWifiMode(Optional.ofNullable(((GwtWifiNetInterfaceConfig) this.gwtConfig).getWirelessMode()));
+            GwtWifiWirelessMode wifiMode = ((GwtWifiNetInterfaceConfig) this.gwtConfig).getWirelessModeEnum();
 
-            if (wifiMode.equals(GwtWifiWirelessMode.netWifiWirelessModeAccessPoint.name())) {
-                setWifiMasterProperties();
-            }
-
-            if (wifiMode.equals(GwtWifiWirelessMode.netWifiWirelessModeStation.name())) {
-                setWifiInfraProperties();
+            switch (wifiMode) {
+                case netWifiWirelessModeAccessPoint:
+                    setWifiMasterProperties();
+                    break;
+                case netWifiWirelessModeAdHoc:
+                    break;
+                case netWifiWirelessModeDisabled:
+                    break;
+                case netWifiWirelessModeStation:
+                    setWifiInfraProperties();
+                    break;
+                default:
+                    break;
             }
         }
     }
@@ -118,7 +124,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
         this.properties.setWifiMasterDriver(this.ifname, gwtWifiConfig.getDriver());
         this.properties.setWifiMasterIgnoreSsid(this.ifname, gwtWifiConfig.ignoreSSID());
         this.properties.setWifiMasterPassphrase(this.ifname, gwtWifiConfig.getPassword());
-        this.properties.setWifiMasterChannel(this.ifname, gwtWifiConfig.getChannels().get(0));
+        this.properties.setWifiMasterChannel(this.ifname, gwtWifiConfig.getChannels());
 
         this.properties.setWifiMasterMode(this.ifname,
                 EnumsParser.getWifiMode(Optional.ofNullable(gwtWifiConfig.getWirelessMode())));
@@ -143,7 +149,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
         this.properties.setWifiInfraDriver(this.ifname, gwtWifiConfig.getDriver());
         this.properties.setWifiInfraIgnoreSsid(this.ifname, gwtWifiConfig.ignoreSSID());
         this.properties.setWifiInfraPassphrase(this.ifname, gwtWifiConfig.getPassword());
-        this.properties.setWifiInfraChannel(this.ifname, gwtWifiConfig.getChannels().get(0));
+        this.properties.setWifiInfraChannel(this.ifname, gwtWifiConfig.getChannels());
 
         this.properties.setWifiInfraMode(this.ifname,
                 EnumsParser.getWifiMode(Optional.ofNullable(gwtWifiConfig.getWirelessMode())));


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

This PR adds the list of all possible values for channel frequencies in the 2.4GHz and 5GHz bands for the web UI.

**Related Issue:** N/A.

**Description of the solution adopted:** The generated list seems coherent with the central frequencies: https://en.wikipedia.org/wiki/List_of_WLAN_channels.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.