### PR TITLE
fix(web2): logic fixes on net config update

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.net.NetConfig;
-import org.eclipse.kura.net.admin.FirewallConfigurationService;
 import org.eclipse.kura.net.firewall.FirewallNatConfig;
 import org.eclipse.kura.net.firewall.FirewallOpenPortConfigIP4;
 import org.eclipse.kura.net.firewall.FirewallPortForwardConfigIP4;
@@ -33,6 +32,7 @@ import org.eclipse.kura.web.shared.model.GwtFirewallPortForwardEntry;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.eclipse.kura.net.admin.FirewallConfigurationService;
 
 public class GwtNetworkServiceImpl {
 
@@ -67,6 +67,9 @@ public class GwtNetworkServiceImpl {
     public static void updateNetInterfaceConfigurations(GwtNetInterfaceConfig config) throws GwtKuraException {
         try {
             NetworkConfigurationServiceAdapter adapter = new NetworkConfigurationServiceAdapter();
+
+            logger.debug("Updating Network Configuration Service with properties:\n{}\n", config.getProperties());
+
             adapter.updateConfiguration(config);
         } catch (GwtKuraException | KuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
@@ -60,7 +60,7 @@ public class NetworkConfigurationServiceAdapter {
      */
     public void updateConfiguration(GwtNetInterfaceConfig gwtConfig) throws KuraException {
         NetworkConfigurationServicePropertiesBuilder builder = new NetworkConfigurationServicePropertiesBuilder(
-                gwtConfig);
+                gwtConfig, this.netConfServProperties);
         Map<String, Object> newProperties = builder.build();
 
         this.configurationService.updateConfiguration(NETWORK_CONFIGURATION_SERVICE_PID, newProperties);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -13,7 +13,6 @@
 package org.eclipse.kura.web.server.net2.configuration;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -31,10 +30,6 @@ public class NetworkConfigurationServiceProperties {
     private static final String NA = "N/A";
     private static final Logger logger = LoggerFactory.getLogger(NetworkConfigurationServiceProperties.class);
 
-    public NetworkConfigurationServiceProperties() {
-        this.properties = new HashMap<>();
-    }
-
     public NetworkConfigurationServiceProperties(Map<String, Object> properties) {
         this.properties = properties;
     }
@@ -49,16 +44,29 @@ public class NetworkConfigurationServiceProperties {
 
     private static final String NET_INTERFACES = "net.interfaces";
 
-    public List<String> getNetworkInterfaces() {
+    public void addNetworkInterfaceIfNotPresent(String ifname) {
         List<String> ifnames = new LinkedList<>();
 
         String netInterfaces = (String) this.properties.get(NET_INTERFACES);
         String[] interfaces = netInterfaces.split(",");
+
         for (String name : interfaces) {
             ifnames.add(name.trim());
         }
 
-        return ifnames;
+        if (!ifnames.contains(ifname)) {
+            ifnames.add(ifname);
+        }
+
+        StringBuilder result = new StringBuilder();
+
+        for (String name : ifnames) {
+            result.append(name);
+            result.append(",");
+        }
+        
+        String withoutTrailingComma = result.toString().substring(0, result.length() - 1);
+        this.properties.put(NET_INTERFACES, withoutTrailingComma);
     }
 
     /*

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import org.eclipse.kura.web.server.net2.utils.EnumsParser;
 import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetIfConfigMode;
+import org.eclipse.kura.web.shared.model.GwtNetIfStatus;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetRouterMode;
 import org.eclipse.kura.web.shared.model.GwtWifiConfig;
@@ -60,11 +61,24 @@ public class NetworkConfigurationServicePropertiesBuilder {
     private void setIpv4Properties() {
         this.properties.setIp4Status(this.ifname,
                 EnumsParser.getNetInterfaceStatus(Optional.ofNullable(this.gwtConfig.getStatus())));
-        this.properties.setIp4WanPriority(ifname, this.gwtConfig.getWanPriority());
-        this.properties.setIp4Address(this.ifname, this.gwtConfig.getIpAddress());
-        this.properties.setIp4Netmask(this.ifname, this.gwtConfig.getSubnetMask());
-        this.properties.setIp4Gateway(this.ifname, this.gwtConfig.getGateway());
-        this.properties.setIp4DnsServers(this.ifname, this.gwtConfig.getDnsServers());
+
+        boolean isDhcpClient = this.gwtConfig.getConfigMode().equals(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
+        boolean isManual = !isDhcpClient;
+        boolean isWan = this.gwtConfig.getStatus().equals(GwtNetIfStatus.netIPv4StatusEnabledWAN.name());
+
+        if (isWan) {
+            this.properties.setIp4WanPriority(ifname, this.gwtConfig.getWanPriority());
+            this.properties.setIp4DnsServers(this.ifname, this.gwtConfig.getDnsServers());
+        }
+
+        if (isManual) {
+            this.properties.setIp4Address(this.ifname, this.gwtConfig.getIpAddress());
+            this.properties.setIp4Netmask(this.ifname, this.gwtConfig.getSubnetMask());
+        }
+
+        if (isManual && isWan) {
+            this.properties.setIp4Gateway(this.ifname, this.gwtConfig.getGateway());
+        }
     }
 
     private void setIpv4DhcpClientProperties() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -31,10 +31,12 @@ public class NetworkConfigurationServicePropertiesBuilder {
     private final NetworkConfigurationServiceProperties properties;
     private final String ifname;
 
-    public NetworkConfigurationServicePropertiesBuilder(GwtNetInterfaceConfig gwtConfig) {
+    public NetworkConfigurationServicePropertiesBuilder(GwtNetInterfaceConfig gwtConfig,
+            Map<String, Object> currentNetConfServProps) {
         this.gwtConfig = gwtConfig;
-        this.properties = new NetworkConfigurationServiceProperties();
+        this.properties = new NetworkConfigurationServiceProperties(currentNetConfServProps);
         this.ifname = this.gwtConfig.getName();
+        this.properties.addNetworkInterfaceIfNotPresent(ifname);
     }
 
     public Map<String, Object> build() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -89,9 +89,6 @@ public class NetworkStatusServiceAdapter {
         if (networkInterface.getUsbDevice() != null) {
             gwtConfig.setHwUsbDevice(networkInterface.getUsbDevice().getUsbDevicePath());
         }
-
-        logger.debug("GWT common state properties for interface {}:\\n{}\\n", gwtConfig.getName(),
-                gwtConfig.getProperties());
     }
 
     private void setIpv4DhcpClientProperties(GwtNetInterfaceConfig gwtConfig,

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
@@ -44,11 +44,11 @@ public class GwtNetInterfaceConfig extends KuraBaseModel implements Serializable
         set("status", status);
     }
 
-    public int getWanPriority() {
+    public Integer getWanPriority() {
         return get("priority");
     }
 
-    public void setWanPriority(int priority) {
+    public void setWanPriority(Integer priority) {
         set("priority", priority);
     }
 


### PR DESCRIPTION
Fixed the population of properties related to the TCP IP stack, added unseen network interface names in snapshot property.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
