### PR TITLE
build(nm): add autogen code for interfacing with ModemManager 1.14.12 over DBus

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/ModemManager1.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/ModemManager1.java
@@ -1,0 +1,21 @@
+package org.freedesktop;
+
+import java.util.Map;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusProperty(name = "Version", type = String.class, access = Access.READ)
+public interface ModemManager1 extends DBusInterface {
+
+
+    public void ScanDevices();
+    public void SetLogging(String level);
+    public void ReportKernelEvent(Map<String, Variant<?>> properties);
+    public void InhibitDevice(String uid, boolean inhibit);
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/ModemManager1.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/ModemManager1.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop;
 
 import java.util.Map;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Bearer.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Bearer.java
@@ -1,0 +1,59 @@
+package org.freedesktop.modemmanager1;
+
+import java.util.Map;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Bearer")
+@DBusProperty(name = "Interface", type = String.class, access = Access.READ)
+@DBusProperty(name = "Connected", type = Boolean.class, access = Access.READ)
+@DBusProperty(name = "Suspended", type = Boolean.class, access = Access.READ)
+@DBusProperty(name = "Ip4Config", type = Bearer.PropertyIp4ConfigType.class, access = Access.READ)
+@DBusProperty(name = "Ip6Config", type = Bearer.PropertyIp6ConfigType.class, access = Access.READ)
+@DBusProperty(name = "Stats", type = Bearer.PropertyStatsType.class, access = Access.READ)
+@DBusProperty(name = "IpTimeout", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "BearerType", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Properties", type = Bearer.PropertyPropertiesType.class, access = Access.READ)
+public interface Bearer extends DBusInterface {
+
+
+    public void Connect();
+    public void Disconnect();
+
+
+    public static interface PropertyIp4ConfigType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+
+    public static interface PropertyIp6ConfigType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+
+    public static interface PropertyStatsType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+
+    public static interface PropertyPropertiesType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Bearer.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Bearer.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import java.util.Map;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Call.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Call.java
@@ -1,0 +1,89 @@
+package org.freedesktop.modemmanager1;
+
+import java.util.Map;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Call")
+@DBusProperty(name = "State", type = Integer.class, access = Access.READ)
+@DBusProperty(name = "StateReason", type = Integer.class, access = Access.READ)
+@DBusProperty(name = "Direction", type = Integer.class, access = Access.READ)
+@DBusProperty(name = "Number", type = String.class, access = Access.READ)
+@DBusProperty(name = "Multiparty", type = Boolean.class, access = Access.READ)
+@DBusProperty(name = "AudioPort", type = String.class, access = Access.READ)
+@DBusProperty(name = "AudioFormat", type = Call.PropertyAudioFormatType.class, access = Access.READ)
+public interface Call extends DBusInterface {
+
+
+    public void Start();
+    public void Accept();
+    public void Deflect(String number);
+    public void JoinMultiparty();
+    public void LeaveMultiparty();
+    public void Hangup();
+    public void SendDtmf(String dtmf);
+
+
+    public static class DtmfReceived extends DBusSignal {
+
+        private final String dtmf;
+
+        public DtmfReceived(String _path, String _dtmf) throws DBusException {
+            super(_path, _dtmf);
+            this.dtmf = _dtmf;
+        }
+
+
+        public String getDtmf() {
+            return dtmf;
+        }
+
+
+    }
+
+    public static class StateChanged extends DBusSignal {
+
+        private final int old;
+        private final int newparam;
+        private final UInt32 reason;
+
+        public StateChanged(String _path, int _old, int _new, UInt32 _reason) throws DBusException {
+            super(_path, _old, _new, _reason);
+            this.old = _old;
+            this.new = _new;
+            this.reason = _reason;
+        }
+
+
+        public int getOld() {
+            return old;
+        }
+
+        public int getNewparam() {
+            return newparam;
+        }
+
+        public UInt32 getReason() {
+            return reason;
+        }
+
+
+    }
+
+    public static interface PropertyAudioFormatType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Call.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Call.java
@@ -60,7 +60,7 @@ public interface Call extends DBusInterface {
         public StateChanged(String _path, int _old, int _new, UInt32 _reason) throws DBusException {
             super(_path, _old, _new, _reason);
             this.old = _old;
-            this.new = _new;
+            this.newparam = _new;
             this.reason = _reason;
         }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Call.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Call.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import java.util.Map;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Modem.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Modem.java
@@ -79,7 +79,7 @@ public interface Modem extends DBusInterface {
         public StateChanged(String _path, int _old, int _new, UInt32 _reason) throws DBusException {
             super(_path, _old, _new, _reason);
             this.old = _old;
-            this.new = _new;
+            this.newparam = _new;
             this.reason = _reason;
         }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Modem.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Modem.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Modem.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Modem.java
@@ -1,0 +1,164 @@
+package org.freedesktop.modemmanager1;
+
+import java.util.List;
+import java.util.Map;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+import org.freedesktop.modemmanager1.PropertyCurrentModesStruct;
+import org.freedesktop.modemmanager1.PropertyPortsStruct;
+import org.freedesktop.modemmanager1.PropertySignalQualityStruct;
+import org.freedesktop.modemmanager1.PropertySupportedModesStruct;
+import org.freedesktop.modemmanager1.SetCurrentModesStruct;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem")
+@DBusProperty(name = "Sim", type = DBusPath.class, access = Access.READ)
+@DBusProperty(name = "Bearers", type = Modem.PropertyBearersType.class, access = Access.READ)
+@DBusProperty(name = "SupportedCapabilities", type = Modem.PropertySupportedCapabilitiesType.class, access = Access.READ)
+@DBusProperty(name = "CurrentCapabilities", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "MaxBearers", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "MaxActiveBearers", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Manufacturer", type = String.class, access = Access.READ)
+@DBusProperty(name = "Model", type = String.class, access = Access.READ)
+@DBusProperty(name = "Revision", type = String.class, access = Access.READ)
+@DBusProperty(name = "CarrierConfiguration", type = String.class, access = Access.READ)
+@DBusProperty(name = "CarrierConfigurationRevision", type = String.class, access = Access.READ)
+@DBusProperty(name = "HardwareRevision", type = String.class, access = Access.READ)
+@DBusProperty(name = "DeviceIdentifier", type = String.class, access = Access.READ)
+@DBusProperty(name = "Device", type = String.class, access = Access.READ)
+@DBusProperty(name = "Drivers", type = Modem.PropertyDriversType.class, access = Access.READ)
+@DBusProperty(name = "Plugin", type = String.class, access = Access.READ)
+@DBusProperty(name = "PrimaryPort", type = String.class, access = Access.READ)
+@DBusProperty(name = "Ports", type = Modem.PropertyPortsType.class, access = Access.READ)
+@DBusProperty(name = "EquipmentIdentifier", type = String.class, access = Access.READ)
+@DBusProperty(name = "UnlockRequired", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "UnlockRetries", type = Modem.PropertyUnlockRetriesType.class, access = Access.READ)
+@DBusProperty(name = "State", type = Integer.class, access = Access.READ)
+@DBusProperty(name = "StateFailedReason", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "AccessTechnologies", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "SignalQuality", type = PropertySignalQualityStruct.class, access = Access.READ)
+@DBusProperty(name = "OwnNumbers", type = Modem.PropertyOwnNumbersType.class, access = Access.READ)
+@DBusProperty(name = "PowerState", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "SupportedModes", type = Modem.PropertySupportedModesType.class, access = Access.READ)
+@DBusProperty(name = "CurrentModes", type = PropertyCurrentModesStruct.class, access = Access.READ)
+@DBusProperty(name = "SupportedBands", type = Modem.PropertySupportedBandsType.class, access = Access.READ)
+@DBusProperty(name = "CurrentBands", type = Modem.PropertyCurrentBandsType.class, access = Access.READ)
+@DBusProperty(name = "SupportedIpFamilies", type = UInt32.class, access = Access.READ)
+public interface Modem extends DBusInterface {
+
+
+    public void Enable(boolean enable);
+    public List<DBusPath> ListBearers();
+    public DBusPath CreateBearer(Map<String, Variant<?>> properties);
+    public void DeleteBearer(DBusPath bearer);
+    public void Reset();
+    public void FactoryReset(String code);
+    public void SetPowerState(UInt32 state);
+    public void SetCurrentCapabilities(UInt32 capabilities);
+    public void SetCurrentModes(SetCurrentModesStruct modes);
+    public void SetCurrentBands(List<UInt32> bands);
+    public String Command(String cmd, UInt32 timeout);
+
+
+    public static class StateChanged extends DBusSignal {
+
+        private final int old;
+        private final int newparam;
+        private final UInt32 reason;
+
+        public StateChanged(String _path, int _old, int _new, UInt32 _reason) throws DBusException {
+            super(_path, _old, _new, _reason);
+            this.old = _old;
+            this.new = _new;
+            this.reason = _reason;
+        }
+
+
+        public int getOld() {
+            return old;
+        }
+
+        public int getNewparam() {
+            return newparam;
+        }
+
+        public UInt32 getReason() {
+            return reason;
+        }
+
+
+    }
+
+    public static interface PropertyBearersType extends TypeRef<List<DBusPath>> {
+
+
+
+
+    }
+
+    public static interface PropertySupportedCapabilitiesType extends TypeRef<List<UInt32>> {
+
+
+
+
+    }
+
+    public static interface PropertyDriversType extends TypeRef<List<String>> {
+
+
+
+
+    }
+
+    public static interface PropertyPortsType extends TypeRef<List<PropertyPortsStruct>> {
+
+
+
+
+    }
+
+    public static interface PropertyUnlockRetriesType extends TypeRef<Map<UInt32, UInt32>> {
+
+
+
+
+    }
+
+    public static interface PropertyOwnNumbersType extends TypeRef<List<String>> {
+
+
+
+
+    }
+
+    public static interface PropertySupportedModesType extends TypeRef<List<PropertySupportedModesStruct>> {
+
+
+
+
+    }
+
+    public static interface PropertySupportedBandsType extends TypeRef<List<UInt32>> {
+
+
+
+
+    }
+
+    public static interface PropertyCurrentBandsType extends TypeRef<List<UInt32>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyCurrentModesStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyCurrentModesStruct.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import org.freedesktop.dbus.Struct;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyCurrentModesStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyCurrentModesStruct.java
@@ -1,0 +1,31 @@
+package org.freedesktop.modemmanager1;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyCurrentModesStruct extends Struct {
+    @Position(0)
+    private final UInt32 member0;
+    @Position(1)
+    private final UInt32 member1;
+
+    public PropertyCurrentModesStruct(UInt32 member0, UInt32 member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+
+    public UInt32 getMember0() {
+        return member0;
+    }
+
+    public UInt32 getMember1() {
+        return member1;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyPortsStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyPortsStruct.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import org.freedesktop.dbus.Struct;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyPortsStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyPortsStruct.java
@@ -1,0 +1,31 @@
+package org.freedesktop.modemmanager1;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyPortsStruct extends Struct {
+    @Position(0)
+    private final String member0;
+    @Position(1)
+    private final UInt32 member1;
+
+    public PropertyPortsStruct(String member0, UInt32 member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+
+    public String getMember0() {
+        return member0;
+    }
+
+    public UInt32 getMember1() {
+        return member1;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertySignalQualityStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertySignalQualityStruct.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import org.freedesktop.dbus.Struct;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertySignalQualityStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertySignalQualityStruct.java
@@ -1,0 +1,31 @@
+package org.freedesktop.modemmanager1;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertySignalQualityStruct extends Struct {
+    @Position(0)
+    private final UInt32 member0;
+    @Position(1)
+    private final boolean member1;
+
+    public PropertySignalQualityStruct(UInt32 member0, boolean member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+
+    public UInt32 getMember0() {
+        return member0;
+    }
+
+    public boolean getMember1() {
+        return member1;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertySupportedModesStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertySupportedModesStruct.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import org.freedesktop.dbus.Struct;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertySupportedModesStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertySupportedModesStruct.java
@@ -1,0 +1,31 @@
+package org.freedesktop.modemmanager1;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertySupportedModesStruct extends Struct {
+    @Position(0)
+    private final UInt32 member0;
+    @Position(1)
+    private final UInt32 member1;
+
+    public PropertySupportedModesStruct(UInt32 member0, UInt32 member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+
+    public UInt32 getMember0() {
+        return member0;
+    }
+
+    public UInt32 getMember1() {
+        return member1;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyValidityStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyValidityStruct.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import org.freedesktop.dbus.Struct;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyValidityStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/PropertyValidityStruct.java
@@ -1,0 +1,32 @@
+package org.freedesktop.modemmanager1;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyValidityStruct extends Struct {
+    @Position(0)
+    private final UInt32 member0;
+    @Position(1)
+    private final Variant<?> member1;
+
+    public PropertyValidityStruct(UInt32 member0, Variant<?> member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+
+    public UInt32 getMember0() {
+        return member0;
+    }
+
+    public Variant<?> getMember1() {
+        return member1;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/SetCurrentModesStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/SetCurrentModesStruct.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import org.freedesktop.dbus.Struct;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/SetCurrentModesStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/SetCurrentModesStruct.java
@@ -1,0 +1,31 @@
+package org.freedesktop.modemmanager1;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+
+/**
+ * Auto-generated class.
+ */
+public class SetCurrentModesStruct extends Struct {
+    @Position(0)
+    private final UInt32 member0;
+    @Position(1)
+    private final UInt32 member1;
+
+    public SetCurrentModesStruct(UInt32 member0, UInt32 member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+
+    public UInt32 getMember0() {
+        return member0;
+    }
+
+    public UInt32 getMember1() {
+        return member1;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Sim.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Sim.java
@@ -1,0 +1,34 @@
+package org.freedesktop.modemmanager1;
+
+import java.util.List;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Sim")
+@DBusProperty(name = "SimIdentifier", type = String.class, access = Access.READ)
+@DBusProperty(name = "Imsi", type = String.class, access = Access.READ)
+@DBusProperty(name = "OperatorIdentifier", type = String.class, access = Access.READ)
+@DBusProperty(name = "OperatorName", type = String.class, access = Access.READ)
+@DBusProperty(name = "EmergencyNumbers", type = Sim.PropertyEmergencyNumbersType.class, access = Access.READ)
+public interface Sim extends DBusInterface {
+
+
+    public void SendPin(String pin);
+    public void SendPuk(String puk, String pin);
+    public void EnablePin(String pin, boolean enabled);
+    public void ChangePin(String oldPin, String newPin);
+
+
+    public static interface PropertyEmergencyNumbersType extends TypeRef<List<String>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Sim.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Sim.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Sms.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Sms.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Sms.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/Sms.java
@@ -1,0 +1,45 @@
+package org.freedesktop.modemmanager1;
+
+import java.util.List;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.modemmanager1.PropertyValidityStruct;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Sms")
+@DBusProperty(name = "State", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "PduType", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Number", type = String.class, access = Access.READ)
+@DBusProperty(name = "Text", type = String.class, access = Access.READ)
+@DBusProperty(name = "Data", type = Sms.PropertyDataType.class, access = Access.READ)
+@DBusProperty(name = "SMSC", type = String.class, access = Access.READ)
+@DBusProperty(name = "Validity", type = PropertyValidityStruct.class, access = Access.READ)
+@DBusProperty(name = "Class", type = Integer.class, access = Access.READ)
+@DBusProperty(name = "TeleserviceId", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "ServiceCategory", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "DeliveryReportRequest", type = Boolean.class, access = Access.READ)
+@DBusProperty(name = "MessageReference", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Timestamp", type = String.class, access = Access.READ)
+@DBusProperty(name = "DischargeTimestamp", type = String.class, access = Access.READ)
+@DBusProperty(name = "DeliveryState", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Storage", type = UInt32.class, access = Access.READ)
+public interface Sms extends DBusInterface {
+
+
+    public void Send();
+    public void Store(UInt32 storage);
+
+
+    public static interface PropertyDataType extends TypeRef<List<Byte>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Firmware.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Firmware.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Firmware.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Firmware.java
@@ -1,0 +1,23 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.List;
+import java.util.Map;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.Variant;
+import org.freedesktop.modemmanager1.modem.PropertyUpdateSettingsStruct;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Firmware")
+@DBusProperty(name = "UpdateSettings", type = PropertyUpdateSettingsStruct.class, access = Access.READ)
+public interface Firmware extends DBusInterface {
+
+
+    public ListTuple List();
+    public void Select(String uniqueid);
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ListTuple.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ListTuple.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ListTuple.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ListTuple.java
@@ -1,0 +1,36 @@
+package org.freedesktop.modemmanager1.modem;
+
+import org.freedesktop.dbus.Tuple;
+import org.freedesktop.dbus.annotations.Position;
+
+/**
+ * Auto-generated class.
+ */
+public class ListTuple extends Tuple {
+    @Position(0)
+    private String selected;
+    @Position(1)
+    private List<Map<String, Variant<?>>> installed;
+
+    public ListTuple(String selected, List<Map<String, Variant<?>>> installed) {
+        this.selected = selected;
+        this.installed = installed;
+    }
+
+    public void setSelected(String arg) {
+        selected = arg;
+    }
+
+    public String getSelected() {
+        return selected;
+    }
+    public void setInstalled(List<Map<String, Variant<?>>> arg) {
+        installed = arg;
+    }
+
+    public List<Map<String, Variant<?>>> getInstalled() {
+        return installed;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ListTuple.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ListTuple.java
@@ -1,7 +1,11 @@
 package org.freedesktop.modemmanager1.modem;
 
+import java.util.List;
+import java.util.Map;
+
 import org.freedesktop.dbus.Tuple;
 import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.Variant;
 
 /**
  * Auto-generated class.

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Location.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Location.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Location.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Location.java
@@ -1,0 +1,48 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.List;
+import java.util.Map;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Location")
+@DBusProperty(name = "Capabilities", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "SupportedAssistanceData", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Enabled", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "SignalsLocation", type = Boolean.class, access = Access.READ)
+@DBusProperty(name = "Location", type = Location.PropertyLocationType.class, access = Access.READ)
+@DBusProperty(name = "SuplServer", type = String.class, access = Access.READ)
+@DBusProperty(name = "AssistanceDataServers", type = Location.PropertyAssistanceDataServersType.class, access = Access.READ)
+@DBusProperty(name = "GpsRefreshRate", type = UInt32.class, access = Access.READ)
+public interface Location extends DBusInterface {
+
+
+    public void Setup(UInt32 sources, boolean signalLocation);
+    public Map<UInt32, Variant<?>> GetLocation();
+    public void SetSuplServer(String supl);
+    public void InjectAssistanceData(List<Byte> data);
+    public void SetGpsRefreshRate(UInt32 rate);
+
+
+    public static interface PropertyLocationType extends TypeRef<Map<UInt32, Variant>> {
+
+
+
+
+    }
+
+    public static interface PropertyAssistanceDataServersType extends TypeRef<List<String>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Messaging.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Messaging.java
@@ -30,18 +30,18 @@ public interface Messaging extends DBusInterface {
 
     public static class Added extends DBusSignal {
 
-        private final DBusPath path;
+        private final DBusPath dbusPath;
         private final boolean received;
 
-        public Added(String _path, DBusPath _path, boolean _received) throws DBusException {
-            super(_path, _path, _received);
-            this.path = _path;
+        public Added(String _path, DBusPath _dbusPath, boolean _received) throws DBusException {
+            super(_path, _dbusPath, _received);
+            this.dbusPath = _dbusPath;
             this.received = _received;
         }
 
 
-        public DBusPath getPath() {
-            return path;
+        public DBusPath getDbusPath() {
+            return dbusPath;
         }
 
         public boolean getReceived() {
@@ -53,16 +53,16 @@ public interface Messaging extends DBusInterface {
 
     public static class Deleted extends DBusSignal {
 
-        private final DBusPath path;
+        private final DBusPath dbusPath;
 
-        public Deleted(String _path, DBusPath _path) throws DBusException {
-            super(_path, _path);
-            this.path = _path;
+        public Deleted(String _path, DBusPath _dbusPath) throws DBusException {
+            super(_path, _dbusPath);
+            this.dbusPath = _dbusPath;
         }
 
 
-        public DBusPath getPath() {
-            return path;
+        public DBusPath getDbusPath() {
+            return dbusPath;
         }
 
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Messaging.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Messaging.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Messaging.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Messaging.java
@@ -1,0 +1,84 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.List;
+import java.util.Map;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Messaging")
+@DBusProperty(name = "Messages", type = Messaging.PropertyMessagesType.class, access = Access.READ)
+@DBusProperty(name = "SupportedStorages", type = Messaging.PropertySupportedStoragesType.class, access = Access.READ)
+@DBusProperty(name = "DefaultStorage", type = UInt32.class, access = Access.READ)
+public interface Messaging extends DBusInterface {
+
+
+    public List<DBusPath> List();
+    public void Delete(DBusPath path);
+    public DBusPath Create(Map<String, Variant<?>> properties);
+
+
+    public static class Added extends DBusSignal {
+
+        private final DBusPath path;
+        private final boolean received;
+
+        public Added(String _path, DBusPath _path, boolean _received) throws DBusException {
+            super(_path, _path, _received);
+            this.path = _path;
+            this.received = _received;
+        }
+
+
+        public DBusPath getPath() {
+            return path;
+        }
+
+        public boolean getReceived() {
+            return received;
+        }
+
+
+    }
+
+    public static class Deleted extends DBusSignal {
+
+        private final DBusPath path;
+
+        public Deleted(String _path, DBusPath _path) throws DBusException {
+            super(_path, _path);
+            this.path = _path;
+        }
+
+
+        public DBusPath getPath() {
+            return path;
+        }
+
+
+    }
+
+    public static interface PropertyMessagesType extends TypeRef<List<DBusPath>> {
+
+
+
+
+    }
+
+    public static interface PropertySupportedStoragesType extends TypeRef<List<UInt32>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Modem3gpp.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Modem3gpp.java
@@ -1,0 +1,51 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.List;
+import java.util.Map;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+import org.freedesktop.modemmanager1.modem.PropertyPcoStruct;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Modem3gpp")
+@DBusProperty(name = "Imei", type = String.class, access = Access.READ)
+@DBusProperty(name = "RegistrationState", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "OperatorCode", type = String.class, access = Access.READ)
+@DBusProperty(name = "OperatorName", type = String.class, access = Access.READ)
+@DBusProperty(name = "EnabledFacilityLocks", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "SubscriptionState", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "EpsUeModeOperation", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Pco", type = Modem3gpp.PropertyPcoType.class, access = Access.READ)
+@DBusProperty(name = "InitialEpsBearer", type = DBusPath.class, access = Access.READ)
+@DBusProperty(name = "InitialEpsBearerSettings", type = Modem3gpp.PropertyInitialEpsBearerSettingsType.class, access = Access.READ)
+public interface Modem3gpp extends DBusInterface {
+
+
+    public void Register(String operatorId);
+    public List<Map<String, Variant<?>>> Scan();
+    public void SetEpsUeModeOperation(UInt32 mode);
+    public void SetInitialEpsBearerSettings(Map<String, Variant<?>> settings);
+
+
+    public static interface PropertyPcoType extends TypeRef<List<PropertyPcoStruct>> {
+
+
+
+
+    }
+
+    public static interface PropertyInitialEpsBearerSettingsType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Modem3gpp.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Modem3gpp.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ModemCdma.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ModemCdma.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.Map;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ModemCdma.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/ModemCdma.java
@@ -1,0 +1,59 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.Map;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.ModemCdma")
+@DBusProperty(name = "ActivationState", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Meid", type = String.class, access = Access.READ)
+@DBusProperty(name = "Esn", type = String.class, access = Access.READ)
+@DBusProperty(name = "Sid", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Nid", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Cdma1xRegistrationState", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "EvdoRegistrationState", type = UInt32.class, access = Access.READ)
+public interface ModemCdma extends DBusInterface {
+
+
+    public void Activate(String carrierCode);
+    public void ActivateManual(Map<String, Variant<?>> properties);
+
+
+    public static class ActivationStateChanged extends DBusSignal {
+
+        private final UInt32 activationState;
+        private final UInt32 activationError;
+        private final Map<String, Variant<?>> statusChanges;
+
+        public ActivationStateChanged(String _path, UInt32 _activationState, UInt32 _activationError, Map<String, Variant<?>> _statusChanges) throws DBusException {
+            super(_path, _activationState, _activationError, _statusChanges);
+            this.activationState = _activationState;
+            this.activationError = _activationError;
+            this.statusChanges = _statusChanges;
+        }
+
+
+        public UInt32 getActivationState() {
+            return activationState;
+        }
+
+        public UInt32 getActivationError() {
+            return activationError;
+        }
+
+        public Map<String, Variant<?>> getStatusChanges() {
+            return statusChanges;
+        }
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Oma.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Oma.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Oma.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Oma.java
@@ -1,0 +1,66 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.List;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.modemmanager1.modem.PropertyPendingNetworkInitiatedSessionsStruct;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Oma")
+@DBusProperty(name = "Features", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "PendingNetworkInitiatedSessions", type = Oma.PropertyPendingNetworkInitiatedSessionsType.class, access = Access.READ)
+@DBusProperty(name = "SessionType", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "SessionState", type = Integer.class, access = Access.READ)
+public interface Oma extends DBusInterface {
+
+
+    public void Setup(UInt32 features);
+    public void StartClientInitiatedSession(UInt32 sessionType);
+    public void AcceptNetworkInitiatedSession(UInt32 sessionId, boolean accept);
+    public void CancelSession();
+
+
+    public static interface PropertyPendingNetworkInitiatedSessionsType extends TypeRef<List<PropertyPendingNetworkInitiatedSessionsStruct>> {
+
+
+
+
+    }
+
+    public static class SessionStateChanged extends DBusSignal {
+
+        private final int oldSessionState;
+        private final int newSessionState;
+        private final UInt32 sessionStateFailedReason;
+
+        public SessionStateChanged(String _path, int _oldSessionState, int _newSessionState, UInt32 _sessionStateFailedReason) throws DBusException {
+            super(_path, _oldSessionState, _newSessionState, _sessionStateFailedReason);
+            this.oldSessionState = _oldSessionState;
+            this.newSessionState = _newSessionState;
+            this.sessionStateFailedReason = _sessionStateFailedReason;
+        }
+
+
+        public int getOldSessionState() {
+            return oldSessionState;
+        }
+
+        public int getNewSessionState() {
+            return newSessionState;
+        }
+
+        public UInt32 getSessionStateFailedReason() {
+            return sessionStateFailedReason;
+        }
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPcoStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPcoStruct.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPcoStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPcoStruct.java
@@ -1,0 +1,39 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.List;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyPcoStruct extends Struct {
+    @Position(0)
+    private final UInt32 member0;
+    @Position(1)
+    private final boolean member1;
+    @Position(2)
+    private final List<byte> member2;
+
+    public PropertyPcoStruct(UInt32 member0, boolean member1, List<byte> member2) {
+        this.member0 = member0;
+        this.member1 = member1;
+        this.member2 = member2;
+    }
+
+
+    public UInt32 getMember0() {
+        return member0;
+    }
+
+    public boolean getMember1() {
+        return member1;
+    }
+
+    public List<byte> getMember2() {
+        return member2;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPcoStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPcoStruct.java
@@ -14,9 +14,9 @@ public class PropertyPcoStruct extends Struct {
     @Position(1)
     private final boolean member1;
     @Position(2)
-    private final List<byte> member2;
+    private final List<Byte> member2;
 
-    public PropertyPcoStruct(UInt32 member0, boolean member1, List<byte> member2) {
+    public PropertyPcoStruct(UInt32 member0, boolean member1, List<Byte> member2) {
         this.member0 = member0;
         this.member1 = member1;
         this.member2 = member2;
@@ -31,7 +31,7 @@ public class PropertyPcoStruct extends Struct {
         return member1;
     }
 
-    public List<byte> getMember2() {
+    public List<Byte> getMember2() {
         return member2;
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPendingNetworkInitiatedSessionsStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPendingNetworkInitiatedSessionsStruct.java
@@ -1,0 +1,31 @@
+package org.freedesktop.modemmanager1.modem;
+
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyPendingNetworkInitiatedSessionsStruct extends Struct {
+    @Position(0)
+    private final UInt32 member0;
+    @Position(1)
+    private final UInt32 member1;
+
+    public PropertyPendingNetworkInitiatedSessionsStruct(UInt32 member0, UInt32 member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+
+    public UInt32 getMember0() {
+        return member0;
+    }
+
+    public UInt32 getMember1() {
+        return member1;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPendingNetworkInitiatedSessionsStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyPendingNetworkInitiatedSessionsStruct.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import org.freedesktop.dbus.Struct;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyUpdateSettingsStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyUpdateSettingsStruct.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.Map;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyUpdateSettingsStruct.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/PropertyUpdateSettingsStruct.java
@@ -1,0 +1,33 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.Map;
+import org.freedesktop.dbus.Struct;
+import org.freedesktop.dbus.annotations.Position;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+public class PropertyUpdateSettingsStruct extends Struct {
+    @Position(0)
+    private final UInt32 member0;
+    @Position(1)
+    private final Map<String, Variant<?>> member1;
+
+    public PropertyUpdateSettingsStruct(UInt32 member0, Map<String, Variant<?>> member1) {
+        this.member0 = member0;
+        this.member1 = member1;
+    }
+
+
+    public UInt32 getMember0() {
+        return member0;
+    }
+
+    public Map<String, Variant<?>> getMember1() {
+        return member1;
+    }
+
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Signal.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Signal.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.Map;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Signal.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Signal.java
@@ -1,0 +1,62 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.Map;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Signal")
+@DBusProperty(name = "Rate", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "Cdma", type = Signal.PropertyCdmaType.class, access = Access.READ)
+@DBusProperty(name = "Evdo", type = Signal.PropertyEvdoType.class, access = Access.READ)
+@DBusProperty(name = "Gsm", type = Signal.PropertyGsmType.class, access = Access.READ)
+@DBusProperty(name = "Umts", type = Signal.PropertyUmtsType.class, access = Access.READ)
+@DBusProperty(name = "Lte", type = Signal.PropertyLteType.class, access = Access.READ)
+public interface Signal extends DBusInterface {
+
+
+    public void Setup(UInt32 rate);
+
+
+    public static interface PropertyCdmaType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+
+    public static interface PropertyEvdoType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+
+    public static interface PropertyGsmType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+
+    public static interface PropertyUmtsType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+
+    public static interface PropertyLteType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Simple.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Simple.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.Map;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Simple.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Simple.java
@@ -1,0 +1,20 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.Map;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Simple")
+public interface Simple extends DBusInterface {
+
+
+    public DBusPath Connect(Map<String, Variant<?>> properties);
+    public void Disconnect(DBusPath bearer);
+    public Map<String, Variant<?>> GetStatus();
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Time.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Time.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.Map;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Time.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Time.java
@@ -1,0 +1,47 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.Map;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Time")
+@DBusProperty(name = "NetworkTimezone", type = Time.PropertyNetworkTimezoneType.class, access = Access.READ)
+public interface Time extends DBusInterface {
+
+
+    public String GetNetworkTime();
+
+
+    public static interface PropertyNetworkTimezoneType extends TypeRef<Map<String, Variant>> {
+
+
+
+
+    }
+
+    public static class NetworkTimeChanged extends DBusSignal {
+
+        private final String time;
+
+        public NetworkTimeChanged(String _path, String _time) throws DBusException {
+            super(_path, _time);
+            this.time = _time;
+        }
+
+
+        public String getTime() {
+            return time;
+        }
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Voice.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Voice.java
@@ -1,0 +1,75 @@
+package org.freedesktop.modemmanager1.modem;
+
+import java.util.List;
+import java.util.Map;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.TypeRef;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Voice")
+@DBusProperty(name = "Calls", type = Voice.PropertyCallsType.class, access = Access.READ)
+@DBusProperty(name = "EmergencyOnly", type = Boolean.class, access = Access.READ)
+public interface Voice extends DBusInterface {
+
+
+    public List<DBusPath> ListCalls();
+    public void DeleteCall(DBusPath path);
+    public DBusPath CreateCall(Map<String, Variant<?>> properties);
+    public void HoldAndAccept();
+    public void HangupAndAccept();
+    public void HangupAll();
+    public void Transfer();
+    public void CallWaitingSetup(boolean enable);
+    public boolean CallWaitingQuery();
+
+
+    public static class CallAdded extends DBusSignal {
+
+        private final DBusPath path;
+
+        public CallAdded(String _path, DBusPath _path) throws DBusException {
+            super(_path, _path);
+            this.path = _path;
+        }
+
+
+        public DBusPath getPath() {
+            return path;
+        }
+
+
+    }
+
+    public static class CallDeleted extends DBusSignal {
+
+        private final DBusPath path;
+
+        public CallDeleted(String _path, DBusPath _path) throws DBusException {
+            super(_path, _path);
+            this.path = _path;
+        }
+
+
+        public DBusPath getPath() {
+            return path;
+        }
+
+
+    }
+
+    public static interface PropertyCallsType extends TypeRef<List<DBusPath>> {
+
+
+
+
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Voice.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Voice.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Voice.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/Voice.java
@@ -34,16 +34,16 @@ public interface Voice extends DBusInterface {
 
     public static class CallAdded extends DBusSignal {
 
-        private final DBusPath path;
+        private final DBusPath dbusPath;
 
-        public CallAdded(String _path, DBusPath _path) throws DBusException {
-            super(_path, _path);
-            this.path = _path;
+        public CallAdded(String _path, DBusPath _dbusPath) throws DBusException {
+            super(_path, _dbusPath);
+            this.dbusPath = _dbusPath;
         }
 
 
-        public DBusPath getPath() {
-            return path;
+        public DBusPath getDbusPath() {
+            return dbusPath;
         }
 
 
@@ -51,16 +51,16 @@ public interface Voice extends DBusInterface {
 
     public static class CallDeleted extends DBusSignal {
 
-        private final DBusPath path;
+        private final DBusPath dbusPath;
 
-        public CallDeleted(String _path, DBusPath _path) throws DBusException {
-            super(_path, _path);
-            this.path = _path;
+        public CallDeleted(String _path, DBusPath _dbusPath) throws DBusException {
+            super(_path, _dbusPath);
+            this.dbusPath = _dbusPath;
         }
 
 
-        public DBusPath getPath() {
-            return path;
+        public DBusPath getDbusPath() {
+            return dbusPath;
         }
 
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/modem3gpp/Ussd.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/modem3gpp/Ussd.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.freedesktop.modemmanager1.modem.modem3gpp;
 
 import org.freedesktop.dbus.annotations.DBusInterfaceName;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/modem3gpp/Ussd.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/freedesktop/modemmanager1/modem/modem3gpp/Ussd.java
@@ -1,0 +1,23 @@
+package org.freedesktop.modemmanager1.modem.modem3gpp;
+
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.annotations.DBusProperty;
+import org.freedesktop.dbus.annotations.DBusProperty.Access;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.UInt32;
+
+/**
+ * Auto-generated class.
+ */
+@DBusInterfaceName("org.freedesktop.ModemManager1.Modem.Modem3gpp.Ussd")
+@DBusProperty(name = "State", type = UInt32.class, access = Access.READ)
+@DBusProperty(name = "NetworkNotification", type = String.class, access = Access.READ)
+@DBusProperty(name = "NetworkRequest", type = String.class, access = Access.READ)
+public interface Ussd extends DBusInterface {
+
+
+    public String Initiate(String command);
+    public String Respond(String response);
+    public void Cancel();
+
+}


### PR DESCRIPTION
This PR adds the auto-generated code required for interfacing with [ModemManager](https://www.freedesktop.org/wiki/Software/ModemManager/) over DBus.

This code was generated using [dbus-java](https://github.com/hypfvieh/dbus-java) **3.3.2** and [ModemManager](https://www.freedesktop.org/wiki/Software/ModemManager/) **1.14.12**.

### Code generation

The process for generating the DBus object code is explained in the [dbus-java wiki here](https://hypfvieh.github.io/dbus-java/code-generation.html).

I used a Raspberry Pi running the latest version of Raspberry Pi OS with ModemManager 1.14.12 installed and run the following command for each ModemManager object:

```bash
mvn exec:java \
	-Dexec.mainClass="org.freedesktop.dbus.utils.generator.InterfaceCodeGenerator" \
	-Dexec.executable="java" \
	-Dexec.args="org.freedesktop.ModemManager1 --system --outputDir /tmp/classes /org/freedesktop/ModemManager1"
```
