### PR TITLE
fix(nm): Fixed plug of new network devices

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiInterfaceStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiInterfaceStatus.java
@@ -12,7 +12,6 @@
  ******************************************************************************/
 package org.eclipse.kura.net.status.wifi;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiInterfaceStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiInterfaceStatus.java
@@ -98,10 +98,10 @@ public class WifiInterfaceStatus extends NetworkInterfaceStatus {
     public static class WifiInterfaceStatusBuilder extends NetworkInterfaceStatusBuilder<WifiInterfaceStatusBuilder> {
 
         private Set<WifiCapability> capabilities = EnumSet.of(WifiCapability.NONE);
-        private List<Long> supportedBitrates = Arrays.asList(0L);
+        private List<Long> supportedBitrates = Collections.emptyList();
         private Set<WifiRadioMode> supportedRadioModes = EnumSet.of(WifiRadioMode.UNKNOWN);
-        private List<Integer> supportedChannels = Arrays.asList(0);
-        private List<Long> supportedFrequencies = Arrays.asList(0L);
+        private List<Integer> supportedChannels = Collections.emptyList();
+        private List<Long> supportedFrequencies = Collections.emptyList();
         private String countryCode = "00";
         private WifiMode mode = WifiMode.UNKNOWN;
         private Optional<WifiAccessPoint> currentWifiAccessPoint = Optional.empty();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -16,6 +16,7 @@ package org.eclipse.kura.web.client.ui.network;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.messages.Messages;
@@ -415,13 +416,15 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             this.selectedNetIfConfig = (GwtWifiNetInterfaceConfig) config;
             logger.severe("config: " + selectedNetIfConfig);
             this.activeConfig = this.selectedNetIfConfig.getActiveWifiConfig();
-            logger.severe("active config: " + this.activeConfig);
-            logger.severe("wireless mode: " + this.activeConfig.getWirelessMode());
-            logger.severe("channels " + this.activeConfig.getChannels());
-            if (this.activeConfig.getChannels() != null && !TabWirelessUi.this.activeConfig.getChannels().isEmpty()) {
-                updateChanneList(TabWirelessUi.this.activeConfig);
+            if (Objects.nonNull(this.activeConfig)) {
+                logger.severe("active config: " + this.activeConfig);
+                logger.severe("wireless mode: " + this.activeConfig.getWirelessMode());
+                logger.severe("channels " + this.activeConfig.getChannels());
+                if (this.activeConfig.getChannels() != null
+                        && !TabWirelessUi.this.activeConfig.getChannels().isEmpty()) {
+                    updateChanneList(TabWirelessUi.this.activeConfig);
+                }
             }
-
             loadCountryCode();
         }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -61,7 +61,7 @@ public class GwtNetworkServiceImpl {
                 } else {
                     Optional<NetworkInterfaceType> ifType = status.getNetInterfaceType(ifName);
                     if (ifType.isPresent()) {
-                        GwtNetInterfaceConfig gwtConfig = configuration.createGwtNetInterfaceConfig(ifName,
+                        GwtNetInterfaceConfig gwtConfig = configuration.getDefaultGwtNetInterfaceConfig(ifName,
                                 ifType.get());
                         status.fillWithStatusProperties(ifName, gwtConfig);
                         result.add(gwtConfig);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.kura.web.server.net2;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.net.admin.FirewallConfigurationService;
@@ -22,6 +23,7 @@ import org.eclipse.kura.net.NetConfig;
 import org.eclipse.kura.net.firewall.FirewallNatConfig;
 import org.eclipse.kura.net.firewall.FirewallOpenPortConfigIP4;
 import org.eclipse.kura.net.firewall.FirewallPortForwardConfigIP4;
+import org.eclipse.kura.net.status.NetworkInterfaceType;
 import org.eclipse.kura.web.server.net2.configuration.NetworkConfigurationServiceAdapter;
 import org.eclipse.kura.web.server.net2.status.NetworkStatusServiceAdapter;
 import org.eclipse.kura.web.server.util.ServiceLocator;
@@ -48,12 +50,25 @@ public class GwtNetworkServiceImpl {
             NetworkConfigurationServiceAdapter configuration = new NetworkConfigurationServiceAdapter();
             NetworkStatusServiceAdapter status = new NetworkStatusServiceAdapter();
 
+            List<String> configuredInterfaceNames = configuration.getConfiguredNetworkInterfaceNames();
+            List<String> systemInterfaceNames = status.getNetInterfaces();
             List<GwtNetInterfaceConfig> result = new LinkedList<>();
-            for (String ifname : status.getNetInterfaces()) {
-                GwtNetInterfaceConfig gwtConfig = configuration.getGwtNetInterfaceConfig(ifname);
-                status.fillWithStatusProperties(ifname, gwtConfig);
-
-                result.add(gwtConfig);
+            for (String ifName : systemInterfaceNames) {
+                if (configuredInterfaceNames.contains(ifName)) {
+                    GwtNetInterfaceConfig gwtConfig = configuration.getGwtNetInterfaceConfig(ifName);
+                    status.fillWithStatusProperties(ifName, gwtConfig);
+                    result.add(gwtConfig);
+                } else {
+                    Optional<NetworkInterfaceType> ifType = status.getNetInterfaceType(ifName);
+                    if (ifType.isPresent()) {
+                        GwtNetInterfaceConfig gwtConfig = configuration.createGwtNetInterfaceConfig(ifName,
+                                ifType.get());
+                        status.fillWithStatusProperties(ifName, gwtConfig);
+                        result.add(gwtConfig);
+                    } else {
+                        logger.warn("Cannot create configuration for {}", ifName);
+                    }
+                }
             }
 
             return result;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -101,14 +101,9 @@ public class GwtNetInterfaceConfigBuilder {
         this.gwtConfig.setName(this.ifName);
         this.gwtConfig.setHwName(this.ifName);
 
-        Optional<String> ifType = this.properties.getType(this.ifName);
-        if (ifType.isPresent()) {
-            this.gwtConfig.setHwType(ifType.get());
-        }
-
-        if (this.gwtConfig instanceof GwtWifiNetInterfaceConfig) {
-            String wifiMode = EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMode(this.ifName));
-            ((GwtWifiNetInterfaceConfig) gwtConfig).setWirelessMode(wifiMode);
+        Optional<String> interfaceType = this.properties.getType(this.ifName);
+        if (interfaceType.isPresent()) {
+            this.gwtConfig.setHwType(interfaceType.get());
         }
     }
 
@@ -163,6 +158,7 @@ public class GwtNetInterfaceConfigBuilder {
     private void setWifiProperties() {
         if (this.gwtConfig instanceof GwtWifiNetInterfaceConfig) {
             String wifiMode = EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMode(this.ifName));
+            ((GwtWifiNetInterfaceConfig) gwtConfig).setWirelessMode(wifiMode);
 
             if (wifiMode.equals(GwtWifiWirelessMode.netWifiWirelessModeAccessPoint.name())) {
                 setWifiMasterProperties();
@@ -183,7 +179,6 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setDriver(this.properties.getWifiMasterDriver(this.ifName));
         gwtWifiConfig.setIgnoreSSID(this.properties.getWifiMasterIgnoreSsid(this.ifName));
         gwtWifiConfig.setPassword(new String(this.properties.getWifiMasterPassphrase(this.ifName).getPassword()));
-        gwtWifiConfig.setChannels(this.properties.getWifiMasterChannel(this.ifName));
         gwtWifiConfig.setWirelessMode(
                 EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMasterMode(this.ifName)));
         gwtWifiConfig.setSecurity(
@@ -217,7 +212,6 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setDriver(this.properties.getWifiInfraDriver(this.ifName));
         gwtWifiConfig.setIgnoreSSID(this.properties.getWifiInfraIgnoreSsid(this.ifName));
         gwtWifiConfig.setPassword(new String(this.properties.getWifiInfraPassphrase(this.ifName).getPassword()));
-        gwtWifiConfig.setChannels(this.properties.getWifiInfraChannel(this.ifName));
         gwtWifiConfig
                 .setWirelessMode(EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiInfraMode(this.ifName)));
         gwtWifiConfig

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -13,9 +13,10 @@
 package org.eclipse.kura.web.server.net2.configuration;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
-import org.eclipse.kura.net.NetInterfaceType;
+import org.eclipse.kura.net.status.NetworkInterfaceType;
 import org.eclipse.kura.net.wifi.WifiBgscanModule;
 import org.eclipse.kura.web.server.net2.utils.EnumsParser;
 import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
@@ -36,19 +37,29 @@ public class GwtNetInterfaceConfigBuilder {
 
     private final NetworkConfigurationServiceProperties properties;
     private GwtNetInterfaceConfig gwtConfig;
-    private String ifname;
+    private String ifName;
+    private NetworkInterfaceType ifType;
+
+    public GwtNetInterfaceConfigBuilder() {
+        this.properties = new NetworkConfigurationServiceProperties();
+    }
 
     public GwtNetInterfaceConfigBuilder(Map<String, Object> confServiceProperties) {
         this.properties = new NetworkConfigurationServiceProperties(confServiceProperties);
     }
 
     public GwtNetInterfaceConfigBuilder forInterface(String ifname) {
-        this.ifname = ifname;
-        this.gwtConfig = createGwtNetInterfaceConfigSubtype();
+        this.ifName = ifname;
+        return this;
+    }
+
+    public GwtNetInterfaceConfigBuilder forType(NetworkInterfaceType ifType) {
+        this.ifType = ifType;
         return this;
     }
 
     public GwtNetInterfaceConfig build() {
+        this.gwtConfig = createGwtNetInterfaceConfigSubtype();
         setCommonProperties();
         setIpv4Properties();
         setIpv4DhcpClientProperties();
@@ -61,50 +72,62 @@ public class GwtNetInterfaceConfigBuilder {
     }
 
     private GwtNetInterfaceConfig createGwtNetInterfaceConfigSubtype() {
-        Optional<String> ifType = this.properties.getType(this.ifname);
-
-        if (ifType.isPresent() && ifType.get().equals(NetInterfaceType.WIFI.name())) {
+        NetworkInterfaceType type = getInterfaceType();
+        if (type.equals(NetworkInterfaceType.WIFI)) {
             return new GwtWifiNetInterfaceConfig();
         }
 
-        if (ifType.isPresent() && ifType.get().equals(NetInterfaceType.MODEM.name())) {
+        if (type.equals(NetworkInterfaceType.MODEM)) {
             return new GwtModemInterfaceConfig();
         }
 
         return new GwtNetInterfaceConfig();
     }
 
-    private void setCommonProperties() {
-        this.gwtConfig.setName(this.ifname);
-        this.gwtConfig.setHwName(this.ifname);
+    private NetworkInterfaceType getInterfaceType() {
+        NetworkInterfaceType type = NetworkInterfaceType.UNKNOWN;
+        if (Objects.nonNull(this.ifType)) {
+            return this.ifType;
+        } else {
+            Optional<String> typeFromProperties = this.properties.getType(this.ifName);
+            if (typeFromProperties.isPresent() && !typeFromProperties.get().isEmpty()) {
+                type = NetworkInterfaceType.valueOf(typeFromProperties.get());
+            }
+        }
+        return type;
+    }
 
-        Optional<String> ifType = this.properties.getType(this.ifname);
+    private void setCommonProperties() {
+        this.gwtConfig.setName(this.ifName);
+        this.gwtConfig.setHwName(this.ifName);
+
+        Optional<String> ifType = this.properties.getType(this.ifName);
         if (ifType.isPresent()) {
             this.gwtConfig.setHwType(ifType.get());
         }
 
         if (this.gwtConfig instanceof GwtWifiNetInterfaceConfig) {
-            String wifiMode = EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMode(this.ifname));
+            String wifiMode = EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMode(this.ifName));
             ((GwtWifiNetInterfaceConfig) gwtConfig).setWirelessMode(wifiMode);
         }
     }
 
     private void setIpv4Properties() {
-        this.gwtConfig.setStatus(EnumsParser.getGwtNetIfStatus(this.properties.getIp4Status(this.ifname)));
+        this.gwtConfig.setStatus(EnumsParser.getGwtNetIfStatus(this.properties.getIp4Status(this.ifName)));
 
-        Optional<Integer> wanPriority = this.properties.getIp4WanPriority(ifname);
+        Optional<Integer> wanPriority = this.properties.getIp4WanPriority(ifName);
         if (wanPriority.isPresent()) {
             this.gwtConfig.setWanPriority(wanPriority.get());
         }
 
-        this.gwtConfig.setIpAddress(this.properties.getIp4Address(this.ifname));
-        this.gwtConfig.setSubnetMask(this.properties.getIp4Netmask(this.ifname));
-        this.gwtConfig.setGateway(this.properties.getIp4Gateway(this.ifname));
-        this.gwtConfig.setDnsServers(this.properties.getIp4DnsServers(this.ifname));
+        this.gwtConfig.setIpAddress(this.properties.getIp4Address(this.ifName));
+        this.gwtConfig.setSubnetMask(this.properties.getIp4Netmask(this.ifName));
+        this.gwtConfig.setGateway(this.properties.getIp4Gateway(this.ifName));
+        this.gwtConfig.setDnsServers(this.properties.getIp4DnsServers(this.ifName));
     }
 
     private void setIpv4DhcpClientProperties() {
-        if (this.properties.getDhcpClient4Enabled(this.ifname)) {
+        if (this.properties.getDhcpClient4Enabled(this.ifName)) {
             this.gwtConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
         } else {
             this.gwtConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeManual.name());
@@ -112,19 +135,19 @@ public class GwtNetInterfaceConfigBuilder {
     }
 
     private void setIpv4DhcpServerProperties() {
-        if (this.properties.getDhcpServer4Enabled(this.ifname)) {
-            this.gwtConfig.setRouterDhcpBeginAddress(this.properties.getDhcpServer4RangeStart(this.ifname));
-            this.gwtConfig.setRouterDhcpEndAddress(this.properties.getDhcpServer4RangeEnd(this.ifname));
-            this.gwtConfig.setRouterDhcpSubnetMask(this.properties.getDhcpServer4Netmask(this.ifname));
-            this.gwtConfig.setRouterDhcpDefaultLease(this.properties.getDhcpServer4LeaseTime(this.ifname));
-            this.gwtConfig.setRouterDhcpMaxLease(this.properties.getDhcpServer4MaxLeaseTime(this.ifname));
-            this.gwtConfig.setRouterDnsPass(this.properties.getDhcpServer4PassDns(this.ifname));
+        if (this.properties.getDhcpServer4Enabled(this.ifName)) {
+            this.gwtConfig.setRouterDhcpBeginAddress(this.properties.getDhcpServer4RangeStart(this.ifName));
+            this.gwtConfig.setRouterDhcpEndAddress(this.properties.getDhcpServer4RangeEnd(this.ifName));
+            this.gwtConfig.setRouterDhcpSubnetMask(this.properties.getDhcpServer4Netmask(this.ifName));
+            this.gwtConfig.setRouterDhcpDefaultLease(this.properties.getDhcpServer4LeaseTime(this.ifName));
+            this.gwtConfig.setRouterDhcpMaxLease(this.properties.getDhcpServer4MaxLeaseTime(this.ifName));
+            this.gwtConfig.setRouterDnsPass(this.properties.getDhcpServer4PassDns(this.ifName));
         }
     }
 
     private void setRouterMode() {
-        boolean isDhcpServer = this.properties.getDhcpServer4Enabled(this.ifname);
-        boolean isNat = this.properties.getDhcpServer4PassDns(this.ifname);
+        boolean isDhcpServer = this.properties.getDhcpServer4Enabled(this.ifName);
+        boolean isNat = this.properties.getDhcpServer4PassDns(this.ifName);
 
         if (isDhcpServer && isNat) {
             this.gwtConfig.setRouterMode(GwtNetRouterMode.netRouterDchpNat.name());
@@ -139,7 +162,7 @@ public class GwtNetInterfaceConfigBuilder {
 
     private void setWifiProperties() {
         if (this.gwtConfig instanceof GwtWifiNetInterfaceConfig) {
-            String wifiMode = EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMode(this.ifname));
+            String wifiMode = EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMode(this.ifName));
 
             if (wifiMode.equals(GwtWifiWirelessMode.netWifiWirelessModeAccessPoint.name())) {
                 setWifiMasterProperties();
@@ -156,32 +179,32 @@ public class GwtNetInterfaceConfigBuilder {
 
         // common wifi properties
 
-        gwtWifiConfig.setWirelessSsid(this.properties.getWifiMasterSsid(this.ifname));
-        gwtWifiConfig.setDriver(this.properties.getWifiMasterDriver(this.ifname));
-        gwtWifiConfig.setIgnoreSSID(this.properties.getWifiMasterIgnoreSsid(this.ifname));
-        gwtWifiConfig.setPassword(new String(this.properties.getWifiMasterPassphrase(this.ifname).getPassword()));
-        gwtWifiConfig.setChannels(this.properties.getWifiMasterChannel(this.ifname));
+        gwtWifiConfig.setWirelessSsid(this.properties.getWifiMasterSsid(this.ifName));
+        gwtWifiConfig.setDriver(this.properties.getWifiMasterDriver(this.ifName));
+        gwtWifiConfig.setIgnoreSSID(this.properties.getWifiMasterIgnoreSsid(this.ifName));
+        gwtWifiConfig.setPassword(new String(this.properties.getWifiMasterPassphrase(this.ifName).getPassword()));
+        gwtWifiConfig.setChannels(this.properties.getWifiMasterChannel(this.ifName));
         gwtWifiConfig.setWirelessMode(
-                EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMasterMode(this.ifname)));
+                EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMasterMode(this.ifName)));
         gwtWifiConfig.setSecurity(
-                EnumsParser.getGwtWifiSecurity(this.properties.getWifiMasterSecurityType(this.ifname)));
+                EnumsParser.getGwtWifiSecurity(this.properties.getWifiMasterSecurityType(this.ifName)));
         gwtWifiConfig.setPairwiseCiphers(
-                EnumsParser.getGwtWifiCiphers(this.properties.getWifiMasterPairwiseCiphers(this.ifname)));
+                EnumsParser.getGwtWifiCiphers(this.properties.getWifiMasterPairwiseCiphers(this.ifName)));
         gwtWifiConfig.setGroupCiphers(
-                EnumsParser.getGwtWifiCiphers(this.properties.getWifiMasterGroupCiphers(this.ifname)));
+                EnumsParser.getGwtWifiCiphers(this.properties.getWifiMasterGroupCiphers(this.ifName)));
 
         // wifi master specific properties
 
         Optional<String> radioMode = EnumsParser
-                .getGwtWifiRadioMode(this.properties.getWifiMasterRadioMode(this.ifname));
+                .getGwtWifiRadioMode(this.properties.getWifiMasterRadioMode(this.ifName));
         if (radioMode.isPresent()) {
             gwtWifiConfig.setRadioMode(radioMode.get());
         }
 
         this.gwtConfig.setHwRssi(NA);
-        this.gwtConfig.setHwDriver(this.properties.getWifiMasterDriver(this.ifname));
+        this.gwtConfig.setHwDriver(this.properties.getWifiMasterDriver(this.ifName));
         ((GwtWifiNetInterfaceConfig) this.gwtConfig).setAccessPointWifiConfig(gwtWifiConfig);
-        logger.debug("GWT Wifi Master Configuration for interface {}:\n{}\n", this.ifname,
+        logger.debug("GWT Wifi Master Configuration for interface {}:\n{}\n", this.ifName,
                 gwtWifiConfig.getProperties());
     }
 
@@ -190,29 +213,29 @@ public class GwtNetInterfaceConfigBuilder {
 
         // common wifi properties
 
-        gwtWifiConfig.setWirelessSsid(this.properties.getWifiInfraSsid(this.ifname));
-        gwtWifiConfig.setDriver(this.properties.getWifiInfraDriver(this.ifname));
-        gwtWifiConfig.setIgnoreSSID(this.properties.getWifiInfraIgnoreSsid(this.ifname));
-        gwtWifiConfig.setPassword(new String(this.properties.getWifiInfraPassphrase(this.ifname).getPassword()));
-        gwtWifiConfig.setChannels(this.properties.getWifiInfraChannel(this.ifname));
+        gwtWifiConfig.setWirelessSsid(this.properties.getWifiInfraSsid(this.ifName));
+        gwtWifiConfig.setDriver(this.properties.getWifiInfraDriver(this.ifName));
+        gwtWifiConfig.setIgnoreSSID(this.properties.getWifiInfraIgnoreSsid(this.ifName));
+        gwtWifiConfig.setPassword(new String(this.properties.getWifiInfraPassphrase(this.ifName).getPassword()));
+        gwtWifiConfig.setChannels(this.properties.getWifiInfraChannel(this.ifName));
         gwtWifiConfig
-                .setWirelessMode(EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiInfraMode(this.ifname)));
+                .setWirelessMode(EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiInfraMode(this.ifName)));
         gwtWifiConfig
-                .setSecurity(EnumsParser.getGwtWifiSecurity(this.properties.getWifiInfraSecurityType(this.ifname)));
+                .setSecurity(EnumsParser.getGwtWifiSecurity(this.properties.getWifiInfraSecurityType(this.ifName)));
         gwtWifiConfig.setPairwiseCiphers(
-                EnumsParser.getGwtWifiCiphers(this.properties.getWifiInfraPairwiseCiphers(this.ifname)));
+                EnumsParser.getGwtWifiCiphers(this.properties.getWifiInfraPairwiseCiphers(this.ifName)));
         gwtWifiConfig.setGroupCiphers(
-                EnumsParser.getGwtWifiCiphers(this.properties.getWifiInfraGroupCiphers(this.ifname)));
+                EnumsParser.getGwtWifiCiphers(this.properties.getWifiInfraGroupCiphers(this.ifName)));
 
         // wifi infra specific properties
 
-        setBgScanProperties(gwtWifiConfig, this.properties.getWifiInfraBgscan(this.ifname));
-        gwtWifiConfig.setPingAccessPoint(this.properties.getWifiInfraPingAP(this.ifname));
+        setBgScanProperties(gwtWifiConfig, this.properties.getWifiInfraBgscan(this.ifName));
+        gwtWifiConfig.setPingAccessPoint(this.properties.getWifiInfraPingAP(this.ifName));
 
         this.gwtConfig.setHwRssi(NA);
-        this.gwtConfig.setHwDriver(this.properties.getWifiInfraDriver(this.ifname));
+        this.gwtConfig.setHwDriver(this.properties.getWifiInfraDriver(this.ifName));
         ((GwtWifiNetInterfaceConfig) this.gwtConfig).setStationWifiConfig(gwtWifiConfig);
-        logger.debug("GWT Wifi Infra Configuration for interface {}:\n{}\n", this.ifname,
+        logger.debug("GWT Wifi Infra Configuration for interface {}:\n{}\n", this.ifName,
                 gwtWifiConfig.getProperties());
     }
 
@@ -246,33 +269,33 @@ public class GwtNetInterfaceConfigBuilder {
             GwtModemInterfaceConfig gwtModemConfig = (GwtModemInterfaceConfig) this.gwtConfig;
 
             gwtModemConfig
-                    .setAuthType(EnumsParser.getGwtModemAuthType(this.properties.getModemAuthType(this.ifname)));
-            gwtModemConfig.setPdpType(EnumsParser.getGwtModemPdpType(this.properties.getModemPdpType(this.ifname)));
+                    .setAuthType(EnumsParser.getGwtModemAuthType(this.properties.getModemAuthType(this.ifName)));
+            gwtModemConfig.setPdpType(EnumsParser.getGwtModemPdpType(this.properties.getModemPdpType(this.ifName)));
             gwtModemConfig.setHwState(
-                    EnumsParser.getNetInterfaceState(this.properties.getModemConnectionStatus(this.ifname)));
+                    EnumsParser.getNetInterfaceState(this.properties.getModemConnectionStatus(this.ifName)));
 
-            gwtModemConfig.setDialString(this.properties.getModemDialString(this.ifname));
-            gwtModemConfig.setUsername(this.properties.getModemUsername(this.ifname));
-            gwtModemConfig.setPassword(new String(this.properties.getModemPassword(this.ifname).getPassword()));
-            gwtModemConfig.setResetTimeout(this.properties.getModemResetTimeout(this.ifname));
-            gwtModemConfig.setPersist(this.properties.getModemPersistEnabled(this.ifname));
-            gwtModemConfig.setHoldoff(this.properties.getModemHoldoff(this.ifname));
-            gwtModemConfig.setPppNum(this.properties.getModemPppNum(this.ifname));
-            gwtModemConfig.setMaxFail(this.properties.getModemMaxFail(this.ifname));
-            gwtModemConfig.setIdle(this.properties.getModemIdle(this.ifname));
-            gwtModemConfig.setActiveFilter(this.properties.getModemActiveFilter(this.ifname));
-            gwtModemConfig.setLcpEchoInterval(this.properties.getModemIpcEchoInterval(this.ifname));
-            gwtModemConfig.setLcpEchoFailure(this.properties.getModemIpcEchoFailure(this.ifname));
-            gwtModemConfig.setGpsEnabled(this.properties.getModemGpsEnabled(this.ifname));
-            gwtModemConfig.setDiversityEnabled(this.properties.getModemDiversityEnabled(this.ifname));
-            gwtModemConfig.setApn(this.properties.getModemApn(this.ifname));
-            gwtModemConfig.setModemId(this.properties.getUsbProductName(this.ifname));
-            gwtModemConfig.setManufacturer(this.properties.getUsbVendorName(this.ifname));
-            gwtModemConfig.setModel(this.properties.getUsbProductId(this.ifname));
-            gwtModemConfig.setHwUsbDevice(this.properties.getUsbDevicePath(this.ifname));
+            gwtModemConfig.setDialString(this.properties.getModemDialString(this.ifName));
+            gwtModemConfig.setUsername(this.properties.getModemUsername(this.ifName));
+            gwtModemConfig.setPassword(new String(this.properties.getModemPassword(this.ifName).getPassword()));
+            gwtModemConfig.setResetTimeout(this.properties.getModemResetTimeout(this.ifName));
+            gwtModemConfig.setPersist(this.properties.getModemPersistEnabled(this.ifName));
+            gwtModemConfig.setHoldoff(this.properties.getModemHoldoff(this.ifName));
+            gwtModemConfig.setPppNum(this.properties.getModemPppNum(this.ifName));
+            gwtModemConfig.setMaxFail(this.properties.getModemMaxFail(this.ifName));
+            gwtModemConfig.setIdle(this.properties.getModemIdle(this.ifName));
+            gwtModemConfig.setActiveFilter(this.properties.getModemActiveFilter(this.ifName));
+            gwtModemConfig.setLcpEchoInterval(this.properties.getModemIpcEchoInterval(this.ifName));
+            gwtModemConfig.setLcpEchoFailure(this.properties.getModemIpcEchoFailure(this.ifName));
+            gwtModemConfig.setGpsEnabled(this.properties.getModemGpsEnabled(this.ifName));
+            gwtModemConfig.setDiversityEnabled(this.properties.getModemDiversityEnabled(this.ifName));
+            gwtModemConfig.setApn(this.properties.getModemApn(this.ifName));
+            gwtModemConfig.setModemId(this.properties.getUsbProductName(this.ifName));
+            gwtModemConfig.setManufacturer(this.properties.getUsbVendorName(this.ifName));
+            gwtModemConfig.setModel(this.properties.getUsbProductId(this.ifName));
+            gwtModemConfig.setHwUsbDevice(this.properties.getUsbDevicePath(this.ifName));
             gwtModemConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
 
-            logger.debug("GWT Modem Configuration for interface {}:\n{}\n", this.ifname,
+            logger.debug("GWT Modem Configuration for interface {}:\n{}\n", this.ifName,
                     gwtModemConfig.getProperties());
         }
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
@@ -64,14 +64,14 @@ public class NetworkConfigurationServiceAdapter {
     }
 
     /**
-     * Return an empty {@link GwtNetInterfaceConfig} for the given network interface
-     * name and type
+     * Return a {@link GwtNetInterfaceConfig} for the given network interface
+     * name and type with default values
      * 
      * @param ifName the network interface name
      * @param ifType the network interface type
      * @return a new {@link GwtNetInterfaceConfig}
      */
-    public GwtNetInterfaceConfig createGwtNetInterfaceConfig(String ifName, NetworkInterfaceType ifType) {
+    public GwtNetInterfaceConfig getDefaultGwtNetInterfaceConfig(String ifName, NetworkInterfaceType ifType) {
         GwtNetInterfaceConfig gwtConfig = new GwtNetInterfaceConfigBuilder()
                 .forInterface(ifName).forType(ifType).build();
         logger.debug("Created GWT Network Configuration for interface {} and type {}", ifName, ifType);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -24,6 +24,7 @@ import org.eclipse.kura.net.IP4Address;
 import org.eclipse.kura.net.IPAddress;
 import org.eclipse.kura.net.status.NetworkInterfaceIpAddress;
 import org.eclipse.kura.net.status.NetworkInterfaceStatus;
+import org.eclipse.kura.net.status.NetworkInterfaceType;
 import org.eclipse.kura.net.status.NetworkStatusService;
 import org.eclipse.kura.net.status.modem.ModemInterfaceStatus;
 import org.eclipse.kura.net.status.modem.Sim;
@@ -58,23 +59,26 @@ public class NetworkStatusServiceAdapter {
         return this.networkStatusService.getInterfaceNames();
     }
 
-    public Optional<GwtNetInterfaceConfig> fillWithStatusProperties(String ifname,
+    public void fillWithStatusProperties(String ifName,
             GwtNetInterfaceConfig gwtConfigToUpdate) {
-
-        Optional<NetworkInterfaceStatus> networkInterfaceInfo = this.networkStatusService.getNetworkStatus(ifname);
+        Optional<NetworkInterfaceStatus> networkInterfaceInfo = this.networkStatusService.getNetworkStatus(ifName);
 
         if (networkInterfaceInfo.isPresent()) {
             setCommonStateProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
             setIpv4DhcpClientProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
             setWifiStateProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
             setModemStateProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
-
-            return Optional.of(gwtConfigToUpdate);
         }
 
-        logger.debug("No status information retrieved for interface '{}'.", ifname);
+    }
 
-        return Optional.empty();
+    public Optional<NetworkInterfaceType> getNetInterfaceType(String ifName) {
+        Optional<NetworkInterfaceStatus> networkInterfaceInfo = this.networkStatusService.getNetworkStatus(ifName);
+        Optional<NetworkInterfaceType> ifType = Optional.empty();
+        if (networkInterfaceInfo.isPresent()) {
+            ifType = Optional.of(networkInterfaceInfo.get().getType());
+        }
+        return ifType;
     }
 
     @SuppressWarnings("restriction")

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -205,6 +205,14 @@ public class NetworkStatusServiceAdapter {
                 wifiInterfaceInfo.getActiveWifiAccessPoint()
                         .ifPresent(accessPoint -> rssi.set(String.valueOf(accessPoint.getSignalQuality())));
                 gwtWifiNetInterfaceConfig.setHwRssi(rssi.get());
+                if (Objects.nonNull(gwtWifiNetInterfaceConfig.getStationWifiConfig())) {
+                    gwtWifiNetInterfaceConfig.getStationWifiConfig()
+                            .setChannels(wifiInterfaceInfo.getSupportedChannels());
+                } else {
+                    GwtWifiConfig gwtConfig = new GwtWifiConfig();
+                    gwtConfig.setChannels(wifiInterfaceInfo.getSupportedChannels());
+                    gwtWifiNetInterfaceConfig.setStationWifiConfig(gwtConfig);
+                }
             }
         }
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
@@ -60,7 +60,7 @@ public class EnumsParser {
             }
         }
 
-        return GwtWifiWirelessMode.netWifiWirelessModeDisabled.name();
+        return GwtWifiWirelessMode.netWifiWirelessModeStation.name();
     }
 
     /**
@@ -166,7 +166,7 @@ public class EnumsParser {
             }
         }
 
-        return GwtWifiSecurity.netWifiSecurityNONE.name();
+        return GwtWifiSecurity.netWifiSecurityWPA2.name();
     }
 
     /**
@@ -214,7 +214,7 @@ public class EnumsParser {
             }
         }
 
-        return GwtWifiCiphers.netWifiCiphers_NONE.name();
+        return GwtWifiCiphers.netWifiCiphers_CCMP.name();
     }
 
     /**
@@ -268,7 +268,8 @@ public class EnumsParser {
             }
         }
 
-        return Optional.empty();
+        return Optional.of(GwtWifiRadioMode.netWifiRadioModeBGN.name());
+
     }
 
     /**


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

When a new network device is plugged into the device, the webUI search for a configuration in to the `NetworkConfigurationService`. If this is not present (and this is the case of new devices), a generic configuration object is returned. Since this can be an issue for wifi or modem interfaces, this PR modifies the logic returning an object of the correct type.