### PR TITLE
test(nm): added test coverage for NMStatusConverter

### DIFF
--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -93,7 +93,7 @@ public class NMStatusConverterTest {
         givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
 
         givenIpv4ConfigPropertiesWith("Gateway", "");
-        givenIpv4ConfigPropertiesWithDNS("192.168.1.1");
+        givenIpv4ConfigPropertiesWithDNS(Arrays.asList());
         givenIpv4ConfigPropertiesWithAddress("127.0.0.1", new UInt32(8));
 
         whenBuildLoopbackStatusIsCalledWith("lo", this.mockDeviceProperties, Optional.of(this.mockIp4ConfigProperties));
@@ -110,7 +110,7 @@ public class NMStatusConverterTest {
                 new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
 
         thenResultingIp4InterfaceGatewayIsMissing();
-        thenResultingIp4InterfaceDNSIs(IPAddress.parseHostAddress("192.168.1.1"));
+        thenResultingIp4InterfaceDNSIsMissing();
         thenResultingIp4InterfaceAddressIs(IPAddress.parseHostAddress("127.0.0.1"), (short) 8);
     }
 
@@ -128,12 +128,17 @@ public class NMStatusConverterTest {
                 .thenReturn(propertyValue);
     }
 
-    private void givenIpv4ConfigPropertiesWithDNS(String ip4Address) {
-        Map<String, Variant<?>> structure = new HashMap<>();
-        structure.put("address", new Variant<>(ip4Address));
+    private void givenIpv4ConfigPropertiesWithDNS(List<String> addresses) {
+        List<Map<String, Variant<?>>> addressList = Arrays.asList();
 
-        when(this.mockIp4ConfigProperties.Get(eq(NM_IP4CONFIG_BUS_NAME), eq("NameserverData")))
-                .thenReturn(Arrays.asList(structure));
+        for (String address : addresses) {
+            Map<String, Variant<?>> structure = new HashMap<>();
+            structure.put("address", new Variant<>(address));
+
+            addressList.add(structure);
+        }
+
+        when(this.mockIp4ConfigProperties.Get(eq(NM_IP4CONFIG_BUS_NAME), eq("NameserverData"))).thenReturn(addressList);
     }
 
     private void givenIpv4ConfigPropertiesWithAddress(String address, UInt32 prefix) {
@@ -215,6 +220,14 @@ public class NMStatusConverterTest {
 
         assertTrue(address.getGateway().isPresent());
         assertEquals(expectedResult, address.getGateway().get());
+    }
+
+    private void thenResultingIp4InterfaceDNSIsMissing() {
+        assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+        NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
+
+        List<IP4Address> dns = address.getDnsServerAddresses();
+        assertTrue(dns.isEmpty());
     }
 
     private void thenResultingIp4InterfaceDNSIs(IPAddress expectedResult) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -92,9 +92,9 @@ public class NMStatusConverterTest {
         givenDevicePropertiesWith("Mtu", new UInt32(69));
         givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
 
-        givenIpv4ConfigPropertiesWith("Gateway", "127.0.0.1");
+        givenIpv4ConfigPropertiesWith("Gateway", "");
         givenIpv4ConfigPropertiesWithDNS("192.168.1.1");
-        givenIpv4ConfigPropertiesWithAddress("127.0.0.1", new UInt32(24));
+        givenIpv4ConfigPropertiesWithAddress("127.0.0.1", new UInt32(8));
 
         whenBuildLoopbackStatusIsCalledWith("lo", this.mockDeviceProperties, Optional.of(this.mockIp4ConfigProperties));
 
@@ -109,9 +109,9 @@ public class NMStatusConverterTest {
         thenResultingNetworkInterfaceHardwareAddressIs(
                 new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
 
-        thenResultingIp4InterfaceGatewayIs(IPAddress.parseHostAddress("127.0.0.1"));
+        thenResultingIp4InterfaceGatewayIsMissing();
         thenResultingIp4InterfaceDNSIs(IPAddress.parseHostAddress("192.168.1.1"));
-        thenResultingIp4InterfaceAddressIs(IPAddress.parseHostAddress("127.0.0.1"), (short) 24);
+        thenResultingIp4InterfaceAddressIs(IPAddress.parseHostAddress("127.0.0.1"), (short) 8);
     }
 
     /*
@@ -202,14 +202,19 @@ public class NMStatusConverterTest {
         assertFalse(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
     }
 
+    private void thenResultingIp4InterfaceGatewayIsMissing() {
+        assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+        NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
+
+        assertFalse(address.getGateway().isPresent());
+    }
+
     private void thenResultingIp4InterfaceGatewayIs(IPAddress expectedResult) {
         assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
         NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
 
         assertTrue(address.getGateway().isPresent());
-        IPAddress gateway = address.getGateway().get();
-
-        assertEquals(expectedResult, gateway);
+        assertEquals(expectedResult, address.getGateway().get());
     }
 
     private void thenResultingIp4InterfaceDNSIs(IPAddress expectedResult) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -74,6 +74,7 @@ public class NMStatusConverterTest {
 
         thenNoExceptionIsThrown();
 
+        thenResultingNetworkInterfaceIsVirtual(true);
         thenResultingNetworkInterfaceAutoConnectIs(true);
         thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.UNMANAGED);
         thenResultingNetworkInterfaceFirmwareVersionIs("awesomeFirmwareVersion");
@@ -103,6 +104,7 @@ public class NMStatusConverterTest {
 
         thenNoExceptionIsThrown();
 
+        thenResultingNetworkInterfaceIsVirtual(true);
         thenResultingNetworkInterfaceAutoConnectIs(false);
         thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
         thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
@@ -148,6 +150,7 @@ public class NMStatusConverterTest {
 
         thenNoExceptionIsThrown();
 
+        thenResultingNetworkInterfaceIsVirtual(false);
         thenResultingNetworkInterfaceAutoConnectIs(true);
         thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.UNMANAGED);
         thenResultingNetworkInterfaceFirmwareVersionIs("awesomeFirmwareVersion");
@@ -232,6 +235,10 @@ public class NMStatusConverterTest {
 
     private void thenNullPointerExceptionIsThrown() {
         assertTrue(this.nullPointerExceptionWasThrown);
+    }
+
+    private void thenResultingNetworkInterfaceIsVirtual(boolean expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.isVirtual());
     }
 
     private void thenResultingNetworkInterfaceAutoConnectIs(boolean expectedResult) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -22,6 +22,7 @@ import org.eclipse.kura.net.status.NetworkInterfaceIpAddressStatus;
 import org.eclipse.kura.net.status.NetworkInterfaceState;
 import org.eclipse.kura.net.status.NetworkInterfaceStatus;
 import org.eclipse.kura.nm.NMDeviceState;
+import org.eclipse.kura.usb.UsbNetDevice;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.Variant;
@@ -114,6 +115,24 @@ public class NMStatusConverterTest {
         thenResultingIp4InterfaceAddressIs(IPAddress.parseHostAddress("127.0.0.1"), (short) 8);
     }
 
+    @Test
+    public void buildEthernetStatusThrowsWithEmptyProperties() {
+        whenBuildEthernetStatusIsCalledWith("eth0", this.mockDeviceProperties, Optional.empty(), Optional.empty());
+
+        thenNullPointerExceptionIsThrown();
+    }
+
+    @Test
+    public void buildEthernetStatusThrowsWithPartialProperties() {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_UNMANAGED));
+        givenDevicePropertiesWith("Autoconnect", true);
+        givenDevicePropertiesWith("FirmwareVersion", "awesomeFirmwareVersion");
+
+        whenBuildEthernetStatusIsCalledWith("eth0", this.mockDeviceProperties, Optional.empty(), Optional.empty());
+
+        thenNullPointerExceptionIsThrown();
+    }
+
     /*
      * Given
      */
@@ -158,6 +177,16 @@ public class NMStatusConverterTest {
             Optional<Properties> ip4Properties) {
         try {
             this.resultingStatus = NMStatusConverter.buildLoopbackStatus(ifaceName, deviceProps, ip4Properties);
+        } catch (NullPointerException e) {
+            this.nullPointerExceptionWasThrown = true;
+        }
+    }
+
+    private void whenBuildEthernetStatusIsCalledWith(String ifaceName, Properties deviceProps,
+            Optional<Properties> ip4Properties, Optional<UsbNetDevice> usbDevice) {
+        try {
+            this.resultingStatus = NMStatusConverter.buildEthernetStatus(ifaceName, deviceProps, ip4Properties,
+                    usbDevice);
         } catch (NullPointerException e) {
             this.nullPointerExceptionWasThrown = true;
         }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -12,7 +12,9 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Optional;
 
+import org.eclipse.kura.net.IP4Address;
 import org.eclipse.kura.net.IPAddress;
+import org.eclipse.kura.net.status.NetworkInterfaceIpAddressStatus;
 import org.eclipse.kura.net.status.NetworkInterfaceState;
 import org.eclipse.kura.net.status.NetworkInterfaceStatus;
 import org.eclipse.kura.nm.NMDeviceState;
@@ -72,7 +74,7 @@ public class NMStatusConverterTest {
         thenResultingNetworkInterfaceMtuIs(42);
         thenResultingNetworkInterfaceHardwareAddressIs(new byte[] { 0, 0, 0, 0, 0, 0 });
 
-        assertEquals(Optional.empty(), this.resultingStatus.getInterfaceIp4Addresses());
+        thenResultingIp4InterfaceAddressIsMissing();
     }
 
     @Test
@@ -102,8 +104,7 @@ public class NMStatusConverterTest {
         thenResultingNetworkInterfaceHardwareAddressIs(
                 new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
 
-        assertEquals(IPAddress.parseHostAddress("127.0.0.1"),
-                this.resultingStatus.getInterfaceIp4Addresses().get().getGateway().get());
+        thenResultingIp4InterfaceGatewayIs(IPAddress.parseHostAddress("127.0.0.1"));
     }
 
     /*
@@ -171,5 +172,19 @@ public class NMStatusConverterTest {
 
     private void thenResultingNetworkInterfaceHardwareAddressIs(byte[] expectedResult) {
         assertArrayEquals(expectedResult, this.resultingStatus.getHardwareAddress());
+    }
+
+    private void thenResultingIp4InterfaceAddressIsMissing() {
+        assertFalse(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+    }
+
+    private void thenResultingIp4InterfaceGatewayIs(IPAddress expectedResult) {
+        assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+        NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
+
+        assertTrue(address.getGateway().isPresent());
+        IPAddress gateway = address.getGateway().get();
+
+        assertEquals(expectedResult, gateway);
     }
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -40,6 +40,17 @@ public class NMStatusConverterTest {
     }
 
     @Test
+    public void buildLoopbackStatusThrowsWithPartialProperties() {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_UNMANAGED));
+        givenDevicePropertiesWith("Autoconnect", true);
+        givenDevicePropertiesWith("FirmwareVersion", "awesomeFirmwareVersion");
+
+        whenBuildLoopbackStatusIsCalledWith("lo", this.mockDeviceProperties, Optional.empty());
+
+        thenNullPointerExceptionIsThrown();
+    }
+
+    @Test
     public void buildLoopbackStatusWorksWithoutIPV4Info() {
         givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_UNMANAGED));
         givenDevicePropertiesWith("Autoconnect", true);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -94,6 +94,10 @@ public class NMStatusConverterTest {
                 this.resultingStatus.getInterfaceIp4Addresses().get().getGateway().get());
     }
 
+    /*
+     * Given
+     */
+
     private void givenDevicePropertiesWith(String propertyName, Object propertyValue) {
         when(this.mockDeviceProperties.Get(eq(NM_DEVICE_BUS_NAME), eq(propertyName)))
                 .thenReturn(propertyValue);
@@ -104,6 +108,10 @@ public class NMStatusConverterTest {
                 .thenReturn(propertyValue);
     }
 
+    /*
+     * When
+     */
+
     private void whenBuildLoopbackStatusIsCalledWith(String ifaceName, Properties deviceProps,
             Optional<Properties> ip4Properties) {
         try {
@@ -112,6 +120,10 @@ public class NMStatusConverterTest {
             this.nullPointerExceptionWasThrown = true;
         }
     }
+
+    /*
+     * Then
+     */
 
     private void thenNoExceptionIsThrown() {
         assertFalse(this.nullPointerExceptionWasThrown);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -1,0 +1,49 @@
+package org.eclipse.kura.nm.status;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.eclipse.kura.net.status.NetworkInterfaceState;
+import org.eclipse.kura.net.status.NetworkInterfaceStatus;
+import org.eclipse.kura.nm.NMDeviceState;
+import org.freedesktop.dbus.interfaces.Properties;
+import org.freedesktop.dbus.types.UInt32;
+import org.junit.Test;
+
+public class NMStatusConverterTest {
+
+    private static final String NM_DEVICE_BUS_NAME = "org.freedesktop.NetworkManager.Device";
+
+    @Test
+    public void buildLoopbackStatusWorksWithoutIPV4Info() {
+        Properties mockProperties = mock(Properties.class);
+
+        when(mockProperties.Get(eq(NM_DEVICE_BUS_NAME), eq("State")))
+                .thenReturn(NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_UNMANAGED));
+        when(mockProperties.Get(eq(NM_DEVICE_BUS_NAME), eq("Autoconnect"))).thenReturn(true);
+        when(mockProperties.Get(eq(NM_DEVICE_BUS_NAME), eq("FirmwareVersion"))).thenReturn("awesomeFirmwareVersion");
+        when(mockProperties.Get(eq(NM_DEVICE_BUS_NAME), eq("Driver"))).thenReturn("awesomeDriver");
+        when(mockProperties.Get(eq(NM_DEVICE_BUS_NAME), eq("DriverVersion"))).thenReturn("awesomeDriverVersion");
+        when(mockProperties.Get(eq(NM_DEVICE_BUS_NAME), eq("Mtu"))).thenReturn(new UInt32(42));
+        when(mockProperties.Get(eq(NM_DEVICE_BUS_NAME), eq("HwAddress"))).thenReturn("00:00:00:00:00:00");
+
+        NetworkInterfaceStatus status = NMStatusConverter.buildLoopbackStatus("lo", mockProperties, Optional.empty());
+
+        assertTrue(status.isAutoConnect());
+        assertEquals(NetworkInterfaceState.UNMANAGED, status.getState());
+        assertEquals("awesomeFirmwareVersion", status.getFirmwareVersion());
+        assertEquals("awesomeDriver", status.getDriver());
+        assertEquals("awesomeDriverVersion", status.getDriverVersion());
+        assertEquals(42, status.getMtu());
+        assertArrayEquals(new byte[] { 0, 0, 0, 0, 0, 0 }, status.getHardwareAddress());
+
+        assertEquals(Optional.empty(), status.getInterfaceIp4Addresses());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -66,13 +66,13 @@ public class NMStatusConverterTest {
 
     @Test
     public void buildLoopbackStatusWorksWithIPV4Info() throws UnknownHostException {
-        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_UNMANAGED));
-        givenDevicePropertiesWith("Autoconnect", true);
-        givenDevicePropertiesWith("FirmwareVersion", "awesomeFirmwareVersion");
-        givenDevicePropertiesWith("Driver", "awesomeDriver");
-        givenDevicePropertiesWith("DriverVersion", "awesomeDriverVersion");
-        givenDevicePropertiesWith("Mtu", new UInt32(42));
-        givenDevicePropertiesWith("HwAddress", "00:00:00:00:00:00");
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
+        givenDevicePropertiesWith("Autoconnect", false);
+        givenDevicePropertiesWith("FirmwareVersion", "isThisRealLife");
+        givenDevicePropertiesWith("Driver", "isThisJustFantasy");
+        givenDevicePropertiesWith("DriverVersion", "caughtInALandslide");
+        givenDevicePropertiesWith("Mtu", new UInt32(69));
+        givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
 
         givenIpv4ConfigPropertiesWith("Gateway", "127.0.0.1");
         givenIpv4ConfigPropertiesWith("NameserverData", Arrays.asList());
@@ -82,13 +82,14 @@ public class NMStatusConverterTest {
 
         thenNoExceptionIsThrown();
 
-        thenResultingNetworkInterfaceAutoConnectIs(true);
-        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.UNMANAGED);
-        thenResultingNetworkInterfaceFirmwareVersionIs("awesomeFirmwareVersion");
-        thenResultingNetworkInterfaceDriverIs("awesomeDriver");
-        thenResultingNetworkInterfaceDriverVersionIs("awesomeDriverVersion");
-        thenResultingNetworkInterfaceMtuIs(42);
-        thenResultingNetworkInterfaceHardwareAddressIs(new byte[] { 0, 0, 0, 0, 0, 0 });
+        thenResultingNetworkInterfaceAutoConnectIs(false);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
+        thenResultingNetworkInterfaceDriverIs("isThisJustFantasy");
+        thenResultingNetworkInterfaceDriverVersionIs("caughtInALandslide");
+        thenResultingNetworkInterfaceMtuIs(69);
+        thenResultingNetworkInterfaceHardwareAddressIs(
+                new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
 
         assertEquals(IPAddress.parseHostAddress("127.0.0.1"),
                 this.resultingStatus.getInterfaceIp4Addresses().get().getGateway().get());

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -53,13 +53,13 @@ public class NMStatusConverterTest {
 
         thenNoExceptionIsThrown();
 
-        assertTrue(this.resultingStatus.isAutoConnect());
-        assertEquals(NetworkInterfaceState.UNMANAGED, this.resultingStatus.getState());
-        assertEquals("awesomeFirmwareVersion", this.resultingStatus.getFirmwareVersion());
-        assertEquals("awesomeDriver", this.resultingStatus.getDriver());
-        assertEquals("awesomeDriverVersion", this.resultingStatus.getDriverVersion());
-        assertEquals(42, this.resultingStatus.getMtu());
-        assertArrayEquals(new byte[] { 0, 0, 0, 0, 0, 0 }, this.resultingStatus.getHardwareAddress());
+        thenResultingNetworkInterfaceAutoConnectIs(true);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.UNMANAGED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("awesomeFirmwareVersion");
+        thenResultingNetworkInterfaceDriverIs("awesomeDriver");
+        thenResultingNetworkInterfaceDriverVersionIs("awesomeDriverVersion");
+        thenResultingNetworkInterfaceMtuIs(42);
+        thenResultingNetworkInterfaceHardwareAddressIs(new byte[] { 0, 0, 0, 0, 0, 0 });
 
         assertEquals(Optional.empty(), this.resultingStatus.getInterfaceIp4Addresses());
     }
@@ -82,13 +82,13 @@ public class NMStatusConverterTest {
 
         thenNoExceptionIsThrown();
 
-        assertTrue(this.resultingStatus.isAutoConnect());
-        assertEquals(NetworkInterfaceState.UNMANAGED, this.resultingStatus.getState());
-        assertEquals("awesomeFirmwareVersion", this.resultingStatus.getFirmwareVersion());
-        assertEquals("awesomeDriver", this.resultingStatus.getDriver());
-        assertEquals("awesomeDriverVersion", this.resultingStatus.getDriverVersion());
-        assertEquals(42, this.resultingStatus.getMtu());
-        assertArrayEquals(new byte[] { 0, 0, 0, 0, 0, 0 }, this.resultingStatus.getHardwareAddress());
+        thenResultingNetworkInterfaceAutoConnectIs(true);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.UNMANAGED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("awesomeFirmwareVersion");
+        thenResultingNetworkInterfaceDriverIs("awesomeDriver");
+        thenResultingNetworkInterfaceDriverVersionIs("awesomeDriverVersion");
+        thenResultingNetworkInterfaceMtuIs(42);
+        thenResultingNetworkInterfaceHardwareAddressIs(new byte[] { 0, 0, 0, 0, 0, 0 });
 
         assertEquals(IPAddress.parseHostAddress("127.0.0.1"),
                 this.resultingStatus.getInterfaceIp4Addresses().get().getGateway().get());
@@ -133,4 +133,31 @@ public class NMStatusConverterTest {
         assertTrue(this.nullPointerExceptionWasThrown);
     }
 
+    private void thenResultingNetworkInterfaceAutoConnectIs(boolean expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.isAutoConnect());
+    }
+
+    private void thenResultingNetworkInterfaceStateIs(NetworkInterfaceState expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getState());
+    }
+
+    private void thenResultingNetworkInterfaceFirmwareVersionIs(String expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getFirmwareVersion());
+    }
+
+    private void thenResultingNetworkInterfaceDriverIs(String expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getDriver());
+    }
+
+    private void thenResultingNetworkInterfaceDriverVersionIs(String expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getDriverVersion());
+    }
+
+    private void thenResultingNetworkInterfaceMtuIs(int expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getMtu());
+    }
+
+    private void thenResultingNetworkInterfaceHardwareAddressIs(byte[] expectedResult) {
+        assertArrayEquals(expectedResult, this.resultingStatus.getHardwareAddress());
+    }
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -37,6 +37,7 @@ public class NMStatusConverterTest {
 
     private Properties mockDeviceProperties = mock(Properties.class);
     private Properties mockIp4ConfigProperties = mock(Properties.class);
+    private UsbNetDevice mockUsbDevice = mock(UsbNetDevice.class);
 
     private NetworkInterfaceStatus resultingStatus;
     private EthernetInterfaceStatus resultingEthernetStatus;
@@ -203,6 +204,35 @@ public class NMStatusConverterTest {
         thenResultingIp4InterfaceAddressIs(IPAddress.parseHostAddress("192.168.1.82"), (short) 24);
     }
 
+    @Test
+    public void buildEthernetStatusWorksWithUsbDeviceInfo() {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
+        givenDevicePropertiesWith("Autoconnect", false);
+        givenDevicePropertiesWith("FirmwareVersion", "isThisRealLife");
+        givenDevicePropertiesWith("Driver", "isThisJustFantasy");
+        givenDevicePropertiesWith("DriverVersion", "caughtInALandslide");
+        givenDevicePropertiesWith("Mtu", new UInt32(69));
+        givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
+
+        whenBuildEthernetStatusIsCalledWith("eth0", this.mockDeviceProperties, Optional.empty(),
+                Optional.of(this.mockUsbDevice));
+
+        thenNoExceptionIsThrown();
+
+        thenResultingNetworkInterfaceIsVirtual(false);
+        thenResultingNetworkInterfaceAutoConnectIs(false);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
+        thenResultingNetworkInterfaceDriverIs("isThisJustFantasy");
+        thenResultingNetworkInterfaceDriverVersionIs("caughtInALandslide");
+        thenResultingNetworkInterfaceMtuIs(69);
+        thenResultingNetworkInterfaceHardwareAddressIs(
+                new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
+
+        thenResultingEthernetInterfaceLinkUpIs(true);
+        thenResultingEthernetInterfaceUsbDeviceIs(this.mockUsbDevice);
+    }
+
     /*
      * Given
      */
@@ -363,6 +393,11 @@ public class NMStatusConverterTest {
 
     private void thenResultingEthernetInterfaceUsbDeviceIsMissing() {
         assertFalse(this.resultingEthernetStatus.getUsbNetDevice().isPresent());
+    }
+
+    private void thenResultingEthernetInterfaceUsbDeviceIs(UsbNetDevice mockUsbDevice2) {
+        assertTrue(this.resultingEthernetStatus.getUsbNetDevice().isPresent());
+        assertEquals(mockUsbDevice2, this.resultingEthernetStatus.getUsbNetDevice().get());
     }
 
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -230,14 +230,16 @@ public class NMStatusConverterTest {
         assertTrue(dns.isEmpty());
     }
 
-    private void thenResultingIp4InterfaceDNSIs(IPAddress expectedResult) {
+    private void thenResultingIp4InterfaceDNSIs(List<IPAddress> expectedDNSAddresses) {
         assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
         NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
 
         List<IP4Address> dns = address.getDnsServerAddresses();
-        assertEquals(1, dns.size());
+        assertEquals(expectedDNSAddresses.size(), dns.size());
 
-        assertEquals(expectedResult, dns.get(0));
+        for (IPAddress expectedDNSAddress : expectedDNSAddresses) {
+            assertTrue(dns.contains(expectedDNSAddress));
+        }
     }
 
     private void thenResultingIp4InterfaceAddressIs(IPAddress expectedAddress, short expectedPrefix) {


### PR DESCRIPTION
This PR adds the unit tests for the `NMStatusConverter` class.

This PR depends on https://github.com/eclipse/kura/pull/4419 and tests won't pass until it is merged.