### PR TITLE
refactor(WireHelperService): Catch case that service pid is an array.

### DIFF
--- a/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
@@ -145,9 +145,9 @@ public final class WireHelperServiceImpl implements WireHelperService {
         }
 
         if (wireComponentRef.getProperty(SERVICE_PID) instanceof java.util.ArrayList) {
-            throw new RuntimeException(
-                    "The service PID of {} is an array. It should be a string. (Maybe you used the same PID twice in OSGi metadata?)",
-                    wireComponentRef.getClass().getCanonicalName());
+            throw new RuntimeException(String.format(
+                    "The service PID of %s is an array. It should be a string. (Maybe you used the same PID twice in OSGi metadata?)",
+                    wireComponentRef.getClass().getCanonicalName()));
         }
         final String servicePid = (String) wireComponentRef.getProperty(SERVICE_PID);
         final String kuraServicePid = (String) wireComponentRef.getProperty(KURA_SERVICE_PID);

--- a/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
@@ -144,6 +144,9 @@ public final class WireHelperServiceImpl implements WireHelperService {
             return null;
         }
 
+        if (wireComponentRef.getProperty(SERVICE_PID) instanceof java.util.ArrayList) {
+         throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,"The service PID of {} is an array. It should be a string. (Maybe two components with the same PID?)"
+        }
         final String servicePid = (String) wireComponentRef.getProperty(SERVICE_PID);
         final String kuraServicePid = (String) wireComponentRef.getProperty(KURA_SERVICE_PID);
         int receiverPortCount = getIntOrDefault(wireComponentRef.getProperty(RECEIVER_PORT_COUNT_PROP_NAME.value()),

--- a/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
@@ -145,7 +145,7 @@ public final class WireHelperServiceImpl implements WireHelperService {
         }
 
         if (wireComponentRef.getProperty(SERVICE_PID) instanceof java.util.ArrayList) {
-            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,"The service PID of {} is an array. It should be a string. (Maybe two components with the same PID?)",wireComponentRef.getClass().getCanonicalName());
+            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,"The service PID of {} is an array. It should be a string. (Maybe two components with the same PID?)", wireComponentRef.getClass().getCanonicalName());
         }
         final String servicePid = (String) wireComponentRef.getProperty(SERVICE_PID);
         final String kuraServicePid = (String) wireComponentRef.getProperty(KURA_SERVICE_PID);

--- a/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
@@ -19,6 +19,7 @@ import static org.eclipse.kura.wire.graph.Constants.EMITTER_PORT_COUNT_PROP_NAME
 import static org.eclipse.kura.wire.graph.Constants.RECEIVER_PORT_COUNT_PROP_NAME;
 import static org.osgi.framework.Constants.SERVICE_PID;
 
+import org.eclipse.kura.KuraException;
 import org.eclipse.kura.util.service.ServiceUtil;
 import org.eclipse.kura.wire.WireComponent;
 import org.eclipse.kura.wire.WireEmitter;
@@ -28,6 +29,7 @@ import org.eclipse.kura.wire.WireSupport;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
+
 
 /**
  * The Class WireHelperServiceImpl is the implementation of

--- a/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
@@ -145,7 +145,9 @@ public final class WireHelperServiceImpl implements WireHelperService {
         }
 
         if (wireComponentRef.getProperty(SERVICE_PID) instanceof java.util.ArrayList) {
-            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,"The service PID of {} is an array. It should be a string. (Maybe two components with the same PID?)", wireComponentRef.getClass().getCanonicalName());
+            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,
+                    "The service PID of {} is an array. It should be a string. (Maybe two components with the same PID?)",
+                    wireComponentRef.getClass().getCanonicalName());
         }
         final String servicePid = (String) wireComponentRef.getProperty(SERVICE_PID);
         final String kuraServicePid = (String) wireComponentRef.getProperty(KURA_SERVICE_PID);

--- a/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
@@ -145,7 +145,7 @@ public final class WireHelperServiceImpl implements WireHelperService {
         }
 
         if (wireComponentRef.getProperty(SERVICE_PID) instanceof java.util.ArrayList) {
-         throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,"The service PID of {} is an array. It should be a string. (Maybe two components with the same PID?)"
+            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,"The service PID of {} is an array. It should be a string. (Maybe two components with the same PID?)",wireComponentRef.getClass().getCanonicalName());
         }
         final String servicePid = (String) wireComponentRef.getProperty(SERVICE_PID);
         final String kuraServicePid = (String) wireComponentRef.getProperty(KURA_SERVICE_PID);

--- a/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
@@ -19,8 +19,6 @@ import static org.eclipse.kura.wire.graph.Constants.EMITTER_PORT_COUNT_PROP_NAME
 import static org.eclipse.kura.wire.graph.Constants.RECEIVER_PORT_COUNT_PROP_NAME;
 import static org.osgi.framework.Constants.SERVICE_PID;
 
-import org.eclipse.kura.KuraErrorCode;
-import org.eclipse.kura.KuraException;
 import org.eclipse.kura.util.service.ServiceUtil;
 import org.eclipse.kura.wire.WireComponent;
 import org.eclipse.kura.wire.WireEmitter;
@@ -30,7 +28,6 @@ import org.eclipse.kura.wire.WireSupport;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceReference;
-
 
 /**
  * The Class WireHelperServiceImpl is the implementation of
@@ -148,8 +145,8 @@ public final class WireHelperServiceImpl implements WireHelperService {
         }
 
         if (wireComponentRef.getProperty(SERVICE_PID) instanceof java.util.ArrayList) {
-            throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,
-                    "The service PID of {} is an array. It should be a string. (Maybe two components with the same PID?)",
+            throw new RuntimeException(
+                    "The service PID of {} is an array. It should be a string. (Maybe you used the same PID twice in OSGi metadata?)",
                     wireComponentRef.getClass().getCanonicalName());
         }
         final String servicePid = (String) wireComponentRef.getProperty(SERVICE_PID);

--- a/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
@@ -19,6 +19,7 @@ import static org.eclipse.kura.wire.graph.Constants.EMITTER_PORT_COUNT_PROP_NAME
 import static org.eclipse.kura.wire.graph.Constants.RECEIVER_PORT_COUNT_PROP_NAME;
 import static org.osgi.framework.Constants.SERVICE_PID;
 
+import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.util.service.ServiceUtil;
 import org.eclipse.kura.wire.WireComponent;

--- a/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
+++ b/kura/org.eclipse.kura.wire.helper.provider/src/main/java/org/eclipse/kura/internal/wire/helper/WireHelperServiceImpl.java
@@ -145,7 +145,7 @@ public final class WireHelperServiceImpl implements WireHelperService {
         }
 
         if (wireComponentRef.getProperty(SERVICE_PID) instanceof java.util.ArrayList) {
-            throw new RuntimeException(String.format(
+            throw new IllegalArgumentException(String.format(
                     "The service PID of %s is an array. It should be a string. (Maybe you used the same PID twice in OSGi metadata?)",
                     wireComponentRef.getClass().getCanonicalName()));
         }


### PR DESCRIPTION
I want to catch an unhandled error. This is what I saw in my environment:

```
!MESSAGE bundle com.***.service:1.0.0 (185)[com.***Component] : The activate method has thrown an exception
java.lang.ClassCastException: java.util.ArrayList cannot be cast to java.lang.String
       at org.eclipse.kura.internal.wire.helper.WireHelperServiceImpl.newWireSupport(WireHelperServiceImpl.java:147)
       at com.beegy.shaun.event.service.publisher.EventPublisherComponent.activate(EventPublisherComponent.java:68)
       at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

Basically, I used mistakenly the service pid twice in my meta-data, Osgi apparently creates an ArrayList for the service pid, so the exception is raised.

The code makes clear that service pid is expected to be a string, not an array. Maybe the developer used the service pid twice and that's an error case that can be catched and reported.

This code can help whoever will face the same configuration mistake in the future.