### PR TITLE
feat(nm): added support for UInt32 conversion for NMDeviceState and NMDeviceType

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceState.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceState.java
@@ -73,4 +73,36 @@ public enum NMDeviceState {
             return NMDeviceState.NM_DEVICE_STATE_UNKNOWN;
         }
     }
+
+    public static UInt32 toUInt32(NMDeviceState state) {
+        switch (state) {
+        case NM_DEVICE_STATE_UNMANAGED:
+            return new UInt32(10);
+        case NM_DEVICE_STATE_UNAVAILABLE:
+            return new UInt32(20);
+        case NM_DEVICE_STATE_DISCONNECTED:
+            return new UInt32(30);
+        case NM_DEVICE_STATE_PREPARE:
+            return new UInt32(40);
+        case NM_DEVICE_STATE_CONFIG:
+            return new UInt32(50);
+        case NM_DEVICE_STATE_NEED_AUTH:
+            return new UInt32(60);
+        case NM_DEVICE_STATE_IP_CONFIG:
+            return new UInt32(70);
+        case NM_DEVICE_STATE_IP_CHECK:
+            return new UInt32(80);
+        case NM_DEVICE_STATE_SECONDARIES:
+            return new UInt32(90);
+        case NM_DEVICE_STATE_ACTIVATED:
+            return new UInt32(100);
+        case NM_DEVICE_STATE_DEACTIVATING:
+            return new UInt32(110);
+        case NM_DEVICE_STATE_FAILED:
+            return new UInt32(120);
+        case NM_DEVICE_STATE_UNKNOWN:
+        default:
+            return new UInt32(0);
+        }
+    }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceType.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceType.java
@@ -121,4 +121,76 @@ public enum NMDeviceType {
             return NM_DEVICE_TYPE_UNKNOWN;
         }
     }
+
+    public static UInt32 toUInt32(NMDeviceType type) {
+        switch (type) {
+        case NM_DEVICE_TYPE_GENERIC:
+            return new UInt32(14);
+        case NM_DEVICE_TYPE_ETHERNET:
+            return new UInt32(1);
+        case NM_DEVICE_TYPE_WIFI:
+            return new UInt32(2);
+        case NM_DEVICE_TYPE_UNUSED1:
+            return new UInt32(3);
+        case NM_DEVICE_TYPE_UNUSED2:
+            return new UInt32(4);
+        case NM_DEVICE_TYPE_BT:
+            return new UInt32(5);
+        case NM_DEVICE_TYPE_OLPC_MESH:
+            return new UInt32(6);
+        case NM_DEVICE_TYPE_WIMAX:
+            return new UInt32(7);
+        case NM_DEVICE_TYPE_MODEM:
+            return new UInt32(8);
+        case NM_DEVICE_TYPE_INFINIBAND:
+            return new UInt32(9);
+        case NM_DEVICE_TYPE_BOND:
+            return new UInt32(10);
+        case NM_DEVICE_TYPE_VLAN:
+            return new UInt32(11);
+        case NM_DEVICE_TYPE_ADSL:
+            return new UInt32(12);
+        case NM_DEVICE_TYPE_BRIDGE:
+            return new UInt32(13);
+        case NM_DEVICE_TYPE_TEAM:
+            return new UInt32(15);
+        case NM_DEVICE_TYPE_TUN:
+            return new UInt32(16);
+        case NM_DEVICE_TYPE_IP_TUNNEL:
+            return new UInt32(17);
+        case NM_DEVICE_TYPE_MACVLAN:
+            return new UInt32(18);
+        case NM_DEVICE_TYPE_VXLAN:
+            return new UInt32(19);
+        case NM_DEVICE_TYPE_VETH:
+            return new UInt32(20);
+        case NM_DEVICE_TYPE_MACSEC:
+            return new UInt32(21);
+        case NM_DEVICE_TYPE_DUMMY:
+            return new UInt32(22);
+        case NM_DEVICE_TYPE_PPP:
+            return new UInt32(23);
+        case NM_DEVICE_TYPE_OVS_INTERFACE:
+            return new UInt32(24);
+        case NM_DEVICE_TYPE_OVS_PORT:
+            return new UInt32(25);
+        case NM_DEVICE_TYPE_OVS_BRIDGE:
+            return new UInt32(26);
+        case NM_DEVICE_TYPE_WPAN:
+            return new UInt32(27);
+        case NM_DEVICE_TYPE_6LOWPAN:
+            return new UInt32(28);
+        case NM_DEVICE_TYPE_WIREGUARD:
+            return new UInt32(29);
+        case NM_DEVICE_TYPE_WIFI_P2P:
+            return new UInt32(30);
+        case NM_DEVICE_TYPE_VRF:
+            return new UInt32(31);
+        case NM_DEVICE_TYPE_LOOPBACK:
+            return new UInt32(32);
+        case NM_DEVICE_TYPE_UNKNOWN:
+        default:
+            return new UInt32(0);
+        }
+    }
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceStateTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceStateTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 public class NMDeviceStateTest {
 
     NMDeviceState state;
+    UInt32 stateInt;
 
     @Test
     public void conversionWorksForStateUnknown() {
@@ -182,9 +183,97 @@ public class NMDeviceStateTest {
         whenStateIsSetTo(NMDeviceState.NM_DEVICE_STATE_FAILED);
         thenIsConnectShouldReturn(true);
     }
+    
+    @Test
+    public void conversionWorksForStateUnknownToUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+        thenStateUIntShouldBeEqualTo(new UInt32(0));
+    }
 
-    public void whenInt32StateIsPassed(UInt32 type) {
-        this.state = NMDeviceState.fromUInt32(type);
+    @Test
+    public void conversionWorksForStateUnmanagedUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNMANAGED);
+        thenStateUIntShouldBeEqualTo(new UInt32(10));
+    }
+
+    @Test
+    public void conversionWorksForStateUnavailableUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE);
+        thenStateUIntShouldBeEqualTo(new UInt32(20));
+    }
+
+    @Test
+    public void conversionWorksForStateDisconnectedUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
+        thenStateUIntShouldBeEqualTo(new UInt32(30));
+    }
+
+    @Test
+    public void conversionWorksForStatePrepareUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_PREPARE);
+        thenStateUIntShouldBeEqualTo(new UInt32(40));
+    }
+
+    @Test
+    public void conversionWorksForStateConfigUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_CONFIG);
+        thenStateUIntShouldBeEqualTo(new UInt32(50));
+    }
+
+    @Test
+    public void conversionWorksForStateNeedAuthUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_NEED_AUTH);
+        thenStateUIntShouldBeEqualTo(new UInt32(60));
+    }
+
+    @Test
+    public void conversionWorksForStateIpConfigUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_IP_CONFIG);
+        thenStateUIntShouldBeEqualTo(new UInt32(70));
+    }
+
+    @Test
+    public void conversionWorksForStateIpCheckUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_IP_CHECK);
+        thenStateUIntShouldBeEqualTo(new UInt32(80));
+    }
+
+    @Test
+    public void conversionWorksForStateSecondariesUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_SECONDARIES);
+        thenStateUIntShouldBeEqualTo(new UInt32(90));
+    }
+
+    @Test
+    public void conversionWorksForStateActivatedUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_ACTIVATED);
+        thenStateUIntShouldBeEqualTo(new UInt32(100));
+    }
+
+    @Test
+    public void conversionWorksForStateDeactivatingUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING);
+        thenStateUIntShouldBeEqualTo(new UInt32(110));
+    }
+
+    @Test
+    public void conversionWorksForStateFailedUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_FAILED);
+        thenStateUIntShouldBeEqualTo(new UInt32(120));
+    }
+
+    @Test
+    public void conversionWorksForStateUnknownDefaultUINT() {
+        whenNMDeviceStateIsPassed(NMDeviceState.NM_DEVICE_STATE_UNKNOWN);
+        thenStateUIntShouldBeEqualTo(new UInt32(0));
+    }
+
+    public void whenInt32StateIsPassed(UInt32 state) {
+        this.state = NMDeviceState.fromUInt32(state);
+    }
+    
+    public void whenNMDeviceStateIsPassed(NMDeviceState state) {
+        this.stateInt = NMDeviceState.toUInt32(state);
     }
 
     public void whenStateIsSetTo(NMDeviceState type) {
@@ -193,6 +282,10 @@ public class NMDeviceStateTest {
 
     public void thenStateShouldBeEqualTo(NMDeviceState type) {
         assertEquals(this.state, type);
+    }
+    
+    public void thenStateUIntShouldBeEqualTo(UInt32 state) {
+        assertEquals(this.stateInt, state);
     }
 
     public void thenIsConnectShouldReturn(Boolean bool) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceTypeTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDeviceTypeTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 public class NMDeviceTypeTest {
 
     NMDeviceType type;
+    UInt32 typeInt;
 
     @Test
     public void conversionWorksForTypeUnknown() {
@@ -225,13 +226,218 @@ public class NMDeviceTypeTest {
         thenTypeShouldBeEqualTo(NMDeviceType.NM_DEVICE_TYPE_UNKNOWN);
     }
 
+    @Test
+    public void conversionWorksForTypeUnknownUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_UNKNOWN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(0));
+    }
+
+    @Test
+    public void conversionWorksForTypeEthernetUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(1));
+    }
+
+    @Test
+    public void conversionWorksForTypeWiFiUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(2));
+    }
+
+    @Test
+    public void conversionWorksForTypeUnusedUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_UNUSED1);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(3));
+    }
+
+    @Test
+    public void conversionWorksForTypeUnused2UInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_UNUSED2);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(4));
+    }
+
+    @Test
+    public void conversionWorksForTypeBtUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_BT);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(5));
+    }
+
+    @Test
+    public void conversionWorksForTypeOlpcMeshUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_OLPC_MESH);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(6));
+    }
+
+    @Test
+    public void conversionWorksForTypeWiMaxUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WIMAX);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(7));
+    }
+
+    @Test
+    public void conversionWorksForTypeModemUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_MODEM);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(8));
+    }
+
+    @Test
+    public void conversionWorksForTypeInfinibandUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_INFINIBAND);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(9));
+    }
+
+    @Test
+    public void conversionWorksForTypeBondUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_BOND);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(10));
+    }
+
+    @Test
+    public void conversionWorksForTypeVlanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_VLAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(11));
+    }
+
+    @Test
+    public void conversionWorksForTypeAdslUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_ADSL);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(12));
+    }
+
+    @Test
+    public void conversionWorksForTypeBridgeUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_BRIDGE);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(13));
+    }
+
+    @Test
+    public void conversionWorksForTypeGenericUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_GENERIC);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(14));
+    }
+
+    @Test
+    public void conversionWorksForTypeTeamUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_TEAM);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(15));
+    }
+
+    @Test
+    public void conversionWorksForTypeTunUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_TUN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(16));
+    }
+
+    @Test
+    public void conversionWorksForTypeIpTunnelUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_IP_TUNNEL);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(17));
+    }
+
+    @Test
+    public void conversionWorksForTypeMacVlanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_MACVLAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(18));
+    }
+
+    @Test
+    public void conversionWorksForTypeVxlanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_VXLAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(19));
+    }
+
+    @Test
+    public void conversionWorksForTypeVethUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_VETH);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(20));
+    }
+
+    @Test
+    public void conversionWorksForTypeMacsecUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_MACSEC);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(21));
+    }
+
+    @Test
+    public void conversionWorksForTypeDummyUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_DUMMY);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(22));
+    }
+
+    @Test
+    public void conversionWorksForTypePppUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_PPP);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(23));
+    }
+
+    @Test
+    public void conversionWorksForTypeOvsInterfaceUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_OVS_INTERFACE);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(24));
+    }
+
+    @Test
+    public void conversionWorksForTypeOvsPortUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_OVS_PORT);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(25));
+    }
+
+    @Test
+    public void conversionWorksForTypeOvsBridgeUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_OVS_BRIDGE);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(26));
+    }
+
+    @Test
+    public void conversionWorksForTypeWpanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WPAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(27));
+    }
+
+    @Test
+    public void conversionWorksForType6LowPanUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_6LOWPAN);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(28));
+    }
+
+    @Test
+    public void conversionWorksForTypeWireguardUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WIREGUARD);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(29));
+    }
+
+    @Test
+    public void conversionWorksForTypeWiFiP2pUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_WIFI_P2P);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(30));
+    }
+
+    @Test
+    public void conversionWorksForTypeVrfUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_VRF);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(31));
+    }
+
+    @Test
+    public void conversionWorksForTypeNullUInt() {
+        whenNMDeviceTypeStateIsPassed(NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
+        thenTypeUInt32ShouldBeEqualTo(new UInt32(32));
+    }
+
     private void whenInt32StateIsPassed(UInt32 type) {
         this.type = NMDeviceType.fromUInt32(type);
     }
 
+    private void whenNMDeviceTypeStateIsPassed(NMDeviceType type) {
+        this.typeInt = NMDeviceType.toUInt32(type);
+    }
+
     private void thenTypeShouldBeEqualTo(NMDeviceType type) {
         assertEquals(this.type, type);
+    }
 
+    private void thenTypeUInt32ShouldBeEqualTo(UInt32 type) {
+        assertEquals(this.typeInt, type);
     }
 
 }


### PR DESCRIPTION
added support for toUInt32, and test coverage for NMDeviceState and NMDeviceType

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
