### PR TITLE
fix(web2): construct the net properties from scratch instead of using old data

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.eclipse.kura.KuraException;
+import org.eclipse.kura.net.admin.FirewallConfigurationService;
 import org.eclipse.kura.net.NetConfig;
 import org.eclipse.kura.net.firewall.FirewallNatConfig;
 import org.eclipse.kura.net.firewall.FirewallOpenPortConfigIP4;
@@ -32,7 +33,6 @@ import org.eclipse.kura.web.shared.model.GwtFirewallPortForwardEntry;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.eclipse.kura.net.admin.FirewallConfigurationService;
 
 public class GwtNetworkServiceImpl {
 
@@ -53,8 +53,6 @@ public class GwtNetworkServiceImpl {
                 GwtNetInterfaceConfig gwtConfig = configuration.getGwtNetInterfaceConfig(ifname);
                 status.fillWithStatusProperties(ifname, gwtConfig);
 
-                logger.debug("GWT Network Configuration for interface {}:\n{}\n", ifname, gwtConfig.getProperties());
-
                 result.add(gwtConfig);
             }
 
@@ -67,8 +65,6 @@ public class GwtNetworkServiceImpl {
     public static void updateNetInterfaceConfigurations(GwtNetInterfaceConfig config) throws GwtKuraException {
         try {
             NetworkConfigurationServiceAdapter adapter = new NetworkConfigurationServiceAdapter();
-
-            logger.debug("Updating Network Configuration Service with properties:\n{}\n", config.getProperties());
 
             adapter.updateConfiguration(config);
         } catch (GwtKuraException | KuraException e) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -13,7 +13,7 @@
 package org.eclipse.kura.web.server.net2.configuration;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -30,43 +30,16 @@ public class NetworkConfigurationServiceProperties {
     private static final String NA = "N/A";
     private static final Logger logger = LoggerFactory.getLogger(NetworkConfigurationServiceProperties.class);
 
+    public NetworkConfigurationServiceProperties() {
+        this.properties = new HashMap<>();
+    }
+
     public NetworkConfigurationServiceProperties(Map<String, Object> properties) {
         this.properties = properties;
     }
 
     public Map<String, Object> getProperties() {
         return this.properties;
-    }
-
-    /*
-     * Interface names
-     */
-
-    private static final String NET_INTERFACES = "net.interfaces";
-
-    public void addNetworkInterfaceIfNotPresent(String ifname) {
-        List<String> ifnames = new LinkedList<>();
-
-        String netInterfaces = (String) this.properties.get(NET_INTERFACES);
-        String[] interfaces = netInterfaces.split(",");
-
-        for (String name : interfaces) {
-            ifnames.add(name.trim());
-        }
-
-        if (!ifnames.contains(ifname)) {
-            ifnames.add(ifname);
-        }
-
-        StringBuilder result = new StringBuilder();
-
-        for (String name : ifnames) {
-            result.append(name);
-            result.append(",");
-        }
-        
-        String withoutTrailingComma = result.toString().substring(0, result.length() - 1);
-        this.properties.put(NET_INTERFACES, withoutTrailingComma);
     }
 
     /*

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -31,12 +31,10 @@ public class NetworkConfigurationServicePropertiesBuilder {
     private final NetworkConfigurationServiceProperties properties;
     private final String ifname;
 
-    public NetworkConfigurationServicePropertiesBuilder(GwtNetInterfaceConfig gwtConfig,
-            Map<String, Object> currentNetConfServProps) {
+    public NetworkConfigurationServicePropertiesBuilder(GwtNetInterfaceConfig gwtConfig) {
         this.gwtConfig = gwtConfig;
-        this.properties = new NetworkConfigurationServiceProperties(currentNetConfServProps);
+        this.properties = new NetworkConfigurationServiceProperties();
         this.ifname = this.gwtConfig.getName();
-        this.properties.addNetworkInterfaceIfNotPresent(ifname);
     }
 
     public Map<String, Object> build() {
@@ -64,8 +62,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
         this.properties.setIp4Status(this.ifname,
                 EnumsParser.getNetInterfaceStatus(Optional.ofNullable(this.gwtConfig.getStatus())));
 
-        boolean isDhcpClient = this.gwtConfig.getConfigMode().equals(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
-        boolean isManual = !isDhcpClient;
+        boolean isManual = this.gwtConfig.getConfigMode().equals(GwtNetIfConfigMode.netIPv4ConfigModeManual.name());
         boolean isWan = this.gwtConfig.getStatus().equals(GwtNetIfStatus.netIPv4StatusEnabledWAN.name());
 
         if (isWan) {


### PR DESCRIPTION
This PR fixes a regression that was introduced in some previous PR.

**Related Issue:** N/A.

**Description of the solution adopted:** The properties for the network configuration service are created from zero, instead of starting from the last cached properties object. In this way we prevent the UI from sending unconsistent values. There is still a problem on the Network Configuration Service nm implementation: the Configuration Service merges the properties found on the snapshot prior sending them to the component. Some further checks need to be performed there.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
