### PR TITLE
fix(web2): apply button dirty on modified priority

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
@@ -433,7 +433,8 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
                 TabTcpIpUi.this.helpText.add(new Span(MSGS.netIPv4ToolTipPriority()));
             }
         });
-        this.status.addMouseOutHandler(event -> resetHelp());
+        this.priority.addMouseOutHandler(event -> resetHelp());
+        this.priority.addValueChangeHandler(valChangeEvent -> setDirty(true));
     }
 
     private void initDHCPLeaseField() {


### PR DESCRIPTION
Signed-off-by: Marcello Martina <martina.marcello.rinaldo@outlook.com>

After modifying the **WAN Priority** field, the apply button remained disabled. This PR sets the dirty flag to enable the apply button after a modification.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
