### PR TITLE
refactor(nm): Removed useless ConfigurationService dependency from nm

### DIFF
--- a/kura/org.eclipse.kura.nm/OSGI-INF/networkConfigurationService.xml
+++ b/kura/org.eclipse.kura.nm/OSGI-INF/networkConfigurationService.xml
@@ -23,5 +23,4 @@
    <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
    <reference bind="setExecutorService" cardinality="1..1" interface="org.eclipse.kura.executor.PrivilegedExecutorService" name="PrivilegedExecutorService" policy="static" unbind="unsetExecutorService"/>
    <reference name="CryptoService" interface="org.eclipse.kura.crypto.CryptoService" bind="setCryptoService" unbind="unsetCryptoService" cardinality="1..1" policy="static"/>
-   <reference bind="setConfigurationService" cardinality="1..1" interface="org.eclipse.kura.configuration.ConfigurationService" name="ConfigurationService" policy="static"/> 
 </scr:component>

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
-import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.configuration.SelfConfiguringComponent;
 import org.eclipse.kura.core.configuration.ComponentConfigurationImpl;
@@ -65,7 +64,6 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
     private EventAdmin eventAdmin;
     private CommandExecutorService commandExecutorService;
     private CryptoService cryptoService;
-    private ConfigurationService configurationService;
     private DhcpServerMonitor dhcpServerMonitor;
 
     private LinuxNetworkUtil linuxNetworkUtil;
@@ -116,10 +114,6 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
         if (this.cryptoService.equals(cryptoService)) {
             this.cryptoService = null;
         }
-    }
-
-    public void setConfigurationService(final ConfigurationService configurationService) {
-        this.configurationService = configurationService;
     }
 
     public NMConfigurationServiceImpl() {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImplTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
-import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.configuration.metatype.AD;
 import org.eclipse.kura.configuration.metatype.OCD;
 import org.eclipse.kura.core.net.EthernetInterfaceImpl;
@@ -50,7 +49,6 @@ import org.osgi.service.event.EventAdmin;
 public class NMConfigurationServiceImplTest {
 
     private NMConfigurationServiceImpl networkConfigurationService;
-    private ConfigurationService configurationServiceMock;
     private final Map<String, Object> properties = new HashMap<>();
     private ComponentConfiguration configuration;
     private Map<String, Object> retrievedProperties;
@@ -305,9 +303,6 @@ public class NMConfigurationServiceImplTest {
         when(networkServiceMock.getNetworkInterfaces()).thenReturn(interfaces);
         this.networkConfigurationService.setNetworkService(networkServiceMock);
 
-        this.configurationServiceMock = mock(ConfigurationService.class);
-        this.networkConfigurationService.setConfigurationService(configurationServiceMock);
-
         this.posted = new AtomicBoolean(false);
 
         doAnswer(invocation -> {
@@ -331,21 +326,6 @@ public class NMConfigurationServiceImplTest {
 
     private void whenServiceIsUpdated() {
         this.networkConfigurationService.activate(null, this.properties);
-    }
-
-    private void whenServiceIsActivatedWithOneWanInterface() {
-        Map<String, Object> props = new HashMap<>();
-        props.put("net.interfaces", "eth0");
-        props.put("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
-        this.networkConfigurationService.activate(null, props);
-    }
-
-    private void whenServiceIsUpdatedWithTwoWanInterface() {
-        Map<String, Object> props = new HashMap<>();
-        props.put("net.interfaces", "eth0,eth1");
-        props.put("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
-        props.put("net.interface.eth1.config.ip4.status", "netIPv4StatusEnabledWAN");
-        this.networkConfigurationService.update(props);
     }
 
     private void whenComponentDefinitionIsRetrieved() throws KuraException {
@@ -675,14 +655,6 @@ public class NMConfigurationServiceImplTest {
             }
         }
         assertEquals(40, adsConfigured);
-    }
-
-    private void thenOldWanIntefaceIsDisabled() {
-        assertEquals("netIPv4StatusDisabled", this.event.getProperty("net.interface.eth1.config.ip4.status"));
-    }
-
-    private void thenSnapshotIsTaken() throws KuraException {
-        verify(this.configurationServiceMock).snapshot();
     }
 
     private void thenPropertiesNumberIsCorrect() {


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR removes the `ConfigurationService` dependency from the `NetworkConfigurationServiceImpl`. This was used before the implementation of the failover feature to check for multiple WAN interfaces and to manually take the snapshot.

