### PR TITLE
ci: cancel running build if new one is started

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 node {
-    properties([buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')), gitLabConnection('gitlab.eclipse.org'), [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false], [$class: 'JobLocalConfiguration', changeReasonComment: '']])
+    properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')), gitLabConnection('gitlab.eclipse.org'), [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false], [$class: 'JobLocalConfiguration', changeReasonComment: '']])
 
     deleteDir()
 

--- a/README.md
+++ b/README.md
@@ -184,5 +184,3 @@ Check the following [link](https://www.eclipse.org/kura/downloads.php) to downlo
 ## Docker Image
 Eclipse Kura is available also as a [Docker container](https://hub.docker.com/r/eclipse/kura/)
 To easily run, use: `docker run -d -p 443:443 -t eclipse/kura`.
-
-This is just a test

--- a/README.md
+++ b/README.md
@@ -184,3 +184,5 @@ Check the following [link](https://www.eclipse.org/kura/downloads.php) to downlo
 ## Docker Image
 Eclipse Kura is available also as a [Docker container](https://hub.docker.com/r/eclipse/kura/)
 To easily run, use: `docker run -d -p 443:443 -t eclipse/kura`.
+
+This is just a test


### PR DESCRIPTION
This PR updates the Kura Jenkinsfile such that it will cancel all previous running builds (on a branch by branch, PR by PR basis) if a new one is triggered. The feature [was added in Jenkins 2.42](https://issues.jenkins.io/browse/JENKINS-43353).

**Example**: I commit and push to branch `feature1`. Open a PR then `BUILD_1` is started on Jenkins. I make another commit and push to branch `feature1` while `BUILD_1` is still running.
- Before this changes, `BUILD_2` would need to wait for `BUILD_1` to complete before being ran.
- After this PR, `BUILD_1` gets cancelled and `BUILD_2` is started.

**Probably unwanted side-effect**: this behaviour will apply on `develop` branch too. Which means that **not all commits on the `develop` branch** will be built. Is this ok for us?

From [Jenkins docs](https://www.jenkins.io/doc/book/pipeline/syntax/):

> **disableConcurrentBuilds**
> Disallow concurrent executions of the Pipeline. Can be useful for preventing simultaneous accesses to shared resources, etc. For example: options { disableConcurrentBuilds() } to queue a build when there’s already an executing build of the Pipeline, or options { disableConcurrentBuilds(abortPrevious: true) } to abort the running one and start the new build.