### PR TITLE
fix(nm): handle empty "Gateway" property correctly

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -415,7 +416,9 @@ public class NMStatusConverter {
     private static void setIP4Gateway(Properties ip4configProperties,
             NetworkInterfaceIpAddressStatus<IP4Address> ip4AddressStatus) throws UnknownHostException {
         String gateway = ip4configProperties.Get(NM_IP4CONFIG_BUS_NAME, "Gateway");
-        ip4AddressStatus.setGateway((IP4Address) IPAddress.parseHostAddress(gateway));
+        if (Objects.nonNull(gateway) && !gateway.isEmpty()) {
+            ip4AddressStatus.setGateway((IP4Address) IPAddress.parseHostAddress(gateway));
+        }
     }
 
     private static byte[] getMacAddressBytes(String macAddress) {


### PR DESCRIPTION
Fix for when the "Gateway" property returns an empty string in the `NMStatusConverter` code.

Due to [how `InetAddress.getByName` works](https://docs.oracle.com/javase/7/docs/api/java/net/InetAddress.html#getByName(java.lang.String)):

> If the host is null then an InetAddress representing an address of the loopback interface is returned. See [RFC 3330](http://www.ietf.org/rfc/rfc3330.txt) section 2 and [RFC 2373](http://www.ietf.org/rfc/rfc2373.txt) section 2.5.3.

the empty string gets converted to "127.0.0.1", but this is **wrong** in our case: the empty string means that the "Gateway" is not set!