### PR TITLE
fix(nm): Fix gateway setting in dhcp mode

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -85,6 +85,11 @@ public class NMSettingsConverter {
             addressEntry.put("address", new Variant<>(address));
             addressEntry.put("prefix", new Variant<>(new UInt32(prefix)));
 
+            if (ip4Status.equals(KuraIpStatus.ENABLEDWAN)) {
+                Optional<String> gateway = props.getOpt(String.class, "net.interface.%s.config.ip4.gateway", iface);
+                gateway.ifPresent(gatewayAddress -> settings.put("gateway", new Variant<>(gatewayAddress)));
+            }
+
             List<Map<String, Variant<?>>> addressData = Arrays.asList(addressEntry);
             settings.put("address-data", new Variant<>(addressData, "aa{sv}"));
         } else {
@@ -99,11 +104,6 @@ public class NMSettingsConverter {
             if (dnsServers.isPresent()) {
                 settings.put("dns", new Variant<>(convertIp4(dnsServers.get()), "au"));
                 settings.put("ignore-auto-dns", new Variant<>(true));
-            }
-            
-            Optional<String> gateway = props.getOpt(String.class, "net.interface.%s.config.ip4.gateway", iface);
-            if (gateway.isPresent()) {
-                settings.put("gateway", new Variant<>(gateway.get()));
             }
 
             Optional<Integer> wanPriority = props.getOpt(Integer.class, "net.interface.%s.config.ip4.wan.priority",


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

It seems that when in DHCP client mode, the static gateway is applied in any case. The value comes from a previous configuration. This PR fixes this issue, moving the instructions for setting the gateway only in the static configuration (and if the interface is in WAN mode).

**Related Issue:** This PR fixes/closes N/A
