### PR TITLE
fix: correct behaviour for `netIPvXStatusUnmanaged`

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -233,7 +233,7 @@ public class NMDbusConnector {
         if (interfaceStatus == KuraInterfaceStatus.DISABLED) {
             disable(device);
         } else if (interfaceStatus == KuraInterfaceStatus.UNMANAGED) {
-            setDeviceManaged(device, false);
+            logger.info("Iface \"{}\" set as Kura UNMANAGED. Skipping configuration.", iface);
         } else { // NMDeviceEnable.ENABLED
             if (Boolean.FALSE.equals(isDeviceManaged(device))) {
                 setDeviceManaged(device, true);


### PR DESCRIPTION
Currently, the new Kura networking, when an interface is set to UNMANAGED, will set the NetworkManager `isManaged` flag to false.

We decided that the Kura device unmanaged and the NetworkManaged device unmanaged should be two distinguished concepts.

**Scenario**: A user wants to configure an interface in a way that Kura doesn’t support. He/she can set the network interface as Kura unmanaged and still use NetworkManager (through `nmcli` or `nmtui`) to configure it.

This is also the behaviour of the old Kura networking.

This PR fixes the behaviour on the new Kura networking