### PR TITLE
fix(api): Added missing wifi capabilities

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiCapability.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiCapability.java
@@ -40,6 +40,10 @@ public enum WifiCapability {
     /** The device supports 2.4GHz frequencies. */
     FREQ_2GHZ,
     /** The device supports 5GHz frequencies. */
-    FREQ_5GHZ;
+    FREQ_5GHZ,
+    /** The device supports mesh points. */
+    MESH,
+    /** The device supports WPA2 in IBSS networks */
+    IBSS_RSN;
 
 }


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds a couple of missing entries in the `WifiCapability` enum.