### PR TITLE
test: Coverage for NMSettingConverter

### DIFF
--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -721,21 +721,6 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullDnsServer() {
-		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.eth0.config.ip4.dnsServers", null);
-		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
-				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-
-	}
-
-	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiSsid() {
 		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
 		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -349,18 +349,13 @@ public class NMSettingsConverterTest {
 
 	public void givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(String inter, Boolean dhcpStatus,
 			String netStatus) {
-		internetNetworkPropertiesInstanciationMap
-				.put(String.format("net.interface.%s.config.dhcpClient4.enabled", inter), dhcpStatus);
-		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.status", inter),
-				netStatus);
-		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.address", inter),
-				"192.168.0.12");
-		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.prefix", inter),
-				(short) 25);
-		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.dnsServers", inter),
-				"1.1.1.1");
-		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.gateway", inter),
-				"192.168.0.1");
+		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.dhcpClient4.enabled",
+				dhcpStatus);
+		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.status", netStatus);
+		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.address", "192.168.0.12");
+		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.prefix", (short) 25);
+		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.dnsServers", "1.1.1.1");
+		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.gateway", "192.168.0.1");
 	}
 
 	public void givenExpectedValidWifiConfigurationSetToLan(String inter) {
@@ -469,23 +464,20 @@ public class NMSettingsConverterTest {
 
 	public void givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(String inter, String ssid,
 			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
-		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.wifi.mode", inter),
-				propMode);
+		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.wifi.mode", propMode);
 		internetNetworkPropertiesInstanciationMap.put(
-				String.format("net.interface.%s.config.wifi.%s.passphrase", inter, propMode.toLowerCase()),
+				"net.interface." + inter + ".config.wifi." + propMode.toLowerCase() + ".passphrase",
 				new Password("test"));
 		internetNetworkPropertiesInstanciationMap.put(
-				String.format("net.interface.%s.config.wifi.%s.securityType", inter, propMode.toLowerCase()),
+				"net.interface." + inter + ".config.wifi." + propMode.toLowerCase() + ".securityType",
 				"SECURITY_WPA_WPA2");
 		if (groupEnabled) {
-			internetNetworkPropertiesInstanciationMap.put(
-					String.format("net.interface.%s.config.wifi.%s.groupCiphers", inter, propMode.toLowerCase()),
-					"CCMP");
+			internetNetworkPropertiesInstanciationMap
+					.put("net.interface." + inter + ".config.wifi." + propMode.toLowerCase() + ".groupCiphers", "CCMP");
 		}
 		if (ciphersEnabled) {
 			internetNetworkPropertiesInstanciationMap.put(
-					String.format("net.interface.%s.config.wifi.%s.pairwiseCiphers", inter, propMode.toLowerCase()),
-					"CCMP");
+					"net.interface." + inter + ".config.wifi." + propMode.toLowerCase() + ".pairwiseCiphers", "CCMP");
 		}
 	}
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -140,8 +140,8 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
-		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true, false);
-		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true, false);
+		givenValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "testssid", "INFRA", true, false);
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "testssid", "infrastructure", true, false);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -150,8 +150,8 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
-		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
-		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters("wlan0", "ssidtest", "propmode", true, true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters("wlan0", "ssidtest", "propmode", true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -167,10 +167,10 @@ public class NMSettingsConverterTest {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
-		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, false);
-		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, false);
-		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, false);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
 				true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
@@ -189,10 +189,10 @@ public class NMSettingsConverterTest {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
-		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, false);
-		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, false);
-		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, false);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
 				true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
@@ -211,10 +211,10 @@ public class NMSettingsConverterTest {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
-		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, false);
-		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, false);
-		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, false);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
 				true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
@@ -233,10 +233,10 @@ public class NMSettingsConverterTest {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
-		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, true);
-		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, true);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
 				true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
@@ -255,10 +255,10 @@ public class NMSettingsConverterTest {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
-		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, true);
-		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, true);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
 				true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
@@ -346,7 +346,7 @@ public class NMSettingsConverterTest {
 
 		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
 
-		givenValidBuildIpv4Config(dhcpStatus);
+		givenValidBuildIpv4ConfigWithDhcpStatusSetTo(dhcpStatus);
 		givenValidBuildIpv6Config();
 		if (netStatus.equals("netIPv4StatusEnabledLAN")) {
 			internalMethodHashMap.put("ignore-auto-dns", new Variant<>(true));
@@ -367,7 +367,7 @@ public class NMSettingsConverterTest {
 
 	}
 
-	public void givenValidBuildIpv4Config(boolean dhcpStatus) {
+	public void givenValidBuildIpv4ConfigWithDhcpStatusSetTo(boolean dhcpStatus) {
 		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
 		if (!dhcpStatus) {
 			internalMethodHashMap.put("method", new Variant<>("manual"));
@@ -392,7 +392,7 @@ public class NMSettingsConverterTest {
 		this.internalComparatorAllSettingsMap.put("ipv6", internalMethodHashMap);
 	}
 
-	public void givenValid80211WirelessSettingsWithInterfaceNameAndSsid(String inter, String ssid, String propMode,
+	public void givenValid80211WirelessSettingsWithTheFollowingParameters(String inter, String ssid, String propMode,
 			Boolean channelEnabled, Boolean isHidden) {
 		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.wifi.mode", inter),
 				propMode);
@@ -413,7 +413,7 @@ public class NMSettingsConverterTest {
 		
 	}
 
-	public void givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(String inter, String ssid,
+	public void givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(String inter, String ssid,
 			String propMode, Boolean channelEnabled, Boolean isHidden) {
 
 		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
@@ -434,7 +434,7 @@ public class NMSettingsConverterTest {
 		this.internalComparatorMap.putAll(internalMethodHashMap);
 	}
 
-	public void givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(String inter, String ssid,
+	public void givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(String inter, String ssid,
 			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
 		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.wifi.mode", inter),
 				propMode);
@@ -456,7 +456,7 @@ public class NMSettingsConverterTest {
 		}
 	}
 
-	public void givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(String inter, String ssid,
+	public void givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(String inter, String ssid,
 			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
 
 		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -830,13 +830,10 @@ public class NMSettingsConverterTest {
         try {
             this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
         } catch (NoSuchElementException e) {
-            e.printStackTrace();
             this.hasNoSuchElementExceptionBeenThrown = true;
         } catch (IllegalArgumentException e) {
-            e.printStackTrace();
             this.hasAnIllegalArgumentExceptionThrown = true;
         } catch (Exception e) {
-            e.printStackTrace();
             this.hasAGenericExecptionBeenThrown = true;
         }
     }
@@ -845,13 +842,10 @@ public class NMSettingsConverterTest {
         try {
             this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
         } catch (NoSuchElementException e) {
-            e.printStackTrace();
             this.hasNoSuchElementExceptionBeenThrown = true;
         } catch (IllegalArgumentException e) {
-            e.printStackTrace();
             this.hasAnIllegalArgumentExceptionThrown = true;
         } catch (Exception e) {
-            e.printStackTrace();
             this.hasAGenericExecptionBeenThrown = true;
         }
     }
@@ -860,13 +854,10 @@ public class NMSettingsConverterTest {
         try {
             this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
         } catch (NoSuchElementException e) {
-            e.printStackTrace();
             this.hasNoSuchElementExceptionBeenThrown = true;
         } catch (IllegalArgumentException e) {
-            e.printStackTrace();
             this.hasAnIllegalArgumentExceptionThrown = true;
         } catch (Exception e) {
-            e.printStackTrace();
             this.hasAGenericExecptionBeenThrown = true;
         }
     }
@@ -875,13 +866,10 @@ public class NMSettingsConverterTest {
         try {
             this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
         } catch (NoSuchElementException e) {
-            e.printStackTrace();
             this.hasNoSuchElementExceptionBeenThrown = true;
         } catch (IllegalArgumentException e) {
-            e.printStackTrace();
             this.hasAnIllegalArgumentExceptionThrown = true;
         } catch (Exception e) {
-            e.printStackTrace();
             this.hasAGenericExecptionBeenThrown = true;
         }
     }
@@ -890,13 +878,10 @@ public class NMSettingsConverterTest {
         try {
             this.resultMap = NMSettingsConverter.buildConnectionSettings(connection, iface, deviceType);
         } catch (NoSuchElementException e) {
-            e.printStackTrace();
             this.hasNoSuchElementExceptionBeenThrown = true;
         } catch (IllegalArgumentException e) {
-            e.printStackTrace();
             this.hasAnIllegalArgumentExceptionThrown = true;
         } catch (Exception e) {
-            e.printStackTrace();
             this.hasAGenericExecptionBeenThrown = true;
         }
     }
@@ -905,13 +890,10 @@ public class NMSettingsConverterTest {
         try {
             this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
         } catch (NoSuchElementException e) {
-            e.printStackTrace();
             this.hasNoSuchElementExceptionBeenThrown = true;
         } catch (IllegalArgumentException e) {
-            e.printStackTrace();
             this.hasAnIllegalArgumentExceptionThrown = true;
         } catch (Exception e) {
-            e.printStackTrace();
             this.hasAGenericExecptionBeenThrown = true;
         }
     }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -467,7 +467,9 @@ public class NMSettingsConverterTest {
 		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
 	}
 
-	// given
+	/*
+	 * Given
+	 */
 
 	public void givenNetworkPropsCreatedWithTheMap(Map<String, Object> properties) {
 		this.networkProperties = new NetworkProperties(properties);
@@ -477,7 +479,9 @@ public class NMSettingsConverterTest {
 		this.internetNetworkPropertiesInstanciationMap.put(key, value);
 	}
 
-	// when
+	/*
+	 * When
+	 */
 
 	public void whenBuildSettingsIsRunWith(NetworkProperties properties, Optional<Connection> oldConnection,
 			String iface, NMDeviceType deviceType) {
@@ -540,7 +544,10 @@ public class NMSettingsConverterTest {
 		}
 	}
 
-	// then
+	/*
+	 * Then
+	 */
+	
 	public void thenResultingMapContains(String key, Object value) {
 		assertEquals(value, this.resultMap.get(key).getValue());
 	}
@@ -566,7 +573,10 @@ public class NMSettingsConverterTest {
 		assertFalse(this.hasAGenericExecptionBeenThrown);
 	}
 
-	//helper classes
+	/*
+	 * Helper Methods
+	 */
+	
 	public Object buildAddressDataWith(String ipAddr, UInt32 prefix) {
 		
 		Map<String, Variant<?>> addressEntry = new HashMap<>();
@@ -575,8 +585,8 @@ public class NMSettingsConverterTest {
 		
 		List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
 		
-		Variant<?> dataVarient = new Variant<>(addressData, "aa{sv}");
+		Variant<?> dataVariant = new Variant<>(addressData, "aa{sv}");
 		
-		return dataVarient.getValue();
+		return dataVariant.getValue();
 	}
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -47,7 +47,7 @@ public class NMSettingsConverterTest {
 	Boolean hasAGenericExecptionBeenThrown = false;
 
 	@Test
-	public void shouldThrowErrorWhenBuildSettingsWithEmptyMap() {
+	public void buildSettingsShouldThrowWhenGivenEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
@@ -56,7 +56,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldThrowErrorWhenBuildIpv4SettingsWithEmptyMap() {
+	public void buildIpv4SettingsShouldThrowWhenGivenEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
@@ -64,7 +64,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldThrowErrorWhenBuildIpv6SettingsWithEmptyMap() {
+	public void buildIpv6SettingsShouldThrowErrorWhenWhenGivenEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
@@ -72,7 +72,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldThrowErrorWhenBuild80211WirelessSettingsWithEmptyMap() {
+	public void build80211WirelessSettingsShouldThrowErrorWhenGivenEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
@@ -80,7 +80,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldThrowErrorWhenBuild80211WirelessSecuritySettingsWithEmptyMap() {
+	public void build80211WirelessSecuritySettingsShouldThrowWhenGivenEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
@@ -88,7 +88,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpEnabledForWAN() {
+	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForWan() {
 		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledWAN");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
@@ -100,7 +100,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpDisabledForWAN() {
+	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForWan() {
 		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledWAN");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
@@ -113,7 +113,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpEnabledForLAN() {
+	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForLan() {
 		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledLAN");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
@@ -125,7 +125,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpDisabledForLAN() {
+	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForLan() {
 		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledLAN");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
@@ -137,7 +137,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpDisabledForOther() {
+	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndUnmanaged() {
 		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
@@ -149,7 +149,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldBuild80211WirelessSettingsWithExpectedInputs() {
+	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
 		givenEmptyMaps();
 		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true);
 		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true);
@@ -160,7 +160,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldBuild80211WirelessSecurityWithExpectedInputs() {
+	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
 		givenEmptyMaps();
 		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
 		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
@@ -171,7 +171,7 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void shouldBuildSettingsWithExpectedInputs() {
+	public void buildSettingsShouldWorkWithExpectedInputs() {
 		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -45,6 +45,9 @@ public class NMSettingsConverterTest {
 
 	Boolean hasIllegalArgumentExceptionBeenThrown = false;
 	Boolean hasAGenericExecptionBeenThrown = false;
+	
+	String netInterface; 
+	String kuraIP4Status;
 
 	@Test
 	public void buildSettingsShouldThrowWhenGivenEmptyMap() {
@@ -167,10 +170,10 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiUnmanged() {
 
-		String netInterface = "wlan0";
-		String kuraNetType = "netIPv4StatusUnmanaged";
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusUnmanaged");
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
@@ -191,10 +194,10 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLan() {
 
-		String netInterface = "wlan0";
-		String kuraNetType = "netIPv4StatusManagedLan";
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusManagedLan");
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan(netInterface);
@@ -216,10 +219,10 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildSettingsShouldWorkWithExpectedConfiguredForInputsWiFiWan() {
 
-		String netInterface = "wlan0";
-		String kuraNetType = "netIPv4StatusManagedWan";
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusManagedWan");
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToWan(netInterface);
@@ -241,10 +244,10 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLanAndHiddenSsid() {
 
-		String netInterface = "wlan0";
-		String kuraNetType = "netIPv4StatusManagedLan";
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusManagedLan");
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan(netInterface);
@@ -266,10 +269,10 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
 
-		String netInterface = "wlan0";
-		String kuraNetType = "netIPv4StatusManagedWan";
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusManagedWan");
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToWan(netInterface);
@@ -291,10 +294,10 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndUnmanaged() {
 
-		String netInterface = "eth0";
-		String kuraNetType = "netIPv4StatusUnmanaged";
+		givenNetInterface("eth0");
+		givenIP4Status("netIPv4StatusUnmanaged");
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
@@ -308,10 +311,10 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
 
-		String netInterface = "eth0";
-		String kuraNetType = "netIPv4StatusManagedLan";
+		givenNetInterface("eth0");
+		givenIP4Status("netIPv4StatusManagedLan");
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan(netInterface);
@@ -326,10 +329,10 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
 
-		String netInterface = "eth0";
-		String kuraNetType = "netIPv4StatusManagedWan";
+		givenNetInterface("eth0");
+		givenIP4Status("netIPv4StatusManagedWan");
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToWan(netInterface);
@@ -342,6 +345,14 @@ public class NMSettingsConverterTest {
 	}
 
 	// given
+	
+	public void givenNetInterface(String netInterface){
+		this.netInterface = netInterface;
+	}
+	
+	public void givenIP4Status(String kuraIP4Status){
+		this.kuraIP4Status = kuraIP4Status;
+	}
 
 	public void givenNetworkPropsCreatedWithTheMap(Map<String, Object> properties) {
 		this.networkProperties = new NetworkProperties(properties);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -162,8 +162,8 @@ public class NMSettingsConverterTest {
 	@Test
 	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
 		givenEmptyMaps();
-		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
-		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -178,8 +178,8 @@ public class NMSettingsConverterTest {
 				"netIPv4StatusUnmanaged");
 		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true);
 		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true);
-		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
-		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
@@ -322,8 +322,10 @@ public class NMSettingsConverterTest {
 		try {
 			this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
 		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
 			hasIllegalArgumentExceptionBeenThrown = true;
 		} catch (Exception e) {
+			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
 		}
 	}
@@ -332,8 +334,10 @@ public class NMSettingsConverterTest {
 		try {
 			this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
 		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
 			hasIllegalArgumentExceptionBeenThrown = true;
 		} catch (Exception e) {
+			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
 		}
 	}
@@ -342,8 +346,10 @@ public class NMSettingsConverterTest {
 		try {
 			this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
 		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
 			hasIllegalArgumentExceptionBeenThrown = true;
 		} catch (Exception e) {
+			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
 		}
 	}
@@ -353,8 +359,10 @@ public class NMSettingsConverterTest {
 		try {
 			this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
 		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
 			hasIllegalArgumentExceptionBeenThrown = true;
 		} catch (Exception e) {
+			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
 		}
 	}
@@ -364,8 +372,10 @@ public class NMSettingsConverterTest {
 		try {
 			this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
 		} catch (IllegalArgumentException e) {
+			e.printStackTrace();
 			hasIllegalArgumentExceptionBeenThrown = true;
 		} catch (Exception e) {
+			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
 		}
 	}
@@ -377,12 +387,11 @@ public class NMSettingsConverterTest {
 	}
 	
 	public void thenMapResultFromWifiSettingsShouldEqualInternalMapForWifiSettings() {
-		//Workaround to compare String.getBytes()
+		//Workaround to compare String.getBytes(StandardCharsets.UTF_8)
 		
 		String  internalSsid = new String((byte[]) internalComparatorMap.get("ssid").getValue(), StandardCharsets.UTF_8);
 		String resultSsid = new String((byte[]) this.resultMap.get("ssid").getValue(), StandardCharsets.UTF_8);
 
-		//.getBytes(StandardCharsets.UTF_8)
 		assertEquals(internalSsid, resultSsid);
 		
 		//Remove ssid fields from Maps before comparison

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -227,7 +227,7 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("mode", "infrastructure");
         thenResultingMapContainsBytes("ssid", "ssidtest");
         thenResultingMapContains("band", "bg");
-        thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
+        thenResultingMapContains("channel", new UInt32(10));
     }
 
     @Test
@@ -245,7 +245,7 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("mode", "infrastructure");
         thenResultingMapContainsBytes("ssid", "ssidtest");
         thenResultingMapContains("band", "bg");
-        thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
+        thenResultingMapContains("channel", new UInt32(10));
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -85,8 +85,9 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForWan() {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledWAN");
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
-				"netIPv4StatusEnabledWAN");
+		givenValidBuildIpv4ConfigWithDhcpEnabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToWan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -96,8 +97,9 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForWan() {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledWAN");
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
-				"netIPv4StatusEnabledWAN");
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToWan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -108,8 +110,9 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForLan() {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledLAN");
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
-				"netIPv4StatusEnabledLAN");
+		givenValidBuildIpv4ConfigWithDhcpEnabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToLan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -119,8 +122,9 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForLan() {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledLAN");
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
-				"netIPv4StatusEnabledLAN");
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToLan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -130,8 +134,8 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndUnmanaged() {
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
-				"netIPv4StatusUnmanaged");
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -141,7 +145,8 @@ public class NMSettingsConverterTest {
 	@Test
 	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
 		givenValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "testssid", "INFRA", true, false);
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "testssid", "infrastructure", true, false);
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "testssid", "infrastructure", true,
+				false);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -151,7 +156,8 @@ public class NMSettingsConverterTest {
 	@Test
 	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
 		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters("wlan0", "ssidtest", "propmode", true, true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters("wlan0", "ssidtest", "propmode", true, true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters("wlan0", "ssidtest", "propmode", true,
+				true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -160,18 +166,20 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiUnmanged() {
-		
+
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusUnmanaged";
-		
+
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
-				kuraNetType);
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
 		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, false);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, false);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
 				true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
@@ -179,21 +187,24 @@ public class NMSettingsConverterTest {
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLan() {
-		
+
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusManagedLan";
-		
+
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
-				kuraNetType);
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToLan(netInterface);
 		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, false);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, false);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
 				true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
@@ -201,21 +212,24 @@ public class NMSettingsConverterTest {
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldWorkWithExpectedConfiguredForInputsWiFiWan() {
-		
+
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusManagedWan";
-		
+
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
-				kuraNetType);
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToWan(netInterface);
 		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, false);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, false);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
 				true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
@@ -223,21 +237,24 @@ public class NMSettingsConverterTest {
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLanAndHiddenSsid() {
-		
+
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusManagedLan";
-		
+
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
-				kuraNetType);
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToLan(netInterface);
 		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, true);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, true);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
 				true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
@@ -245,21 +262,24 @@ public class NMSettingsConverterTest {
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
-		
+
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusManagedWan";
-		
+
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
-				kuraNetType);
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToWan(netInterface);
 		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true, true);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure", true,
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, true);
+		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
 				true);
+		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
+				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
@@ -267,16 +287,16 @@ public class NMSettingsConverterTest {
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndUnmanaged() {
-		
+
 		String netInterface = "eth0";
 		String kuraNetType = "netIPv4StatusUnmanaged";
-		
+
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
-				kuraNetType);
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
@@ -284,16 +304,17 @@ public class NMSettingsConverterTest {
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
-		
+
 		String netInterface = "eth0";
 		String kuraNetType = "netIPv4StatusManagedLan";
-		
+
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
-				kuraNetType);
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToLan(netInterface);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
@@ -301,16 +322,17 @@ public class NMSettingsConverterTest {
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
-		
+
 		String netInterface = "eth0";
 		String kuraNetType = "netIPv4StatusManagedWan";
-		
+
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
-				kuraNetType);
+		givenValidBuildIpv4ConfigWithDhcpDisabled();
+		givenValidBuildIpv6Config();
+		givenExpectedValidWifiConfigurationSetToWan(netInterface);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
@@ -341,47 +363,57 @@ public class NMSettingsConverterTest {
 				"192.168.0.1");
 	}
 
-	public void givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(String inter,
-			Boolean dhcpStatus, String netStatus) {
+	public void givenExpectedValidWifiConfigurationSetToLan(String inter) {
 
 		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
 
-		givenValidBuildIpv4ConfigWithDhcpStatusSetTo(dhcpStatus);
-		givenValidBuildIpv6Config();
-		if (netStatus.equals("netIPv4StatusEnabledLAN")) {
+		internalMethodHashMap.put("ignore-auto-dns", new Variant<>(true));
+		internalMethodHashMap.put("ignore-auto-routes", new Variant<>(true));
+
+		this.internalComparatorMap.putAll(internalMethodHashMap);
+
+	}
+
+	public void givenExpectedValidWifiConfigurationSetToWan(String inter) {
+
+		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
+
+		Optional<List<String>> dnsServers = Optional.of(Arrays.asList("1.1.1.1"));
+		if (dnsServers.isPresent()) {
+			internalMethodHashMap.put("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au"));
 			internalMethodHashMap.put("ignore-auto-dns", new Variant<>(true));
-			internalMethodHashMap.put("ignore-auto-routes", new Variant<>(true));
-		} else if (netStatus.equals("netIPv4StatusEnabledWAN")) {
-			Optional<List<String>> dnsServers = Optional.of(Arrays.asList("1.1.1.1"));
-			if (dnsServers.isPresent()) {
-				internalMethodHashMap.put("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au"));
-				internalMethodHashMap.put("ignore-auto-dns", new Variant<>(true));
-			}
-			Optional<String> gateway = Optional.of("192.168.0.1");
-			if (gateway.isPresent()) {
-				internalMethodHashMap.put("gateway", new Variant<>(gateway.get()));
-			}
+		}
+
+		Optional<String> gateway = Optional.of("192.168.0.1");
+		if (gateway.isPresent()) {
+			internalMethodHashMap.put("gateway", new Variant<>(gateway.get()));
 		}
 
 		this.internalComparatorMap.putAll(internalMethodHashMap);
 
 	}
 
-	public void givenValidBuildIpv4ConfigWithDhcpStatusSetTo(boolean dhcpStatus) {
+	public void givenValidBuildIpv4ConfigWithDhcpEnabled() {
 		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
-		if (!dhcpStatus) {
-			internalMethodHashMap.put("method", new Variant<>("manual"));
 
-			Map<String, Variant<?>> addressEntry = new HashMap<>();
-			addressEntry.put("address", new Variant<>("192.168.0.12"));
-			addressEntry.put("prefix", new Variant<>(new UInt32(25)));
+		internalMethodHashMap.put("method", new Variant<>("auto"));
 
-			List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
-			internalMethodHashMap.put("address-data", new Variant<>(addressData, "aa{sv}"));
+		this.internalComparatorMap.putAll(internalMethodHashMap);
+		this.internalComparatorAllSettingsMap.put("ipv4", internalMethodHashMap);
+	}
 
-		} else {
-			internalMethodHashMap.put("method", new Variant<>("auto"));
-		}
+	public void givenValidBuildIpv4ConfigWithDhcpDisabled() {
+		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
+
+		internalMethodHashMap.put("method", new Variant<>("manual"));
+
+		Map<String, Variant<?>> addressEntry = new HashMap<>();
+		addressEntry.put("address", new Variant<>("192.168.0.12"));
+		addressEntry.put("prefix", new Variant<>(new UInt32(25)));
+
+		List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
+		internalMethodHashMap.put("address-data", new Variant<>(addressData, "aa{sv}"));
+
 		this.internalComparatorMap.putAll(internalMethodHashMap);
 		this.internalComparatorAllSettingsMap.put("ipv4", internalMethodHashMap);
 	}
@@ -405,12 +437,13 @@ public class NMSettingsConverterTest {
 			internetNetworkPropertiesInstanciationMap
 					.put(String.format("net.interface.%s.config.wifi.%s.channel", inter, propMode.toLowerCase()), "10");
 		}
-		
-		if(isHidden) {
-			internetNetworkPropertiesInstanciationMap
-			.put(String.format("net.interface.%s.config.wifi.%s.ignoreSSID", inter, propMode.toLowerCase()), isHidden);
+
+		if (isHidden) {
+			internetNetworkPropertiesInstanciationMap.put(
+					String.format("net.interface.%s.config.wifi.%s.ignoreSSID", inter, propMode.toLowerCase()),
+					isHidden);
 		}
-		
+
 	}
 
 	public void givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(String inter, String ssid,
@@ -425,8 +458,8 @@ public class NMSettingsConverterTest {
 		if (channelEnabled) {
 			internalMethodHashMap.put("channel", new Variant<>(new UInt32(Short.parseShort("10"))));
 		}
-		
-		if(isHidden) {
+
+		if (isHidden) {
 			internalMethodHashMap.put("hidden", new Variant<>(isHidden));
 		}
 
@@ -574,20 +607,23 @@ public class NMSettingsConverterTest {
 	}
 
 	public void thenMapResultShouldEqualInternalBuildMap() {
-		
+
 		// Workaround to compare String.getBytes(StandardCharsets.UTF_8)
 		if (this.internalComparatorAllSettingsMap.containsKey("802-11-wireless")) {
-			String internalSsid = new String((byte[]) internalComparatorAllSettingsMap.get("802-11-wireless").get("ssid").getValue(), StandardCharsets.UTF_8);
-			String resultSsid = new String((byte[]) this.resultAllSettingsMap.get("802-11-wireless").get("ssid").getValue(), StandardCharsets.UTF_8);
-			
+			String internalSsid = new String(
+					(byte[]) internalComparatorAllSettingsMap.get("802-11-wireless").get("ssid").getValue(),
+					StandardCharsets.UTF_8);
+			String resultSsid = new String(
+					(byte[]) this.resultAllSettingsMap.get("802-11-wireless").get("ssid").getValue(),
+					StandardCharsets.UTF_8);
+
 			internalComparatorAllSettingsMap.get("802-11-wireless").put("ssid", new Variant<>("wpa-psk"));
 			resultAllSettingsMap.get("802-11-wireless").put("ssid", new Variant<>("wpa-psk"));
-			
+
 			assertEquals(internalSsid, resultSsid);
 		}
 		// Remove SSID fields from Maps before comparison
-		
-		
+
 		assertEquals(this.internalComparatorAllSettingsMap, this.resultAllSettingsMap);
 	}
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.eclipse.kura.configuration.Password;
@@ -43,42 +44,42 @@ public class NMSettingsConverterTest {
 
 	NetworkProperties networkProperties;
 
-	Boolean hasIllegalArgumentExceptionBeenThrown = false;
+	Boolean hasNoSuchElementExceptionBeenThrown = false;
 	Boolean hasAGenericExecptionBeenThrown = false;
 
 	@Test
 	public void buildSettingsShouldThrowWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-		thenIllegalArgumentExceptionHasBeenThrown();
+		thenNoSuchElementExceptionThrown();
 	}
 
 	@Test
 	public void buildIpv4SettingsShouldThrowWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-		thenIllegalArgumentExceptionHasBeenThrown();
+		thenNoSuchElementExceptionThrown();
 	}
 
 	@Test
 	public void buildIpv6SettingsShouldThrowErrorWhenWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv6SettingsIsRunWith(this.networkProperties, "wlan0");
-		thenIllegalArgumentExceptionHasBeenThrown();
+		thenNoSuchElementExceptionThrown();
 	}
 
 	@Test
 	public void build80211WirelessSettingsShouldThrowErrorWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
-		thenIllegalArgumentExceptionHasBeenThrown();
+		thenNoSuchElementExceptionThrown();
 	}
 
 	@Test
 	public void build80211WirelessSecuritySettingsShouldThrowWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
-		thenIllegalArgumentExceptionHasBeenThrown();
+		thenNoSuchElementExceptionThrown();
 	}
 
 	@Test
@@ -487,9 +488,9 @@ public class NMSettingsConverterTest {
 			String iface, NMDeviceType deviceType) {
 		try {
 			this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
-		} catch (IllegalArgumentException e) {
+		} catch (NoSuchElementException e) {
 			e.printStackTrace();
-			hasIllegalArgumentExceptionBeenThrown = true;
+			hasNoSuchElementExceptionBeenThrown = true;
 		} catch (Exception e) {
 			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
@@ -499,9 +500,9 @@ public class NMSettingsConverterTest {
 	public void whenBuildIpv4SettingsIsRunWith(NetworkProperties props, String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
-		} catch (IllegalArgumentException e) {
+		} catch (NoSuchElementException e) {
 			e.printStackTrace();
-			hasIllegalArgumentExceptionBeenThrown = true;
+			hasNoSuchElementExceptionBeenThrown = true;
 		} catch (Exception e) {
 			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
@@ -511,9 +512,9 @@ public class NMSettingsConverterTest {
 	public void whenBuildIpv6SettingsIsRunWith(NetworkProperties props, String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
-		} catch (IllegalArgumentException e) {
+		} catch (NoSuchElementException e) {
 			e.printStackTrace();
-			hasIllegalArgumentExceptionBeenThrown = true;
+			hasNoSuchElementExceptionBeenThrown = true;
 		} catch (Exception e) {
 			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
@@ -523,9 +524,9 @@ public class NMSettingsConverterTest {
 	public void whenBuild80211WirelessSettingsIsRunWith(NetworkProperties props, String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
-		} catch (IllegalArgumentException e) {
+		} catch (NoSuchElementException e) {
 			e.printStackTrace();
-			hasIllegalArgumentExceptionBeenThrown = true;
+			hasNoSuchElementExceptionBeenThrown = true;
 		} catch (Exception e) {
 			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
@@ -535,9 +536,9 @@ public class NMSettingsConverterTest {
 	public void whenBuild80211WirelessSecuritySettingsIsRunWith(NetworkProperties props, String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
-		} catch (IllegalArgumentException e) {
+		} catch (NoSuchElementException e) {
 			e.printStackTrace();
-			hasIllegalArgumentExceptionBeenThrown = true;
+			hasNoSuchElementExceptionBeenThrown = true;
 		} catch (Exception e) {
 			e.printStackTrace();
 			hasAGenericExecptionBeenThrown = true;
@@ -564,12 +565,12 @@ public class NMSettingsConverterTest {
 		assertEquals(value, new String((byte[]) this.resultAllSettingsMap.get(key).get(subKey).getValue(), StandardCharsets.UTF_8));
 	}
 
-	public void thenIllegalArgumentExceptionHasBeenThrown() {
-		assertTrue(this.hasIllegalArgumentExceptionBeenThrown);
+	public void thenNoSuchElementExceptionThrown() {
+		assertTrue(this.hasNoSuchElementExceptionBeenThrown);
 	}
 
 	public void thenNoExceptionsHaveBeenThrown() {
-		assertFalse(this.hasIllegalArgumentExceptionBeenThrown);
+		assertFalse(this.hasNoSuchElementExceptionBeenThrown);
 		assertFalse(this.hasAGenericExecptionBeenThrown);
 	}
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -13,6 +13,8 @@
 package org.eclipse.kura.nm.configuration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -22,6 +24,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.kura.configuration.Password;
+import org.eclipse.kura.nm.NMDeviceType;
+import org.eclipse.kura.nm.NetworkProperties;
 import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.networkmanager.settings.Connection;
@@ -39,40 +43,48 @@ public class NMSettingsConverterTest {
 
 	NetworkProperties networkProperties;
 
-	@Test(expected = IllegalArgumentException.class)
+	Boolean hasIllegalArgumentExceptionBeenThrown = false;
+	Boolean hasAGenericExecptionBeenThrown = false;
+
+	@Test
 	public void shouldThrowErrorWhenBuildSettingsWithEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldThrowErrorWhenBuildIpv4SettingsWithEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldThrowErrorWhenBuildIpv6SettingsWithEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldThrowErrorWhenBuild80211WirelessSettingsWithEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldThrowErrorWhenBuild80211WirelessSecuritySettingsWithEmptyMap() {
 		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
 	@Test
@@ -83,6 +95,7 @@ public class NMSettingsConverterTest {
 				"netIPv4StatusEnabledWAN");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
 
@@ -94,6 +107,7 @@ public class NMSettingsConverterTest {
 				"netIPv4StatusEnabledWAN");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 
 	}
@@ -106,6 +120,7 @@ public class NMSettingsConverterTest {
 				"netIPv4StatusEnabledLAN");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
 
@@ -117,6 +132,7 @@ public class NMSettingsConverterTest {
 				"netIPv4StatusEnabledLAN");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
 
@@ -128,6 +144,7 @@ public class NMSettingsConverterTest {
 				"netIPv4StatusUnmanaged");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
 
@@ -138,6 +155,7 @@ public class NMSettingsConverterTest {
 		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
 
@@ -148,6 +166,7 @@ public class NMSettingsConverterTest {
 		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
 
@@ -164,6 +183,7 @@ public class NMSettingsConverterTest {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
 	}
 
@@ -218,9 +238,9 @@ public class NMSettingsConverterTest {
 			internalComparatorMap.put("ignore-auto-dns", new Variant<>(true));
 			internalComparatorMap.put("ignore-auto-routes", new Variant<>(true));
 		} else if (netStatus.equals("netIPv4StatusEnabledWAN")) {
-			Optional<List<String>> dnsServers = Optional.of(List.of("1.1.1.1"));
+			Optional<List<String>> dnsServers = Optional.of(Arrays.asList("1.1.1.1"));
 			if (dnsServers.isPresent()) {
-				internalComparatorMap.put("dns", new Variant<>(List.of(new UInt32(16843009)), "au"));
+				internalComparatorMap.put("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au"));
 				internalComparatorMap.put("ignore-auto-dns", new Variant<>(true));
 			}
 			Optional<String> gateway = Optional.of("192.168.0.1");
@@ -299,24 +319,53 @@ public class NMSettingsConverterTest {
 
 	public void whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties properties,
 			Optional<Connection> oldConnection, String iface, NMDeviceType deviceType) {
-		this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
+		try {
+			this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
+		} catch (IllegalArgumentException e) {
+			hasIllegalArgumentExceptionBeenThrown = true;
+		} catch (Exception e) {
+			hasAGenericExecptionBeenThrown = true;
+		}
 	}
 
 	public void whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
-		this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
+		try {
+			this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
+		} catch (IllegalArgumentException e) {
+			hasIllegalArgumentExceptionBeenThrown = true;
+		} catch (Exception e) {
+			hasAGenericExecptionBeenThrown = true;
+		}
 	}
 
 	public void whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
-		this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
+		try {
+			this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
+		} catch (IllegalArgumentException e) {
+			hasIllegalArgumentExceptionBeenThrown = true;
+		} catch (Exception e) {
+			hasAGenericExecptionBeenThrown = true;
+		}
 	}
 
 	public void whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props,
 			String iface) {
-		this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
+		try {
+			this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
+		} catch (IllegalArgumentException e) {
+			hasIllegalArgumentExceptionBeenThrown = true;
+		}
 	}
 
 	public void whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props,
 			String iface) {
+		try {
+
+		} catch (IllegalArgumentException e) {
+			hasIllegalArgumentExceptionBeenThrown = true;
+		} catch (Exception e) {
+			hasAGenericExecptionBeenThrown = true;
+		}
 		this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
 	}
 
@@ -328,6 +377,15 @@ public class NMSettingsConverterTest {
 
 	public void thenMapResultShouldEqualInternalBuildMap() {
 		assertEquals(this.internalComparatorAllSettingsMap, this.resultAllSettingsMap);
+	}
+	
+	public void thenIllegalArgumentExceptionHasBeenThrown() {
+		assertTrue(this.hasIllegalArgumentExceptionBeenThrown);
+	}
+	
+	public void thenNoExceptionsHaveBeenThrown() {
+		assertFalse(this.hasIllegalArgumentExceptionBeenThrown);
+		assertFalse(this.hasAGenericExecptionBeenThrown);
 	}
 
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -761,56 +761,6 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiMode() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", null);
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiRadioMode() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiPassword() {
 		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
 		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
@@ -853,56 +803,6 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", null);
 		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
 		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullGroupCiphers() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", null);
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullPairwiseCiphers() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", null);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -151,8 +151,8 @@ public class NMSettingsConverterTest {
 	@Test
 	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
 		givenEmptyMaps();
-		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true);
-		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true);
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true, false);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true, false);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -171,18 +171,170 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void buildSettingsShouldWorkWithExpectedInputs() {
+	public void buildSettingsShouldWorkWithExpectedInputsWiFi() {
+		
+		String netInterface = "wlan0";
+		String kuraNetType = "netIPv4StatusUnmanaged";
+		
 		givenEmptyMaps();
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
-		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
-				"netIPv4StatusUnmanaged");
-		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true);
-		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true);
-		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
-		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
+				kuraNetType);
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, false);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, false);
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+				true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
+		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		thenNoExceptionsHaveBeenThrown();
+		thenMapResultShouldEqualInternalBuildMap();
+	}
+	
+	@Test
+	public void buildSettingsShouldWorkWithExpectedInputsWiFiLan() {
+		
+		String netInterface = "wlan0";
+		String kuraNetType = "netIPv4StatusManagedLan";
+		
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
+				kuraNetType);
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, false);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, false);
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+				true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		thenNoExceptionsHaveBeenThrown();
+		thenMapResultShouldEqualInternalBuildMap();
+	}
+	
+	@Test
+	public void buildSettingsShouldWorkWithExpectedInputsWiFiWan() {
+		
+		String netInterface = "wlan0";
+		String kuraNetType = "netIPv4StatusManagedWan";
+		
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
+				kuraNetType);
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, false);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, false);
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+				true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		thenNoExceptionsHaveBeenThrown();
+		thenMapResultShouldEqualInternalBuildMap();
+	}
+	
+	@Test
+	public void buildSettingsShouldWorkWithExpectedInputsWiFiLanAndHiddenSsid() {
+		
+		String netInterface = "wlan0";
+		String kuraNetType = "netIPv4StatusManagedLan";
+		
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
+				kuraNetType);
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, true);
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+				true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		thenNoExceptionsHaveBeenThrown();
+		thenMapResultShouldEqualInternalBuildMap();
+	}
+	
+	@Test
+	public void buildSettingsShouldWorkWithExpectedInputsWiFiWanAndHiddenSsid() {
+		
+		String netInterface = "wlan0";
+		String kuraNetType = "netIPv4StatusManagedWan";
+		
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
+				kuraNetType);
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true, true);
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "INFRA", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(netInterface, "ssidtest", "infrastructure", true,
+				true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		thenNoExceptionsHaveBeenThrown();
+		thenMapResultShouldEqualInternalBuildMap();
+	}
+	
+	@Test
+	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndUnmanaged() {
+		
+		String netInterface = "eth0";
+		String kuraNetType = "netIPv4StatusUnmanaged";
+		
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
+				kuraNetType);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+		thenNoExceptionsHaveBeenThrown();
+		thenMapResultShouldEqualInternalBuildMap();
+	}
+	
+	@Test
+	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndLan() {
+		
+		String netInterface = "eth0";
+		String kuraNetType = "netIPv4StatusManagedLan";
+		
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
+				kuraNetType);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+		thenNoExceptionsHaveBeenThrown();
+		thenMapResultShouldEqualInternalBuildMap();
+	}
+	
+	@Test
+	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
+		
+		String netInterface = "eth0";
+		String kuraNetType = "netIPv4StatusManagedWan";
+		
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
+				kuraNetType);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
 	}
@@ -220,39 +372,56 @@ public class NMSettingsConverterTest {
 	public void givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(String inter,
 			Boolean dhcpStatus, String netStatus) {
 
+		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
+
+		givenValidBuildIpv4Config(dhcpStatus);
+		givenValidBuildIpv6Config();
+		if (netStatus.equals("netIPv4StatusEnabledLAN")) {
+			internalMethodHashMap.put("ignore-auto-dns", new Variant<>(true));
+			internalMethodHashMap.put("ignore-auto-routes", new Variant<>(true));
+		} else if (netStatus.equals("netIPv4StatusEnabledWAN")) {
+			Optional<List<String>> dnsServers = Optional.of(Arrays.asList("1.1.1.1"));
+			if (dnsServers.isPresent()) {
+				internalMethodHashMap.put("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au"));
+				internalMethodHashMap.put("ignore-auto-dns", new Variant<>(true));
+			}
+			Optional<String> gateway = Optional.of("192.168.0.1");
+			if (gateway.isPresent()) {
+				internalMethodHashMap.put("gateway", new Variant<>(gateway.get()));
+			}
+		}
+
+		this.internalComparatorMap.putAll(internalMethodHashMap);
+
+	}
+
+	public void givenValidBuildIpv4Config(boolean dhcpStatus) {
+		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
 		if (!dhcpStatus) {
-			internalComparatorMap.put("method", new Variant<>("manual"));
+			internalMethodHashMap.put("method", new Variant<>("manual"));
 
 			Map<String, Variant<?>> addressEntry = new HashMap<>();
 			addressEntry.put("address", new Variant<>("192.168.0.12"));
 			addressEntry.put("prefix", new Variant<>(new UInt32(25)));
 
 			List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
-			internalComparatorMap.put("address-data", new Variant<>(addressData, "aa{sv}"));
+			internalMethodHashMap.put("address-data", new Variant<>(addressData, "aa{sv}"));
 
 		} else {
-			internalComparatorMap.put("method", new Variant<>("auto"));
+			internalMethodHashMap.put("method", new Variant<>("auto"));
 		}
+		this.internalComparatorMap.putAll(internalMethodHashMap);
+		this.internalComparatorAllSettingsMap.put("ipv4", internalMethodHashMap);
+	}
 
-		if (netStatus.equals("netIPv4StatusEnabledLAN")) {
-			internalComparatorMap.put("ignore-auto-dns", new Variant<>(true));
-			internalComparatorMap.put("ignore-auto-routes", new Variant<>(true));
-		} else if (netStatus.equals("netIPv4StatusEnabledWAN")) {
-			Optional<List<String>> dnsServers = Optional.of(Arrays.asList("1.1.1.1"));
-			if (dnsServers.isPresent()) {
-				internalComparatorMap.put("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au"));
-				internalComparatorMap.put("ignore-auto-dns", new Variant<>(true));
-			}
-			Optional<String> gateway = Optional.of("192.168.0.1");
-			if (gateway.isPresent()) {
-				internalComparatorMap.put("gateway", new Variant<>(gateway.get()));
-			}
-		}
-
+	public void givenValidBuildIpv6Config() {
+		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
+		internalMethodHashMap.put("method", new Variant<>("disabled"));
+		this.internalComparatorAllSettingsMap.put("ipv6", internalMethodHashMap);
 	}
 
 	public void givenValid80211WirelessSettingsWithInterfaceNameAndSsid(String inter, String ssid, String propMode,
-			Boolean channelEnabled) {
+			Boolean channelEnabled, Boolean isHidden) {
 		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.wifi.mode", inter),
 				propMode);
 		internetNetworkPropertiesInstanciationMap
@@ -264,17 +433,33 @@ public class NMSettingsConverterTest {
 			internetNetworkPropertiesInstanciationMap
 					.put(String.format("net.interface.%s.config.wifi.%s.channel", inter, propMode.toLowerCase()), "10");
 		}
+		
+		if(isHidden) {
+			internetNetworkPropertiesInstanciationMap
+			.put(String.format("net.interface.%s.config.wifi.%s.ignoreSSID", inter, propMode.toLowerCase()), isHidden);
+		}
+		
 	}
 
 	public void givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(String inter, String ssid,
-			String propMode, Boolean channelEnabled) {
-		internalComparatorMap.put("mode", new Variant<>(propMode));
-		// TODO: investigate this .getBytes discrepancy
-		internalComparatorMap.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
-		internalComparatorMap.put("band", new Variant<>("a"));
+			String propMode, Boolean channelEnabled, Boolean isHidden) {
+
+		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
+
+		internalMethodHashMap.put("mode", new Variant<>(propMode));
+		internalMethodHashMap.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
+		internalMethodHashMap.put("band", new Variant<>("a"));
+
 		if (channelEnabled) {
-			internalComparatorMap.put("channel", new Variant<>(new UInt32(Short.parseShort("10"))));
+			internalMethodHashMap.put("channel", new Variant<>(new UInt32(Short.parseShort("10"))));
 		}
+		
+		if(isHidden) {
+			internalMethodHashMap.put("hidden", new Variant<>(isHidden));
+		}
+
+		this.internalComparatorAllSettingsMap.put("802-11-wireless", internalMethodHashMap);
+		this.internalComparatorMap.putAll(internalMethodHashMap);
 	}
 
 	public void givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(String inter, String ssid,
@@ -302,17 +487,32 @@ public class NMSettingsConverterTest {
 	public void givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(String inter, String ssid,
 			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
 
-		internalComparatorMap.put("psk", new Variant<>(new Password("test").toString()));
-		internalComparatorMap.put("key-mgmt", new Variant<>("wpa-psk"));
+		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
+
+		internalMethodHashMap.put("psk", new Variant<>(new Password("test").toString()));
+		internalMethodHashMap.put("key-mgmt", new Variant<>("wpa-psk"));
 
 		if (groupEnabled) {
-			internalComparatorMap.put("group", new Variant<>(Arrays.asList("ccmp"), "as"));
+			internalMethodHashMap.put("group", new Variant<>(Arrays.asList("ccmp"), "as"));
 		}
 
 		if (ciphersEnabled) {
-			internalComparatorMap.put("pairwise", new Variant<>(Arrays.asList("ccmp"), "as"));
+			internalMethodHashMap.put("pairwise", new Variant<>(Arrays.asList("ccmp"), "as"));
 		}
 
+		this.internalComparatorAllSettingsMap.put("802-11-wireless-security", internalMethodHashMap);
+		this.internalComparatorMap.putAll(internalMethodHashMap);
+
+	}
+
+	public void givenExpectedBuildAllConnectionField(String inter, String interfaceType) {
+		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
+
+		internalMethodHashMap.put("id", new Variant<>(String.format("kura-%s-connection", inter)));
+		internalMethodHashMap.put("interface-name", new Variant<>(inter));
+		internalMethodHashMap.put("type", new Variant<>(interfaceType));
+
+		this.internalComparatorAllSettingsMap.put("connection", internalMethodHashMap);
 	}
 
 	// when
@@ -385,30 +585,44 @@ public class NMSettingsConverterTest {
 	public void thenMapResultShouldEqualInternalMap() {
 		assertEquals(this.internalComparatorMap, this.resultMap);
 	}
-	
+
 	public void thenMapResultFromWifiSettingsShouldEqualInternalMapForWifiSettings() {
-		//Workaround to compare String.getBytes(StandardCharsets.UTF_8)
-		
-		String  internalSsid = new String((byte[]) internalComparatorMap.get("ssid").getValue(), StandardCharsets.UTF_8);
+		// Workaround to compare String.getBytes(StandardCharsets.UTF_8)
+
+		String internalSsid = new String((byte[]) internalComparatorMap.get("ssid").getValue(), StandardCharsets.UTF_8);
 		String resultSsid = new String((byte[]) this.resultMap.get("ssid").getValue(), StandardCharsets.UTF_8);
 
 		assertEquals(internalSsid, resultSsid);
-		
-		//Remove ssid fields from Maps before comparison
+
+		// Remove ssid fields from Maps before comparison
 		this.internalComparatorMap.put("ssid", new Variant<>(""));
 		this.resultMap.put("ssid", new Variant<>(""));
-		
+
 		assertEquals(this.internalComparatorMap, this.resultMap);
 	}
 
 	public void thenMapResultShouldEqualInternalBuildMap() {
+		
+		// Workaround to compare String.getBytes(StandardCharsets.UTF_8)
+		if (this.internalComparatorAllSettingsMap.containsKey("802-11-wireless")) {
+			String internalSsid = new String((byte[]) internalComparatorAllSettingsMap.get("802-11-wireless").get("ssid").getValue(), StandardCharsets.UTF_8);
+			String resultSsid = new String((byte[]) this.resultAllSettingsMap.get("802-11-wireless").get("ssid").getValue(), StandardCharsets.UTF_8);
+			
+			internalComparatorAllSettingsMap.get("802-11-wireless").put("ssid", new Variant<>("wpa-psk"));
+			resultAllSettingsMap.get("802-11-wireless").put("ssid", new Variant<>("wpa-psk"));
+			
+			assertEquals(internalSsid, resultSsid);
+		}
+		// Remove ssid fields from Maps before comparison
+		
+		
 		assertEquals(this.internalComparatorAllSettingsMap, this.resultAllSettingsMap);
 	}
-	
+
 	public void thenIllegalArgumentExceptionHasBeenThrown() {
 		assertTrue(this.hasIllegalArgumentExceptionBeenThrown);
 	}
-	
+
 	public void thenNoExceptionsHaveBeenThrown() {
 		assertFalse(this.hasIllegalArgumentExceptionBeenThrown);
 		assertFalse(this.hasAGenericExecptionBeenThrown);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -471,16 +471,16 @@ public class NMSettingsConverterTest {
 				new Password("test"));
 		internetNetworkPropertiesInstanciationMap.put(
 				String.format("net.interface.%s.config.wifi.%s.securityType", inter, propMode.toLowerCase()),
-				"SECURITY_WPA_WPA2"); // wpa
+				"SECURITY_WPA_WPA2");
 		if (groupEnabled) {
 			internetNetworkPropertiesInstanciationMap.put(
 					String.format("net.interface.%s.config.wifi.%s.groupCiphers", inter, propMode.toLowerCase()),
-					"CCMP"); // option
+					"CCMP");
 		}
 		if (ciphersEnabled) {
 			internetNetworkPropertiesInstanciationMap.put(
 					String.format("net.interface.%s.config.wifi.%s.pairwiseCiphers", inter, propMode.toLowerCase()),
-					"CCMP"); // ccmp
+					"CCMP");
 		}
 	}
 
@@ -594,7 +594,7 @@ public class NMSettingsConverterTest {
 
 		assertEquals(internalSsid, resultSsid);
 
-		// Remove ssid fields from Maps before comparison
+		// Remove SSID fields from Maps before comparison
 		this.internalComparatorMap.put("ssid", new Variant<>(""));
 		this.resultMap.put("ssid", new Variant<>(""));
 
@@ -613,7 +613,7 @@ public class NMSettingsConverterTest {
 			
 			assertEquals(internalSsid, resultSsid);
 		}
-		// Remove ssid fields from Maps before comparison
+		// Remove SSID fields from Maps before comparison
 		
 		
 		assertEquals(this.internalComparatorAllSettingsMap, this.resultAllSettingsMap);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -600,7 +600,6 @@ public class NMSettingsConverterTest {
 	}
 
 	// then
-
 	public void thenResultingMapContains(String key, Object value) {
 		assertEquals(value, this.resultMap.get(key).getValue());
 	}
@@ -617,59 +616,6 @@ public class NMSettingsConverterTest {
 		assertEquals(value, new String((byte[]) this.resultAllSettingsMap.get(key).get(subKey).getValue(), StandardCharsets.UTF_8));
 	}
 
-	public Object buildAddressDataWith(String ipAddr, UInt32 prefix) {
-
-		Map<String, Variant<?>> addressEntry = new HashMap<>();
-		addressEntry.put("address", new Variant<>(ipAddr));
-		addressEntry.put("prefix", new Variant<>(prefix));
-
-		List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
-
-		Variant<?> dataVarient = new Variant<>(addressData, "aa{sv}");
-
-		return dataVarient.getValue();
-	}
-
-	public void thenMapResultShouldEqualInternalMap() {
-		assertEquals(this.internalComparatorMap, this.resultMap);
-	}
-
-	public void thenMapResultFromWifiSettingsShouldEqualInternalMapForWifiSettings() {
-		// Workaround to compare String.getBytes(StandardCharsets.UTF_8)
-
-		String internalSsid = new String((byte[]) internalComparatorMap.get("ssid").getValue(), StandardCharsets.UTF_8);
-		String resultSsid = new String((byte[]) this.resultMap.get("ssid").getValue(), StandardCharsets.UTF_8);
-
-		assertEquals(internalSsid, resultSsid);
-
-		// Remove SSID fields from Maps before comparison
-		this.internalComparatorMap.put("ssid", new Variant<>(""));
-		this.resultMap.put("ssid", new Variant<>(""));
-
-		assertEquals(this.internalComparatorMap, this.resultMap);
-	}
-
-	public void thenMapResultShouldEqualInternalBuildMap() {
-
-		// Workaround to compare String.getBytes(StandardCharsets.UTF_8)
-		if (this.internalComparatorAllSettingsMap.containsKey("802-11-wireless")) {
-			String internalSsid = new String(
-					(byte[]) internalComparatorAllSettingsMap.get("802-11-wireless").get("ssid").getValue(),
-					StandardCharsets.UTF_8);
-			String resultSsid = new String(
-					(byte[]) this.resultAllSettingsMap.get("802-11-wireless").get("ssid").getValue(),
-					StandardCharsets.UTF_8);
-
-			internalComparatorAllSettingsMap.get("802-11-wireless").put("ssid", new Variant<>("wpa-psk"));
-			resultAllSettingsMap.get("802-11-wireless").put("ssid", new Variant<>("wpa-psk"));
-
-			assertEquals(internalSsid, resultSsid);
-		}
-		// Remove SSID fields from Maps before comparison
-
-		assertEquals(this.internalComparatorAllSettingsMap, this.resultAllSettingsMap);
-	}
-
 	public void thenIllegalArgumentExceptionHasBeenThrown() {
 		assertTrue(this.hasIllegalArgumentExceptionBeenThrown);
 	}
@@ -679,4 +625,17 @@ public class NMSettingsConverterTest {
 		assertFalse(this.hasAGenericExecptionBeenThrown);
 	}
 
+	//helper classes
+	public Object buildAddressDataWith(String ipAddr, UInt32 prefix) {
+		
+		Map<String, Variant<?>> addressEntry = new HashMap<>();
+		addressEntry.put("address", new Variant<>(ipAddr));
+		addressEntry.put("prefix", new Variant<>(prefix));
+		
+		List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
+		
+		Variant<?> dataVarient = new Variant<>(addressData, "aa{sv}");
+		
+		return dataVarient.getValue();
+	}
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -156,7 +156,7 @@ public class NMSettingsConverterTest {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalMap();
+		thenMapResultFromWifiSettingsShouldEqualInternalMapForWifiSettings();
 	}
 
 	@Test
@@ -354,24 +354,41 @@ public class NMSettingsConverterTest {
 			this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
 		} catch (IllegalArgumentException e) {
 			hasIllegalArgumentExceptionBeenThrown = true;
+		} catch (Exception e) {
+			hasAGenericExecptionBeenThrown = true;
 		}
 	}
 
 	public void whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props,
 			String iface) {
 		try {
-
+			this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
 		} catch (IllegalArgumentException e) {
 			hasIllegalArgumentExceptionBeenThrown = true;
 		} catch (Exception e) {
 			hasAGenericExecptionBeenThrown = true;
 		}
-		this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
 	}
 
 	// then
 
 	public void thenMapResultShouldEqualInternalMap() {
+		assertEquals(this.internalComparatorMap, this.resultMap);
+	}
+	
+	public void thenMapResultFromWifiSettingsShouldEqualInternalMapForWifiSettings() {
+		//Workaround to compare String.getBytes()
+		
+		String  internalSsid = new String((byte[]) internalComparatorMap.get("ssid").getValue(), StandardCharsets.UTF_8);
+		String resultSsid = new String((byte[]) this.resultMap.get("ssid").getValue(), StandardCharsets.UTF_8);
+
+		//.getBytes(StandardCharsets.UTF_8)
+		assertEquals(internalSsid, resultSsid);
+		
+		//Remove ssid fields from Maps before comparison
+		this.internalComparatorMap.put("ssid", new Variant<>(""));
+		this.resultMap.put("ssid", new Variant<>(""));
+		
 		assertEquals(this.internalComparatorMap, this.resultMap);
 	}
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -32,940 +32,939 @@ import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.networkmanager.settings.Connection;
 import org.junit.Test;
-
 import org.mockito.Mockito;
 
 public class NMSettingsConverterTest {
 
-	Map<String, Variant<?>> internalComparatorMap = new HashMap<>();
-	Map<String, Variant<?>> resultMap;
-
-	Map<String, Map<String, Variant<?>>> internalComparatorAllSettingsMap = new HashMap<>();
-	Map<String, Map<String, Variant<?>>> resultAllSettingsMap = new HashMap<>();
-
-	Map<String, Object> internetNetworkPropertiesInstanciationMap = new HashMap<>();
-
-	NetworkProperties networkProperties;
-	Connection mockedConnection;
-
-	Boolean hasNoSuchElementExceptionBeenThrown = false;
-	Boolean hasAnIllegalArgumentExceptionThrown = false;
-	Boolean hasAGenericExecptionBeenThrown = false;
-
-	@Test
-	public void buildSettingsShouldThrowWhenGivenEmptyMap() {
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildIpv4SettingsShouldThrowWhenGivenEmptyMap() {
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void build80211WirelessSettingsShouldThrowErrorWhenGivenEmptyMap() {
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void build80211WirelessSecuritySettingsShouldThrowWhenGivenEmptyMap() {
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForWan() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
-
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-		thenNoExceptionsHaveBeenThrown();
-
-		thenResultingMapContains("method", "auto");
-	}
-
-	@Test
-	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForWan() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("method", "manual");
-		thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingMapContains("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au").getValue());
-		thenResultingMapContains("ignore-auto-dns", true);
-		thenResultingMapContains("gateway", "192.168.0.1");
-
-	}
-
-	@Test
-	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForLan() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("method", "auto");
-		thenResultingMapContains("ignore-auto-dns", true);
-		thenResultingMapContains("ignore-auto-routes", true);
-	}
-
-	@Test
-	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForLan() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("method", "manual");
-		thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingMapContains("ignore-auto-dns", true);
-		thenResultingMapContains("ignore-auto-routes", true);
-	}
-
-	@Test
-	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndUnmanaged() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("method", "manual");
-		thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-	}
-
-	@Test
-	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
-
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("mode", "infrastructure");
-		thenResultingMapContainsBytes("ssid", "ssidtest");
-		thenResultingMapContains("band", "a");
-		thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
-	}
-	
-	@Test
-	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndModeAp() {
-		
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "MASTER");
-		givenMapWith("net.interface.wlan0.config.wifi.master.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.master.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.master.channel", "10");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
-		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
-		
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("mode", "ap");
-		thenResultingMapContainsBytes("ssid", "ssidtest");
-		thenResultingMapContains("band", "a");
-		thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
-	}
-	
-	@Test
-	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndModeMalformed() {
-		
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "MALFORMED_VALUE");
-		givenMapWith("net.interface.wlan0.config.wifi.master.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.master.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.master.channel", "10");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
-		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
-		
-		thenIllegalArgumentExceptionThrown();
-	}
-	
-	@Test
-	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndBandBg() {
-		
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211b");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
-		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
-		
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("mode", "infrastructure");
-		thenResultingMapContainsBytes("ssid", "ssidtest");
-		thenResultingMapContains("band", "bg");
-		thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
-	}
-	
-	@Test
-	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndBandBgExt() {
-		
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211nHT20");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
-		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
-		
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("mode", "infrastructure");
-		thenResultingMapContainsBytes("ssid", "ssidtest");
-		thenResultingMapContains("band", "bg");
-		thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
-	}
-	
-	@Test
-	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndMalformedBand() {
-		
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "MALFORMED_VALUE");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
-		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
-		
-		thenIllegalArgumentExceptionThrown();
-	}
-
-	@Test
-	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
-
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("psk", new Password("test").toString());
-		thenResultingMapContains("key-mgmt", "wpa-psk");
-		thenResultingMapContains("group", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-		thenResultingMapContains("pairwise", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-	}
-
-	@Test
-	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapTkip() {
-
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "TKIP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "TKIP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("psk", new Password("test").toString());
-		thenResultingMapContains("key-mgmt", "wpa-psk");
-		thenResultingMapContains("group", new Variant<>(Arrays.asList("tkip"), "as").getValue());
-		thenResultingMapContains("pairwise", new Variant<>(Arrays.asList("tkip"), "as").getValue());
-	}
-
-	@Test
-	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapCcmpTkip() {
-
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP_TKIP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP_TKIP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("psk", new Password("test").toString());
-		thenResultingMapContains("key-mgmt", "wpa-psk");
-		thenResultingMapContains("group", new Variant<>(Arrays.asList("tkip", "ccmp"), "as").getValue());
-		thenResultingMapContains("pairwise", new Variant<>(Arrays.asList("tkip", "ccmp"), "as").getValue());
-	}
-	
-	@Test
-	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapAndMalformedCiphers() {
-		
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "MALFORMED_VALUE");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP_TKIP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
-		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
-		
-		thenIllegalArgumentExceptionThrown();
-	}
-
-	@Test
-	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapNone() {
-
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "NONE");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("key-mgmt", "none");
-	}
-	
-	@Test
-	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapMalformedSecurity() {
-		
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "MALFORMED_VALUE");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
-		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
-		
-		thenIllegalArgumentExceptionThrown();
-	}
-
-	@Test
-	public void buildConnectionSettingsShouldWorkWithWifi() {
-		whenBuildConnectionSettings(Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("type", "802-11-wireless");
-	}
-
-	@Test
-	public void buildConnectionSettingsShouldWorkWithEthernet() {
-		whenBuildConnectionSettings(Optional.empty(), "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("type", "802-3-ethernet");
-	}
-
-	@Test
-	public void buildConnectionSettingsShouldWorkWithUnsupported() {
-		whenBuildConnectionSettings(Optional.empty(), "modem0", NMDeviceType.NM_DEVICE_TYPE_ADSL);
-
-		thenIllegalArgumentExceptionThrown();
-	}
-
-	@Test
-	public void buildConnectionSettingsShouldWorkWithWifiMockedConnection() {
-
-		givenMapWith("connection", "test", new Variant<>("test"));
-		givenMockConnection();
-
-		whenBuildConnectionSettings(Optional.of(this.mockedConnection), "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingMapContains("test", "test");
-	}
-
-	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiUnmanged() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-		thenResultingBuildAllMapContains("ipv4", "method", "manual");
-		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
-		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
-		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
-		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
-		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
-		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
-		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
-		thenResultingBuildAllMapContains("802-11-wireless-security", "group",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-	}
-
-	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLan() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-		thenResultingBuildAllMapContains("ipv4", "method", "manual");
-		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
-		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
-		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
-		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
-		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
-		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
-		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
-		thenResultingBuildAllMapContains("802-11-wireless-security", "group",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-	}
-
-	@Test
-	public void buildSettingsShouldWorkWithExpectedConfiguredForInputsWiFiWan() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-		thenResultingBuildAllMapContains("ipv4", "method", "manual");
-		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
-		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
-		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
-		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
-		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
-		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
-		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
-		thenResultingBuildAllMapContains("802-11-wireless-security", "group",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-	}
-
-	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLanAndHiddenSsid() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-		thenResultingBuildAllMapContains("ipv4", "method", "manual");
-		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
-		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
-		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
-		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
-		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
-		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
-		thenResultingBuildAllMapContains("802-11-wireless", "hidden", true);
-		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
-		thenResultingBuildAllMapContains("802-11-wireless-security", "group",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-	}
-
-	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-		thenResultingBuildAllMapContains("ipv4", "method", "manual");
-		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
-		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
-		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
-		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
-		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
-		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
-		thenResultingBuildAllMapContains("802-11-wireless", "hidden", true);
-		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
-		thenResultingBuildAllMapContains("802-11-wireless-security", "group",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
-				new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-	}
-
-	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndUnmanaged() {
-		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusUnmanaged");
-		givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
-				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-		thenResultingBuildAllMapContains("ipv4", "method", "manual");
-		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
-		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
-	}
-
-	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
-		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedLan");
-		givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
-				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-		thenResultingBuildAllMapContains("ipv4", "method", "manual");
-		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
-		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
-	}
-
-	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
-		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
-				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-
-		thenNoExceptionsHaveBeenThrown();
-		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-		thenResultingBuildAllMapContains("ipv4", "method", "manual");
-		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
-		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
-	}
-
-	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullIp() {
-		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.eth0.config.ip4.address", null);
-		givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
-				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullPrefix() {
-		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.eth0.config.ip4.prefix", null);
-		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
-				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullStatus() {
-		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.eth0.config.ip4.status", null);
-		givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
-				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiSsid() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", null);
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiPassword() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", null);
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", null);
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	@Test
-	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiSecurityType() {
-		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", null);
-		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-
-		thenNoSuchElementExceptionThrown();
-	}
-
-	/*
-	 * Given
-	 */
-
-	public void givenNetworkPropsCreatedWithTheMap(Map<String, Object> properties) {
-		this.networkProperties = new NetworkProperties(properties);
-	}
-
-	public void givenMapWith(String key, Object value) {
-		this.internetNetworkPropertiesInstanciationMap.put(key, value);
-	}
-
-	public void givenMapWith(String key, String subKey, Variant<?> value) {
-
-		if (this.internalComparatorAllSettingsMap.containsKey(key)) {
-			this.internalComparatorAllSettingsMap.get(key).put(subKey, value);
-		} else {
-			this.internalComparatorAllSettingsMap.put(key, Collections.singletonMap(subKey, value));
-		}
-	}
-
-	public void givenMockConnection() {
-		this.mockedConnection = Mockito.mock(Connection.class);
-		Mockito.when(this.mockedConnection.GetSettings()).thenReturn(this.internalComparatorAllSettingsMap);
-
-	}
-
-	/*
-	 * When
-	 */
-
-	public void whenBuildSettingsIsRunWith(NetworkProperties properties, Optional<Connection> oldConnection,
-			String iface, NMDeviceType deviceType) {
-		try {
-			this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
-		} catch (NoSuchElementException e) {
-			e.printStackTrace();
-			hasNoSuchElementExceptionBeenThrown = true;
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-			hasAnIllegalArgumentExceptionThrown = true;
-		} catch (Exception e) {
-			e.printStackTrace();
-			hasAGenericExecptionBeenThrown = true;
-		}
-	}
-
-	public void whenBuildIpv4SettingsIsRunWith(NetworkProperties props, String iface) {
-		try {
-			this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
-		} catch (NoSuchElementException e) {
-			e.printStackTrace();
-			hasNoSuchElementExceptionBeenThrown = true;
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-			hasAnIllegalArgumentExceptionThrown = true;
-		} catch (Exception e) {
-			e.printStackTrace();
-			hasAGenericExecptionBeenThrown = true;
-		}
-	}
-
-	public void whenBuildIpv6SettingsIsRunWith(NetworkProperties props, String iface) {
-		try {
-			this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
-		} catch (NoSuchElementException e) {
-			e.printStackTrace();
-			hasNoSuchElementExceptionBeenThrown = true;
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-			hasAnIllegalArgumentExceptionThrown = true;
-		} catch (Exception e) {
-			e.printStackTrace();
-			hasAGenericExecptionBeenThrown = true;
-		}
-	}
-
-	public void whenBuild80211WirelessSettingsIsRunWith(NetworkProperties props, String iface) {
-		try {
-			this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
-		} catch (NoSuchElementException e) {
-			e.printStackTrace();
-			hasNoSuchElementExceptionBeenThrown = true;
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-			hasAnIllegalArgumentExceptionThrown = true;
-		} catch (Exception e) {
-			e.printStackTrace();
-			hasAGenericExecptionBeenThrown = true;
-		}
-	}
-
-	public void whenBuildConnectionSettings(Optional<Connection> connection, String iface, NMDeviceType deviceType) {
-		try {
-			this.resultMap = NMSettingsConverter.buildConnectionSettings(connection, iface, deviceType);
-		} catch (NoSuchElementException e) {
-			e.printStackTrace();
-			hasNoSuchElementExceptionBeenThrown = true;
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-			hasAnIllegalArgumentExceptionThrown = true;
-		} catch (Exception e) {
-			e.printStackTrace();
-			hasAGenericExecptionBeenThrown = true;
-		}
-	}
-
-	public void whenBuild80211WirelessSecuritySettingsIsRunWith(NetworkProperties props, String iface) {
-		try {
-			this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
-		} catch (NoSuchElementException e) {
-			e.printStackTrace();
-			hasNoSuchElementExceptionBeenThrown = true;
-		} catch (IllegalArgumentException e) {
-			e.printStackTrace();
-			hasAnIllegalArgumentExceptionThrown = true;
-		} catch (Exception e) {
-			e.printStackTrace();
-			hasAGenericExecptionBeenThrown = true;
-		}
-	}
-
-	/*
-	 * Then
-	 */
-
-	public void thenResultingMapContains(String key, Object value) {
-		assertEquals(value, this.resultMap.get(key).getValue());
-	}
-
-	public void thenResultingMapContainsBytes(String key, Object value) {
-		assertEquals(value, new String((byte[]) this.resultMap.get(key).getValue(), StandardCharsets.UTF_8));
-	}
-
-	public void thenResultingBuildAllMapContains(String key, String subKey, Object value) {
-		assertEquals(value, this.resultAllSettingsMap.get(key).get(subKey).getValue());
-	}
-
-	public void thenResultingBuildAllMapContainsBytes(String key, String subKey, Object value) {
-		assertEquals(value,
-				new String((byte[]) this.resultAllSettingsMap.get(key).get(subKey).getValue(), StandardCharsets.UTF_8));
-	}
-
-	public void thenNoSuchElementExceptionThrown() {
-		assertTrue(this.hasNoSuchElementExceptionBeenThrown);
-	}
-
-	public void thenIllegalArgumentExceptionThrown() {
-		assertTrue(this.hasAnIllegalArgumentExceptionThrown);
-	}
-
-	public void thenNoExceptionsHaveBeenThrown() {
-		assertFalse(this.hasNoSuchElementExceptionBeenThrown);
-		assertFalse(this.hasAGenericExecptionBeenThrown);
-		assertFalse(this.hasAnIllegalArgumentExceptionThrown);
-	}
-
-	/*
-	 * Helper Methods
-	 */
-
-	public Object buildAddressDataWith(String ipAddr, UInt32 prefix) {
-
-		Map<String, Variant<?>> addressEntry = new HashMap<>();
-		addressEntry.put("address", new Variant<>(ipAddr));
-		addressEntry.put("prefix", new Variant<>(prefix));
-
-		List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
-
-		Variant<?> dataVariant = new Variant<>(addressData, "aa{sv}");
-
-		return dataVariant.getValue();
-	}
+    Map<String, Variant<?>> internalComparatorMap = new HashMap<>();
+    Map<String, Variant<?>> resultMap;
+
+    Map<String, Map<String, Variant<?>>> internalComparatorAllSettingsMap = new HashMap<>();
+    Map<String, Map<String, Variant<?>>> resultAllSettingsMap = new HashMap<>();
+
+    Map<String, Object> internetNetworkPropertiesInstanciationMap = new HashMap<>();
+
+    NetworkProperties networkProperties;
+    Connection mockedConnection;
+
+    Boolean hasNoSuchElementExceptionBeenThrown = false;
+    Boolean hasAnIllegalArgumentExceptionThrown = false;
+    Boolean hasAGenericExecptionBeenThrown = false;
+
+    @Test
+    public void buildSettingsShouldThrowWhenGivenEmptyMap() {
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        thenNoSuchElementExceptionThrown();
+    }
+
+    @Test
+    public void buildIpv4SettingsShouldThrowWhenGivenEmptyMap() {
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+        thenNoSuchElementExceptionThrown();
+    }
+
+    @Test
+    public void build80211WirelessSettingsShouldThrowErrorWhenGivenEmptyMap() {
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+        thenNoSuchElementExceptionThrown();
+    }
+
+    @Test
+    public void build80211WirelessSecuritySettingsShouldThrowWhenGivenEmptyMap() {
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+        whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+        thenNoSuchElementExceptionThrown();
+    }
+
+    @Test
+    public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForWan() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
+
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+        thenNoExceptionsHaveBeenThrown();
+
+        thenResultingMapContains("method", "auto");
+    }
+
+    @Test
+    public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForWan() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("method", "manual");
+        thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingMapContains("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au").getValue());
+        thenResultingMapContains("ignore-auto-dns", true);
+        thenResultingMapContains("gateway", "192.168.0.1");
+
+    }
+
+    @Test
+    public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForLan() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("method", "auto");
+        thenResultingMapContains("ignore-auto-dns", true);
+        thenResultingMapContains("ignore-auto-routes", true);
+    }
+
+    @Test
+    public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForLan() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("method", "manual");
+        thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingMapContains("ignore-auto-dns", true);
+        thenResultingMapContains("ignore-auto-routes", true);
+    }
+
+    @Test
+    public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndUnmanaged() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("method", "manual");
+        thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+    }
+
+    @Test
+    public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("mode", "infrastructure");
+        thenResultingMapContainsBytes("ssid", "ssidtest");
+        thenResultingMapContains("band", "a");
+        thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
+    }
+
+    @Test
+    public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndModeAp() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "MASTER");
+        givenMapWith("net.interface.wlan0.config.wifi.master.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.master.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.master.channel", "10");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("mode", "ap");
+        thenResultingMapContainsBytes("ssid", "ssidtest");
+        thenResultingMapContains("band", "a");
+        thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
+    }
+
+    @Test
+    public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndModeMalformed() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "MALFORMED_VALUE");
+        givenMapWith("net.interface.wlan0.config.wifi.master.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.master.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.master.channel", "10");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenIllegalArgumentExceptionThrown();
+    }
+
+    @Test
+    public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndBandBg() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211b");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("mode", "infrastructure");
+        thenResultingMapContainsBytes("ssid", "ssidtest");
+        thenResultingMapContains("band", "bg");
+        thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
+    }
+
+    @Test
+    public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndBandBgExt() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211nHT20");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("mode", "infrastructure");
+        thenResultingMapContainsBytes("ssid", "ssidtest");
+        thenResultingMapContains("band", "bg");
+        thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
+    }
+
+    @Test
+    public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndMalformedBand() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "MALFORMED_VALUE");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenIllegalArgumentExceptionThrown();
+    }
+
+    @Test
+    public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("psk", new Password("test").toString());
+        thenResultingMapContains("key-mgmt", "wpa-psk");
+        thenResultingMapContains("group", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+        thenResultingMapContains("pairwise", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+    }
+
+    @Test
+    public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapTkip() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "TKIP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "TKIP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("psk", new Password("test").toString());
+        thenResultingMapContains("key-mgmt", "wpa-psk");
+        thenResultingMapContains("group", new Variant<>(Arrays.asList("tkip"), "as").getValue());
+        thenResultingMapContains("pairwise", new Variant<>(Arrays.asList("tkip"), "as").getValue());
+    }
+
+    @Test
+    public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapCcmpTkip() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP_TKIP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP_TKIP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("psk", new Password("test").toString());
+        thenResultingMapContains("key-mgmt", "wpa-psk");
+        thenResultingMapContains("group", new Variant<>(Arrays.asList("tkip", "ccmp"), "as").getValue());
+        thenResultingMapContains("pairwise", new Variant<>(Arrays.asList("tkip", "ccmp"), "as").getValue());
+    }
+
+    @Test
+    public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapAndMalformedCiphers() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "MALFORMED_VALUE");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP_TKIP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenIllegalArgumentExceptionThrown();
+    }
+
+    @Test
+    public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapNone() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "NONE");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("key-mgmt", "none");
+    }
+
+    @Test
+    public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapMalformedSecurity() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "MALFORMED_VALUE");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenIllegalArgumentExceptionThrown();
+    }
+
+    @Test
+    public void buildConnectionSettingsShouldWorkWithWifi() {
+        whenBuildConnectionSettings(Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("type", "802-11-wireless");
+    }
+
+    @Test
+    public void buildConnectionSettingsShouldWorkWithEthernet() {
+        whenBuildConnectionSettings(Optional.empty(), "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("type", "802-3-ethernet");
+    }
+
+    @Test
+    public void buildConnectionSettingsShouldWorkWithUnsupported() {
+        whenBuildConnectionSettings(Optional.empty(), "modem0", NMDeviceType.NM_DEVICE_TYPE_ADSL);
+
+        thenIllegalArgumentExceptionThrown();
+    }
+
+    @Test
+    public void buildConnectionSettingsShouldWorkWithWifiMockedConnection() {
+
+        givenMapWith("connection", "test", new Variant<>("test"));
+        givenMockConnection();
+
+        whenBuildConnectionSettings(Optional.of(this.mockedConnection), "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("test", "test");
+    }
+
+    @Test
+    public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiUnmanged() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+        thenResultingBuildAllMapContains("ipv4", "method", "manual");
+        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+        thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
+        thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+        thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+        thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+        thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+        thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+        thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+        thenResultingBuildAllMapContains("802-11-wireless-security", "group",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+    }
+
+    @Test
+    public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLan() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+        thenResultingBuildAllMapContains("ipv4", "method", "manual");
+        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+        thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
+        thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+        thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+        thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+        thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+        thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+        thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+        thenResultingBuildAllMapContains("802-11-wireless-security", "group",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+    }
+
+    @Test
+    public void buildSettingsShouldWorkWithExpectedConfiguredForInputsWiFiWan() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+        thenResultingBuildAllMapContains("ipv4", "method", "manual");
+        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+        thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
+        thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+        thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+        thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+        thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+        thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+        thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+        thenResultingBuildAllMapContains("802-11-wireless-security", "group",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+    }
+
+    @Test
+    public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLanAndHiddenSsid() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+        thenResultingBuildAllMapContains("ipv4", "method", "manual");
+        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+        thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
+        thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+        thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+        thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+        thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+        thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+        thenResultingBuildAllMapContains("802-11-wireless", "hidden", true);
+        thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+        thenResultingBuildAllMapContains("802-11-wireless-security", "group",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+    }
+
+    @Test
+    public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+        thenResultingBuildAllMapContains("ipv4", "method", "manual");
+        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+        thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
+        thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+        thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+        thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+        thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+        thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+        thenResultingBuildAllMapContains("802-11-wireless", "hidden", true);
+        thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+        thenResultingBuildAllMapContains("802-11-wireless-security", "group",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+        thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
+                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+    }
+
+    @Test
+    public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndUnmanaged() {
+        givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusUnmanaged");
+        givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+        thenResultingBuildAllMapContains("ipv4", "method", "manual");
+        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
+        thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
+        thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
+    }
+
+    @Test
+    public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
+        givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedLan");
+        givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+        thenResultingBuildAllMapContains("ipv4", "method", "manual");
+        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
+        thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
+        thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
+    }
+
+    @Test
+    public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
+        givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+        thenResultingBuildAllMapContains("ipv4", "method", "manual");
+        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
+        thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
+        thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
+    }
+
+    @Test
+    public void buildSettingsShouldThrowDhcpDisabledAndNullIp() {
+        givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.eth0.config.ip4.address", null);
+        givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        thenNoSuchElementExceptionThrown();
+    }
+
+    @Test
+    public void buildSettingsShouldThrowDhcpDisabledAndNullPrefix() {
+        givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.eth0.config.ip4.prefix", null);
+        givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        thenNoSuchElementExceptionThrown();
+    }
+
+    @Test
+    public void buildSettingsShouldThrowDhcpDisabledAndNullStatus() {
+        givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.eth0.config.ip4.status", null);
+        givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        thenNoSuchElementExceptionThrown();
+    }
+
+    @Test
+    public void buildSettingsShouldThrowDhcpDisabledAndNullWifiSsid() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", null);
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenNoSuchElementExceptionThrown();
+    }
+
+    @Test
+    public void buildSettingsShouldThrowDhcpDisabledAndNullWifiPassword() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", null);
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", null);
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenNoSuchElementExceptionThrown();
+    }
+
+    @Test
+    public void buildSettingsShouldThrowDhcpDisabledAndNullWifiSecurityType() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", null);
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenNoSuchElementExceptionThrown();
+    }
+
+    /*
+     * Given
+     */
+
+    public void givenNetworkPropsCreatedWithTheMap(Map<String, Object> properties) {
+        this.networkProperties = new NetworkProperties(properties);
+    }
+
+    public void givenMapWith(String key, Object value) {
+        this.internetNetworkPropertiesInstanciationMap.put(key, value);
+    }
+
+    public void givenMapWith(String key, String subKey, Variant<?> value) {
+
+        if (this.internalComparatorAllSettingsMap.containsKey(key)) {
+            this.internalComparatorAllSettingsMap.get(key).put(subKey, value);
+        } else {
+            this.internalComparatorAllSettingsMap.put(key, Collections.singletonMap(subKey, value));
+        }
+    }
+
+    public void givenMockConnection() {
+        this.mockedConnection = Mockito.mock(Connection.class);
+        Mockito.when(this.mockedConnection.GetSettings()).thenReturn(this.internalComparatorAllSettingsMap);
+
+    }
+
+    /*
+     * When
+     */
+
+    public void whenBuildSettingsIsRunWith(NetworkProperties properties, Optional<Connection> oldConnection,
+            String iface, NMDeviceType deviceType) {
+        try {
+            this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
+        } catch (NoSuchElementException e) {
+            e.printStackTrace();
+            this.hasNoSuchElementExceptionBeenThrown = true;
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            this.hasAnIllegalArgumentExceptionThrown = true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.hasAGenericExecptionBeenThrown = true;
+        }
+    }
+
+    public void whenBuildIpv4SettingsIsRunWith(NetworkProperties props, String iface) {
+        try {
+            this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
+        } catch (NoSuchElementException e) {
+            e.printStackTrace();
+            this.hasNoSuchElementExceptionBeenThrown = true;
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            this.hasAnIllegalArgumentExceptionThrown = true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.hasAGenericExecptionBeenThrown = true;
+        }
+    }
+
+    public void whenBuildIpv6SettingsIsRunWith(NetworkProperties props, String iface) {
+        try {
+            this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
+        } catch (NoSuchElementException e) {
+            e.printStackTrace();
+            this.hasNoSuchElementExceptionBeenThrown = true;
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            this.hasAnIllegalArgumentExceptionThrown = true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.hasAGenericExecptionBeenThrown = true;
+        }
+    }
+
+    public void whenBuild80211WirelessSettingsIsRunWith(NetworkProperties props, String iface) {
+        try {
+            this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
+        } catch (NoSuchElementException e) {
+            e.printStackTrace();
+            this.hasNoSuchElementExceptionBeenThrown = true;
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            this.hasAnIllegalArgumentExceptionThrown = true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.hasAGenericExecptionBeenThrown = true;
+        }
+    }
+
+    public void whenBuildConnectionSettings(Optional<Connection> connection, String iface, NMDeviceType deviceType) {
+        try {
+            this.resultMap = NMSettingsConverter.buildConnectionSettings(connection, iface, deviceType);
+        } catch (NoSuchElementException e) {
+            e.printStackTrace();
+            this.hasNoSuchElementExceptionBeenThrown = true;
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            this.hasAnIllegalArgumentExceptionThrown = true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.hasAGenericExecptionBeenThrown = true;
+        }
+    }
+
+    public void whenBuild80211WirelessSecuritySettingsIsRunWith(NetworkProperties props, String iface) {
+        try {
+            this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
+        } catch (NoSuchElementException e) {
+            e.printStackTrace();
+            this.hasNoSuchElementExceptionBeenThrown = true;
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            this.hasAnIllegalArgumentExceptionThrown = true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.hasAGenericExecptionBeenThrown = true;
+        }
+    }
+
+    /*
+     * Then
+     */
+
+    public void thenResultingMapContains(String key, Object value) {
+        assertEquals(value, this.resultMap.get(key).getValue());
+    }
+
+    public void thenResultingMapContainsBytes(String key, Object value) {
+        assertEquals(value, new String((byte[]) this.resultMap.get(key).getValue(), StandardCharsets.UTF_8));
+    }
+
+    public void thenResultingBuildAllMapContains(String key, String subKey, Object value) {
+        assertEquals(value, this.resultAllSettingsMap.get(key).get(subKey).getValue());
+    }
+
+    public void thenResultingBuildAllMapContainsBytes(String key, String subKey, Object value) {
+        assertEquals(value,
+                new String((byte[]) this.resultAllSettingsMap.get(key).get(subKey).getValue(), StandardCharsets.UTF_8));
+    }
+
+    public void thenNoSuchElementExceptionThrown() {
+        assertTrue(this.hasNoSuchElementExceptionBeenThrown);
+    }
+
+    public void thenIllegalArgumentExceptionThrown() {
+        assertTrue(this.hasAnIllegalArgumentExceptionThrown);
+    }
+
+    public void thenNoExceptionsHaveBeenThrown() {
+        assertFalse(this.hasNoSuchElementExceptionBeenThrown);
+        assertFalse(this.hasAGenericExecptionBeenThrown);
+        assertFalse(this.hasAnIllegalArgumentExceptionThrown);
+    }
+
+    /*
+     * Helper Methods
+     */
+
+    public Object buildAddressDataWith(String ipAddr, UInt32 prefix) {
+
+        Map<String, Variant<?>> addressEntry = new HashMap<>();
+        addressEntry.put("address", new Variant<>(ipAddr));
+        addressEntry.put("prefix", new Variant<>(prefix));
+
+        List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
+
+        Variant<?> dataVariant = new Variant<>(addressData, "aa{sv}");
+
+        return dataVariant.getValue();
+    }
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -45,15 +45,15 @@ public class NMSettingsConverterTest {
 
 	Boolean hasIllegalArgumentExceptionBeenThrown = false;
 	Boolean hasAGenericExecptionBeenThrown = false;
-	
-	String netInterface; 
+
+	String netInterface;
 	String kuraIP4Status;
+	Boolean KuraDhcpStatus;
 
 	@Test
 	public void buildSettingsShouldThrowWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0",
-				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
@@ -87,10 +87,15 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForWan() {
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledWAN");
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusEnabledWAN");
+		givenDhcpStatus(true);
+
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+
 		givenValidBuildIpv4ConfigWithDhcpEnabled();
 		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToWan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
@@ -99,7 +104,17 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForWan() {
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledWAN");
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusEnabledWAN");
+		givenDhcpStatus(false);
+
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToWan("wlan0");
@@ -112,7 +127,13 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForLan() {
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledLAN");
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusEnabledLAN");
+		givenDhcpStatus(true);
+
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+
 		givenValidBuildIpv4ConfigWithDhcpEnabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan("wlan0");
@@ -124,7 +145,17 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForLan() {
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledLAN");
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusEnabledLAN");
+		givenDhcpStatus(false);
+
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan("wlan0");
@@ -136,7 +167,17 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndUnmanaged() {
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
+		givenNetInterface("wlan0");
+		givenIP4Status("netIPv4StatusUnmanaged");
+		givenDhcpStatus(false);
+
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
@@ -147,8 +188,14 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
-		givenValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "testssid", "INFRA", true, false);
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "testssid", "infrastructure", true,
+		givenNetInterface("wlan0");
+		
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
+		
+		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "ssidtest", "infrastructure", true,
 				false);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
@@ -172,11 +219,23 @@ public class NMSettingsConverterTest {
 
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusUnmanaged");
+		givenDhcpStatus(false);
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
-		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
+
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
+		
 		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
 				true, false);
 		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
@@ -196,12 +255,24 @@ public class NMSettingsConverterTest {
 
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusManagedLan");
+		givenDhcpStatus(false);
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan(netInterface);
-		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
+		
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
+
 		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
 				true, false);
 		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
@@ -221,12 +292,24 @@ public class NMSettingsConverterTest {
 
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusManagedWan");
+		givenDhcpStatus(false);
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToWan(netInterface);
-		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, false);
+		
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
+		
 		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
 				true, false);
 		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
@@ -246,12 +329,25 @@ public class NMSettingsConverterTest {
 
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusManagedLan");
+		givenDhcpStatus(false);
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan(netInterface);
-		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
+		
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ignoreSSID",	true);
+		
 		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
 				true, true);
 		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
@@ -271,12 +367,25 @@ public class NMSettingsConverterTest {
 
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusManagedWan");
+		givenDhcpStatus(false);
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToWan(netInterface);
-		givenValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true, true);
+
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ignoreSSID",	true);
+		
 		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
 				true, true);
 		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
@@ -296,8 +405,15 @@ public class NMSettingsConverterTest {
 
 		givenNetInterface("eth0");
 		givenIP4Status("netIPv4StatusUnmanaged");
+		givenDhcpStatus(false);
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
@@ -313,8 +429,15 @@ public class NMSettingsConverterTest {
 
 		givenNetInterface("eth0");
 		givenIP4Status("netIPv4StatusManagedLan");
+		givenDhcpStatus(false);
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan(netInterface);
@@ -331,8 +454,15 @@ public class NMSettingsConverterTest {
 
 		givenNetInterface("eth0");
 		givenIP4Status("netIPv4StatusManagedWan");
+		givenDhcpStatus(false);
 
-		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToWan(netInterface);
@@ -345,28 +475,25 @@ public class NMSettingsConverterTest {
 	}
 
 	// given
-	
-	public void givenNetInterface(String netInterface){
+
+	public void givenNetInterface(String netInterface) {
 		this.netInterface = netInterface;
 	}
-	
-	public void givenIP4Status(String kuraIP4Status){
+
+	public void givenIP4Status(String kuraIP4Status) {
 		this.kuraIP4Status = kuraIP4Status;
+	}
+
+	public void givenDhcpStatus(Boolean KuraDhcpStatus) {
+		this.KuraDhcpStatus = KuraDhcpStatus;
 	}
 
 	public void givenNetworkPropsCreatedWithTheMap(Map<String, Object> properties) {
 		this.networkProperties = new NetworkProperties(properties);
 	}
 
-	public void givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(String inter, Boolean dhcpStatus,
-			String netStatus) {
-		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.dhcpClient4.enabled",
-				dhcpStatus);
-		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.status", netStatus);
-		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.address", "192.168.0.12");
-		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.prefix", (short) 25);
-		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.dnsServers", "1.1.1.1");
-		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.ip4.gateway", "192.168.0.1");
+	public void givenMapWith(String key, Object value) {
+		this.internetNetworkPropertiesInstanciationMap.put(key, value);
 	}
 
 	public void givenExpectedValidWifiConfigurationSetToLan(String inter) {
@@ -385,6 +512,7 @@ public class NMSettingsConverterTest {
 		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
 
 		Optional<List<String>> dnsServers = Optional.of(Arrays.asList("1.1.1.1"));
+
 		if (dnsServers.isPresent()) {
 			internalMethodHashMap.put("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au"));
 			internalMethodHashMap.put("ignore-auto-dns", new Variant<>(true));
@@ -428,28 +556,6 @@ public class NMSettingsConverterTest {
 		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
 		internalMethodHashMap.put("method", new Variant<>("disabled"));
 		this.internalComparatorAllSettingsMap.put("ipv6", internalMethodHashMap);
-	}
-
-	public void givenValid80211WirelessSettingsWithTheFollowingParameters(String inter, String ssid, String propMode,
-			Boolean channelEnabled, Boolean isHidden) {
-		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.wifi.mode", inter),
-				propMode);
-		internetNetworkPropertiesInstanciationMap
-				.put(String.format("net.interface.%s.config.wifi.%s.ssid", inter, propMode.toLowerCase()), ssid);
-		internetNetworkPropertiesInstanciationMap.put(
-				String.format("net.interface.%s.config.wifi.%s.radioMode", inter, propMode.toLowerCase()),
-				"RADIO_MODE_80211a");
-		if (channelEnabled) {
-			internetNetworkPropertiesInstanciationMap
-					.put(String.format("net.interface.%s.config.wifi.%s.channel", inter, propMode.toLowerCase()), "10");
-		}
-
-		if (isHidden) {
-			internetNetworkPropertiesInstanciationMap.put(
-					String.format("net.interface.%s.config.wifi.%s.ignoreSSID", inter, propMode.toLowerCase()),
-					isHidden);
-		}
-
 	}
 
 	public void givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(String inter, String ssid,
@@ -525,8 +631,8 @@ public class NMSettingsConverterTest {
 
 	// when
 
-	public void whenBuildSettingsIsRunWith(NetworkProperties properties,
-			Optional<Connection> oldConnection, String iface, NMDeviceType deviceType) {
+	public void whenBuildSettingsIsRunWith(NetworkProperties properties, Optional<Connection> oldConnection,
+			String iface, NMDeviceType deviceType) {
 		try {
 			this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
 		} catch (IllegalArgumentException e) {
@@ -562,8 +668,7 @@ public class NMSettingsConverterTest {
 		}
 	}
 
-	public void whenBuild80211WirelessSettingsIsRunWith(NetworkProperties props,
-			String iface) {
+	public void whenBuild80211WirelessSettingsIsRunWith(NetworkProperties props, String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
 		} catch (IllegalArgumentException e) {
@@ -575,8 +680,7 @@ public class NMSettingsConverterTest {
 		}
 	}
 
-	public void whenBuild80211WirelessSecuritySettingsIsRunWith(NetworkProperties props,
-			String iface) {
+	public void whenBuild80211WirelessSecuritySettingsIsRunWith(NetworkProperties props, String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
 		} catch (IllegalArgumentException e) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -49,7 +49,7 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildSettingsShouldThrowWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		thenIllegalArgumentExceptionHasBeenThrown();
 	}
@@ -57,28 +57,28 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildIpv4SettingsShouldThrowWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
 	@Test
 	public void buildIpv6SettingsShouldThrowErrorWhenWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuildIpv6SettingsIsRunWith(this.networkProperties, "wlan0");
 		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
 	@Test
 	public void build80211WirelessSettingsShouldThrowErrorWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
 		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
 	@Test
 	public void build80211WirelessSecuritySettingsShouldThrowWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
 		thenIllegalArgumentExceptionHasBeenThrown();
 	}
 
@@ -89,7 +89,7 @@ public class NMSettingsConverterTest {
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToWan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
@@ -101,7 +101,7 @@ public class NMSettingsConverterTest {
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToWan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 
@@ -114,7 +114,7 @@ public class NMSettingsConverterTest {
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
@@ -126,7 +126,7 @@ public class NMSettingsConverterTest {
 		givenValidBuildIpv6Config();
 		givenExpectedValidWifiConfigurationSetToLan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
@@ -137,7 +137,7 @@ public class NMSettingsConverterTest {
 		givenValidBuildIpv4ConfigWithDhcpDisabled();
 		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
@@ -148,7 +148,7 @@ public class NMSettingsConverterTest {
 		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "testssid", "infrastructure", true,
 				false);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultFromWifiSettingsShouldEqualInternalMapForWifiSettings();
 	}
@@ -159,7 +159,7 @@ public class NMSettingsConverterTest {
 		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters("wlan0", "ssidtest", "propmode", true,
 				true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalMap();
 	}
@@ -182,7 +182,7 @@ public class NMSettingsConverterTest {
 				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
@@ -207,7 +207,7 @@ public class NMSettingsConverterTest {
 				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
@@ -232,7 +232,7 @@ public class NMSettingsConverterTest {
 				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
@@ -257,7 +257,7 @@ public class NMSettingsConverterTest {
 				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
@@ -282,7 +282,7 @@ public class NMSettingsConverterTest {
 				true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
@@ -299,7 +299,7 @@ public class NMSettingsConverterTest {
 		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
@@ -317,7 +317,7 @@ public class NMSettingsConverterTest {
 		givenExpectedValidWifiConfigurationSetToLan(netInterface);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
@@ -335,7 +335,7 @@ public class NMSettingsConverterTest {
 		givenExpectedValidWifiConfigurationSetToWan(netInterface);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
-		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 		thenNoExceptionsHaveBeenThrown();
 		thenMapResultShouldEqualInternalBuildMap();
@@ -514,7 +514,7 @@ public class NMSettingsConverterTest {
 
 	// when
 
-	public void whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties properties,
+	public void whenBuildSettingsIsRunWith(NetworkProperties properties,
 			Optional<Connection> oldConnection, String iface, NMDeviceType deviceType) {
 		try {
 			this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
@@ -527,7 +527,7 @@ public class NMSettingsConverterTest {
 		}
 	}
 
-	public void whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+	public void whenBuildIpv4SettingsIsRunWith(NetworkProperties props, String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
 		} catch (IllegalArgumentException e) {
@@ -539,7 +539,7 @@ public class NMSettingsConverterTest {
 		}
 	}
 
-	public void whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+	public void whenBuildIpv6SettingsIsRunWith(NetworkProperties props, String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
 		} catch (IllegalArgumentException e) {
@@ -551,7 +551,7 @@ public class NMSettingsConverterTest {
 		}
 	}
 
-	public void whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props,
+	public void whenBuild80211WirelessSettingsIsRunWith(NetworkProperties props,
 			String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
@@ -564,7 +564,7 @@ public class NMSettingsConverterTest {
 		}
 	}
 
-	public void whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props,
+	public void whenBuild80211WirelessSecuritySettingsIsRunWith(NetworkProperties props,
 			String iface) {
 		try {
 			this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -33,13 +33,13 @@ import org.junit.Test;
 
 public class NMSettingsConverterTest {
 
-	Map<String, Variant<?>> internalComparatorMap;
+	Map<String, Variant<?>> internalComparatorMap = new HashMap<>();
 	Map<String, Variant<?>> resultMap;
 
-	Map<String, Map<String, Variant<?>>> internalComparatorAllSettingsMap;
-	Map<String, Map<String, Variant<?>>> resultAllSettingsMap;
+	Map<String, Map<String, Variant<?>>> internalComparatorAllSettingsMap = new HashMap<>();
+	Map<String, Map<String, Variant<?>>> resultAllSettingsMap = new HashMap<>();
 
-	Map<String, Object> internetNetworkPropertiesInstanciationMap;
+	Map<String, Object> internetNetworkPropertiesInstanciationMap = new HashMap<>();
 
 	NetworkProperties networkProperties;
 
@@ -48,7 +48,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildSettingsShouldThrowWhenGivenEmptyMap() {
-		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
@@ -57,7 +56,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldThrowWhenGivenEmptyMap() {
-		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenIllegalArgumentExceptionHasBeenThrown();
@@ -65,7 +63,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv6SettingsShouldThrowErrorWhenWhenGivenEmptyMap() {
-		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenIllegalArgumentExceptionHasBeenThrown();
@@ -73,7 +70,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void build80211WirelessSettingsShouldThrowErrorWhenGivenEmptyMap() {
-		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenIllegalArgumentExceptionHasBeenThrown();
@@ -81,7 +77,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void build80211WirelessSecuritySettingsShouldThrowWhenGivenEmptyMap() {
-		givenEmptyMaps();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
 		thenIllegalArgumentExceptionHasBeenThrown();
@@ -89,7 +84,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForWan() {
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledWAN");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
 				"netIPv4StatusEnabledWAN");
@@ -101,7 +95,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForWan() {
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledWAN");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
 				"netIPv4StatusEnabledWAN");
@@ -114,7 +107,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForLan() {
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledLAN");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
 				"netIPv4StatusEnabledLAN");
@@ -126,7 +118,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForLan() {
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledLAN");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
 				"netIPv4StatusEnabledLAN");
@@ -138,7 +129,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndUnmanaged() {
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
 				"netIPv4StatusUnmanaged");
@@ -150,7 +140,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
-		givenEmptyMaps();
 		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true, false);
 		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true, false);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
@@ -161,7 +150,6 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
-		givenEmptyMaps();
 		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
 		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propmode", true, true);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
@@ -171,12 +159,11 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsWiFi() {
+	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiUnmanged() {
 		
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusUnmanaged";
 		
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
@@ -194,12 +181,11 @@ public class NMSettingsConverterTest {
 	}
 	
 	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsWiFiLan() {
+	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLan() {
 		
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusManagedLan";
 		
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
@@ -217,12 +203,11 @@ public class NMSettingsConverterTest {
 	}
 	
 	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsWiFiWan() {
+	public void buildSettingsShouldWorkWithExpectedConfiguredForInputsWiFiWan() {
 		
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusManagedWan";
 		
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
@@ -240,12 +225,11 @@ public class NMSettingsConverterTest {
 	}
 	
 	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsWiFiLanAndHiddenSsid() {
+	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLanAndHiddenSsid() {
 		
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusManagedLan";
 		
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
@@ -263,12 +247,11 @@ public class NMSettingsConverterTest {
 	}
 	
 	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsWiFiWanAndHiddenSsid() {
+	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
 		
 		String netInterface = "wlan0";
 		String kuraNetType = "netIPv4StatusManagedWan";
 		
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
@@ -286,12 +269,11 @@ public class NMSettingsConverterTest {
 	}
 	
 	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndUnmanaged() {
+	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndUnmanaged() {
 		
 		String netInterface = "eth0";
 		String kuraNetType = "netIPv4StatusUnmanaged";
 		
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
@@ -304,12 +286,11 @@ public class NMSettingsConverterTest {
 	}
 	
 	@Test
-	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndLan() {
+	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
 		
 		String netInterface = "eth0";
 		String kuraNetType = "netIPv4StatusManagedLan";
 		
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
@@ -327,7 +308,6 @@ public class NMSettingsConverterTest {
 		String netInterface = "eth0";
 		String kuraNetType = "netIPv4StatusManagedWan";
 		
-		givenEmptyMaps();
 		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false, kuraNetType);
 		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(netInterface, false,
 				kuraNetType);
@@ -340,14 +320,6 @@ public class NMSettingsConverterTest {
 	}
 
 	// given
-
-	public void givenEmptyMaps() {
-		internalComparatorMap = new HashMap<>();
-		resultMap = new HashMap<>();
-		internalComparatorAllSettingsMap = new HashMap<>();
-		resultAllSettingsMap = new HashMap<>();
-		internetNetworkPropertiesInstanciationMap = new HashMap<>();
-	}
 
 	public void givenNetworkPropsCreatedWithTheMap(Map<String, Object> properties) {
 		this.networkProperties = new NetworkProperties(properties);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -1,0 +1,333 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.nm.configuration;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.kura.configuration.Password;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+import org.freedesktop.networkmanager.settings.Connection;
+import org.junit.Test;
+
+public class NMSettingsConverterTest {
+
+	Map<String, Variant<?>> internalComparatorMap;
+	Map<String, Variant<?>> resultMap;
+
+	Map<String, Map<String, Variant<?>>> internalComparatorAllSettingsMap;
+	Map<String, Map<String, Variant<?>>> resultAllSettingsMap;
+
+	Map<String, Object> internetNetworkPropertiesInstanciationMap;
+
+	NetworkProperties networkProperties;
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuildSettingsWithEmptyMap() {
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
+				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuildIpv4SettingsWithEmptyMap() {
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuildIpv6SettingsWithEmptyMap() {
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuild80211WirelessSettingsWithEmptyMap() {
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowErrorWhenBuild80211WirelessSecuritySettingsWithEmptyMap() {
+		givenEmptyMaps();
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpEnabledForWAN() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledWAN");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
+				"netIPv4StatusEnabledWAN");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpDisabledForWAN() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledWAN");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
+				"netIPv4StatusEnabledWAN");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpEnabledForLAN() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true, "netIPv4StatusEnabledLAN");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", true,
+				"netIPv4StatusEnabledLAN");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpDisabledForLAN() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusEnabledLAN");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
+				"netIPv4StatusEnabledLAN");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuildIpv4SettingsWithExpectedInputsAndDhcpDisabledForOther() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
+				"netIPv4StatusUnmanaged");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuild80211WirelessSettingsWithExpectedInputs() {
+		givenEmptyMaps();
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuild80211WirelessSecurityWithExpectedInputs() {
+		givenEmptyMaps();
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, "wlan0");
+		thenMapResultShouldEqualInternalMap();
+	}
+
+	@Test
+	public void shouldBuildSettingsWithExpectedInputs() {
+		givenEmptyMaps();
+		givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false, "netIPv4StatusUnmanaged");
+		givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus("wlan0", false,
+				"netIPv4StatusUnmanaged");
+		givenValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "INFRA", true);
+		givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid("wlan0", "testssid", "infrastructure", true);
+		givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid("wlan0", "ssidtest", "propMode", true, true);
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(this.networkProperties, Optional.empty(), "wlan0",
+				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		thenMapResultShouldEqualInternalBuildMap();
+	}
+
+	// given
+
+	public void givenEmptyMaps() {
+		internalComparatorMap = new HashMap<>();
+		resultMap = new HashMap<>();
+		internalComparatorAllSettingsMap = new HashMap<>();
+		resultAllSettingsMap = new HashMap<>();
+		internetNetworkPropertiesInstanciationMap = new HashMap<>();
+	}
+
+	public void givenNetworkPropsCreatedWithTheMap(Map<String, Object> properties) {
+		this.networkProperties = new NetworkProperties(properties);
+	}
+
+	public void givenValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(String inter, Boolean dhcpStatus,
+			String netStatus) {
+		internetNetworkPropertiesInstanciationMap
+				.put(String.format("net.interface.%s.config.dhcpClient4.enabled", inter), dhcpStatus);
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.status", inter),
+				netStatus);
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.address", inter),
+				"192.168.0.12");
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.prefix", inter),
+				(short) 25);
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.dnsServers", inter),
+				"1.1.1.1");
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.ip4.gateway", inter),
+				"192.168.0.1");
+	}
+
+	public void givenExpectedValidWifiConfigurationWithInterfaceNameAndDhcpBoolAndNetStatus(String inter,
+			Boolean dhcpStatus, String netStatus) {
+
+		if (!dhcpStatus) {
+			internalComparatorMap.put("method", new Variant<>("manual"));
+
+			Map<String, Variant<?>> addressEntry = new HashMap<>();
+			addressEntry.put("address", new Variant<>("192.168.0.12"));
+			addressEntry.put("prefix", new Variant<>(new UInt32(25)));
+
+			List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
+			internalComparatorMap.put("address-data", new Variant<>(addressData, "aa{sv}"));
+
+		} else {
+			internalComparatorMap.put("method", new Variant<>("auto"));
+		}
+
+		if (netStatus.equals("netIPv4StatusEnabledLAN")) {
+			internalComparatorMap.put("ignore-auto-dns", new Variant<>(true));
+			internalComparatorMap.put("ignore-auto-routes", new Variant<>(true));
+		} else if (netStatus.equals("netIPv4StatusEnabledWAN")) {
+			Optional<List<String>> dnsServers = Optional.of(List.of("1.1.1.1"));
+			if (dnsServers.isPresent()) {
+				internalComparatorMap.put("dns", new Variant<>(List.of(new UInt32(16843009)), "au"));
+				internalComparatorMap.put("ignore-auto-dns", new Variant<>(true));
+			}
+			Optional<String> gateway = Optional.of("192.168.0.1");
+			if (gateway.isPresent()) {
+				internalComparatorMap.put("gateway", new Variant<>(gateway.get()));
+			}
+		}
+
+	}
+
+	public void givenValid80211WirelessSettingsWithInterfaceNameAndSsid(String inter, String ssid, String propMode,
+			Boolean channelEnabled) {
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.wifi.mode", inter),
+				propMode);
+		internetNetworkPropertiesInstanciationMap
+				.put(String.format("net.interface.%s.config.wifi.%s.ssid", inter, propMode.toLowerCase()), ssid);
+		internetNetworkPropertiesInstanciationMap.put(
+				String.format("net.interface.%s.config.wifi.%s.radioMode", inter, propMode.toLowerCase()),
+				"RADIO_MODE_80211a");
+		if (channelEnabled) {
+			internetNetworkPropertiesInstanciationMap
+					.put(String.format("net.interface.%s.config.wifi.%s.channel", inter, propMode.toLowerCase()), "10");
+		}
+	}
+
+	public void givenExpectedValid80211WirelessSettingsWithInterfaceNameAndSsid(String inter, String ssid,
+			String propMode, Boolean channelEnabled) {
+		internalComparatorMap.put("mode", new Variant<>(propMode));
+		// TODO: investigate this .getBytes discrepancy
+		internalComparatorMap.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
+		internalComparatorMap.put("band", new Variant<>("a"));
+		if (channelEnabled) {
+			internalComparatorMap.put("channel", new Variant<>(new UInt32(Short.parseShort("10"))));
+		}
+	}
+
+	public void givenValid80211WirelessSecuritySettingsWithInterfaceNameAndSsid(String inter, String ssid,
+			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
+		internetNetworkPropertiesInstanciationMap.put(String.format("net.interface.%s.config.wifi.mode", inter),
+				propMode);
+		internetNetworkPropertiesInstanciationMap.put(
+				String.format("net.interface.%s.config.wifi.%s.passphrase", inter, propMode.toLowerCase()),
+				new Password("test"));
+		internetNetworkPropertiesInstanciationMap.put(
+				String.format("net.interface.%s.config.wifi.%s.securityType", inter, propMode.toLowerCase()),
+				"SECURITY_WPA_WPA2"); // wpa
+		if (groupEnabled) {
+			internetNetworkPropertiesInstanciationMap.put(
+					String.format("net.interface.%s.config.wifi.%s.groupCiphers", inter, propMode.toLowerCase()),
+					"CCMP"); // option
+		}
+		if (ciphersEnabled) {
+			internetNetworkPropertiesInstanciationMap.put(
+					String.format("net.interface.%s.config.wifi.%s.pairwiseCiphers", inter, propMode.toLowerCase()),
+					"CCMP"); // ccmp
+		}
+	}
+
+	public void givenExpected80211WirelessSecuritySettingsWithInterfaceNameAndSsid(String inter, String ssid,
+			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
+
+		internalComparatorMap.put("psk", new Variant<>(new Password("test").toString()));
+		internalComparatorMap.put("key-mgmt", new Variant<>("wpa-psk"));
+
+		if (groupEnabled) {
+			internalComparatorMap.put("group", new Variant<>(Arrays.asList("ccmp"), "as"));
+		}
+
+		if (ciphersEnabled) {
+			internalComparatorMap.put("pairwise", new Variant<>(Arrays.asList("ccmp"), "as"));
+		}
+
+	}
+
+	// when
+
+	public void whenBuildSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties properties,
+			Optional<Connection> oldConnection, String iface, NMDeviceType deviceType) {
+		this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
+	}
+
+	public void whenBuildIpv4SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+		this.resultMap = NMSettingsConverter.buildIpv4Settings(props, iface);
+	}
+
+	public void whenBuildIpv6SettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props, String iface) {
+		this.resultMap = NMSettingsConverter.buildIpv6Settings(props, iface);
+	}
+
+	public void whenBuild80211WirelessSettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props,
+			String iface) {
+		this.resultMap = NMSettingsConverter.build80211WirelessSettings(props, iface);
+	}
+
+	public void whenBuild80211WirelessSecuritySettingsIsRunWithNetworkPropsAndIfaceString(NetworkProperties props,
+			String iface) {
+		this.resultMap = NMSettingsConverter.build80211WirelessSecuritySettings(props, iface);
+	}
+
+	// then
+
+	public void thenMapResultShouldEqualInternalMap() {
+		assertEquals(this.internalComparatorMap, this.resultMap);
+	}
+
+	public void thenMapResultShouldEqualInternalBuildMap() {
+		assertEquals(this.internalComparatorAllSettingsMap, this.resultAllSettingsMap);
+	}
+
+}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -180,6 +180,88 @@ public class NMSettingsConverterTest {
 		thenResultingMapContains("band", "a");
 		thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
 	}
+	
+	@Test
+	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndModeAp() {
+		
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "MASTER");
+		givenMapWith("net.interface.wlan0.config.wifi.master.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.master.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface.wlan0.config.wifi.master.channel", "10");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
+		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+		
+		thenNoExceptionsHaveBeenThrown();
+		thenResultingMapContains("mode", "ap");
+		thenResultingMapContainsBytes("ssid", "ssidtest");
+		thenResultingMapContains("band", "a");
+		thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
+	}
+	
+	@Test
+	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndModeMalformed() {
+		
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "MALFORMED_VALUE");
+		givenMapWith("net.interface.wlan0.config.wifi.master.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.master.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface.wlan0.config.wifi.master.channel", "10");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
+		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+		
+		thenIllegalArgumentExceptionThrown();
+	}
+	
+	@Test
+	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndBandBg() {
+		
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211b");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
+		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+		
+		thenNoExceptionsHaveBeenThrown();
+		thenResultingMapContains("mode", "infrastructure");
+		thenResultingMapContainsBytes("ssid", "ssidtest");
+		thenResultingMapContains("band", "bg");
+		thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
+	}
+	
+	@Test
+	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndBandBgExt() {
+		
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211nHT20");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
+		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+		
+		thenNoExceptionsHaveBeenThrown();
+		thenResultingMapContains("mode", "infrastructure");
+		thenResultingMapContainsBytes("ssid", "ssidtest");
+		thenResultingMapContains("band", "bg");
+		thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
+	}
+	
+	@Test
+	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndMalformedBand() {
+		
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "MALFORMED_VALUE");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
+		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+		
+		thenIllegalArgumentExceptionThrown();
+	}
 
 	@Test
 	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
@@ -201,6 +283,90 @@ public class NMSettingsConverterTest {
 	}
 
 	@Test
+	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapTkip() {
+
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "TKIP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "TKIP");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+
+		thenNoExceptionsHaveBeenThrown();
+		thenResultingMapContains("psk", new Password("test").toString());
+		thenResultingMapContains("key-mgmt", "wpa-psk");
+		thenResultingMapContains("group", new Variant<>(Arrays.asList("tkip"), "as").getValue());
+		thenResultingMapContains("pairwise", new Variant<>(Arrays.asList("tkip"), "as").getValue());
+	}
+
+	@Test
+	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapCcmpTkip() {
+
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP_TKIP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP_TKIP");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+
+		thenNoExceptionsHaveBeenThrown();
+		thenResultingMapContains("psk", new Password("test").toString());
+		thenResultingMapContains("key-mgmt", "wpa-psk");
+		thenResultingMapContains("group", new Variant<>(Arrays.asList("tkip", "ccmp"), "as").getValue());
+		thenResultingMapContains("pairwise", new Variant<>(Arrays.asList("tkip", "ccmp"), "as").getValue());
+	}
+	
+	@Test
+	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapAndMalformedCiphers() {
+		
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "MALFORMED_VALUE");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP_TKIP");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
+		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+		
+		thenIllegalArgumentExceptionThrown();
+	}
+
+	@Test
+	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapNone() {
+
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "NONE");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+
+		thenNoExceptionsHaveBeenThrown();
+		thenResultingMapContains("key-mgmt", "none");
+	}
+	
+	@Test
+	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMapMalformedSecurity() {
+		
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "MALFORMED_VALUE");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
+		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+		
+		thenIllegalArgumentExceptionThrown();
+	}
+
+	@Test
 	public void buildConnectionSettingsShouldWorkWithWifi() {
 		whenBuildConnectionSettings(Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
@@ -219,14 +385,14 @@ public class NMSettingsConverterTest {
 	@Test
 	public void buildConnectionSettingsShouldWorkWithUnsupported() {
 		whenBuildConnectionSettings(Optional.empty(), "modem0", NMDeviceType.NM_DEVICE_TYPE_ADSL);
-		
+
 		thenIllegalArgumentExceptionThrown();
 	}
 
 	@Test
 	public void buildConnectionSettingsShouldWorkWithWifiMockedConnection() {
-		
-		givenMapWith("connection","test",new Variant<>("test"));
+
+		givenMapWith("connection", "test", new Variant<>("test"));
 		givenMockConnection();
 
 		whenBuildConnectionSettings(Optional.of(this.mockedConnection), "eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
@@ -505,7 +671,7 @@ public class NMSettingsConverterTest {
 		thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
 		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullIp() {
 		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
@@ -515,13 +681,13 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-		
+
 		thenNoSuchElementExceptionThrown();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullPrefix() {
 		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
@@ -531,13 +697,13 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-		
+
 		thenNoSuchElementExceptionThrown();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullStatus() {
 		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
@@ -547,13 +713,13 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-		
+
 		thenNoSuchElementExceptionThrown();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullDnsServer() {
 		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
@@ -563,38 +729,37 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.eth0.config.ip4.dnsServers", null);
 		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
-		
-		
+
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiSsid() {
-			givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-			givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
-			givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-			givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-			givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-			givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-			givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-			givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", null);
-			givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-			givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-			givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
-			givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-			givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-			givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-			givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-			givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
-			givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", null);
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
+		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-			whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
-			thenNoSuchElementExceptionThrown();
-		}
-	
+		thenNoSuchElementExceptionThrown();
+	}
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiMode() {
 		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
@@ -614,12 +779,12 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
 		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-		
+
 		thenNoSuchElementExceptionThrown();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiRadioMode() {
 		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
@@ -639,12 +804,12 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
 		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-		
+
 		thenNoSuchElementExceptionThrown();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiPassword() {
 		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
@@ -664,12 +829,12 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
 		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-		
+
 		thenNoSuchElementExceptionThrown();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullWifiSecurityType() {
 		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
@@ -689,12 +854,12 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
 		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-		
+
 		thenNoSuchElementExceptionThrown();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullGroupCiphers() {
 		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
@@ -714,12 +879,12 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", null);
 		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-		
+
 		thenNoSuchElementExceptionThrown();
 	}
-	
+
 	@Test
 	public void buildSettingsShouldThrowDhcpDisabledAndNullPairwiseCiphers() {
 		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
@@ -739,9 +904,9 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
 		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", null);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
-		
+
 		thenNoSuchElementExceptionThrown();
 	}
 
@@ -756,20 +921,20 @@ public class NMSettingsConverterTest {
 	public void givenMapWith(String key, Object value) {
 		this.internetNetworkPropertiesInstanciationMap.put(key, value);
 	}
-	
+
 	public void givenMapWith(String key, String subKey, Variant<?> value) {
-		
-		if(this.internalComparatorAllSettingsMap.containsKey(key)) {
+
+		if (this.internalComparatorAllSettingsMap.containsKey(key)) {
 			this.internalComparatorAllSettingsMap.get(key).put(subKey, value);
-		}else {
+		} else {
 			this.internalComparatorAllSettingsMap.put(key, Collections.singletonMap(subKey, value));
 		}
 	}
-	
+
 	public void givenMockConnection() {
 		this.mockedConnection = Mockito.mock(Connection.class);
 		Mockito.when(this.mockedConnection.GetSettings()).thenReturn(this.internalComparatorAllSettingsMap);
-		
+
 	}
 
 	/*
@@ -891,7 +1056,7 @@ public class NMSettingsConverterTest {
 	public void thenNoSuchElementExceptionThrown() {
 		assertTrue(this.hasNoSuchElementExceptionBeenThrown);
 	}
-	
+
 	public void thenIllegalArgumentExceptionThrown() {
 		assertTrue(this.hasAnIllegalArgumentExceptionThrown);
 	}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -46,10 +46,6 @@ public class NMSettingsConverterTest {
 	Boolean hasIllegalArgumentExceptionBeenThrown = false;
 	Boolean hasAGenericExecptionBeenThrown = false;
 
-	String netInterface;
-	String kuraIP4Status;
-	Boolean KuraDhcpStatus;
-
 	@Test
 	public void buildSettingsShouldThrowWhenGivenEmptyMap() {
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
@@ -87,12 +83,8 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForWan() {
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusEnabledWAN");
-		givenDhcpStatus(true);
-
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
 
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
@@ -103,15 +95,12 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForWan() {
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusEnabledWAN");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
+		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
@@ -127,11 +116,8 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForLan() {
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusEnabledLAN");
-		givenDhcpStatus(true);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
@@ -144,15 +130,12 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndEnabledForLan() {
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusEnabledLAN");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
+		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
@@ -166,15 +149,12 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndUnmanaged() {
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusUnmanaged");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
+		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
@@ -186,11 +166,11 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
-		givenNetInterface("wlan0");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
+		
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
 		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
@@ -204,12 +184,12 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
-		givenNetInterface("wlan0");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
+		
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
 		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
@@ -223,35 +203,32 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiUnmanged() {
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusUnmanaged");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
+		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		
 		thenNoExceptionsHaveBeenThrown();
 		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
 		thenResultingBuildAllMapContains("ipv4", "method", "manual");
 		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
 		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
 		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
 		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
@@ -265,37 +242,33 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLan() {
-
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusManagedLan");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
+		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		
 		thenNoExceptionsHaveBeenThrown();
 		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
 		thenResultingBuildAllMapContains("ipv4", "method", "manual");
 		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
 		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
 		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
 		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
@@ -309,36 +282,32 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedConfiguredForInputsWiFiWan() {
-
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusManagedWan");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		
 		thenNoExceptionsHaveBeenThrown();
 		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
 		thenResultingBuildAllMapContains("ipv4", "method", "manual");
 		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
 		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
 		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
 		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
@@ -352,37 +321,33 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLanAndHiddenSsid() {
-
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusManagedLan");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");		
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
+		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");		
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		
 		thenNoExceptionsHaveBeenThrown();
 		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
 		thenResultingBuildAllMapContains("ipv4", "method", "manual");
 		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
 		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
 		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
 		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
@@ -397,36 +362,33 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
-		givenNetInterface("wlan0");
-		givenIP4Status("netIPv4StatusManagedWan");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ignoreSSID", true);
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+		givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
+		givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface.wlan0.config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0",
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
 		
 		thenNoExceptionsHaveBeenThrown();
 		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
 		thenResultingBuildAllMapContains("ipv4", "method", "manual");
 		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
 		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
 		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
 		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
@@ -441,92 +403,71 @@ public class NMSettingsConverterTest {
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndUnmanaged() {
-		givenNetInterface("eth0");
-		givenIP4Status("netIPv4StatusUnmanaged");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusUnmanaged");
+		givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 		
 		thenNoExceptionsHaveBeenThrown();
 		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
 		thenResultingBuildAllMapContains("ipv4", "method", "manual");
 		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
 		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
 	}
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
-		givenNetInterface("eth0");
-		givenIP4Status("netIPv4StatusManagedLan");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedLan");
+		givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 		
 		thenNoExceptionsHaveBeenThrown();
 		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
 		thenResultingBuildAllMapContains("ipv4", "method", "manual");
 		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
 		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
 	}
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
-		givenNetInterface("eth0");
-		givenIP4Status("netIPv4StatusManagedWan");
-		givenDhcpStatus(false);
-		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
-		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
+		givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+		givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
+		givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+		givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+		givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+		givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
+		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
 		thenNoExceptionsHaveBeenThrown();
 		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
 		thenResultingBuildAllMapContains("ipv4", "method", "manual");
 		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
-		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
 		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
 	}
 
 	// given
-
-	public void givenNetInterface(String netInterface) {
-		this.netInterface = netInterface;
-	}
-
-	public void givenIP4Status(String kuraIP4Status) {
-		this.kuraIP4Status = kuraIP4Status;
-	}
-
-	public void givenDhcpStatus(Boolean KuraDhcpStatus) {
-		this.KuraDhcpStatus = KuraDhcpStatus;
-	}
 
 	public void givenNetworkPropsCreatedWithTheMap(Map<String, Object> properties) {
 		this.networkProperties = new NetworkProperties(properties);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -94,12 +94,11 @@ public class NMSettingsConverterTest {
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 
-		givenValidBuildIpv4ConfigWithDhcpEnabled();
-		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalMap();
+
+		thenResultingMapContains("method", "auto");
 	}
 
 	@Test
@@ -107,21 +106,22 @@ public class NMSettingsConverterTest {
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusEnabledWAN");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToWan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalMap();
+		thenResultingMapContains("method", "manual");
+		thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingMapContains("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au").getValue());
+		thenResultingMapContains("ignore-auto-dns", true);
+		thenResultingMapContains("gateway", "192.168.0.1");
 
 	}
 
@@ -130,17 +130,16 @@ public class NMSettingsConverterTest {
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusEnabledLAN");
 		givenDhcpStatus(true);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
-
-		givenValidBuildIpv4ConfigWithDhcpEnabled();
-		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToLan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalMap();
+		thenResultingMapContains("method", "auto");
+		thenResultingMapContains("ignore-auto-dns", true);
+		thenResultingMapContains("ignore-auto-routes", true);
 	}
 
 	@Test
@@ -148,21 +147,21 @@ public class NMSettingsConverterTest {
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusEnabledLAN");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToLan("wlan0");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalMap();
+		thenResultingMapContains("method", "manual");
+		thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingMapContains("ignore-auto-dns", true);
+		thenResultingMapContains("ignore-auto-routes", true);
 	}
 
 	@Test
@@ -170,84 +169,98 @@ public class NMSettingsConverterTest {
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusUnmanaged");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
 		whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalMap();
+		thenResultingMapContains("method", "manual");
+		thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
 	}
 
 	@Test
 	public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
 		givenNetInterface("wlan0");
-		
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters("wlan0", "ssidtest", "infrastructure", true,
-				false);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
 		whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
-		thenNoExceptionsHaveBeenThrown();
-		thenMapResultFromWifiSettingsShouldEqualInternalMapForWifiSettings();
+	
+		thenNoExceptionsHaveBeenThrown();		
+		thenResultingMapContains("mode", "infrastructure");
+		thenResultingMapContainsBytes("ssid", "ssidtest");
+		thenResultingMapContains("band", "a");
+		thenResultingMapContains("channel", new UInt32(Short.parseShort("10")));
 	}
 
 	@Test
 	public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters("wlan0", "ssidtest", "propmode", true, true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters("wlan0", "ssidtest", "propmode", true,
-				true);
+		givenNetInterface("wlan0");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+		
 		whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalMap();
+		thenResultingMapContains("psk", new Password("test").toString());
+		thenResultingMapContains("key-mgmt", "wpa-psk");
+		thenResultingMapContains("group", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+		thenResultingMapContains("pairwise", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
 	}
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiUnmanged() {
-
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusUnmanaged");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
-
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, false);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
-				true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, true);
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalBuildMap();
+		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+		thenResultingBuildAllMapContains("ipv4", "method", "manual");
+		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+		thenResultingBuildAllMapContains("802-11-wireless-security", "group", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
 	}
 
 	@Test
@@ -256,35 +269,42 @@ public class NMSettingsConverterTest {
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusManagedLan");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToLan(netInterface);
-		
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, false);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
-				true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, true);
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
+		
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalBuildMap();
+		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+		thenResultingBuildAllMapContains("ipv4", "method", "manual");
+		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+		thenResultingBuildAllMapContains("802-11-wireless-security", "group", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
 	}
 
 	@Test
@@ -293,35 +313,41 @@ public class NMSettingsConverterTest {
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusManagedWan");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToWan(netInterface);
-		
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, false);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
-				true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, true);
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalBuildMap();
+		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+		thenResultingBuildAllMapContains("ipv4", "method", "manual");
+		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+		thenResultingBuildAllMapContains("802-11-wireless-security", "group", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
 	}
 
 	@Test
@@ -330,148 +356,162 @@ public class NMSettingsConverterTest {
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusManagedLan");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToLan(netInterface);
-		
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ignoreSSID",	true);
-		
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, true);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
-				true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, true);
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ignoreSSID", true);
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");		
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalBuildMap();
+		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+		thenResultingBuildAllMapContains("ipv4", "method", "manual");
+		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+		thenResultingBuildAllMapContains("802-11-wireless", "hidden", true);
+		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+		thenResultingBuildAllMapContains("802-11-wireless-security", "group", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
 	}
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
-
 		givenNetInterface("wlan0");
 		givenIP4Status("netIPv4StatusManagedWan");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToWan(netInterface);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ssid", "ssidtest");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.radioMode", "RADIO_MODE_80211a");
 		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.channel", "10");
-		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ignoreSSID",	true);
-		
-		givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, true);
-		givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "INFRA", true,
-				true);
-		givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(netInterface, "ssidtest", "infrastructure",
-				true, true);
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.ignoreSSID", true);
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.mode", "INFRA");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.passphrase",new Password("test"));
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.securityType","SECURITY_WPA_WPA2");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.groupCiphers", "CCMP");
+		givenMapWith("net.interface." + this.netInterface + ".config.wifi.infra.pairwiseCiphers", "CCMP");
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		givenExpectedBuildAllConnectionField(netInterface, "802-11-wireless");
+		
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_WIFI);
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalBuildMap();
+		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+		thenResultingBuildAllMapContains("ipv4", "method", "manual");
+		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
+		thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
+		thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
+		thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
+		thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
+		thenResultingBuildAllMapContains("802-11-wireless", "hidden", true);
+		thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
+		thenResultingBuildAllMapContains("802-11-wireless-security", "group", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+		thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise", new Variant<>(Arrays.asList("ccmp"), "as").getValue());
 	}
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndUnmanaged() {
-
 		givenNetInterface("eth0");
 		givenIP4Status("netIPv4StatusUnmanaged");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
+		
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalBuildMap();
+		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+		thenResultingBuildAllMapContains("ipv4", "method", "manual");
+		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
 	}
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
-
 		givenNetInterface("eth0");
 		givenIP4Status("netIPv4StatusManagedLan");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToLan(netInterface);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
+		
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+		
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalBuildMap();
+		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+		thenResultingBuildAllMapContains("ipv4", "method", "manual");
+		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
 	}
 
 	@Test
 	public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
-
 		givenNetInterface("eth0");
 		givenIP4Status("netIPv4StatusManagedWan");
 		givenDhcpStatus(false);
-
 		givenMapWith("net.interface." + this.netInterface + ".config.dhcpClient4.enabled", this.KuraDhcpStatus);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.status", this.kuraIP4Status);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.address", "192.168.0.12");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.prefix", (short) 25);
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.dnsServers", "1.1.1.1");
 		givenMapWith("net.interface." + this.netInterface + ".config.ip4.gateway", "192.168.0.1");
-
-		givenValidBuildIpv4ConfigWithDhcpDisabled();
-		givenValidBuildIpv6Config();
-		givenExpectedValidWifiConfigurationSetToWan(netInterface);
 		givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-		givenExpectedBuildAllConnectionField(netInterface, "802-3-ethernet");
+
 		whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), netInterface,
 				NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
 		thenNoExceptionsHaveBeenThrown();
-		thenMapResultShouldEqualInternalBuildMap();
+		thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+		thenResultingBuildAllMapContains("ipv4", "method", "manual");
+		thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+		thenResultingBuildAllMapContains("connection", "id", "kura-" + this.netInterface + "-connection");
+		thenResultingBuildAllMapContains("connection", "interface-name", this.netInterface);
+		thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
 	}
 
 	// given
@@ -494,139 +534,6 @@ public class NMSettingsConverterTest {
 
 	public void givenMapWith(String key, Object value) {
 		this.internetNetworkPropertiesInstanciationMap.put(key, value);
-	}
-
-	public void givenExpectedValidWifiConfigurationSetToLan(String inter) {
-
-		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
-
-		internalMethodHashMap.put("ignore-auto-dns", new Variant<>(true));
-		internalMethodHashMap.put("ignore-auto-routes", new Variant<>(true));
-
-		this.internalComparatorMap.putAll(internalMethodHashMap);
-
-	}
-
-	public void givenExpectedValidWifiConfigurationSetToWan(String inter) {
-
-		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
-
-		Optional<List<String>> dnsServers = Optional.of(Arrays.asList("1.1.1.1"));
-
-		if (dnsServers.isPresent()) {
-			internalMethodHashMap.put("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au"));
-			internalMethodHashMap.put("ignore-auto-dns", new Variant<>(true));
-		}
-
-		Optional<String> gateway = Optional.of("192.168.0.1");
-		if (gateway.isPresent()) {
-			internalMethodHashMap.put("gateway", new Variant<>(gateway.get()));
-		}
-
-		this.internalComparatorMap.putAll(internalMethodHashMap);
-
-	}
-
-	public void givenValidBuildIpv4ConfigWithDhcpEnabled() {
-		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
-
-		internalMethodHashMap.put("method", new Variant<>("auto"));
-
-		this.internalComparatorMap.putAll(internalMethodHashMap);
-		this.internalComparatorAllSettingsMap.put("ipv4", internalMethodHashMap);
-	}
-
-	public void givenValidBuildIpv4ConfigWithDhcpDisabled() {
-		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
-
-		internalMethodHashMap.put("method", new Variant<>("manual"));
-
-		Map<String, Variant<?>> addressEntry = new HashMap<>();
-		addressEntry.put("address", new Variant<>("192.168.0.12"));
-		addressEntry.put("prefix", new Variant<>(new UInt32(25)));
-
-		List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
-		internalMethodHashMap.put("address-data", new Variant<>(addressData, "aa{sv}"));
-
-		this.internalComparatorMap.putAll(internalMethodHashMap);
-		this.internalComparatorAllSettingsMap.put("ipv4", internalMethodHashMap);
-	}
-
-	public void givenValidBuildIpv6Config() {
-		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
-		internalMethodHashMap.put("method", new Variant<>("disabled"));
-		this.internalComparatorAllSettingsMap.put("ipv6", internalMethodHashMap);
-	}
-
-	public void givenExpectedValid80211WirelessSettingsWithTheFollowingParameters(String inter, String ssid,
-			String propMode, Boolean channelEnabled, Boolean isHidden) {
-
-		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
-
-		internalMethodHashMap.put("mode", new Variant<>(propMode));
-		internalMethodHashMap.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
-		internalMethodHashMap.put("band", new Variant<>("a"));
-
-		if (channelEnabled) {
-			internalMethodHashMap.put("channel", new Variant<>(new UInt32(Short.parseShort("10"))));
-		}
-
-		if (isHidden) {
-			internalMethodHashMap.put("hidden", new Variant<>(isHidden));
-		}
-
-		this.internalComparatorAllSettingsMap.put("802-11-wireless", internalMethodHashMap);
-		this.internalComparatorMap.putAll(internalMethodHashMap);
-	}
-
-	public void givenValid80211WirelessSecuritySettingsWithTheFollowingParameters(String inter, String ssid,
-			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
-		internetNetworkPropertiesInstanciationMap.put("net.interface." + inter + ".config.wifi.mode", propMode);
-		internetNetworkPropertiesInstanciationMap.put(
-				"net.interface." + inter + ".config.wifi." + propMode.toLowerCase() + ".passphrase",
-				new Password("test"));
-		internetNetworkPropertiesInstanciationMap.put(
-				"net.interface." + inter + ".config.wifi." + propMode.toLowerCase() + ".securityType",
-				"SECURITY_WPA_WPA2");
-		if (groupEnabled) {
-			internetNetworkPropertiesInstanciationMap
-					.put("net.interface." + inter + ".config.wifi." + propMode.toLowerCase() + ".groupCiphers", "CCMP");
-		}
-		if (ciphersEnabled) {
-			internetNetworkPropertiesInstanciationMap.put(
-					"net.interface." + inter + ".config.wifi." + propMode.toLowerCase() + ".pairwiseCiphers", "CCMP");
-		}
-	}
-
-	public void givenExpected80211WirelessSecuritySettingsWithTheFollowingParameters(String inter, String ssid,
-			String propMode, Boolean groupEnabled, Boolean ciphersEnabled) {
-
-		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
-
-		internalMethodHashMap.put("psk", new Variant<>(new Password("test").toString()));
-		internalMethodHashMap.put("key-mgmt", new Variant<>("wpa-psk"));
-
-		if (groupEnabled) {
-			internalMethodHashMap.put("group", new Variant<>(Arrays.asList("ccmp"), "as"));
-		}
-
-		if (ciphersEnabled) {
-			internalMethodHashMap.put("pairwise", new Variant<>(Arrays.asList("ccmp"), "as"));
-		}
-
-		this.internalComparatorAllSettingsMap.put("802-11-wireless-security", internalMethodHashMap);
-		this.internalComparatorMap.putAll(internalMethodHashMap);
-
-	}
-
-	public void givenExpectedBuildAllConnectionField(String inter, String interfaceType) {
-		Map<String, Variant<?>> internalMethodHashMap = new HashMap<>();
-
-		internalMethodHashMap.put("id", new Variant<>(String.format("kura-%s-connection", inter)));
-		internalMethodHashMap.put("interface-name", new Variant<>(inter));
-		internalMethodHashMap.put("type", new Variant<>(interfaceType));
-
-		this.internalComparatorAllSettingsMap.put("connection", internalMethodHashMap);
 	}
 
 	// when
@@ -693,6 +600,35 @@ public class NMSettingsConverterTest {
 	}
 
 	// then
+
+	public void thenResultingMapContains(String key, Object value) {
+		assertEquals(value, this.resultMap.get(key).getValue());
+	}
+	
+	public void thenResultingMapContainsBytes(String key, Object value) {
+		assertEquals(value, new String((byte[]) this.resultMap.get(key).getValue(), StandardCharsets.UTF_8));
+	}
+
+	public void thenResultingBuildAllMapContains(String key, String subKey, Object value) {
+		assertEquals(value, this.resultAllSettingsMap.get(key).get(subKey).getValue());
+	}
+	
+	public void thenResultingBuildAllMapContainsBytes(String key, String subKey, Object value) {
+		assertEquals(value, new String((byte[]) this.resultAllSettingsMap.get(key).get(subKey).getValue(), StandardCharsets.UTF_8));
+	}
+
+	public Object buildAddressDataWith(String ipAddr, UInt32 prefix) {
+
+		Map<String, Variant<?>> addressEntry = new HashMap<>();
+		addressEntry.put("address", new Variant<>(ipAddr));
+		addressEntry.put("prefix", new Variant<>(prefix));
+
+		List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
+
+		Variant<?> dataVarient = new Variant<>(addressData, "aa{sv}");
+
+		return dataVarient.getValue();
+	}
 
 	public void thenMapResultShouldEqualInternalMap() {
 		assertEquals(this.internalComparatorMap, this.resultMap);


### PR DESCRIPTION
This PR aims to add thorough test coverage of the NMSettingConverter for the new Networking Stack in Kura.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
