### PR TITLE
test(nm): initial test coverage for NMDbusConnectorTest

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -372,14 +372,9 @@ public class NMDbusConnector {
             Settings settings = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_SETTINGS_BUS_PATH, Settings.class);
 
             DBusPath connectionPath = settings.GetConnectionByUuid(uuid);
-
-            Connection connection = this.dbusConnection.getRemoteObject(NM_BUS_NAME, connectionPath.getPath(),
-                    Connection.class);
-            if (connection == null) {
-                return Optional.empty();
-            } else {
-                return Optional.of(connection);
-            }
+            
+            return Optional
+                    .of(this.dbusConnection.getRemoteObject(NM_BUS_NAME, connectionPath.getPath(), Connection.class));
         } catch (DBusExecutionException e) {
             logger.debug("Could not find applied connection for {}, caused by", dev.getObjectPath(), e);
             return Optional.empty();

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -372,7 +372,6 @@ public class NMDbusConnector {
             Settings settings = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_SETTINGS_BUS_PATH, Settings.class);
 
             DBusPath connectionPath = settings.GetConnectionByUuid(uuid);
-            
             return Optional
                     .of(this.dbusConnection.getRemoteObject(NM_BUS_NAME, connectionPath.getPath(), Connection.class));
         } catch (DBusExecutionException e) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -69,24 +69,24 @@ public class NMDbusConnector {
             NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceType.NM_DEVICE_TYPE_WIFI,
             NMDeviceType.NM_DEVICE_TYPE_PPP, NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
 
-    protected static NMDbusConnector instance;
+    private static NMDbusConnector instance;
     private final DBusConnection dbusConnection;
     private final NetworkManager nm;
 
     private Map<String, Object> cachedConfiguration = null;
 
-    protected NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
+    private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.nm = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_BUS_PATH, NetworkManager.class);
 
         this.dbusConnection.addSigHandler(NetworkManager.DeviceAdded.class, new NMDeviceAddedHandler());
     }
 
-	public static synchronized NMDbusConnector getInstance() throws DBusException {
+    public static synchronized NMDbusConnector getInstance() throws DBusException {
         return getInstance(DBusConnection.getConnection(DBusConnection.DEFAULT_SYSTEM_BUS_ADDRESS));
     }
 
-	protected static synchronized NMDbusConnector getInstance(DBusConnection dbusConnection) throws DBusException {
+    public static synchronized NMDbusConnector getInstance(DBusConnection dbusConnection) throws DBusException {
         if (Objects.isNull(instance)) {
             instance = new NMDbusConnector(dbusConnection);
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -372,8 +372,14 @@ public class NMDbusConnector {
             Settings settings = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_SETTINGS_BUS_PATH, Settings.class);
 
             DBusPath connectionPath = settings.GetConnectionByUuid(uuid);
-            return Optional
-                    .of(this.dbusConnection.getRemoteObject(NM_BUS_NAME, connectionPath.getPath(), Connection.class));
+
+            Connection connection = this.dbusConnection.getRemoteObject(NM_BUS_NAME, connectionPath.getPath(),
+                    Connection.class);
+            if (connection == null) {
+                return Optional.empty();
+            } else {
+                return Optional.of(connection);
+            }
         } catch (DBusExecutionException e) {
             logger.debug("Could not find applied connection for {}, caused by", dev.getObjectPath(), e);
             return Optional.empty();

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -69,24 +69,24 @@ public class NMDbusConnector {
             NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceType.NM_DEVICE_TYPE_WIFI,
             NMDeviceType.NM_DEVICE_TYPE_PPP, NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
 
-    private static NMDbusConnector instance;
+    protected static NMDbusConnector instance;
     private final DBusConnection dbusConnection;
     private final NetworkManager nm;
 
     private Map<String, Object> cachedConfiguration = null;
 
-    private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
+    protected NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.nm = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_BUS_PATH, NetworkManager.class);
 
         this.dbusConnection.addSigHandler(NetworkManager.DeviceAdded.class, new NMDeviceAddedHandler());
     }
 
-    public static synchronized NMDbusConnector getInstance() throws DBusException {
+	public static synchronized NMDbusConnector getInstance() throws DBusException {
         return getInstance(DBusConnection.getConnection(DBusConnection.DEFAULT_SYSTEM_BUS_ADDRESS));
     }
 
-    public static synchronized NMDbusConnector getInstance(DBusConnection dbusConnection) throws DBusException {
+	protected static synchronized NMDbusConnector getInstance(DBusConnection dbusConnection) throws DBusException {
         if (Objects.isNull(instance)) {
             instance = new NMDbusConnector(dbusConnection);
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceState.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceState.java
@@ -73,4 +73,36 @@ public enum NMDeviceState {
             return NMDeviceState.NM_DEVICE_STATE_UNKNOWN;
         }
     }
+
+    public static UInt32 fromUInt32(NMDeviceState state) {
+        switch (state) {
+        case NM_DEVICE_STATE_UNMANAGED:
+            return new UInt32(10);
+        case NM_DEVICE_STATE_UNAVAILABLE:
+            return new UInt32(20);
+        case NM_DEVICE_STATE_DISCONNECTED:
+            return new UInt32(30);
+        case NM_DEVICE_STATE_PREPARE:
+            return new UInt32(40);
+        case NM_DEVICE_STATE_CONFIG:
+            return new UInt32(50);
+        case NM_DEVICE_STATE_NEED_AUTH:
+            return new UInt32(60);
+        case NM_DEVICE_STATE_IP_CONFIG:
+            return new UInt32(70);
+        case NM_DEVICE_STATE_IP_CHECK:
+            return new UInt32(80);
+        case NM_DEVICE_STATE_SECONDARIES:
+            return new UInt32(90);
+        case NM_DEVICE_STATE_ACTIVATED:
+            return new UInt32(100);
+        case NM_DEVICE_STATE_DEACTIVATING:
+            return new UInt32(110);
+        case NM_DEVICE_STATE_FAILED:
+            return new UInt32(120);
+        case NM_DEVICE_STATE_UNKNOWN:
+        default:
+            return new UInt32(0);
+        }
+    }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceState.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceState.java
@@ -74,7 +74,7 @@ public enum NMDeviceState {
         }
     }
 
-    public static UInt32 fromUInt32(NMDeviceState state) {
+    public static UInt32 toUInt32(NMDeviceState state) {
         switch (state) {
         case NM_DEVICE_STATE_UNMANAGED:
             return new UInt32(10);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceType.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceType.java
@@ -121,4 +121,76 @@ public enum NMDeviceType {
             return NM_DEVICE_TYPE_UNKNOWN;
         }
     }
+
+    public static UInt32 fromUInt32(NMDeviceType type) {
+        switch (type) {
+        case NM_DEVICE_TYPE_GENERIC:
+            return new UInt32(14);
+        case NM_DEVICE_TYPE_ETHERNET:
+            return new UInt32(1);
+        case NM_DEVICE_TYPE_WIFI:
+            return new UInt32(2);
+        case NM_DEVICE_TYPE_UNUSED1:
+            return new UInt32(3);
+        case NM_DEVICE_TYPE_UNUSED2:
+            return new UInt32(4);
+        case NM_DEVICE_TYPE_BT:
+            return new UInt32(5);
+        case NM_DEVICE_TYPE_OLPC_MESH:
+            return new UInt32(6);
+        case NM_DEVICE_TYPE_WIMAX:
+            return new UInt32(7);
+        case NM_DEVICE_TYPE_MODEM:
+            return new UInt32(8);
+        case NM_DEVICE_TYPE_INFINIBAND:
+            return new UInt32(9);
+        case NM_DEVICE_TYPE_BOND:
+            return new UInt32(10);
+        case NM_DEVICE_TYPE_VLAN:
+            return new UInt32(11);
+        case NM_DEVICE_TYPE_ADSL:
+            return new UInt32(12);
+        case NM_DEVICE_TYPE_BRIDGE:
+            return new UInt32(13);
+        case NM_DEVICE_TYPE_TEAM:
+            return new UInt32(15);
+        case NM_DEVICE_TYPE_TUN:
+            return new UInt32(16);
+        case NM_DEVICE_TYPE_IP_TUNNEL:
+            return new UInt32(17);
+        case NM_DEVICE_TYPE_MACVLAN:
+            return new UInt32(18);
+        case NM_DEVICE_TYPE_VXLAN:
+            return new UInt32(19);
+        case NM_DEVICE_TYPE_VETH:
+            return new UInt32(20);
+        case NM_DEVICE_TYPE_MACSEC:
+            return new UInt32(21);
+        case NM_DEVICE_TYPE_DUMMY:
+            return new UInt32(22);
+        case NM_DEVICE_TYPE_PPP:
+            return new UInt32(23);
+        case NM_DEVICE_TYPE_OVS_INTERFACE:
+            return new UInt32(24);
+        case NM_DEVICE_TYPE_OVS_PORT:
+            return new UInt32(25);
+        case NM_DEVICE_TYPE_OVS_BRIDGE:
+            return new UInt32(26);
+        case NM_DEVICE_TYPE_WPAN:
+            return new UInt32(27);
+        case NM_DEVICE_TYPE_6LOWPAN:
+            return new UInt32(28);
+        case NM_DEVICE_TYPE_WIREGUARD:
+            return new UInt32(29);
+        case NM_DEVICE_TYPE_WIFI_P2P:
+            return new UInt32(30);
+        case NM_DEVICE_TYPE_VRF:
+            return new UInt32(31);
+        case NM_DEVICE_TYPE_LOOPBACK:
+            return new UInt32(32);
+        case NM_DEVICE_TYPE_UNKNOWN:
+        default:
+            return new UInt32(0);
+        }
+    }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceType.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceType.java
@@ -122,7 +122,7 @@ public enum NMDeviceType {
         }
     }
 
-    public static UInt32 fromUInt32(NMDeviceType type) {
+    public static UInt32 toUInt32(NMDeviceType type) {
         switch (type) {
         case NM_DEVICE_TYPE_GENERIC:
             return new UInt32(14);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -42,6 +42,7 @@ public class NMDbusConnectorTest {
 
 	Boolean hasDBusExceptionBeenThrown = false;
 	Boolean hasNoSuchElementExceptionThrown = false;
+	Boolean hasNullPointerExceptionThrown = false;
 
 	List<String> internalStringList;
 	Map<String, Object> netConfig = new HashMap<>();
@@ -115,7 +116,7 @@ public class NMDbusConnectorTest {
 
 		whenApplyWithNetowrkConfig(null);
 
-		thenVerifyDBusExceptionIsThrown(); // TODO: add Guard to implimentation
+		thenNullPointerExceptionIsThrown();
 	}
 
 	@Test
@@ -316,8 +317,6 @@ public class NMDbusConnectorTest {
 
 		when(mockedDevice1.GetAppliedConnection(eq(new UInt32(0)))).thenReturn(mockedDevice1ConnectionTouple);
 
-		
-		
 		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
 				.thenReturn(new UInt32(14)); // 1 id Ethernet
 		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
@@ -427,6 +426,9 @@ public class NMDbusConnectorTest {
 		} catch (NoSuchElementException e) {
 			e.printStackTrace();
 			hasNoSuchElementExceptionThrown = true;
+		} catch (NullPointerException e) {
+			e.printStackTrace();
+			hasNullPointerExceptionThrown = true;
 		}
 	}
 
@@ -437,6 +439,10 @@ public class NMDbusConnectorTest {
 
 	public void thenVerifyDBusExceptionIsThrown() {
 		assertTrue(hasDBusExceptionBeenThrown);
+	}
+	
+	public void thenNullPointerExceptionIsThrown() {
+		assertTrue(hasNullPointerExceptionThrown);
 	}
 
 	public void thenVerifyNoSuchElementExceptionIsThrown() {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -56,15 +56,15 @@ public class NMDbusConnectorTest {
     Boolean hasDBusExceptionBeenThrown = false;
     Boolean hasNoSuchElementExceptionThrown = false;
     Boolean hasNullPointerExceptionThrown = false;
-    
+
     NetworkInterfaceStatus netInterface;
     NetworkService networkService;
-    
+
     Map<String, Device> mockDevices = new HashMap<>();
 
     List<String> internalStringList;
     Map<String, Object> netConfig = new HashMap<>();
-    
+
     @After
     public void tearDown() {
         resetSingleton(NMDbusConnector.class, "instance");
@@ -117,11 +117,12 @@ public class NMDbusConnectorTest {
     @Test
     public void getInterfacesShouldWork() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
-        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED,
+                true);
+        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true);
         givenMockedDeviceList();
-        
-        whenGetInterfaces();
+
+        whenGetInterfacesIsCalled();
 
         thenNoExceptionIsThrown();
         thenReturnedDevicesAre(Arrays.asList("wlan0", "eth0"));
@@ -130,24 +131,26 @@ public class NMDbusConnectorTest {
     @Test
     public void applyShouldDoNothingWithNoCache() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
-        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED,
+                true);
+        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true);
         givenMockedDeviceList();
-        
+
         whenApplyIsCalled();
 
         thenNoExceptionIsThrown();
-        thenNetoworkSettingsDoNotChangeForDevice("eth0");
-        thenNetoworkSettingsDoNotChangeForDevice("wlan0");
+        thenNetworkSettingsDoNotChangeForDevice("eth0");
+        thenNetworkSettingsDoNotChangeForDevice("wlan0");
     }
 
     @Test
     public void applyShouldThrowWithNullMap() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
-        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED,
+                true);
+        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true);
         givenMockedDeviceList();
-        
+
         whenApplyIsCalledWith(null);
 
         thenNullPointerExceptionIsThrown();
@@ -156,10 +159,11 @@ public class NMDbusConnectorTest {
     @Test
     public void applyShouldThrowWithEmptyMap() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
-        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED,
+                true);
+        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true);
         givenMockedDeviceList();
-        
+
         whenApplyIsCalledWith(new HashMap<String, Object>());
 
         thenNoSuchElementExceptionIsThrown();
@@ -168,26 +172,28 @@ public class NMDbusConnectorTest {
     @Test
     public void applyShouldDoNothingWithEnabledUnsupportedDevices() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+        givenMockedDevice("unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED,
+                true);
         givenMockedDeviceList();
 
-        givenNetworkConfigMapWith("net.interfaces", "unused0, ");
+        givenNetworkConfigMapWith("net.interfaces", "unused0");
         givenNetworkConfigMapWith("net.interface.unused0.config.dhcpClient4.enabled", true);
         givenNetworkConfigMapWith("net.interface.unused0.config.ip4.status", "netIPv4StatusEnabledWAN");
 
         whenApplyIsCalledWith(netConfig);
 
         thenNoExceptionIsThrown();
-        thenNetoworkSettingsDoNotChangeForDevice("unused0");
+        thenNetworkSettingsDoNotChangeForDevice("unused0");
     }
 
     @Test
     public void applyShouldWorkWithEnabledEthernet() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED,
+                true);
         givenMockedDeviceList();
-        
-        givenNetworkConfigMapWith("net.interfaces", "eth0, ");
+
+        givenNetworkConfigMapWith("net.interfaces", "eth0");
         givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -197,15 +203,36 @@ public class NMDbusConnectorTest {
         whenApplyIsCalledWith(this.netConfig);
 
         thenNoExceptionIsThrown();
-        thenConnectDisconnectIsCalledFor("eth0");
+        thenConnectionUpdateIsCalledFor("eth0");
+        thenNetworkManagerCalledActivateConnection("eth0");
+    }
+
+    @Test
+    public void applyShouldWorkWithEnabledEthernetWithoutInitialConnection() throws DBusException {
+        givenBasicMockedDbusConnector();
+        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED,
+                false);
+        givenMockedDeviceList();
+
+        givenNetworkConfigMapWith("net.interfaces", "eth0");
+        givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+
+        whenApplyIsCalledWith(this.netConfig);
+
+        thenNoExceptionIsThrown();
+        thenNetworkManagerCalledAddAndActivateConnection("eth0");
     }
 
     @Test
     public void applyShouldWorkWithDisabledEthernet() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED, true);
         givenMockedDeviceList();
-        
+
         givenNetworkConfigMapWith("net.interfaces", "eth,");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusDisabled");
 
@@ -218,41 +245,39 @@ public class NMDbusConnectorTest {
     @Test
     public void applyShouldNotDisableLoopbackDevice() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+        givenMockedDevice("lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_ACTIVATED, true);
         givenMockedDeviceList();
-        
+
         givenNetworkConfigMapWith("net.interfaces", "lo,");
         givenNetworkConfigMapWith("net.interface.lo.config.ip4.status", "netIPv4StatusDisabled");
 
         whenApplyIsCalledWith(this.netConfig);
 
         thenNoExceptionIsThrown();
-        thenNetoworkSettingsDoNotChangeForDevice("lo");
+        thenNetworkSettingsDoNotChangeForDevice("lo");
     }
-    
+
     @Test
     public void applyShouldNotDisableLoopbackDeviceOldVersionOfNM() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("lo", NMDeviceType.NM_DEVICE_TYPE_GENERIC, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+        givenMockedDevice("lo", NMDeviceType.NM_DEVICE_TYPE_GENERIC, NMDeviceState.NM_DEVICE_STATE_ACTIVATED, true);
         givenMockedDeviceList();
-        
+
         givenNetworkConfigMapWith("net.interfaces", "lo,");
         givenNetworkConfigMapWith("net.interface.lo.config.ip4.status", "netIPv4StatusDisabled");
-        
+
         whenApplyIsCalledWith(this.netConfig);
-        
+
         thenNoExceptionIsThrown();
-        thenNetoworkSettingsDoNotChangeForDevice("lo");
+        thenNetworkSettingsDoNotChangeForDevice("lo");
     }
-    
+
     @Test
     public void getInterfaceStatusShouldWorkEthernet() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
-        givenExtraStatusMocksFor("eth0", NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED, true);
         givenMockedDeviceList();
         givenNetworkServiceThatAlwaysReturnsEmpty();
-        
 
         whenGetInterfaceStatus("eth0", networkService);
 
@@ -260,58 +285,53 @@ public class NMDbusConnectorTest {
         thenInterfaceStatusIsNotNull();
         thenNetInterfaceTypeIs(NetworkInterfaceType.ETHERNET);
     }
-    
+
     @Test
     public void getInterfaceStatusShouldWorkLoopback() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_FAILED);
-        givenExtraStatusMocksFor("lo", NMDeviceState.NM_DEVICE_STATE_FAILED);
+        givenMockedDevice("lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_FAILED, true);
         givenMockedDeviceList();
         givenNetworkServiceThatAlwaysReturnsEmpty();
-        
+
         whenGetInterfaceStatus("lo", networkService);
-        
+
         thenNoExceptionIsThrown();
         thenInterfaceStatusIsNotNull();
         thenNetInterfaceTypeIs(NetworkInterfaceType.LOOPBACK);
     }
-    
+
     @Test
     public void getInterfaceStatusShouldWorkUnsuported() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1, NMDeviceState.NM_DEVICE_STATE_FAILED);
-        givenExtraStatusMocksFor("unused0", NMDeviceState.NM_DEVICE_STATE_FAILED);
+        givenMockedDevice("unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1, NMDeviceState.NM_DEVICE_STATE_FAILED, true);
         givenMockedDeviceList();
         givenNetworkServiceThatAlwaysReturnsEmpty();
-        
+
         whenGetInterfaceStatus("unused0", networkService);
-        
+
         thenNoExceptionIsThrown();
         thenInterfaceStatusIsNull();
     }
-    
+
     @Test
     public void getInterfaceStatusShouldWorkWireless() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_FAILED);
-        givenExtraStatusMocksFor("wlan0", NMDeviceState.NM_DEVICE_STATE_FAILED);
+        givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_FAILED, true);
         givenMockedDeviceList();
         givenNetworkServiceThatAlwaysReturnsEmpty();
-        
+
         whenGetInterfaceStatus("wlan0", networkService);
-        
+
         thenNoExceptionIsThrown();
         thenInterfaceStatusIsNull();
     }
-    
+
     @Test
     public void getInterfaceStatusShouldWorkEthernetUSB() throws DBusException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
-        givenExtraStatusMocksFor("eth0", NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+        givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED, true);
         givenMockedDeviceList();
         givenNetworkServiceMockedForUsbInterfaceWithName("eth0");
-        
 
         whenGetInterfaceStatus("eth0", networkService);
 
@@ -347,17 +367,18 @@ public class NMDbusConnectorTest {
         doReturn(mockProps).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
                 eq("/org/freedesktop/NetworkManager"), eq(Properties.class));
     }
-    
-    public void givenMockedDevice(String interfaceName, NMDeviceType type, NMDeviceState state) throws DBusException {
+
+    public void givenMockedDevice(String interfaceName, NMDeviceType type, NMDeviceState state,
+            Boolean hasAssociatedConnection) throws DBusException {
         Device mockedDevice1 = mock(Device.class);
-        
+
         this.mockDevices.put(interfaceName, mockedDevice1);
-            
+
         when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/" + interfaceName);
 
         Generic mockedDevice1Generic = mock(Generic.class);
-        when(mockedDevice1Generic.getObjectPath()).thenReturn("/mock/device/lo");
-        
+        when(mockedDevice1Generic.getObjectPath()).thenReturn("/mock/device/" + interfaceName);
+
         DBusPath mockedPath1 = mock(DBusPath.class);
         when(mockedPath1.getPath()).thenReturn("/mock/device/" + interfaceName);
 
@@ -368,26 +389,23 @@ public class NMDbusConnectorTest {
         Settings mockedDevice1Settings = mock(Settings.class);
         when(mockedDevice1Settings.GetConnectionByUuid(eq("mock-uuid-123"))).thenReturn(mockedPath1);
 
-        Connection mockedDevice1Connection = mock(Connection.class, RETURNS_SMART_NULLS);
-        when(mockedDevice1Connection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
-
         GetAppliedConnectionTuple mockedDevice1ConnectionTouple = mock(GetAppliedConnectionTuple.class);
         when(mockedDevice1ConnectionTouple.getConnection()).thenReturn(mockedDevice1ConnectionSetting);
 
         when(mockedDevice1.GetAppliedConnection(eq(new UInt32(0)))).thenReturn(mockedDevice1ConnectionTouple);
 
         Properties mockedProperties1 = mock(Properties.class);
-        
-        if(interfaceName.equals("lo")) {
-            when(mockedProperties1.Get(any(), any())).thenReturn("loopback");            
+
+        if (interfaceName.equals("lo")) {
+            when(mockedProperties1.Get(any(), any())).thenReturn("loopback");
         }
-        
+
         when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
                 .thenReturn(NMDeviceType.toUInt32(type));
         when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
                 .thenReturn(NMDeviceState.toUInt32(state));
-        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn(interfaceName);
-
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface")))
+                .thenReturn(interfaceName);
 
         when(this.mockedNetworkManager.GetDeviceByIpIface(eq(interfaceName))).thenReturn(mockedPath1);
 
@@ -397,54 +415,68 @@ public class NMDbusConnectorTest {
                 eq("/org/freedesktop/NetworkManager/Settings"), eq(Settings.class));
         doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
                 eq("/mock/device/" + interfaceName), eq(Properties.class));
-        doReturn(mockedDevice1Connection).when(this.dbusConnection)
-                .getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/" + interfaceName), eq(Connection.class));
+        if (hasAssociatedConnection) {
+            Connection mockedDevice1Connection = mock(Connection.class, RETURNS_SMART_NULLS);
+            when(mockedDevice1Connection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
+
+            doReturn(mockedDevice1Connection).when(this.dbusConnection).getRemoteObject(
+                    eq("org.freedesktop.NetworkManager"), eq("/mock/device/" + interfaceName), eq(Connection.class));
+        } else {
+            doReturn(null).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                    eq("/mock/device/" + interfaceName), eq(Connection.class));
+        }
+
         doReturn(mockedDevice1Generic).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
                 eq("/mock/device/lo"), eq(Generic.class));
+
+        givenExtraStatusMocksFor(interfaceName, state);
     }
-    
+
     public void givenExtraStatusMocksFor(String interfaceName, NMDeviceState state) throws DBusException {
-        Device mockedDevice1 = this.mockDevices.get(interfaceName);
         Properties mockedProperties = this.dbusConnection.getRemoteObject("org.freedesktop.NetworkManager",
                 "/mock/device/" + interfaceName, Properties.class);
-        
+
         when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Autoconnect"))).thenReturn(true);
-        when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("FirmwareVersion"))).thenReturn("firmware");
+        when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("FirmwareVersion")))
+                .thenReturn("firmware");
         when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Driver"))).thenReturn("driver");
-        when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DriverVersion"))).thenReturn("1.0.0");
-        when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State"))).thenReturn(NMDeviceState.toUInt32(state));
+        when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DriverVersion")))
+                .thenReturn("1.0.0");
+        when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
+                .thenReturn(NMDeviceState.toUInt32(state));
         when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Mtu"))).thenReturn(new UInt32(100));
-        when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("HwAddress"))).thenReturn("F5:5B:32:7C:40:EA");
-        
+        when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("HwAddress")))
+                .thenReturn("F5:5B:32:7C:40:EA");
+
         DBusPath path = mock(DBusPath.class);
         when(path.getPath()).thenReturn("/");
-        
+
         when(mockedProperties.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Ip4Config"))).thenReturn(path);
 
     }
-    
+
     public void givenMockedDeviceList() {
-        
+
         List<DBusPath> devicePaths = new ArrayList<>();
-        
-        for(String interfaceName : this.mockDevices.keySet()) {
+
+        for (String interfaceName : this.mockDevices.keySet()) {
             devicePaths.add(this.mockedNetworkManager.GetDeviceByIpIface(interfaceName));
         }
         when(this.mockedNetworkManager.GetAllDevices()).thenReturn(devicePaths);
     }
-    
+
     public void givenNetworkConfigMapWith(String key, Object value) {
         netConfig.put(key, value);
     }
-    
+
     public void givenNetworkServiceMockedForUsbInterfaceWithName(String interfaceName) {
         this.networkService = mock(NetworkService.class);
-        
+
         UsbNetDevice mockUsbNetDevice = mock(UsbNetDevice.class, RETURNS_DEEP_STUBS);
-        
+
         when(this.networkService.getUsbNetDevice(interfaceName)).thenReturn(Optional.of(mockUsbNetDevice));
     }
-    
+
     public void givenNetworkServiceThatAlwaysReturnsEmpty() {
         this.networkService = mock(NetworkService.class);
         when(this.networkService.getUsbNetDevice(any())).thenReturn(Optional.empty());
@@ -466,7 +498,7 @@ public class NMDbusConnectorTest {
         }
     }
 
-    public void whenGetInterfaces() {
+    public void whenGetInterfacesIsCalled() {
         try {
             this.internalStringList = this.instanceNMDbusConnector.getInterfaces();
         } catch (DBusException e) {
@@ -486,28 +518,23 @@ public class NMDbusConnectorTest {
         try {
             this.instanceNMDbusConnector.apply(networkConfig);
         } catch (DBusException e) {
-            e.printStackTrace();
             hasDBusExceptionBeenThrown = true;
         } catch (NoSuchElementException e) {
-            e.printStackTrace();
             hasNoSuchElementExceptionThrown = true;
         } catch (NullPointerException e) {
-            e.printStackTrace();
             hasNullPointerExceptionThrown = true;
+            e.printStackTrace();
         }
     }
-    
+
     public void whenGetInterfaceStatus(String netInterface, NetworkService netService) {
         try {
             this.netInterface = this.instanceNMDbusConnector.getInterfaceStatus(netInterface, netService);
         } catch (DBusException e) {
-            e.printStackTrace();
             hasDBusExceptionBeenThrown = true;
         } catch (NoSuchElementException e) {
-            e.printStackTrace();
             hasNoSuchElementExceptionThrown = true;
         } catch (NullPointerException e) {
-            e.printStackTrace();
             hasNullPointerExceptionThrown = true;
         }
     }
@@ -515,6 +542,7 @@ public class NMDbusConnectorTest {
     public void thenNoExceptionIsThrown() {
         assertFalse(hasDBusExceptionBeenThrown);
         assertFalse(hasNoSuchElementExceptionThrown);
+        assertFalse(hasNullPointerExceptionThrown);
     }
 
     public void thenDBusExceptionIsThrown() {
@@ -533,10 +561,6 @@ public class NMDbusConnectorTest {
         assertEquals(this.dbusConnection, this.dbusConnectionInternal);
     }
 
-    public void thenConnectionClosed() {
-        verify(this.dbusConnection, atLeastOnce()).disconnect();
-    }
-
     public void thenCheckVersionIsRun() throws DBusException {
         verify(this.dbusConnection, atLeastOnce()).getRemoteObject(eq("org.freedesktop.NetworkManager"),
                 eq("/org/freedesktop/NetworkManager"), any());
@@ -549,33 +573,44 @@ public class NMDbusConnectorTest {
     public void thenReturnedDevicesAre(List<String> list) {
         assertEquals(list, this.internalStringList);
     }
-    
+
     public void thenDisconnectIsCalledFor(String netInterface) {
         verify(this.mockDevices.get(netInterface)).Disconnect();
     }
-    
-    public void thenConnectDisconnectIsCalledFor(String netInterface) throws DBusException {
-        Connection connect = this.dbusConnection.getRemoteObject("org.freedesktop.NetworkManager", "/mock/device/" + netInterface, Connection.class);
+
+    public void thenConnectionUpdateIsCalledFor(String netInterface) throws DBusException {
+        Connection connect = this.dbusConnection.getRemoteObject("org.freedesktop.NetworkManager",
+                "/mock/device/" + netInterface, Connection.class);
         verify(connect).Update(any());
     }
-    
-    public void thenNetoworkSettingsDoNotChangeForDevice(String netInterface) throws DBusException {
-        
-        Connection connect = this.dbusConnection.getRemoteObject("org.freedesktop.NetworkManager", "/mock/device/" + netInterface, Connection.class);
+
+    public void thenNetworkManagerCalledActivateConnection(String netInterface) throws DBusException {
+        verify(this.mockedNetworkManager).ActivateConnection(any(), any(), any());
+    }
+
+    public void thenNetworkManagerCalledAddAndActivateConnection(String netInterface) throws DBusException {
+        verify(this.mockedNetworkManager).AddAndActivateConnection(any(), any(), any());
+    }
+
+    public void thenNetworkSettingsDoNotChangeForDevice(String netInterface) throws DBusException {
+        Connection connect = this.dbusConnection.getRemoteObject("org.freedesktop.NetworkManager",
+                "/mock/device/" + netInterface, Connection.class);
         verify(connect, never()).Update(any());
         verify(this.mockDevices.get(netInterface), never()).Disconnect();
+        verify(this.mockedNetworkManager, never()).ActivateConnection(any(), any(), any());
+        verify(this.mockedNetworkManager, never()).AddAndActivateConnection(any(), any(), any());
     }
-    
+
     public void thenInterfaceStatusIsNull() {
         assertNull(this.netInterface);
     }
-    
+
     public void thenInterfaceStatusIsNotNull() {
         assertNotNull(this.netInterface);
     }
-    
+
     public void thenNetInterfaceTypeIs(NetworkInterfaceType type) {
-      assertEquals(type, this.netInterface.getType());   
+        assertEquals(type, this.netInterface.getType());
     }
- 
+
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.RETURNS_SMART_NULLS;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ import org.freedesktop.NetworkManager;
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.Variant;
@@ -45,6 +47,7 @@ import org.freedesktop.networkmanager.settings.Connection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class NMDbusConnectorTest {
 
@@ -422,7 +425,7 @@ public class NMDbusConnectorTest {
             doReturn(mockedDevice1Connection).when(this.dbusConnection).getRemoteObject(
                     eq("org.freedesktop.NetworkManager"), eq("/mock/device/" + interfaceName), eq(Connection.class));
         } else {
-            doReturn(null).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+            doThrow(new DBusExecutionException("initiate mocked throw")).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
                     eq("/mock/device/" + interfaceName), eq(Connection.class));
         }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.RETURNS_SMART_NULLS;
 import static org.mockito.Mockito.atLeastOnce;
@@ -27,10 +26,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import org.eclipse.kura.net.NetInterface;
-import org.eclipse.kura.net.NetInterfaceAddress;
-import org.eclipse.kura.net.NetInterfaceStatus;
-import org.eclipse.kura.net.NetInterfaceType;
 import org.eclipse.kura.net.NetworkService;
 import org.eclipse.kura.net.status.NetworkInterfaceStatus;
 import org.eclipse.kura.net.status.NetworkInterfaceType;
@@ -50,7 +45,6 @@ import org.freedesktop.networkmanager.settings.Connection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 public class NMDbusConnectorTest {
 
@@ -70,11 +64,6 @@ public class NMDbusConnectorTest {
 
     List<String> internalStringList;
     Map<String, Object> netConfig = new HashMap<>();
-
-    @Before
-    public void setUpPersistantMocks() throws DBusException {
-        givenBasicMockedDbusConnector();
-    }
     
     @After
     public void tearDown() {
@@ -95,6 +84,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void getDbusConnectionShouldWork() throws DBusException {
+        givenBasicMockedDbusConnector();
         whenGetDbusConnectionIsRun();
 
         thenNoExceptionIsThrown();
@@ -104,6 +94,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void checkPermissionsShouldWork() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedPermissions();
 
         whenCheckPermissionsIsRun();
@@ -114,6 +105,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void checkVersionShouldWork() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedVersion();
 
         whenCheckVersionIsRun();
@@ -124,6 +116,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void getInterfacesShouldWork() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDeviceList();
@@ -136,11 +129,12 @@ public class NMDbusConnectorTest {
 
     @Test
     public void applyShouldDoNothingWithNoCache() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDeviceList();
         
-        whenApply();
+        whenApplyIsCalled();
 
         thenNoExceptionIsThrown();
         thenNetoworkSettingsDoNotChangeForDevice("eth0");
@@ -149,6 +143,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void applyShouldThrowWithNullMap() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDeviceList();
@@ -160,6 +155,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void applyShouldThrowWithEmptyMap() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDeviceList();
@@ -171,6 +167,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void applyShouldDoNothingWithEnabledUnsupportedDevices() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDeviceList();
 
@@ -186,6 +183,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void applyShouldWorkWithEnabledEthernet() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         givenMockedDeviceList();
         
@@ -204,6 +202,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void applyShouldWorkWithDisabledEthernet() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
         givenMockedDeviceList();
         
@@ -218,6 +217,7 @@ public class NMDbusConnectorTest {
 
     @Test
     public void applyShouldNotDisableLoopbackDevice() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
         givenMockedDeviceList();
         
@@ -232,6 +232,7 @@ public class NMDbusConnectorTest {
     
     @Test
     public void applyShouldNotDisableLoopbackDeviceOldVersionOfNM() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("lo", NMDeviceType.NM_DEVICE_TYPE_GENERIC, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
         givenMockedDeviceList();
         
@@ -246,6 +247,7 @@ public class NMDbusConnectorTest {
     
     @Test
     public void getInterfaceStatusShouldWorkEthernet() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
         givenExtraStatusMocksFor("eth0", NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
         givenMockedDeviceList();
@@ -261,6 +263,7 @@ public class NMDbusConnectorTest {
     
     @Test
     public void getInterfaceStatusShouldWorkLoopback() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("lo", NMDeviceType.NM_DEVICE_TYPE_LOOPBACK, NMDeviceState.NM_DEVICE_STATE_FAILED);
         givenExtraStatusMocksFor("lo", NMDeviceState.NM_DEVICE_STATE_FAILED);
         givenMockedDeviceList();
@@ -275,6 +278,7 @@ public class NMDbusConnectorTest {
     
     @Test
     public void getInterfaceStatusShouldWorkUnsuported() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("unused0", NMDeviceType.NM_DEVICE_TYPE_UNUSED1, NMDeviceState.NM_DEVICE_STATE_FAILED);
         givenExtraStatusMocksFor("unused0", NMDeviceState.NM_DEVICE_STATE_FAILED);
         givenMockedDeviceList();
@@ -288,6 +292,7 @@ public class NMDbusConnectorTest {
     
     @Test
     public void getInterfaceStatusShouldWorkWireless() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceState.NM_DEVICE_STATE_FAILED);
         givenExtraStatusMocksFor("wlan0", NMDeviceState.NM_DEVICE_STATE_FAILED);
         givenMockedDeviceList();
@@ -301,6 +306,7 @@ public class NMDbusConnectorTest {
     
     @Test
     public void getInterfaceStatusShouldWorkEthernetUSB() throws DBusException {
+        givenBasicMockedDbusConnector();
         givenMockedDevice("eth0", NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
         givenExtraStatusMocksFor("eth0", NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
         givenMockedDeviceList();
@@ -468,7 +474,7 @@ public class NMDbusConnectorTest {
         }
     }
 
-    public void whenApply() {
+    public void whenApplyIsCalled() {
         try {
             this.instanceNMDbusConnector.apply();
         } catch (DBusException e) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1,0 +1,222 @@
+package org.eclipse.kura.nm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.freedesktop.NetworkManager;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.Properties;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.networkmanager.Device;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class NMDbusConnectorTest {
+	static final DBusConnection dbusConnection = Mockito.mock(DBusConnection.class, Mockito.RETURNS_SMART_NULLS);
+	static final NetworkManager mockedNetworkManager = Mockito.mock(NetworkManager.class);
+	static NMDbusConnector instanceNMDbusConnector;
+	DBusConnection dbusConnectionInternal;
+	
+	Boolean hasDBusExceptionBeenThrown = false;
+	
+	List<String> internalStringList;
+	
+	@BeforeClass
+	public static void setUpPersistantMocks() throws DBusException {
+		givenBasicMockedDbusConnector();
+	}
+
+	@Test
+	public void getDbusConnectionShouldWork() throws DBusException {
+		whenGetDbusConnectionIsRun();
+		
+		thenVerifyNoExceptionIsThrown();
+		
+		thenGetDbusConnectionIsMockedConnection();
+	}
+	
+	@Test
+	public void closeConnectionShouldWork() throws DBusException {
+		whenCloseConnectionIsRun();
+		
+		thenVerifyNoExceptionIsThrown();
+		
+		thenVerifyConnectionClosed();
+	}
+	
+	@Test
+	public void checkPermissionsShouldWork() throws DBusException {
+		givenMockedPermissions();
+		
+		whenCheckPermissionsIsRun();
+		
+		thenVerifyNoExceptionIsThrown();
+		thenVerifyCheckPermissionsRan();
+	}
+	
+	@Test
+	public void checkVersionShouldWork() throws DBusException {
+		givenMockedVersion();
+		
+		whenCheckVersionIsRun();
+		
+		thenVerifyNoExceptionIsThrown();
+		thenVerifyCheckVersionIsRun();
+	}
+	
+	@Test
+	public void getInterfacesShouldWork() throws DBusException {
+		givenMockedDevices();
+		
+		whenGetInterfaces();
+		
+		thenVerifyNoExceptionIsThrown();
+		thenReturnedStringListIs(Arrays.asList("mockedDevice1","mockedDevice2"));
+	}
+	
+	@Test
+	public void applyShouldDoNothingWithNoCache() throws DBusException {
+		givenMockedDevices();
+		
+		whenApply();
+		
+		thenVerifyNoExceptionIsThrown();
+		//check if nothing happened
+	}
+
+	public static void givenBasicMockedDbusConnector() throws DBusException {
+		when(NMDbusConnectorTest.dbusConnection.getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/org/freedesktop/NetworkManager"), any()))
+					.thenReturn(NMDbusConnectorTest.mockedNetworkManager);
+		NMDbusConnectorTest.instanceNMDbusConnector = NMDbusConnector.getInstance(NMDbusConnectorTest.dbusConnection);
+	}
+	
+	public void givenMockedPermissions() {
+		
+		Map<String, String> tempPerms = new HashMap<>();
+		
+		tempPerms.put("test1", "testVal1");
+		tempPerms.put("test2", "testVal2");
+		tempPerms.put("test3", "testVal3");
+		
+		when(NMDbusConnectorTest.mockedNetworkManager.GetPermissions()).thenReturn(tempPerms);
+		
+	}
+	
+	public void givenMockedVersion() throws DBusException {
+		
+		Properties mockProps = Mockito.mock(org.freedesktop.dbus.interfaces.Properties.class);
+		when(mockProps.Get(eq("org.freedesktop.NetworkManager"), eq("Version"))).thenReturn("Mock-Version");
+		
+		Mockito.doReturn(mockProps).when(NMDbusConnectorTest.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/org/freedesktop/NetworkManager"),  eq(Properties.class));
+	}
+	
+	public void givenMockedDevices() throws DBusException {
+		
+		Device mockedDevice1 = mock(Device.class);
+		when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/path1");
+		DBusPath mockedPath1 = mock(DBusPath.class);
+		when(mockedPath1.getPath()).thenReturn("/mock/device/path1");
+		Properties mockedProperties1 = mock(Properties.class);
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType"))).thenReturn(new UInt32(1));
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("mockedDevice1");
+		
+		Device mockedDevice2 = mock(Device.class);
+		when(mockedDevice2.getObjectPath()).thenReturn("/mock/device/path2");
+		DBusPath mockedPath2 = mock(DBusPath.class);
+		when(mockedPath2.getPath()).thenReturn("/mock/device/path2");
+		Properties mockedProperties2 = mock(Properties.class);
+		when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType"))).thenReturn(new UInt32(1));
+		when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("mockedDevice2");
+		
+		
+		when(NMDbusConnectorTest.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1, mockedPath2));
+		
+		Mockito.doReturn(mockedDevice1).when(NMDbusConnectorTest.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/path1"),  eq(Device.class));
+		Mockito.doReturn(mockedProperties1).when(NMDbusConnectorTest.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/path1"),  eq(Properties.class));
+
+		Mockito.doReturn(mockedDevice2).when(NMDbusConnectorTest.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/path2"),  eq(Device.class));
+		Mockito.doReturn(mockedProperties2).when(NMDbusConnectorTest.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/path2"),  eq(Properties.class));
+	}
+	
+	public void whenGetDbusConnectionIsRun() {
+		this.dbusConnectionInternal = NMDbusConnectorTest.instanceNMDbusConnector.getDbusConnection();
+	}
+	
+	public void whenCloseConnectionIsRun() {
+		NMDbusConnectorTest.instanceNMDbusConnector.closeConnection();
+	}
+	
+	public void whenCheckPermissionsIsRun() {
+		NMDbusConnectorTest.instanceNMDbusConnector.checkPermissions();
+	}
+	
+	public void whenCheckVersionIsRun() {
+		try {
+			NMDbusConnectorTest.instanceNMDbusConnector.checkVersion();
+		} catch (DBusException e) {
+			hasDBusExceptionBeenThrown = true;
+		}
+	}
+	
+	public void whenGetInterfaces() {
+		try {
+			internalStringList = NMDbusConnectorTest.instanceNMDbusConnector.getInterfaces();
+		} catch (DBusException e) {
+			hasDBusExceptionBeenThrown = true;
+		}
+	}
+	
+	public void whenApply() {
+		try {
+			NMDbusConnectorTest.instanceNMDbusConnector.apply();
+		} catch (DBusException e) {
+			hasDBusExceptionBeenThrown = true;
+		}
+	}
+	
+	public void whenApplyWithNetowrkConfig(Map<String,Object> networkConfig) {
+		try {
+			NMDbusConnectorTest.instanceNMDbusConnector.apply(networkConfig);
+		} catch (DBusException e) {
+			hasDBusExceptionBeenThrown = true;
+		}
+	}
+	
+	public void thenVerifyNoExceptionIsThrown() {
+		assertFalse(hasDBusExceptionBeenThrown);
+	}
+	
+	public void thenGetDbusConnectionIsMockedConnection() {
+		assertEquals(NMDbusConnectorTest.dbusConnection, this.dbusConnectionInternal);
+	}
+	
+	public void thenVerifyConnectionClosed() {
+		verify(NMDbusConnectorTest.dbusConnection, Mockito.atLeastOnce()).disconnect();
+	}
+	
+	public void thenVerifyCheckVersionIsRun() throws DBusException {
+		verify(NMDbusConnectorTest.dbusConnection, Mockito.atLeastOnce()).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/org/freedesktop/NetworkManager"), Mockito.any());
+	}
+	
+	public void thenVerifyCheckPermissionsRan() {
+		verify(NMDbusConnectorTest.mockedNetworkManager, Mockito.atLeastOnce()).GetPermissions();
+	}
+	
+	public void thenReturnedStringListIs(List<String> list) {
+		assertEquals(this.internalStringList, list);
+	}
+
+}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -81,7 +81,7 @@ public class NMDbusConnectorTest {
     public void getDbusConnectionShouldWork() throws DBusException {
         whenGetDbusConnectionIsRun();
 
-        thenVerifyNoExceptionIsThrown();
+        thenNoExceptionIsThrown();
 
         thenGetDbusConnectionIsMockedConnection();
     }
@@ -90,9 +90,9 @@ public class NMDbusConnectorTest {
     public void closeConnectionShouldWork() throws DBusException {
         whenCloseConnectionIsRun();
 
-        thenVerifyNoExceptionIsThrown();
+        thenNoExceptionIsThrown();
 
-        thenVerifyConnectionClosed();
+        thenConnectionClosed();
     }
 
     @Test
@@ -101,8 +101,8 @@ public class NMDbusConnectorTest {
 
         whenCheckPermissionsIsRun();
 
-        thenVerifyNoExceptionIsThrown();
-        thenVerifyCheckPermissionsRan();
+        thenNoExceptionIsThrown();
+        thenCheckPermissionsRan();
     }
 
     @Test
@@ -111,8 +111,8 @@ public class NMDbusConnectorTest {
 
         whenCheckVersionIsRun();
 
-        thenVerifyNoExceptionIsThrown();
-        thenVerifyCheckVersionIsRun();
+        thenNoExceptionIsThrown();
+        thenCheckVersionIsRun();
     }
 
     @Test
@@ -123,7 +123,7 @@ public class NMDbusConnectorTest {
         
         whenGetInterfaces();
 
-        thenVerifyNoExceptionIsThrown();
+        thenNoExceptionIsThrown();
         thenReturnedDevicesAre(Arrays.asList("wlan0", "eth0"));
     }
 
@@ -135,7 +135,7 @@ public class NMDbusConnectorTest {
         
         whenApply();
 
-        thenVerifyNoExceptionIsThrown();
+        thenNoExceptionIsThrown();
         thenNetoworkSettingsDoNotChangeForDevice("eth0");
         thenNetoworkSettingsDoNotChangeForDevice("wlan0");
     }
@@ -159,7 +159,7 @@ public class NMDbusConnectorTest {
         
         whenApplyIsCalledWith(new HashMap<String, Object>());
 
-        thenVerifyNoSuchElementExceptionIsThrown();
+        thenNoSuchElementExceptionIsThrown();
     }
 
     @Test
@@ -173,7 +173,7 @@ public class NMDbusConnectorTest {
 
         whenApplyIsCalledWith(netConfig);
 
-        thenVerifyNoExceptionIsThrown();
+        thenNoExceptionIsThrown();
         thenNetoworkSettingsDoNotChangeForDevice("unused0");
     }
 
@@ -191,7 +191,7 @@ public class NMDbusConnectorTest {
 
         whenApplyIsCalledWith(this.netConfig);
 
-        thenVerifyNoExceptionIsThrown();
+        thenNoExceptionIsThrown();
         thenConnectDisconnectIsCalledFor("eth0");
     }
 
@@ -205,8 +205,8 @@ public class NMDbusConnectorTest {
 
         whenApplyIsCalledWith(this.netConfig);
 
-        thenVerifyNoExceptionIsThrown();
-        thenVerifyDisconnectIsCalledFor("eth0");
+        thenNoExceptionIsThrown();
+        thenDisconnectIsCalledFor("eth0");
     }
 
     @Test
@@ -217,7 +217,7 @@ public class NMDbusConnectorTest {
 
         whenApplyIsCalledWith(this.netConfig);
 
-        thenVerifyNoExceptionIsThrown();
+        thenNoExceptionIsThrown();
         thenNetoworkSettingsDoNotChangeForDevice("lo");
     }
 
@@ -369,12 +369,12 @@ public class NMDbusConnectorTest {
         }
     }
 
-    public void thenVerifyNoExceptionIsThrown() {
+    public void thenNoExceptionIsThrown() {
         assertFalse(hasDBusExceptionBeenThrown);
         assertFalse(hasNoSuchElementExceptionThrown);
     }
 
-    public void thenVerifyDBusExceptionIsThrown() {
+    public void thenDBusExceptionIsThrown() {
         assertTrue(hasDBusExceptionBeenThrown);
     }
 
@@ -382,7 +382,7 @@ public class NMDbusConnectorTest {
         assertTrue(hasNullPointerExceptionThrown);
     }
 
-    public void thenVerifyNoSuchElementExceptionIsThrown() {
+    public void thenNoSuchElementExceptionIsThrown() {
         assertTrue(hasNoSuchElementExceptionThrown);
     }
 
@@ -390,16 +390,16 @@ public class NMDbusConnectorTest {
         assertEquals(this.dbusConnection, this.dbusConnectionInternal);
     }
 
-    public void thenVerifyConnectionClosed() {
+    public void thenConnectionClosed() {
         verify(this.dbusConnection, atLeastOnce()).disconnect();
     }
 
-    public void thenVerifyCheckVersionIsRun() throws DBusException {
+    public void thenCheckVersionIsRun() throws DBusException {
         verify(this.dbusConnection, atLeastOnce()).getRemoteObject(eq("org.freedesktop.NetworkManager"),
                 eq("/org/freedesktop/NetworkManager"), any());
     }
 
-    public void thenVerifyCheckPermissionsRan() {
+    public void thenCheckPermissionsRan() {
         verify(this.mockedNetworkManager, atLeastOnce()).GetPermissions();
     }
 
@@ -407,7 +407,7 @@ public class NMDbusConnectorTest {
         assertEquals(list, this.internalStringList);
     }
     
-    public void thenVerifyDisconnectIsCalledFor(String netInterface) {
+    public void thenDisconnectIsCalledFor(String netInterface) {
         verify(this.mockDevices.get(netInterface)).Disconnect();
     }
     

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -92,7 +92,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
 
-        thenGetDbusConnectionIsMockedConnection();
+        thenGetDbusConnectionReturns(this.dbusConnectionInternal);
     }
 
     @Test
@@ -128,7 +128,7 @@ public class NMDbusConnectorTest {
         whenGetInterfacesIsCalled();
 
         thenNoExceptionIsThrown();
-        thenReturnedDevicesAre(Arrays.asList("wlan0", "eth0"));
+        thenGetInterfacesReturn(Arrays.asList("wlan0", "eth0"));
     }
 
     @Test
@@ -142,8 +142,8 @@ public class NMDbusConnectorTest {
         whenApplyIsCalled();
 
         thenNoExceptionIsThrown();
-        thenNetworkSettingsDoNotChangeForDevice("eth0");
-        thenNetworkSettingsDoNotChangeForDevice("wlan0");
+        thenNetworkSettingsDidNotChangeForDevice("eth0");
+        thenNetworkSettingsDidNotChangeForDevice("wlan0");
     }
 
     @Test
@@ -186,7 +186,7 @@ public class NMDbusConnectorTest {
         whenApplyIsCalledWith(netConfig);
 
         thenNoExceptionIsThrown();
-        thenNetworkSettingsDoNotChangeForDevice("unused0");
+        thenNetworkSettingsDidNotChangeForDevice("unused0");
     }
 
     @Test
@@ -207,7 +207,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("eth0");
-        thenNetworkManagerCalledActivateConnection("eth0");
+        thenActivateConnectionIsCalledFor("eth0");
     }
 
     @Test
@@ -227,7 +227,7 @@ public class NMDbusConnectorTest {
         whenApplyIsCalledWith(this.netConfig);
 
         thenNoExceptionIsThrown();
-        thenNetworkManagerCalledAddAndActivateConnection("eth0");
+        thenAddAndActivateConnectionIsCalledFor("eth0");
     }
 
     @Test
@@ -257,7 +257,7 @@ public class NMDbusConnectorTest {
         whenApplyIsCalledWith(this.netConfig);
 
         thenNoExceptionIsThrown();
-        thenNetworkSettingsDoNotChangeForDevice("lo");
+        thenNetworkSettingsDidNotChangeForDevice("lo");
     }
 
     @Test
@@ -272,7 +272,7 @@ public class NMDbusConnectorTest {
         whenApplyIsCalledWith(this.netConfig);
 
         thenNoExceptionIsThrown();
-        thenNetworkSettingsDoNotChangeForDevice("lo");
+        thenNetworkSettingsDidNotChangeForDevice("lo");
     }
 
     @Test
@@ -560,8 +560,8 @@ public class NMDbusConnectorTest {
         assertTrue(hasNoSuchElementExceptionThrown);
     }
 
-    public void thenGetDbusConnectionIsMockedConnection() {
-        assertEquals(this.dbusConnection, this.dbusConnectionInternal);
+    public void thenGetDbusConnectionReturns(DBusConnection dbusConnection) {
+        assertEquals(this.dbusConnection, dbusConnection);
     }
 
     public void thenCheckVersionIsRun() throws DBusException {
@@ -573,7 +573,7 @@ public class NMDbusConnectorTest {
         verify(this.mockedNetworkManager, atLeastOnce()).GetPermissions();
     }
 
-    public void thenReturnedDevicesAre(List<String> list) {
+    public void thenGetInterfacesReturn(List<String> list) {
         assertEquals(list, this.internalStringList);
     }
 
@@ -587,15 +587,15 @@ public class NMDbusConnectorTest {
         verify(connect).Update(any());
     }
 
-    public void thenNetworkManagerCalledActivateConnection(String netInterface) throws DBusException {
+    public void thenActivateConnectionIsCalledFor(String netInterface) throws DBusException {
         verify(this.mockedNetworkManager).ActivateConnection(any(), any(), any());
     }
 
-    public void thenNetworkManagerCalledAddAndActivateConnection(String netInterface) throws DBusException {
+    public void thenAddAndActivateConnectionIsCalledFor(String netInterface) throws DBusException {
         verify(this.mockedNetworkManager).AddAndActivateConnection(any(), any(), any());
     }
 
-    public void thenNetworkSettingsDoNotChangeForDevice(String netInterface) throws DBusException {
+    public void thenNetworkSettingsDidNotChangeForDevice(String netInterface) throws DBusException {
         Connection connect = this.dbusConnection.getRemoteObject("org.freedesktop.NetworkManager",
                 "/mock/device/" + netInterface, Connection.class);
         verify(connect, never()).Update(any());

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -2,16 +2,22 @@ package org.eclipse.kura.nm;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_SMART_NULLS;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 import org.freedesktop.NetworkManager;
 import org.freedesktop.dbus.DBusPath;
@@ -19,22 +25,27 @@ import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.networkmanager.Device;
+import org.freedesktop.networkmanager.GetAppliedConnectionTuple;
+import org.freedesktop.networkmanager.Settings;
+import org.freedesktop.networkmanager.device.Generic;
+import org.freedesktop.networkmanager.settings.Connection;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 public class NMDbusConnectorTest {
-	DBusConnection dbusConnection = Mockito.mock(DBusConnection.class, Mockito.RETURNS_SMART_NULLS);
-	NetworkManager mockedNetworkManager = Mockito.mock(NetworkManager.class);
+	DBusConnection dbusConnection = mock(DBusConnection.class, RETURNS_SMART_NULLS);
+	NetworkManager mockedNetworkManager = mock(NetworkManager.class);
 	NMDbusConnector instanceNMDbusConnector;
 	DBusConnection dbusConnectionInternal;
-	
+
 	Boolean hasDBusExceptionBeenThrown = false;
-	
+	Boolean hasNoSuchElementExceptionThrown = false;
+
 	List<String> internalStringList;
-	
+	Map<String, Object> netConfig = new HashMap<>();
+
 	@Before
 	public void setUpPersistantMocks() throws DBusException {
 		givenBasicMockedDbusConnector();
@@ -43,59 +54,124 @@ public class NMDbusConnectorTest {
 	@Test
 	public void getDbusConnectionShouldWork() throws DBusException {
 		whenGetDbusConnectionIsRun();
-		
+
 		thenVerifyNoExceptionIsThrown();
-		
+
 		thenGetDbusConnectionIsMockedConnection();
 	}
-	
+
 	@Test
 	public void closeConnectionShouldWork() throws DBusException {
 		whenCloseConnectionIsRun();
-		
+
 		thenVerifyNoExceptionIsThrown();
-		
+
 		thenVerifyConnectionClosed();
 	}
-	
+
 	@Test
 	public void checkPermissionsShouldWork() throws DBusException {
 		givenMockedPermissions();
-		
+
 		whenCheckPermissionsIsRun();
-		
+
 		thenVerifyNoExceptionIsThrown();
 		thenVerifyCheckPermissionsRan();
 	}
-	
+
 	@Test
 	public void checkVersionShouldWork() throws DBusException {
 		givenMockedVersion();
-		
+
 		whenCheckVersionIsRun();
-		
+
 		thenVerifyNoExceptionIsThrown();
 		thenVerifyCheckVersionIsRun();
 	}
-	
+
 	@Test
 	public void getInterfacesShouldWork() throws DBusException {
 		givenMockedDevices();
-		
+
 		whenGetInterfaces();
-		
+
 		thenVerifyNoExceptionIsThrown();
-		thenReturnedStringListIs(Arrays.asList("mockedDevice1","mockedDevice2"));
+		thenReturnedStringListIs(Arrays.asList("mockedDevice1", "mockedDevice2"));
 	}
-	
+
 	@Test
 	public void applyShouldDoNothingWithNoCache() throws DBusException {
 		givenMockedDevices();
-		
+
 		whenApply();
-		
+
 		thenVerifyNoExceptionIsThrown();
-		//check if nothing happened
+		// check if nothing happened
+	}
+
+	@Test
+	public void applyShouldThrowWithNullMap() throws DBusException {
+		givenMockedDevices();
+
+		whenApplyWithNetowrkConfig(null);
+
+		thenVerifyDBusExceptionIsThrown(); // TODO: add Guard to implimentation
+	}
+
+	@Test
+	public void applyShouldThrowWithEmptyMap() throws DBusException {
+		givenMockedDevices();
+
+		whenApplyWithNetowrkConfig(new HashMap<String, Object>());
+
+		thenVerifyNoSuchElementExceptionIsThrown();
+	}
+
+	@Test
+	public void applyShouldWorkWithEnabledUnsupportedDevices() throws DBusException {
+
+		givenMockedDeviceConfiguredToBeUnsupported();
+		givenNetworkConfigWhichEnablesEth0();
+
+		whenApplyWithNetowrkConfig(netConfig);
+
+		thenVerifyNoExceptionIsThrown();
+		// check if nothing happened
+	}
+
+	@Test
+	public void applyShouldWorkWithEnabledEthernet() throws DBusException {
+		givenFullyMockedEthernetDevice();
+		givenNetworkConfigWhichEnablesEth0();
+
+		whenApplyWithNetowrkConfig(this.netConfig);
+
+		thenVerifyNoExceptionIsThrown();
+		// TODO: Verify
+	}
+
+	@Test
+	public void applyShouldWorkWithDisabledEthernet() throws DBusException {
+
+		givenFullyMockedEthernetDevice();
+		givenNetworkConfigWhichDisablesEth0();
+
+		whenApplyWithNetowrkConfig(this.netConfig);
+
+		thenVerifyNoExceptionIsThrown();
+		// TODO: Verify
+	}
+
+	@Test
+	public void applyShouldNotDisableLoopbackDevice() throws DBusException {
+
+		givenFullyMockedLoopbackDevice();
+		givenNetworkConfigWhichDisablesLoopbackDevice();
+
+		whenApplyWithNetowrkConfig(this.netConfig);
+
+		thenVerifyNoExceptionIsThrown();
+		// TODO: Verify
 	}
 
 	public void givenBasicMockedDbusConnector() throws DBusException {
@@ -112,67 +188,212 @@ public class NMDbusConnectorTest {
 	
 		NMDbusConnector.getInstance(this.dbusConnection);
 	}
-	
+
 	public void givenMockedPermissions() {
-		
+
 		Map<String, String> tempPerms = new HashMap<>();
-		
+
 		tempPerms.put("test1", "testVal1");
 		tempPerms.put("test2", "testVal2");
 		tempPerms.put("test3", "testVal3");
-		
+
 		when(mockedNetworkManager.GetPermissions()).thenReturn(tempPerms);
-		
+
 	}
-	
+
 	public void givenMockedVersion() throws DBusException {
-		
-		Properties mockProps = Mockito.mock(org.freedesktop.dbus.interfaces.Properties.class);
+
+		Properties mockProps = mock(org.freedesktop.dbus.interfaces.Properties.class);
 		when(mockProps.Get(eq("org.freedesktop.NetworkManager"), eq("Version"))).thenReturn("Mock-Version");
-		
-		Mockito.doReturn(mockProps).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/org/freedesktop/NetworkManager"),  eq(Properties.class));
+
+		doReturn(mockProps).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/org/freedesktop/NetworkManager"), eq(Properties.class));
 	}
-	
+
 	public void givenMockedDevices() throws DBusException {
-		
+
 		Device mockedDevice1 = mock(Device.class);
 		when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/path1");
 		DBusPath mockedPath1 = mock(DBusPath.class);
 		when(mockedPath1.getPath()).thenReturn("/mock/device/path1");
 		Properties mockedProperties1 = mock(Properties.class);
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType"))).thenReturn(new UInt32(1));
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("mockedDevice1");
-		
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+				.thenReturn(new UInt32(1));
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface")))
+				.thenReturn("mockedDevice1");
+
 		Device mockedDevice2 = mock(Device.class);
 		when(mockedDevice2.getObjectPath()).thenReturn("/mock/device/path2");
 		DBusPath mockedPath2 = mock(DBusPath.class);
 		when(mockedPath2.getPath()).thenReturn("/mock/device/path2");
 		Properties mockedProperties2 = mock(Properties.class);
-		when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType"))).thenReturn(new UInt32(1));
-		when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("mockedDevice2");
-		
-		
-		when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1, mockedPath2));
-		
-		Mockito.doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/path1"),  eq(Device.class));
-		Mockito.doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/path1"),  eq(Properties.class));
+		when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+				.thenReturn(new UInt32(1));
+		when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface")))
+				.thenReturn("mockedDevice2");
 
-		Mockito.doReturn(mockedDevice2).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/path2"),  eq(Device.class));
-		Mockito.doReturn(mockedProperties2).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/path2"),  eq(Properties.class));
+		when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1, mockedPath2));
+
+		doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/path1"), eq(Device.class));
+		doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/path1"), eq(Properties.class));
+
+		doReturn(mockedDevice2).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/path2"), eq(Device.class));
+		doReturn(mockedProperties2).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/path2"), eq(Properties.class));
 	}
-	
+
+	public void givenFullyMockedEthernetDevice() throws DBusException {
+		Device mockedDevice1 = mock(Device.class);
+		when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/eth0");
+
+		DBusPath mockedPath1 = mock(DBusPath.class);
+		when(mockedPath1.getPath()).thenReturn("/mock/device/eth0");
+
+		Map<String, Map<String, Variant<?>>> mockedDevice1ConnectionSetting = new HashMap<String, Map<String, Variant<?>>>();
+		mockedDevice1ConnectionSetting.put("connection",
+				Collections.singletonMap("uuid", new Variant<>("mock-uuid-123")));
+
+		Settings mockedDevice1Settings = mock(Settings.class);
+		when(mockedDevice1Settings.GetConnectionByUuid(eq("mock-uuid-123"))).thenReturn(mockedPath1);
+
+		Connection mockedDevice1Connection = mock(Connection.class, RETURNS_SMART_NULLS);
+		when(mockedDevice1Connection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
+
+		GetAppliedConnectionTuple mockedDevice1ConnectionTouple = mock(GetAppliedConnectionTuple.class);
+		when(mockedDevice1ConnectionTouple.getConnection()).thenReturn(mockedDevice1ConnectionSetting);
+
+		when(mockedDevice1.GetAppliedConnection(eq(new UInt32(0)))).thenReturn(mockedDevice1ConnectionTouple);
+
+		Properties mockedProperties1 = mock(Properties.class);
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+				.thenReturn(new UInt32(1)); // 1 id Ethernet
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
+				.thenReturn(new UInt32(10));
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("eth0");
+
+		when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1));
+
+		when(this.mockedNetworkManager.GetDeviceByIpIface(eq("eth0"))).thenReturn(mockedPath1);
+
+		doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/eth0"), eq(Device.class));
+		doReturn(mockedDevice1Settings).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/org/freedesktop/NetworkManager/Settings"), eq(Settings.class));
+		doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/eth0"), eq(Properties.class));
+		doReturn(mockedDevice1Connection).when(this.dbusConnection)
+				.getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/eth0"), eq(Connection.class));
+	}
+
+	public void givenFullyMockedLoopbackDevice() throws DBusException {
+		Device mockedDevice1 = mock(Device.class);
+		when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/lo");
+
+		Generic mockedDevice1Generic = mock(Generic.class);
+		when(mockedDevice1Generic.getObjectPath()).thenReturn("/mock/device/lo");
+
+		DBusPath mockedPath1 = mock(DBusPath.class);
+		when(mockedPath1.getPath()).thenReturn("/mock/device/lo");
+
+		Map<String, Map<String, Variant<?>>> mockedDevice1ConnectionSetting = new HashMap<String, Map<String, Variant<?>>>();
+		mockedDevice1ConnectionSetting.put("connection",
+				Collections.singletonMap("uuid", new Variant<>("mock-uuid-123")));
+
+		Settings mockedDevice1Settings = mock(Settings.class);
+		when(mockedDevice1Settings.GetConnectionByUuid(eq("mock-uuid-123"))).thenReturn(mockedPath1);
+
+		Connection mockedDevice1Connection = mock(Connection.class, RETURNS_SMART_NULLS);
+		when(mockedDevice1Connection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
+
+		Properties mockedProperties1 = mock(Properties.class);
+		when(mockedProperties1.Get(any(), any())).thenReturn("loopback");
+
+		GetAppliedConnectionTuple mockedDevice1ConnectionTouple = mock(GetAppliedConnectionTuple.class);
+		when(mockedDevice1ConnectionTouple.getConnection()).thenReturn(mockedDevice1ConnectionSetting);
+
+		when(mockedDevice1.GetAppliedConnection(eq(new UInt32(0)))).thenReturn(mockedDevice1ConnectionTouple);
+
+		
+		
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+				.thenReturn(new UInt32(14)); // 1 id Ethernet
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
+				.thenReturn(new UInt32(10));
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("lo");
+
+		when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1));
+
+		when(this.mockedNetworkManager.GetDeviceByIpIface(eq("lo"))).thenReturn(mockedPath1);
+
+		doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/lo"), eq(Device.class));
+		doReturn(mockedDevice1Settings).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/org/freedesktop/NetworkManager/Settings"), eq(Settings.class));
+		doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/lo"), eq(Properties.class));
+		doReturn(mockedDevice1Connection).when(this.dbusConnection)
+				.getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/lo"), eq(Connection.class));
+		doReturn(mockedDevice1Generic).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/lo"), eq(Generic.class));
+	}
+
+	public void givenMockedDeviceConfiguredToBeUnsupported() throws DBusException {
+		Device mockedDevice1 = mock(Device.class);
+		when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/eth0");
+		DBusPath mockedPath1 = mock(DBusPath.class);
+		when(mockedPath1.getPath()).thenReturn("/mock/device/eth0");
+		Properties mockedProperties1 = mock(Properties.class);
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+				.thenReturn(new UInt32(0)); // This field is set to unsupported
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
+				.thenReturn(new UInt32(10));
+		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("eth0");
+
+		when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1));
+
+		when(this.mockedNetworkManager.GetDeviceByIpIface(eq("eth0"))).thenReturn(mockedPath1);
+
+		doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/eth0"), eq(Device.class));
+		doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/mock/device/eth0"), eq(Properties.class));
+	}
+
+	public void givenNetworkConfigWhichEnablesEth0() {
+		netConfig.put("net.interfaces", "eth0, ");
+		netConfig.put("net.interface.eth0.config.dhcpClient4.enabled", false);
+		netConfig.put("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
+		netConfig.put("net.interface.eth0.config.ip4.address", "192.168.0.12");
+		netConfig.put("net.interface.eth0.config.ip4.prefix", (short) 25);
+		netConfig.put("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+		netConfig.put("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
+	}
+
+	public void givenNetworkConfigWhichDisablesEth0() {
+		netConfig.put("net.interfaces", "eth0, ");
+		netConfig.put("net.interface.eth0.config.ip4.status", "netIPv4StatusDisabled");
+	}
+
+	public void givenNetworkConfigWhichDisablesLoopbackDevice() {
+		netConfig.put("net.interfaces", "lo");
+		netConfig.put("net.interface.lo.config.ip4.status", "netIPv4StatusDisabled");
+	}
+
 	public void whenGetDbusConnectionIsRun() {
 		this.dbusConnectionInternal = this.instanceNMDbusConnector.getDbusConnection();
 	}
-	
+
 	public void whenCloseConnectionIsRun() {
 		this.instanceNMDbusConnector.closeConnection();
 	}
-	
+
 	public void whenCheckPermissionsIsRun() {
 		this.instanceNMDbusConnector.checkPermissions();
 	}
-	
+
 	public void whenCheckVersionIsRun() {
 		try {
 			this.instanceNMDbusConnector.checkVersion();
@@ -180,7 +401,7 @@ public class NMDbusConnectorTest {
 			hasDBusExceptionBeenThrown = true;
 		}
 	}
-	
+
 	public void whenGetInterfaces() {
 		try {
 			internalStringList = this.instanceNMDbusConnector.getInterfaces();
@@ -188,7 +409,7 @@ public class NMDbusConnectorTest {
 			hasDBusExceptionBeenThrown = true;
 		}
 	}
-	
+
 	public void whenApply() {
 		try {
 			this.instanceNMDbusConnector.apply();
@@ -196,35 +417,49 @@ public class NMDbusConnectorTest {
 			hasDBusExceptionBeenThrown = true;
 		}
 	}
-	
-	public void whenApplyWithNetowrkConfig(Map<String,Object> networkConfig) {
+
+	public void whenApplyWithNetowrkConfig(Map<String, Object> networkConfig) {
 		try {
 			this.instanceNMDbusConnector.apply(networkConfig);
 		} catch (DBusException e) {
+			e.printStackTrace();
 			hasDBusExceptionBeenThrown = true;
+		} catch (NoSuchElementException e) {
+			e.printStackTrace();
+			hasNoSuchElementExceptionThrown = true;
 		}
 	}
-	
+
 	public void thenVerifyNoExceptionIsThrown() {
 		assertFalse(hasDBusExceptionBeenThrown);
+		assertFalse(hasNoSuchElementExceptionThrown);
 	}
-	
+
+	public void thenVerifyDBusExceptionIsThrown() {
+		assertTrue(hasDBusExceptionBeenThrown);
+	}
+
+	public void thenVerifyNoSuchElementExceptionIsThrown() {
+		assertTrue(hasNoSuchElementExceptionThrown);
+	}
+
 	public void thenGetDbusConnectionIsMockedConnection() {
 		assertEquals(this.dbusConnection, this.dbusConnectionInternal);
 	}
-	
+
 	public void thenVerifyConnectionClosed() {
-		verify(this.dbusConnection, Mockito.atLeastOnce()).disconnect();
+		verify(this.dbusConnection, atLeastOnce()).disconnect();
 	}
-	
+
 	public void thenVerifyCheckVersionIsRun() throws DBusException {
-		verify(this.dbusConnection, Mockito.atLeastOnce()).getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/org/freedesktop/NetworkManager"), Mockito.any());
+		verify(this.dbusConnection, atLeastOnce()).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+				eq("/org/freedesktop/NetworkManager"), any());
 	}
-	
+
 	public void thenVerifyCheckPermissionsRan() {
-		verify(this.mockedNetworkManager, Mockito.atLeastOnce()).GetPermissions();
+		verify(this.mockedNetworkManager, atLeastOnce()).GetPermissions();
 	}
-	
+
 	public void thenReturnedStringListIs(List<String> list) {
 		assertEquals(this.internalStringList, list);
 	}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,443 +32,454 @@ import org.freedesktop.networkmanager.GetAppliedConnectionTuple;
 import org.freedesktop.networkmanager.Settings;
 import org.freedesktop.networkmanager.device.Generic;
 import org.freedesktop.networkmanager.settings.Connection;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class NMDbusConnectorTest {
-	DBusConnection dbusConnection = mock(DBusConnection.class, RETURNS_SMART_NULLS);
-	NetworkManager mockedNetworkManager = mock(NetworkManager.class);
-	NMDbusConnector instanceNMDbusConnector;
-	DBusConnection dbusConnectionInternal;
 
-	Boolean hasDBusExceptionBeenThrown = false;
-	Boolean hasNoSuchElementExceptionThrown = false;
-	Boolean hasNullPointerExceptionThrown = false;
+    DBusConnection dbusConnection = mock(DBusConnection.class, RETURNS_SMART_NULLS);
+    NetworkManager mockedNetworkManager = mock(NetworkManager.class);
+    NMDbusConnector instanceNMDbusConnector;
+    DBusConnection dbusConnectionInternal;
 
-	List<String> internalStringList;
-	Map<String, Object> netConfig = new HashMap<>();
+    Boolean hasDBusExceptionBeenThrown = false;
+    Boolean hasNoSuchElementExceptionThrown = false;
+    Boolean hasNullPointerExceptionThrown = false;
 
-	@Before
-	public void setUpPersistantMocks() throws DBusException {
-		givenBasicMockedDbusConnector();
-	}
+    List<String> internalStringList;
+    Map<String, Object> netConfig = new HashMap<>();
 
-	@Test
-	public void getDbusConnectionShouldWork() throws DBusException {
-		whenGetDbusConnectionIsRun();
+    @Before
+    public void setUpPersistantMocks() throws DBusException {
+        givenBasicMockedDbusConnector();
+    }
+    
+    @After
+    public void tearDown() {
+        resetSingleton(NMDbusConnector.class, "instance");
+    }
 
-		thenVerifyNoExceptionIsThrown();
+    public static <T> void resetSingleton(Class<T> clazz, String fieldName) {
+        Field instance;
+        try {
+            instance = clazz.getDeclaredField(fieldName);
+            instance.setAccessible(true);
+            instance.set(null, null);
+            instance.setAccessible(false);
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
+    }
 
-		thenGetDbusConnectionIsMockedConnection();
-	}
+    @Test
+    public void getDbusConnectionShouldWork() throws DBusException {
+        whenGetDbusConnectionIsRun();
 
-	@Test
-	public void closeConnectionShouldWork() throws DBusException {
-		whenCloseConnectionIsRun();
+        thenVerifyNoExceptionIsThrown();
 
-		thenVerifyNoExceptionIsThrown();
+        thenGetDbusConnectionIsMockedConnection();
+    }
 
-		thenVerifyConnectionClosed();
-	}
+    @Test
+    public void closeConnectionShouldWork() throws DBusException {
+        whenCloseConnectionIsRun();
 
-	@Test
-	public void checkPermissionsShouldWork() throws DBusException {
-		givenMockedPermissions();
+        thenVerifyNoExceptionIsThrown();
 
-		whenCheckPermissionsIsRun();
+        thenVerifyConnectionClosed();
+    }
 
-		thenVerifyNoExceptionIsThrown();
-		thenVerifyCheckPermissionsRan();
-	}
+    @Test
+    public void checkPermissionsShouldWork() throws DBusException {
+        givenMockedPermissions();
 
-	@Test
-	public void checkVersionShouldWork() throws DBusException {
-		givenMockedVersion();
+        whenCheckPermissionsIsRun();
 
-		whenCheckVersionIsRun();
+        thenVerifyNoExceptionIsThrown();
+        thenVerifyCheckPermissionsRan();
+    }
 
-		thenVerifyNoExceptionIsThrown();
-		thenVerifyCheckVersionIsRun();
-	}
+    @Test
+    public void checkVersionShouldWork() throws DBusException {
+        givenMockedVersion();
 
-	@Test
-	public void getInterfacesShouldWork() throws DBusException {
-		givenMockedDevices();
+        whenCheckVersionIsRun();
 
-		whenGetInterfaces();
+        thenVerifyNoExceptionIsThrown();
+        thenVerifyCheckVersionIsRun();
+    }
 
-		thenVerifyNoExceptionIsThrown();
-		thenReturnedStringListIs(Arrays.asList("mockedDevice1", "mockedDevice2"));
-	}
+    @Test
+    public void getInterfacesShouldWork() throws DBusException {
+        givenMockedDevices();
 
-	@Test
-	public void applyShouldDoNothingWithNoCache() throws DBusException {
-		givenMockedDevices();
+        whenGetInterfaces();
 
-		whenApply();
+        thenVerifyNoExceptionIsThrown();
+        thenReturnedStringListIs(Arrays.asList("mockedDevice1", "mockedDevice2"));
+    }
 
-		thenVerifyNoExceptionIsThrown();
-		// check if nothing happened
-	}
+    @Test
+    public void applyShouldDoNothingWithNoCache() throws DBusException {
+        givenMockedDevices();
 
-	@Test
-	public void applyShouldThrowWithNullMap() throws DBusException {
-		givenMockedDevices();
+        whenApply();
 
-		whenApplyWithNetowrkConfig(null);
+        thenVerifyNoExceptionIsThrown();
+        // check if nothing happened
+    }
 
-		thenNullPointerExceptionIsThrown();
-	}
+    @Test
+    public void applyShouldThrowWithNullMap() throws DBusException {
+        givenMockedDevices();
 
-	@Test
-	public void applyShouldThrowWithEmptyMap() throws DBusException {
-		givenMockedDevices();
+        whenApplyWithNetowrkConfig(null);
 
-		whenApplyWithNetowrkConfig(new HashMap<String, Object>());
+        thenNullPointerExceptionIsThrown();
+    }
 
-		thenVerifyNoSuchElementExceptionIsThrown();
-	}
+    @Test
+    public void applyShouldThrowWithEmptyMap() throws DBusException {
+        givenMockedDevices();
 
-	@Test
-	public void applyShouldWorkWithEnabledUnsupportedDevices() throws DBusException {
+        whenApplyWithNetowrkConfig(new HashMap<String, Object>());
 
-		givenMockedDeviceConfiguredToBeUnsupported();
-		givenNetworkConfigWhichEnablesEth0();
+        thenVerifyNoSuchElementExceptionIsThrown();
+    }
 
-		whenApplyWithNetowrkConfig(netConfig);
+    @Test
+    public void applyShouldWorkWithEnabledUnsupportedDevices() throws DBusException {
 
-		thenVerifyNoExceptionIsThrown();
-		// check if nothing happened
-	}
+        givenMockedDeviceConfiguredToBeUnsupported();
+        givenNetworkConfigWhichEnablesEth0();
 
-	@Test
-	public void applyShouldWorkWithEnabledEthernet() throws DBusException {
-		givenFullyMockedEthernetDevice();
-		givenNetworkConfigWhichEnablesEth0();
+        whenApplyWithNetowrkConfig(netConfig);
 
-		whenApplyWithNetowrkConfig(this.netConfig);
+        thenVerifyNoExceptionIsThrown();
+        // check if nothing happened
+    }
 
-		thenVerifyNoExceptionIsThrown();
-		// TODO: Verify
-	}
+    @Test
+    public void applyShouldWorkWithEnabledEthernet() throws DBusException {
+        givenFullyMockedEthernetDevice();
+        givenNetworkConfigWhichEnablesEth0();
 
-	@Test
-	public void applyShouldWorkWithDisabledEthernet() throws DBusException {
+        whenApplyWithNetowrkConfig(this.netConfig);
 
-		givenFullyMockedEthernetDevice();
-		givenNetworkConfigWhichDisablesEth0();
+        thenVerifyNoExceptionIsThrown();
+        // TODO: Verify
+    }
 
-		whenApplyWithNetowrkConfig(this.netConfig);
+    @Test
+    public void applyShouldWorkWithDisabledEthernet() throws DBusException {
 
-		thenVerifyNoExceptionIsThrown();
-		// TODO: Verify
-	}
+        givenFullyMockedEthernetDevice();
+        givenNetworkConfigWhichDisablesEth0();
 
-	@Test
-	public void applyShouldNotDisableLoopbackDevice() throws DBusException {
+        whenApplyWithNetowrkConfig(this.netConfig);
 
-		givenFullyMockedLoopbackDevice();
-		givenNetworkConfigWhichDisablesLoopbackDevice();
+        thenVerifyNoExceptionIsThrown();
+        // TODO: Verify
+    }
 
-		whenApplyWithNetowrkConfig(this.netConfig);
+    @Test
+    public void applyShouldNotDisableLoopbackDevice() throws DBusException {
 
-		thenVerifyNoExceptionIsThrown();
-		// TODO: Verify
-	}
+        givenFullyMockedLoopbackDevice();
+        givenNetworkConfigWhichDisablesLoopbackDevice();
 
-	public void givenBasicMockedDbusConnector() throws DBusException {
+        whenApplyWithNetowrkConfig(this.netConfig);
+
+        thenVerifyNoExceptionIsThrown();
+        // TODO: Verify
+    }
+
+    public void givenBasicMockedDbusConnector() throws DBusException {
 		when(dbusConnection.getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/org/freedesktop/NetworkManager"), any()))
 					.thenReturn(mockedNetworkManager);
 		
-		this.instanceNMDbusConnector = new  NMDbusConnector(this.dbusConnection){
-			
-			protected static synchronized NMDbusConnector getInstance(DBusConnection dbusConnection) throws DBusException {
-				instance = new NMDbusConnector(dbusConnection);
-				return instance;
-		    }
-		};
-	
-		NMDbusConnector.getInstance(this.dbusConnection);
+		this.instanceNMDbusConnector = NMDbusConnector.getInstance(this.dbusConnection);
 	}
 
-	public void givenMockedPermissions() {
+    public void givenMockedPermissions() {
 
-		Map<String, String> tempPerms = new HashMap<>();
+        Map<String, String> tempPerms = new HashMap<>();
 
-		tempPerms.put("test1", "testVal1");
-		tempPerms.put("test2", "testVal2");
-		tempPerms.put("test3", "testVal3");
+        tempPerms.put("test1", "testVal1");
+        tempPerms.put("test2", "testVal2");
+        tempPerms.put("test3", "testVal3");
 
-		when(mockedNetworkManager.GetPermissions()).thenReturn(tempPerms);
+        when(mockedNetworkManager.GetPermissions()).thenReturn(tempPerms);
 
-	}
+    }
 
-	public void givenMockedVersion() throws DBusException {
+    public void givenMockedVersion() throws DBusException {
 
-		Properties mockProps = mock(org.freedesktop.dbus.interfaces.Properties.class);
-		when(mockProps.Get(eq("org.freedesktop.NetworkManager"), eq("Version"))).thenReturn("Mock-Version");
+        Properties mockProps = mock(org.freedesktop.dbus.interfaces.Properties.class);
+        when(mockProps.Get(eq("org.freedesktop.NetworkManager"), eq("Version"))).thenReturn("Mock-Version");
 
-		doReturn(mockProps).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/org/freedesktop/NetworkManager"), eq(Properties.class));
-	}
+        doReturn(mockProps).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/org/freedesktop/NetworkManager"), eq(Properties.class));
+    }
 
-	public void givenMockedDevices() throws DBusException {
+    public void givenMockedDevices() throws DBusException {
 
-		Device mockedDevice1 = mock(Device.class);
-		when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/path1");
-		DBusPath mockedPath1 = mock(DBusPath.class);
-		when(mockedPath1.getPath()).thenReturn("/mock/device/path1");
-		Properties mockedProperties1 = mock(Properties.class);
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
-				.thenReturn(new UInt32(1));
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface")))
-				.thenReturn("mockedDevice1");
+        Device mockedDevice1 = mock(Device.class);
+        when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/path1");
+        DBusPath mockedPath1 = mock(DBusPath.class);
+        when(mockedPath1.getPath()).thenReturn("/mock/device/path1");
+        Properties mockedProperties1 = mock(Properties.class);
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+                .thenReturn(new UInt32(1));
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface")))
+                .thenReturn("mockedDevice1");
 
-		Device mockedDevice2 = mock(Device.class);
-		when(mockedDevice2.getObjectPath()).thenReturn("/mock/device/path2");
-		DBusPath mockedPath2 = mock(DBusPath.class);
-		when(mockedPath2.getPath()).thenReturn("/mock/device/path2");
-		Properties mockedProperties2 = mock(Properties.class);
-		when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
-				.thenReturn(new UInt32(1));
-		when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface")))
-				.thenReturn("mockedDevice2");
+        Device mockedDevice2 = mock(Device.class);
+        when(mockedDevice2.getObjectPath()).thenReturn("/mock/device/path2");
+        DBusPath mockedPath2 = mock(DBusPath.class);
+        when(mockedPath2.getPath()).thenReturn("/mock/device/path2");
+        Properties mockedProperties2 = mock(Properties.class);
+        when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+                .thenReturn(new UInt32(1));
+        when(mockedProperties2.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface")))
+                .thenReturn("mockedDevice2");
 
-		when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1, mockedPath2));
+        when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1, mockedPath2));
 
-		doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/path1"), eq(Device.class));
-		doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/path1"), eq(Properties.class));
+        doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/path1"), eq(Device.class));
+        doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/path1"), eq(Properties.class));
 
-		doReturn(mockedDevice2).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/path2"), eq(Device.class));
-		doReturn(mockedProperties2).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/path2"), eq(Properties.class));
-	}
+        doReturn(mockedDevice2).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/path2"), eq(Device.class));
+        doReturn(mockedProperties2).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/path2"), eq(Properties.class));
+    }
 
-	public void givenFullyMockedEthernetDevice() throws DBusException {
-		Device mockedDevice1 = mock(Device.class);
-		when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/eth0");
+    public void givenFullyMockedEthernetDevice() throws DBusException {
+        Device mockedDevice1 = mock(Device.class);
+        when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/eth0");
 
-		DBusPath mockedPath1 = mock(DBusPath.class);
-		when(mockedPath1.getPath()).thenReturn("/mock/device/eth0");
+        DBusPath mockedPath1 = mock(DBusPath.class);
+        when(mockedPath1.getPath()).thenReturn("/mock/device/eth0");
 
-		Map<String, Map<String, Variant<?>>> mockedDevice1ConnectionSetting = new HashMap<String, Map<String, Variant<?>>>();
-		mockedDevice1ConnectionSetting.put("connection",
-				Collections.singletonMap("uuid", new Variant<>("mock-uuid-123")));
+        Map<String, Map<String, Variant<?>>> mockedDevice1ConnectionSetting = new HashMap<String, Map<String, Variant<?>>>();
+        mockedDevice1ConnectionSetting.put("connection",
+                Collections.singletonMap("uuid", new Variant<>("mock-uuid-123")));
 
-		Settings mockedDevice1Settings = mock(Settings.class);
-		when(mockedDevice1Settings.GetConnectionByUuid(eq("mock-uuid-123"))).thenReturn(mockedPath1);
+        Settings mockedDevice1Settings = mock(Settings.class);
+        when(mockedDevice1Settings.GetConnectionByUuid(eq("mock-uuid-123"))).thenReturn(mockedPath1);
 
-		Connection mockedDevice1Connection = mock(Connection.class, RETURNS_SMART_NULLS);
-		when(mockedDevice1Connection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
+        Connection mockedDevice1Connection = mock(Connection.class, RETURNS_SMART_NULLS);
+        when(mockedDevice1Connection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
 
-		GetAppliedConnectionTuple mockedDevice1ConnectionTouple = mock(GetAppliedConnectionTuple.class);
-		when(mockedDevice1ConnectionTouple.getConnection()).thenReturn(mockedDevice1ConnectionSetting);
+        GetAppliedConnectionTuple mockedDevice1ConnectionTouple = mock(GetAppliedConnectionTuple.class);
+        when(mockedDevice1ConnectionTouple.getConnection()).thenReturn(mockedDevice1ConnectionSetting);
 
-		when(mockedDevice1.GetAppliedConnection(eq(new UInt32(0)))).thenReturn(mockedDevice1ConnectionTouple);
+        when(mockedDevice1.GetAppliedConnection(eq(new UInt32(0)))).thenReturn(mockedDevice1ConnectionTouple);
 
-		Properties mockedProperties1 = mock(Properties.class);
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
-				.thenReturn(new UInt32(1)); // 1 id Ethernet
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
-				.thenReturn(new UInt32(10));
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("eth0");
+        Properties mockedProperties1 = mock(Properties.class);
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+                .thenReturn(new UInt32(1)); // 1 id Ethernet
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
+                .thenReturn(new UInt32(10));
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("eth0");
 
-		when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1));
+        when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1));
 
-		when(this.mockedNetworkManager.GetDeviceByIpIface(eq("eth0"))).thenReturn(mockedPath1);
+        when(this.mockedNetworkManager.GetDeviceByIpIface(eq("eth0"))).thenReturn(mockedPath1);
 
-		doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/eth0"), eq(Device.class));
-		doReturn(mockedDevice1Settings).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/org/freedesktop/NetworkManager/Settings"), eq(Settings.class));
-		doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/eth0"), eq(Properties.class));
-		doReturn(mockedDevice1Connection).when(this.dbusConnection)
-				.getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/eth0"), eq(Connection.class));
-	}
+        doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/eth0"), eq(Device.class));
+        doReturn(mockedDevice1Settings).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/org/freedesktop/NetworkManager/Settings"), eq(Settings.class));
+        doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/eth0"), eq(Properties.class));
+        doReturn(mockedDevice1Connection).when(this.dbusConnection)
+                .getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/eth0"), eq(Connection.class));
+    }
 
-	public void givenFullyMockedLoopbackDevice() throws DBusException {
-		Device mockedDevice1 = mock(Device.class);
-		when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/lo");
+    public void givenFullyMockedLoopbackDevice() throws DBusException {
+        Device mockedDevice1 = mock(Device.class);
+        when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/lo");
 
-		Generic mockedDevice1Generic = mock(Generic.class);
-		when(mockedDevice1Generic.getObjectPath()).thenReturn("/mock/device/lo");
+        Generic mockedDevice1Generic = mock(Generic.class);
+        when(mockedDevice1Generic.getObjectPath()).thenReturn("/mock/device/lo");
 
-		DBusPath mockedPath1 = mock(DBusPath.class);
-		when(mockedPath1.getPath()).thenReturn("/mock/device/lo");
+        DBusPath mockedPath1 = mock(DBusPath.class);
+        when(mockedPath1.getPath()).thenReturn("/mock/device/lo");
 
-		Map<String, Map<String, Variant<?>>> mockedDevice1ConnectionSetting = new HashMap<String, Map<String, Variant<?>>>();
-		mockedDevice1ConnectionSetting.put("connection",
-				Collections.singletonMap("uuid", new Variant<>("mock-uuid-123")));
+        Map<String, Map<String, Variant<?>>> mockedDevice1ConnectionSetting = new HashMap<String, Map<String, Variant<?>>>();
+        mockedDevice1ConnectionSetting.put("connection",
+                Collections.singletonMap("uuid", new Variant<>("mock-uuid-123")));
 
-		Settings mockedDevice1Settings = mock(Settings.class);
-		when(mockedDevice1Settings.GetConnectionByUuid(eq("mock-uuid-123"))).thenReturn(mockedPath1);
+        Settings mockedDevice1Settings = mock(Settings.class);
+        when(mockedDevice1Settings.GetConnectionByUuid(eq("mock-uuid-123"))).thenReturn(mockedPath1);
 
-		Connection mockedDevice1Connection = mock(Connection.class, RETURNS_SMART_NULLS);
-		when(mockedDevice1Connection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
+        Connection mockedDevice1Connection = mock(Connection.class, RETURNS_SMART_NULLS);
+        when(mockedDevice1Connection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
 
-		Properties mockedProperties1 = mock(Properties.class);
-		when(mockedProperties1.Get(any(), any())).thenReturn("loopback");
+        Properties mockedProperties1 = mock(Properties.class);
+        when(mockedProperties1.Get(any(), any())).thenReturn("loopback");
 
-		GetAppliedConnectionTuple mockedDevice1ConnectionTouple = mock(GetAppliedConnectionTuple.class);
-		when(mockedDevice1ConnectionTouple.getConnection()).thenReturn(mockedDevice1ConnectionSetting);
+        GetAppliedConnectionTuple mockedDevice1ConnectionTouple = mock(GetAppliedConnectionTuple.class);
+        when(mockedDevice1ConnectionTouple.getConnection()).thenReturn(mockedDevice1ConnectionSetting);
 
-		when(mockedDevice1.GetAppliedConnection(eq(new UInt32(0)))).thenReturn(mockedDevice1ConnectionTouple);
+        when(mockedDevice1.GetAppliedConnection(eq(new UInt32(0)))).thenReturn(mockedDevice1ConnectionTouple);
 
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
-				.thenReturn(new UInt32(14)); // 1 id Ethernet
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
-				.thenReturn(new UInt32(10));
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("lo");
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+                .thenReturn(new UInt32(14)); // 1 id Ethernet
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
+                .thenReturn(new UInt32(10));
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("lo");
 
-		when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1));
+        when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1));
 
-		when(this.mockedNetworkManager.GetDeviceByIpIface(eq("lo"))).thenReturn(mockedPath1);
+        when(this.mockedNetworkManager.GetDeviceByIpIface(eq("lo"))).thenReturn(mockedPath1);
 
-		doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/lo"), eq(Device.class));
-		doReturn(mockedDevice1Settings).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/org/freedesktop/NetworkManager/Settings"), eq(Settings.class));
-		doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/lo"), eq(Properties.class));
-		doReturn(mockedDevice1Connection).when(this.dbusConnection)
-				.getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/lo"), eq(Connection.class));
-		doReturn(mockedDevice1Generic).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/lo"), eq(Generic.class));
-	}
+        doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/lo"), eq(Device.class));
+        doReturn(mockedDevice1Settings).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/org/freedesktop/NetworkManager/Settings"), eq(Settings.class));
+        doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/lo"), eq(Properties.class));
+        doReturn(mockedDevice1Connection).when(this.dbusConnection)
+                .getRemoteObject(eq("org.freedesktop.NetworkManager"), eq("/mock/device/lo"), eq(Connection.class));
+        doReturn(mockedDevice1Generic).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/lo"), eq(Generic.class));
+    }
 
-	public void givenMockedDeviceConfiguredToBeUnsupported() throws DBusException {
-		Device mockedDevice1 = mock(Device.class);
-		when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/eth0");
-		DBusPath mockedPath1 = mock(DBusPath.class);
-		when(mockedPath1.getPath()).thenReturn("/mock/device/eth0");
-		Properties mockedProperties1 = mock(Properties.class);
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
-				.thenReturn(new UInt32(0)); // This field is set to unsupported
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
-				.thenReturn(new UInt32(10));
-		when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("eth0");
+    public void givenMockedDeviceConfiguredToBeUnsupported() throws DBusException {
+        Device mockedDevice1 = mock(Device.class);
+        when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/eth0");
+        DBusPath mockedPath1 = mock(DBusPath.class);
+        when(mockedPath1.getPath()).thenReturn("/mock/device/eth0");
+        Properties mockedProperties1 = mock(Properties.class);
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("DeviceType")))
+                .thenReturn(new UInt32(0)); // This field is set to unsupported
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("State")))
+                .thenReturn(new UInt32(10));
+        when(mockedProperties1.Get(eq("org.freedesktop.NetworkManager.Device"), eq("Interface"))).thenReturn("eth0");
 
-		when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1));
+        when(this.mockedNetworkManager.GetAllDevices()).thenReturn(Arrays.asList(mockedPath1));
 
-		when(this.mockedNetworkManager.GetDeviceByIpIface(eq("eth0"))).thenReturn(mockedPath1);
+        when(this.mockedNetworkManager.GetDeviceByIpIface(eq("eth0"))).thenReturn(mockedPath1);
 
-		doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/eth0"), eq(Device.class));
-		doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/mock/device/eth0"), eq(Properties.class));
-	}
+        doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/eth0"), eq(Device.class));
+        doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/mock/device/eth0"), eq(Properties.class));
+    }
 
-	public void givenNetworkConfigWhichEnablesEth0() {
-		netConfig.put("net.interfaces", "eth0, ");
-		netConfig.put("net.interface.eth0.config.dhcpClient4.enabled", false);
-		netConfig.put("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
-		netConfig.put("net.interface.eth0.config.ip4.address", "192.168.0.12");
-		netConfig.put("net.interface.eth0.config.ip4.prefix", (short) 25);
-		netConfig.put("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
-		netConfig.put("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
-	}
+    public void givenNetworkConfigWhichEnablesEth0() {
+        netConfig.put("net.interfaces", "eth0, ");
+        netConfig.put("net.interface.eth0.config.dhcpClient4.enabled", false);
+        netConfig.put("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
+        netConfig.put("net.interface.eth0.config.ip4.address", "192.168.0.12");
+        netConfig.put("net.interface.eth0.config.ip4.prefix", (short) 25);
+        netConfig.put("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
+        netConfig.put("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
+    }
 
-	public void givenNetworkConfigWhichDisablesEth0() {
-		netConfig.put("net.interfaces", "eth0, ");
-		netConfig.put("net.interface.eth0.config.ip4.status", "netIPv4StatusDisabled");
-	}
+    public void givenNetworkConfigWhichDisablesEth0() {
+        netConfig.put("net.interfaces", "eth0, ");
+        netConfig.put("net.interface.eth0.config.ip4.status", "netIPv4StatusDisabled");
+    }
 
-	public void givenNetworkConfigWhichDisablesLoopbackDevice() {
-		netConfig.put("net.interfaces", "lo");
-		netConfig.put("net.interface.lo.config.ip4.status", "netIPv4StatusDisabled");
-	}
+    public void givenNetworkConfigWhichDisablesLoopbackDevice() {
+        netConfig.put("net.interfaces", "lo");
+        netConfig.put("net.interface.lo.config.ip4.status", "netIPv4StatusDisabled");
+    }
 
-	public void whenGetDbusConnectionIsRun() {
-		this.dbusConnectionInternal = this.instanceNMDbusConnector.getDbusConnection();
-	}
+    public void whenGetDbusConnectionIsRun() {
+        this.dbusConnectionInternal = this.instanceNMDbusConnector.getDbusConnection();
+    }
 
-	public void whenCloseConnectionIsRun() {
-		this.instanceNMDbusConnector.closeConnection();
-	}
+    public void whenCloseConnectionIsRun() {
+        this.instanceNMDbusConnector.closeConnection();
+    }
 
-	public void whenCheckPermissionsIsRun() {
-		this.instanceNMDbusConnector.checkPermissions();
-	}
+    public void whenCheckPermissionsIsRun() {
+        this.instanceNMDbusConnector.checkPermissions();
+    }
 
-	public void whenCheckVersionIsRun() {
-		try {
-			this.instanceNMDbusConnector.checkVersion();
-		} catch (DBusException e) {
-			hasDBusExceptionBeenThrown = true;
-		}
-	}
+    public void whenCheckVersionIsRun() {
+        try {
+            this.instanceNMDbusConnector.checkVersion();
+        } catch (DBusException e) {
+            hasDBusExceptionBeenThrown = true;
+        }
+    }
 
-	public void whenGetInterfaces() {
-		try {
-			internalStringList = this.instanceNMDbusConnector.getInterfaces();
-		} catch (DBusException e) {
-			hasDBusExceptionBeenThrown = true;
-		}
-	}
+    public void whenGetInterfaces() {
+        try {
+            internalStringList = this.instanceNMDbusConnector.getInterfaces();
+        } catch (DBusException e) {
+            hasDBusExceptionBeenThrown = true;
+        }
+    }
 
-	public void whenApply() {
-		try {
-			this.instanceNMDbusConnector.apply();
-		} catch (DBusException e) {
-			hasDBusExceptionBeenThrown = true;
-		}
-	}
+    public void whenApply() {
+        try {
+            this.instanceNMDbusConnector.apply();
+        } catch (DBusException e) {
+            hasDBusExceptionBeenThrown = true;
+        }
+    }
 
-	public void whenApplyWithNetowrkConfig(Map<String, Object> networkConfig) {
-		try {
-			this.instanceNMDbusConnector.apply(networkConfig);
-		} catch (DBusException e) {
-			e.printStackTrace();
-			hasDBusExceptionBeenThrown = true;
-		} catch (NoSuchElementException e) {
-			e.printStackTrace();
-			hasNoSuchElementExceptionThrown = true;
-		} catch (NullPointerException e) {
-			e.printStackTrace();
-			hasNullPointerExceptionThrown = true;
-		}
-	}
+    public void whenApplyWithNetowrkConfig(Map<String, Object> networkConfig) {
+        try {
+            this.instanceNMDbusConnector.apply(networkConfig);
+        } catch (DBusException e) {
+            e.printStackTrace();
+            hasDBusExceptionBeenThrown = true;
+        } catch (NoSuchElementException e) {
+            e.printStackTrace();
+            hasNoSuchElementExceptionThrown = true;
+        } catch (NullPointerException e) {
+            e.printStackTrace();
+            hasNullPointerExceptionThrown = true;
+        }
+    }
 
-	public void thenVerifyNoExceptionIsThrown() {
-		assertFalse(hasDBusExceptionBeenThrown);
-		assertFalse(hasNoSuchElementExceptionThrown);
-	}
+    public void thenVerifyNoExceptionIsThrown() {
+        assertFalse(hasDBusExceptionBeenThrown);
+        assertFalse(hasNoSuchElementExceptionThrown);
+    }
 
-	public void thenVerifyDBusExceptionIsThrown() {
-		assertTrue(hasDBusExceptionBeenThrown);
-	}
-	
-	public void thenNullPointerExceptionIsThrown() {
-		assertTrue(hasNullPointerExceptionThrown);
-	}
+    public void thenVerifyDBusExceptionIsThrown() {
+        assertTrue(hasDBusExceptionBeenThrown);
+    }
 
-	public void thenVerifyNoSuchElementExceptionIsThrown() {
-		assertTrue(hasNoSuchElementExceptionThrown);
-	}
+    public void thenNullPointerExceptionIsThrown() {
+        assertTrue(hasNullPointerExceptionThrown);
+    }
 
-	public void thenGetDbusConnectionIsMockedConnection() {
-		assertEquals(this.dbusConnection, this.dbusConnectionInternal);
-	}
+    public void thenVerifyNoSuchElementExceptionIsThrown() {
+        assertTrue(hasNoSuchElementExceptionThrown);
+    }
 
-	public void thenVerifyConnectionClosed() {
-		verify(this.dbusConnection, atLeastOnce()).disconnect();
-	}
+    public void thenGetDbusConnectionIsMockedConnection() {
+        assertEquals(this.dbusConnection, this.dbusConnectionInternal);
+    }
 
-	public void thenVerifyCheckVersionIsRun() throws DBusException {
-		verify(this.dbusConnection, atLeastOnce()).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-				eq("/org/freedesktop/NetworkManager"), any());
-	}
+    public void thenVerifyConnectionClosed() {
+        verify(this.dbusConnection, atLeastOnce()).disconnect();
+    }
 
-	public void thenVerifyCheckPermissionsRan() {
-		verify(this.mockedNetworkManager, atLeastOnce()).GetPermissions();
-	}
+    public void thenVerifyCheckVersionIsRun() throws DBusException {
+        verify(this.dbusConnection, atLeastOnce()).getRemoteObject(eq("org.freedesktop.NetworkManager"),
+                eq("/org/freedesktop/NetworkManager"), any());
+    }
 
-	public void thenReturnedStringListIs(List<String> list) {
-		assertEquals(this.internalStringList, list);
-	}
+    public void thenVerifyCheckPermissionsRan() {
+        verify(this.mockedNetworkManager, atLeastOnce()).GetPermissions();
+    }
+
+    public void thenReturnedStringListIs(List<String> list) {
+        assertEquals(this.internalStringList, list);
+    }
 
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceStateTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceStateTest.java
@@ -186,85 +186,85 @@ public class NMDeviceStateTest {
     
     @Test
     public void conversionWorksForStateUnknownToUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
         thenStateUIntShouldBeEqualTo(new UInt32(0));
     }
 
     @Test
     public void conversionWorksForStateUnmanagedUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
         thenStateUIntShouldBeEqualTo(new UInt32(10));
     }
 
     @Test
     public void conversionWorksForStateUnavailableUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
         thenStateUIntShouldBeEqualTo(new UInt32(20));
     }
 
     @Test
     public void conversionWorksForStateDisconnectedUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
         thenStateUIntShouldBeEqualTo(new UInt32(30));
     }
 
     @Test
     public void conversionWorksForStatePrepareUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_PREPARE);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_PREPARE);
         thenStateUIntShouldBeEqualTo(new UInt32(40));
     }
 
     @Test
     public void conversionWorksForStateConfigUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_CONFIG);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_CONFIG);
         thenStateUIntShouldBeEqualTo(new UInt32(50));
     }
 
     @Test
     public void conversionWorksForStateNeedAuthUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
         thenStateUIntShouldBeEqualTo(new UInt32(60));
     }
 
     @Test
     public void conversionWorksForStateIpConfigUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
         thenStateUIntShouldBeEqualTo(new UInt32(70));
     }
 
     @Test
     public void conversionWorksForStateIpCheckUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
         thenStateUIntShouldBeEqualTo(new UInt32(80));
     }
 
     @Test
     public void conversionWorksForStateSecondariesUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
         thenStateUIntShouldBeEqualTo(new UInt32(90));
     }
 
     @Test
     public void conversionWorksForStateActivatedUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
         thenStateUIntShouldBeEqualTo(new UInt32(100));
     }
 
     @Test
     public void conversionWorksForStateDeactivatingUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
         thenStateUIntShouldBeEqualTo(new UInt32(110));
     }
 
     @Test
     public void conversionWorksForStateFailedUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_FAILED);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_FAILED);
         thenStateUIntShouldBeEqualTo(new UInt32(120));
     }
 
     @Test
     public void conversionWorksForStateUnknownDefaultUINT() {
-        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
         thenStateUIntShouldBeEqualTo(new UInt32(0));
     }
 
@@ -272,7 +272,7 @@ public class NMDeviceStateTest {
         this.state = NMDeviceState.fromUInt32(state);
     }
     
-    public void whenNMDeviceStateStateIsPassed(NMDeviceState state) {
+    public void whenNMDeviceStateIsPassed(NMDeviceState state) {
         this.stateInt = NMDeviceState.toUInt32(state);
     }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceStateTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceStateTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 public class NMDeviceStateTest {
 
     NMDeviceState state;
+    UInt32 stateInt;
 
     @Test
     public void conversionWorksForStateUnknown() {
@@ -182,9 +183,97 @@ public class NMDeviceStateTest {
         whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_FAILED);
         thenIsConnectShouldReturn(true);
     }
+    
+    @Test
+    public void conversionWorksForStateUnknownToUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+        thenStateUIntShouldBeEqualTo(new UInt32(0));
+    }
 
-    public void whenInt32StateIsPassed(UInt32 type) {
-        this.state = NMDeviceState.fromUInt32(type);
+    @Test
+    public void conversionWorksForStateUnmanagedUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
+        thenStateUIntShouldBeEqualTo(new UInt32(10));
+    }
+
+    @Test
+    public void conversionWorksForStateUnavailableUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
+        thenStateUIntShouldBeEqualTo(new UInt32(20));
+    }
+
+    @Test
+    public void conversionWorksForStateDisconnectedUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+        thenStateUIntShouldBeEqualTo(new UInt32(30));
+    }
+
+    @Test
+    public void conversionWorksForStatePrepareUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_PREPARE);
+        thenStateUIntShouldBeEqualTo(new UInt32(40));
+    }
+
+    @Test
+    public void conversionWorksForStateConfigUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_CONFIG);
+        thenStateUIntShouldBeEqualTo(new UInt32(50));
+    }
+
+    @Test
+    public void conversionWorksForStateNeedAuthUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
+        thenStateUIntShouldBeEqualTo(new UInt32(60));
+    }
+
+    @Test
+    public void conversionWorksForStateIpConfigUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
+        thenStateUIntShouldBeEqualTo(new UInt32(70));
+    }
+
+    @Test
+    public void conversionWorksForStateIpCheckUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
+        thenStateUIntShouldBeEqualTo(new UInt32(80));
+    }
+
+    @Test
+    public void conversionWorksForStateSecondariesUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
+        thenStateUIntShouldBeEqualTo(new UInt32(90));
+    }
+
+    @Test
+    public void conversionWorksForStateActivatedUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+        thenStateUIntShouldBeEqualTo(new UInt32(100));
+    }
+
+    @Test
+    public void conversionWorksForStateDeactivatingUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
+        thenStateUIntShouldBeEqualTo(new UInt32(110));
+    }
+
+    @Test
+    public void conversionWorksForStateFailedUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_FAILED);
+        thenStateUIntShouldBeEqualTo(new UInt32(120));
+    }
+
+    @Test
+    public void conversionWorksForStateUnknownDefaultUINT() {
+        whenNMDeviceStateStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+        thenStateUIntShouldBeEqualTo(new UInt32(0));
+    }
+
+    public void whenInt32StateIsPassed(UInt32 state) {
+        this.state = NMDeviceState.fromUInt32(state);
+    }
+    
+    public void whenNMDeviceStateStateIsPassed(NMDeviceState state) {
+        this.stateInt = NMDeviceState.toUInt32(state);
     }
 
     public void whenStateIsSetTo(NMDeviceState type) {
@@ -193,6 +282,10 @@ public class NMDeviceStateTest {
 
     public void thenStateShouldBeEqualTo(NMDeviceState type) {
         assertEquals(this.state, type);
+    }
+    
+    public void thenStateUIntShouldBeEqualTo(UInt32 state) {
+        assertEquals(this.stateInt, state);
     }
 
     public void thenIsConnectShouldReturn(Boolean bool) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceTypeTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceTypeTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 public class NMDeviceTypeTest {
 
     NMDeviceType type;
+    UInt32 typeInt;
 
     @Test
     public void conversionWorksForTypeUnknown() {
@@ -225,13 +226,218 @@ public class NMDeviceTypeTest {
         thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_UNKNOWN);
     }
 
+    @Test
+    public void conversionWorksForTypeUnknownUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_UNKNOWN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(0));
+    }
+
+    @Test
+    public void conversionWorksForTypeEthernetUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(1));
+    }
+
+    @Test
+    public void conversionWorksForTypeWiFiUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(2));
+    }
+
+    @Test
+    public void conversionWorksForTypeUnusedUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_UNUSED1);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(3));
+    }
+
+    @Test
+    public void conversionWorksForTypeUnused2UInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_UNUSED2);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(4));
+    }
+
+    @Test
+    public void conversionWorksForTypeBtUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_BT);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(5));
+    }
+
+    @Test
+    public void conversionWorksForTypeOlpcMeshUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_OLPC_MESH);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(6));
+    }
+
+    @Test
+    public void conversionWorksForTypeWiMaxUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WIMAX);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(7));
+    }
+
+    @Test
+    public void conversionWorksForTypeModemUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_MODEM);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(8));
+    }
+
+    @Test
+    public void conversionWorksForTypeInfinibandUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_INFINIBAND);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(9));
+    }
+
+    @Test
+    public void conversionWorksForTypeBondUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_BOND);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(10));
+    }
+
+    @Test
+    public void conversionWorksForTypeVlanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_VLAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(11));
+    }
+
+    @Test
+    public void conversionWorksForTypeAdslUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_ADSL);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(12));
+    }
+
+    @Test
+    public void conversionWorksForTypeBridgeUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_BRIDGE);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(13));
+    }
+
+    @Test
+    public void conversionWorksForTypeGenericUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_GENERIC);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(14));
+    }
+
+    @Test
+    public void conversionWorksForTypeTeamUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_TEAM);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(15));
+    }
+
+    @Test
+    public void conversionWorksForTypeTunUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_TUN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(16));
+    }
+
+    @Test
+    public void conversionWorksForTypeIpTunnelUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_IP_TUNNEL);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(17));
+    }
+
+    @Test
+    public void conversionWorksForTypeMacVlanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_MACVLAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(18));
+    }
+
+    @Test
+    public void conversionWorksForTypeVxlanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_VXLAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(19));
+    }
+
+    @Test
+    public void conversionWorksForTypeVethUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_VETH);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(20));
+    }
+
+    @Test
+    public void conversionWorksForTypeMacsecUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_MACSEC);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(21));
+    }
+
+    @Test
+    public void conversionWorksForTypeDummyUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_DUMMY);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(22));
+    }
+
+    @Test
+    public void conversionWorksForTypePppUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_PPP);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(23));
+    }
+
+    @Test
+    public void conversionWorksForTypeOvsInterfaceUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_OVS_INTERFACE);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(24));
+    }
+
+    @Test
+    public void conversionWorksForTypeOvsPortUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_OVS_PORT);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(25));
+    }
+
+    @Test
+    public void conversionWorksForTypeOvsBridgeUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_OVS_BRIDGE);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(26));
+    }
+
+    @Test
+    public void conversionWorksForTypeWpanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WPAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(27));
+    }
+
+    @Test
+    public void conversionWorksForType6LowPanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_6LOWPAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(28));
+    }
+
+    @Test
+    public void conversionWorksForTypeWireguardUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WIREGUARD);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(29));
+    }
+
+    @Test
+    public void conversionWorksForTypeWiFiP2pUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WIFI_P2P);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(30));
+    }
+
+    @Test
+    public void conversionWorksForTypeVrfUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_VRF);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(31));
+    }
+
+    @Test
+    public void conversionWorksForTypeNullUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(32));
+    }
+
     private void whenInt32StateIsPassed(UInt32 type) {
         this.type = NMDeviceType.fromUInt32(type);
     }
 
+    private void whenNMDeviceTypeStateIsPassed(NMDeviceType type) {
+        this.typeInt = NMDeviceType.toUInt32(type);
+    }
+
     private void thenTypeShouldBeEqualTo(NMDeviceType type) {
         assertEquals(this.type, type);
+    }
 
+    private void thenTypeUInt32ShouldBeEqualTo(UInt32 type) {
+        assertEquals(this.typeInt, type);
     }
 
 }


### PR DESCRIPTION
This PR adds initial test coverage for the NMDbusConnector Class.

a Rebased version of #4385.


Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
