### PR TITLE
fix(net.configuration): Updated pppNum property definition to integer

### DIFF
--- a/kura/org.eclipse.kura.net.configuration/src/main/java/org/eclipse/kura/net/configuration/NetworkConfigurationServiceCommon.java
+++ b/kura/org.eclipse.kura.net.configuration/src/main/java/org/eclipse/kura/net/configuration/NetworkConfigurationServiceCommon.java
@@ -183,7 +183,7 @@ public class NetworkConfigurationServiceCommon {
 
         tocd.addAD(buildAttributeDefinition(
                 String.format(PREFIX + "%s.config.pppNum", ifaceName),
-                NetworkConfigurationPropertyNames.CONFIG_MODEM_PPP_NUM, Tscalar.STRING));
+                NetworkConfigurationPropertyNames.CONFIG_MODEM_PPP_NUM, Tscalar.INTEGER));
     }
 
     private static void getWifiDefinition(Tocd tocd, String ifaceName) {

--- a/kura/test/org.eclipse.kura.net.configuration.test/src/test/java/org/eclipse/kura/net/configuration/NetworkConfigurationServiceCommonTest.java
+++ b/kura/test/org.eclipse.kura.net.configuration.test/src/test/java/org/eclipse/kura/net/configuration/NetworkConfigurationServiceCommonTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.metatype.AD;
+import org.eclipse.kura.configuration.metatype.Scalar;
 import org.eclipse.kura.core.configuration.metatype.Tocd;
 import org.junit.Test;
 
@@ -66,6 +67,13 @@ public class NetworkConfigurationServiceCommonTest {
         givenFullProperties();
         whenTocdIsRetrieved();
         thenComponentDefinitionHasModemProperties();
+    }
+
+    @Test
+    public void pppNumberShouldBeAnInteger() throws KuraException {
+        givenFullProperties();
+        whenTocdIsRetrieved();
+        thenPppNumIsInteger();
     }
 
     private void givenPropertiesWithoutInterfaces() {
@@ -492,6 +500,13 @@ public class NetworkConfigurationServiceCommonTest {
 
     private void thenComponentDefinitionHasModemProperties() {
         assertEquals(28, this.ads.stream().filter(ad -> ad.getName().contains("1-4")).count());
+    }
+
+    private void thenPppNumIsInteger() {
+        Optional<AD> adOptional = this.ads.stream().filter(ad -> ad.getName().equals("net.interface.1-4.config.pppNum"))
+                .findFirst();
+        assertTrue(adOptional.isPresent());
+        assertEquals(Scalar.INTEGER, adOptional.get().getType());
     }
 
 }


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Since the `pppNum` property is an Integer values, this PR updates the definition of this property setting the type to INTEGER.