### PR TITLE
fix: Use 0..1 cardinality for store reference in db wire components

### DIFF
--- a/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/DbWireRecordFilterComponent.xml
+++ b/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/DbWireRecordFilterComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2022, 2023 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,6 @@
            policy="dynamic"
            bind="bindDbService"
            unbind="unbindDbService"
-           cardinality="1..1"
+           cardinality="0..1"
            interface="org.eclipse.kura.db.BaseDbService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/DbWireRecordStoreComponent.xml
+++ b/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/DbWireRecordStoreComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2022, 2023 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,6 @@
            policy="dynamic"
            bind="bindDbService"
            unbind="unbindDbService"
-           cardinality="1..1"
+           cardinality="0..1"
            interface="org.eclipse.kura.db.BaseDbService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/WireRecordQueryComponent.xml
+++ b/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/WireRecordQueryComponent.xml
@@ -41,6 +41,6 @@
            policy="dynamic"
            bind="bindQueryableWireRecordStoreProvider"
            unbind="unbindQueryableWireRecordStoreProvider"
-           cardinality="1..1"
+           cardinality="0..1"
            interface="org.eclipse.kura.wire.store.provider.QueryableWireRecordStoreProvider"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/WireRecordStoreComponent.xml
+++ b/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/WireRecordStoreComponent.xml
@@ -41,6 +41,6 @@
            policy="dynamic"
            bind="bindWireRecordStoreProvider"
            unbind="unbindWireRecordStoreProvider"
-           cardinality="1..1"
+           cardinality="0..1"
            interface="org.eclipse.kura.wire.store.provider.WireRecordStoreProvider"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/DbWireRecordFilterComponent.xml
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/DbWireRecordFilterComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2023 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,6 @@
            policy="dynamic"
            bind="bindDbService"
            unbind="unbindDbService"
-           cardinality="1..1"
+           cardinality="0..1"
            interface="org.eclipse.kura.db.H2DbService"/>
 </scr:component>

--- a/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/DbWireRecordStoreComponent.xml
+++ b/kura/org.eclipse.kura.wire.h2db.component.provider/OSGI-INF/DbWireRecordStoreComponent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     
-    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2023 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,6 @@
            policy="dynamic"
            bind="bindDbService"
            unbind="unbindDbService"
-           cardinality="1..1"
+           cardinality="0..1"
            interface="org.eclipse.kura.db.H2DbService"/>
 </scr:component>


### PR DESCRIPTION
Signed-off-by: Nicola Timeus <nicola.timeus@eurotech.com>

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

This PR changes the cardinality of the store reference of all existing wire components from 1..1 to 0..1.

While it may be desirable to have the component deactivated if the target reference is not satisfied, this causes the current Web UI to display the component in red if this happens, the user is then required to delete and recreate the wire component in order to change its configuration.

This PR changes the cardinality from 1..1 to 0..1 for consistency with the other Kura components that use dynamic references.



