### PR TITLE
docs(container.orchestrator): updated Creating container guide to explain that the name set for PID will be the container name

### DIFF
--- a/docs/core-services/container-orchestration-provider-usage.md
+++ b/docs/core-services/container-orchestration-provider-usage.md
@@ -23,8 +23,8 @@ To use this service select the **ContainerOrchestrationService** option located 
 
 To create a container, select the `+` icon (Create a new component) under **services**. A popup dialogue box will appear. In the field **Factory** select **org.eclipse.kura.container.provider.ContainerInstance** from the drop-down. Then, use the **Name** field to specify a name for the container.
 
-    !!! Note on the 'Name' feild.
-        The name specified in this field will also be the name of the container when it is spun up by the orchestrator.
+!!! note
+    The name specified in the 'Name' field will also be the name of the container when it is spun up by the orchestrator.
 
 After pressing submit, a new component will be added under the **services** tab, with the name that was selected in the dialogue. Select this component to finish configuring the container.
 

--- a/docs/core-services/container-orchestration-provider-usage.md
+++ b/docs/core-services/container-orchestration-provider-usage.md
@@ -21,7 +21,7 @@ To use this service select the **ContainerOrchestrationService** option located 
 
 ## Creating your first container.
 
-To create a container, select the + icon (Create a new component) under **services**. A popup dialogue box will appear. In the field **Factory** select **org.eclipse.kura.container.provider.ContainerInstance** from the drop-down. Then, use the **Name** field to specify a name for the container.
+To create a container, select the `+` icon (Create a new component) under **services**. A popup dialogue box will appear. In the field **Factory** select **org.eclipse.kura.container.provider.ContainerInstance** from the drop-down. Then, use the **Name** field to specify a name for the container.
 
     !!! Note on the 'Name' feild.
         The name specified in this field will also be the name of the container when it is spun up by the orchestrator.

--- a/docs/core-services/container-orchestration-provider-usage.md
+++ b/docs/core-services/container-orchestration-provider-usage.md
@@ -21,7 +21,10 @@ To use this service select the **ContainerOrchestrationService** option located 
 
 ## Creating your first container.
 
-To create a container, select the + icon (Create a new component) under **services**. A popup dialogue box will appear. In the field **Factory** select **org.eclipse.kura.container.provider.ContainerInstance** from the drop-down. Then, using the **Name** field, enter the name of the container you wish to create and Finally press submit to create the component.
+To create a container, select the + icon (Create a new component) under **services**. A popup dialogue box will appear. In the field **Factory** select **org.eclipse.kura.container.provider.ContainerInstance** from the drop-down. Then, use the **Name** field to specify a name for the container.
+
+    !!! Note on the 'Name' feild.
+        The name specified in this field will also be the name of the container when it is spun up by the orchestrator.
 
 After pressing submit, a new component will be added under the **services** tab, with the name that was selected in the dialogue. Select this component to finish configuring the container.
 


### PR DESCRIPTION
updated Creating container guide to explain that the name set for PID will be the container name

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:**

**Description of the solution adopted:** 

**Screenshots:** <img width="901" alt="image" src="https://user-images.githubusercontent.com/29900100/218116553-e6f6bc80-3ad4-40d8-a9df-549c0625a651.png">

**Any side note on the changes made:**
