### PR TITLE
fix(web2): Fixed typo in wifi master/infra configuration

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -166,7 +166,7 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setSecurity(
                 EnumsParser.getGwtWifiSecurity(this.properties.getWifiMasterSecurityType(this.ifname)));
         gwtWifiConfig.setPairwiseCiphers(
-                EnumsParser.getGwtWifiCiphers(this.properties.getWifiInfraPairwiseCiphers(this.ifname)));
+                EnumsParser.getGwtWifiCiphers(this.properties.getWifiMasterPairwiseCiphers(this.ifname)));
         gwtWifiConfig.setGroupCiphers(
                 EnumsParser.getGwtWifiCiphers(this.properties.getWifiMasterGroupCiphers(this.ifname)));
 
@@ -200,7 +200,7 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig
                 .setSecurity(EnumsParser.getGwtWifiSecurity(this.properties.getWifiInfraSecurityType(this.ifname)));
         gwtWifiConfig.setPairwiseCiphers(
-                EnumsParser.getGwtWifiCiphers(this.properties.getWifiMasterPairwiseCiphers(this.ifname)));
+                EnumsParser.getGwtWifiCiphers(this.properties.getWifiInfraPairwiseCiphers(this.ifname)));
         gwtWifiConfig.setGroupCiphers(
                 EnumsParser.getGwtWifiCiphers(this.properties.getWifiInfraGroupCiphers(this.ifname)));
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR fixes a typo in the wifi master/infra configuration for the web2.

**Related Issue:** This PR fixes/closes N/A
