### PR TITLE
refactor(nm): Deleted NMDbusConnector close connection method

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -97,10 +97,6 @@ public class NMDbusConnector {
         return this.dbusConnection;
     }
 
-    public void closeConnection() {
-        this.dbusConnection.disconnect();
-    }
-
     public void checkPermissions() {
         Map<String, String> getPermissions = this.nm.GetPermissions();
         for (Entry<String, String> entry : getPermissions.entrySet()) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -160,9 +160,6 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
 
     public void deactivate(ComponentContext componentContext) {
         logger.debug("Deactivate NetworkConfigurationService...");
-        if (Objects.nonNull(this.nmDbusConnector)) {
-            this.nmDbusConnector.closeConnection();
-        }
         this.dhcpServerMonitor.stop();
         this.dhcpServerMonitor.clear();
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
@@ -41,7 +41,6 @@ public class NMStatusServiceImpl implements NetworkStatusService {
 
     public void deactivate() {
         logger.debug("Deactivate NMStatusService...");
-        this.nmDbusConnector.closeConnection();
     }
 
     @Override


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR removes the `NMDbusConnector.closeConnection` method and its references.