### PR TITLE
feat: Added options for SQLite encryption extensions

### DIFF
--- a/kura/org.eclipse.kura.db.sqlite.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.db.sqlite.provider/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Bundle-ActivationPolicy: lazy
 Import-Package: com.zaxxer.hikari;version="2.7.9",
  org.eclipse.kura;version="[1.7,2.0)",
  org.eclipse.kura.configuration;version="[1.2,2.0)",
+ org.eclipse.kura.crypto;version="1.3.0",
  org.eclipse.kura.data;version="[1.1,2.0)",
  org.eclipse.kura.db;version="[2.0,2.1)",
  org.eclipse.kura.message.store;version="[1.0,2.0)",

--- a/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/metatype/org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl.xml
+++ b/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/metatype/org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl.xml
@@ -34,6 +34,25 @@
             default="/opt/mydb.sqlite"
             description="Defines the database path. The parameter value should be set to the absolute path to the database file (it should end with the database file name, it is not enough to specify only the parent directory). This parameter is only relevant for persisted databases.">
          </AD>
+         
+         <AD id="db.key"
+            name="Encryption Key"
+            type="Password"
+            cardinality="0" 
+            required="false"
+            description="Allows to specify a key/passphrase for encrypting the database file. This feature requires a SQLite binary with an encryption extension, and is only relevant for persisted databases. The key format can be specified using the Encryption Key Format parameter. If the value of this parameter is changed, the encryption key of the database will be updated accordingly. This parameter can be left empty to create an unencrypted database or to decrypt an encrypted one."/>
+            
+         <AD id="db.key.format"
+            name="Encryption Key Format"
+            type="String"
+            cardinality="0" 
+            required="true"
+            default="ASCII"
+            description="Allows to specify the format of the Encryption Key parameter value. The possible values are ASCII (an ASCII string), Hex SSE (the key is an hexadecimal string to be used with the SSE extension) or Hex SQLCipher (the key is an hexadecimal string to be used with the SQLCipher extension)">
+            <Option label="ASCII" value="ASCII"/>
+            <Option label="Hex SSE" value="HEX_SSE"/>
+            <Option label="Hex SQLCipher" value="HEX_SQLCIPHER"/>
+         </AD>
 
          <AD id="db.journal.mode"
             name="Journal Mode"

--- a/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl.xml
+++ b/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl.xml
@@ -21,4 +21,5 @@
    </service>
    <property name="service.pid" value="org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl"/>
    <reference bind="setDebugShell" cardinality="1..1" interface="org.eclipse.kura.internal.db.sqlite.provider.SqliteDebugShell" name="SqliteDebugShell" policy="static"/>
+   <reference bind="setCryptoService" cardinality="1..1" interface="org.eclipse.kura.crypto.CryptoService" name="CryptoService" policy="static"/>
 </scr:component>

--- a/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/DatabaseLoader.java
+++ b/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/DatabaseLoader.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.internal.db.sqlite.provider;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.crypto.CryptoService;
+import org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceOptions.EncryptionKeyFormat;
+import org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceOptions.EncryptionKeySpec;
+import org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceOptions.JournalMode;
+import org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceOptions.Mode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sqlite.SQLiteConfig;
+import org.sqlite.SQLiteDataSource;
+
+public class DatabaseLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseLoader.class);
+
+    private final SqliteDbServiceOptions newOptions;
+    private final Optional<SqliteDbServiceOptions> oldOptions;
+    private final CryptoService cryptoService;
+
+    public DatabaseLoader(final SqliteDbServiceOptions newOptions, final Optional<SqliteDbServiceOptions> oldOptions,
+            final CryptoService cryptoService) {
+        this.newOptions = newOptions;
+        this.oldOptions = oldOptions;
+        this.cryptoService = cryptoService;
+    }
+
+    protected SQLiteDataSource openDataSource() throws SQLException, KuraException {
+
+        final String dbUrl = this.newOptions.getDbUrl();
+
+        if (newOptions.getMode() != Mode.PERSISTED) {
+            return openDataSource(dbUrl, Optional.empty(), Optional.empty());
+        }
+
+        final List<Optional<EncryptionKeySpec>> applicableEncryptionKeys = new ArrayList<>();
+
+        final Optional<EncryptionKeySpec> keyFromNewOptions = this.newOptions.getEncryptionKey(cryptoService);
+
+        addEncryptionKey(applicableEncryptionKeys, keyFromNewOptions, "key from new options");
+
+        if (this.oldOptions.isPresent()) {
+            addEncryptionKey(applicableEncryptionKeys, this.oldOptions.get().getEncryptionKey(cryptoService),
+                    "key from old options");
+        }
+
+        addEncryptionKey(applicableEncryptionKeys, getCryptoServiceEntry(newOptions.getPath()),
+                "key from CryptoService");
+
+        applicableEncryptionKeys.add(Optional.empty());
+
+        Exception lastException = null;
+        final Optional<JournalMode> journalMode = Optional.of(this.newOptions.getJournalMode());
+
+        for (final Optional<EncryptionKeySpec> encryptionKey : applicableEncryptionKeys) {
+            try {
+                SQLiteDataSource result = openDataSource(dbUrl, encryptionKey, journalMode);
+
+                if (!encryptionKey.equals(keyFromNewOptions)) {
+                    changeEncryptionKey(result, keyFromNewOptions);
+                    result = openDataSource(dbUrl, keyFromNewOptions, journalMode);
+                }
+
+                updateCryptoServiceEntry(newOptions.getPath(), keyFromNewOptions);
+
+                return result;
+            } catch (final Exception e) {
+                logger.debug("database open attempt failed", e);
+                lastException = e;
+                // try next one
+            }
+        }
+
+        throw new SQLException("Failed to open database", lastException);
+    }
+
+    private void addEncryptionKey(final List<Optional<EncryptionKeySpec>> applicableEncryptionKeys,
+            final Optional<EncryptionKeySpec> keyFromNewOptions, final String type) {
+        if (keyFromNewOptions.isPresent()) {
+            logger.debug("adding {}", type);
+            applicableEncryptionKeys.add(keyFromNewOptions);
+        }
+    }
+
+    private void updateCryptoServiceEntry(final String dbPath, final Optional<EncryptionKeySpec> keyFromOptions)
+            throws KuraException {
+        final String entryKey = getCryptoServicePasswordEntryKey(dbPath);
+        final char[] entryValue = encodeCrtpyoServicePasswordEntry(keyFromOptions).toCharArray();
+
+        final char[] currentValue = this.cryptoService.getKeyStorePassword(entryKey);
+
+        if (!Arrays.equals(entryValue, currentValue)) {
+            this.cryptoService.setKeyStorePassword(entryKey, entryValue);
+        }
+    }
+
+    private String getCryptoServicePasswordEntryKey(final String dbPath) {
+        return "sqlite:db:" + dbPath;
+    }
+
+    private String encodeCrtpyoServicePasswordEntry(final Optional<EncryptionKeySpec> encryptionKey) {
+        if (encryptionKey.isPresent()) {
+            return encryptionKey.get().getFormat().name() + ":" + encryptionKey.get().getKey();
+        } else {
+            return "";
+        }
+    }
+
+    private Optional<EncryptionKeySpec> getCryptoServiceEntry(final String dbPath) {
+        try {
+            final String raw = new String(
+                    this.cryptoService.getKeyStorePassword(getCryptoServicePasswordEntryKey(dbPath)));
+
+            final int index = raw.indexOf(':');
+
+            final EncryptionKeyFormat format = EncryptionKeyFormat.valueOf(raw.substring(0, index));
+            final String key = raw.substring(index + 1);
+
+            return Optional.of(new EncryptionKeySpec(key, format));
+        } catch (final Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    protected SQLiteDataSource openDataSource(final String url, final Optional<EncryptionKeySpec> encryptionKey,
+            final Optional<JournalMode> journalMode) throws SQLException {
+        final SQLiteConfig config = new SQLiteConfig();
+
+        if (encryptionKey.isPresent()) {
+            config.setPragma(SQLiteConfig.Pragma.PASSWORD, encryptionKey.get().getKey());
+            config.setHexKeyMode(encryptionKey.get().getFormat().toHexKeyMode());
+        }
+
+        if (journalMode.isPresent()) {
+            config.setJournalMode(journalMode.get() == JournalMode.ROLLBACK_JOURNAL ? SQLiteConfig.JournalMode.DELETE
+                    : SQLiteConfig.JournalMode.WAL);
+        }
+
+        final SQLiteDataSource dataSource = buildDataSource(config);
+        dataSource.setUrl(url);
+
+        dataSource.getConnection().close();
+        return dataSource;
+    }
+
+    protected void changeEncryptionKey(final SQLiteDataSource dataSource,
+            final Optional<EncryptionKeySpec> encryptionKey) throws SQLException {
+        logger.info("Updating encryption key for {}", dataSource.getUrl());
+
+        if (encryptionKey.isPresent()) {
+            final EncryptionKeySpec encryptionKeySpec = encryptionKey.get();
+
+            final String key = encryptionKey.get().getKey().replace("'", "''");
+
+            if (encryptionKeySpec.getFormat() == EncryptionKeyFormat.HEX_SQLCIPHER) {
+                executeQuery(dataSource, "PRAGMA rekey = \"x'" + key + "'\";");
+            } else if (encryptionKeySpec.getFormat() == EncryptionKeyFormat.HEX_SSE) {
+                executeQuery(dataSource, "PRAGMA hexrekey = '" + key + "';");
+            } else {
+                executeQuery(dataSource, "PRAGMA rekey = '" + key + "';");
+            }
+        } else {
+            executeQuery(dataSource, "PRAGMA rekey = '';");
+        }
+    }
+
+    protected void executeQuery(final SQLiteDataSource dataSource, final String query) throws SQLException {
+        try (final Connection conn = dataSource.getConnection(); final Statement stmt = conn.createStatement()) {
+            stmt.execute(query);
+        }
+    }
+
+    protected SQLiteDataSource buildDataSource(final SQLiteConfig config) {
+        return new SQLiteDataSource(config);
+    }
+
+}

--- a/kura/test/org.eclipse.kura.db.sqlite.provider.test/META-INF/MANIFEST.MF
+++ b/kura/test/org.eclipse.kura.db.sqlite.provider.test/META-INF/MANIFEST.MF
@@ -13,5 +13,8 @@ Import-Package: org.apache.felix.service.command;version="1.0.0",
  org.eclipse.kura.core.testutil.service;version="[1.0,2.0)",
  org.eclipse.kura.db;version="2.0.0",
  org.junit;version="4.12.0",
+ org.mockito;version="4.8.1",
+ org.mockito.invocation;version="4.8.1",
+ org.mockito.stubbing;version="4.8.1",
  org.osgi.framework;version="1.10.0"
-Require-Bundle: org.eclipse.kura.db.sqlite.provider
+Fragment-Host: org.eclipse.kura.db.sqlite.provider

--- a/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/test/java/org/eclipse/kura/internal/db/sqlite/provider/DatabaseLoaderTest.java
+++ b/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/test/java/org/eclipse/kura/internal/db/sqlite/provider/DatabaseLoaderTest.java
@@ -1,0 +1,633 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.internal.db.sqlite.provider;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.crypto.CryptoService;
+import org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceOptions.EncryptionKeyFormat;
+import org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceOptions.EncryptionKeySpec;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sqlite.SQLiteConfig;
+import org.sqlite.SQLiteConfig.HexKeyMode;
+import org.sqlite.SQLiteConfig.JournalMode;
+import org.sqlite.SQLiteDataSource;
+
+public class DatabaseLoaderTest {
+
+    private static final String TEST_DB_CRYPTO_ENTRY_KEY = "sqlite:db:foo";
+
+    private static final String PERSISTED = "PERSISTED";
+
+    private static final String TEST_ENCRYPTION_KEY = "foobar";
+
+    private static final String DB_KEY = "db.key";
+
+    private static final String DB_PATH = "db.path";
+
+    private static final String KURA_SERVICE_PID = "kura.service.pid";
+
+    private static final String DB_MODE = "db.mode";
+
+    private static final String TEST_DB_URL = "jdbc:sqlite:file:foo";
+
+    @Test
+    public void shouldOpenInMemoryDatabase() {
+        givenNewOptionsProperty(DB_MODE, "IN_MEMORY");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+        thenOpenDataSourceInvocationCountIs(1);
+        thenOpenDataSourceInvocationUrlIs(0, "jdbc:sqlite:file:foo?mode=memory&cache=shared");
+        thenOpenDataSourceInvocationKeyIs(0, Optional.empty());
+
+        thenThereAreNoEntriesInCryptoService();
+    }
+
+    @Test
+    public void shouldOpenUnencryptedDatabaseIfNoPasswordsAreStored() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenUnencryptedDatabase();
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(1);
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(0, Optional.empty());
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY, "");
+        thenCryptoServiceUpdateCountIs(1);
+    }
+
+    @Test
+    public void shouldSupportRollbackJournalMode() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenNewOptionsProperty("db.journal.mode", "ROLLBACK_JOURNAL");
+        givenUnencryptedDatabase();
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(1);
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.DELETE);
+        thenOpenDataSourceInvocationKeyIs(0, Optional.empty());
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY, "");
+        thenCryptoServiceUpdateCountIs(1);
+    }
+
+    @Test
+    public void shouldOpenUnencryptedDatabaseWithPasswordInOldOptions() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+
+        givenOldOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+
+        givenUnencryptedDatabase();
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+        thenOpenDataSourceInvocationCountIs(2);
+
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII)));
+
+        thenOpenDataSourceInvocationUrlIs(1, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(1, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(1, Optional.empty());
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY, "");
+    }
+
+    @Test
+    public void shouldOpenUnencryptedDatabaseWithPasswordInCrypto() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+
+        givenCryptoServiceEntry(TEST_DB_CRYPTO_ENTRY_KEY, "ASCII:" + TEST_ENCRYPTION_KEY);
+
+        givenUnencryptedDatabase();
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+        thenOpenDataSourceInvocationCountIs(2);
+
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII)));
+
+        thenOpenDataSourceInvocationUrlIs(1, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(1, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(1, Optional.empty());
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY, "");
+    }
+
+    @Test
+    public void shouldOpenEncryptedDatabaseIfNoPasswordsAreStoredWithAsciiKey() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenNewOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII));
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(1);
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII)));
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY,
+                EncryptionKeyFormat.ASCII.name() + ":" + TEST_ENCRYPTION_KEY);
+    }
+
+    @Test
+    public void shouldOpenEncryptedDatabaseIfNoPasswordsAreStoredWithSSEHekKey() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenNewOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+        givenNewOptionsProperty("db.key.format", EncryptionKeyFormat.HEX_SSE.name());
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.HEX_SSE));
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(1);
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.HEX_SSE)));
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY,
+                EncryptionKeyFormat.HEX_SSE.name() + ":" + TEST_ENCRYPTION_KEY);
+    }
+
+    @Test
+    public void shouldOpenEncryptedDatabaseIfNoPasswordsAreStoredWithSQLCipherHekKey() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenNewOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+        givenNewOptionsProperty("db.key.format", EncryptionKeyFormat.HEX_SQLCIPHER.name());
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.HEX_SQLCIPHER));
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(1);
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.HEX_SQLCIPHER)));
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY,
+                EncryptionKeyFormat.HEX_SQLCIPHER.name() + ":" + TEST_ENCRYPTION_KEY);
+    }
+
+    @Test
+    public void shouldDecryptEncryptedDatabaseWithPasswordInOldOptions() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenOldOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII));
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(2);
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII)));
+
+        thenOpenDataSourceInvocationUrlIs(1, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(1, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(1, Optional.empty());
+
+        thenQueryIsExecuted(0, "PRAGMA rekey = '';");
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY, "");
+
+    }
+
+    @Test
+    public void shouldDecryptEncryptedDatabaseWithPasswordInCrypto() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenOldOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+
+        givenCryptoServiceEntry(TEST_DB_CRYPTO_ENTRY_KEY, "ASCII:" + TEST_ENCRYPTION_KEY);
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII));
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(2);
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII)));
+
+        thenOpenDataSourceInvocationUrlIs(1, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(1, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(1, Optional.empty());
+
+        thenQueryIsExecuted(0, "PRAGMA rekey = '';");
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY, "");
+    }
+
+    @Test
+    public void shouldSupportRekeyWithAsciiKey() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenOldOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+        givenNewOptionsProperty(DB_KEY, "otherkey");
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII));
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(3);
+
+        thenOpenDataSourceInvocationKeyIs(0, Optional.of(new EncryptionKeySpec("otherkey", EncryptionKeyFormat.ASCII)));
+        thenOpenDataSourceInvocationKeyIs(1,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII)));
+        thenOpenDataSourceInvocationKeyIs(2, Optional.of(new EncryptionKeySpec("otherkey", EncryptionKeyFormat.ASCII)));
+
+        thenQueryIsExecuted(0, "PRAGMA rekey = 'otherkey';");
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY, "ASCII:otherkey");
+    }
+
+    @Test
+    public void shouldSupportRekeyWithSseHexKey() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenOldOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+        givenNewOptionsProperty(DB_KEY, "otherkey");
+        givenNewOptionsProperty("db.key.format", EncryptionKeyFormat.HEX_SSE.name());
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII));
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(3);
+
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec("otherkey", EncryptionKeyFormat.HEX_SSE)));
+        thenOpenDataSourceInvocationKeyIs(1,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII)));
+        thenOpenDataSourceInvocationKeyIs(2,
+                Optional.of(new EncryptionKeySpec("otherkey", EncryptionKeyFormat.HEX_SSE)));
+
+        thenQueryIsExecuted(0, "PRAGMA hexrekey = 'otherkey';");
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY, "HEX_SSE:otherkey");
+    }
+
+    @Test
+    public void shouldSupportRekeyWithSqlcipherHexKey() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenOldOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+        givenNewOptionsProperty(DB_KEY, "otherkey");
+        givenNewOptionsProperty("db.key.format", EncryptionKeyFormat.HEX_SQLCIPHER.name());
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII));
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(3);
+
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec("otherkey", EncryptionKeyFormat.HEX_SQLCIPHER)));
+        thenOpenDataSourceInvocationKeyIs(1,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII)));
+        thenOpenDataSourceInvocationKeyIs(2,
+                Optional.of(new EncryptionKeySpec("otherkey", EncryptionKeyFormat.HEX_SQLCIPHER)));
+
+        thenQueryIsExecuted(0, "PRAGMA rekey = \"x'otherkey'\";");
+
+        thenCryptoServiceEntryIs(TEST_DB_CRYPTO_ENTRY_KEY, "HEX_SQLCIPHER:otherkey");
+    }
+
+    @Test
+    public void shouldNotUpdateCryptoServiceStoredKeysIfNotNeeded() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenNewOptionsProperty(DB_KEY, TEST_ENCRYPTION_KEY);
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII));
+        givenCryptoServiceEntry(TEST_DB_CRYPTO_ENTRY_KEY, EncryptionKeyFormat.ASCII.name() + ":" + TEST_ENCRYPTION_KEY);
+
+        whenDataSourceIsCreated();
+
+        thenNoExceptionIsThrown();
+
+        thenOpenDataSourceInvocationCountIs(1);
+        thenOpenDataSourceInvocationUrlIs(0, TEST_DB_URL);
+        thenOpenDataSourceInvocationJournalModeIs(0, JournalMode.WAL);
+        thenOpenDataSourceInvocationKeyIs(0,
+                Optional.of(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII)));
+
+        thenCryptoServiceUpdateCountIs(0);
+    }
+
+    @Test
+    public void shouldFailIfCorrectEncryptionKeyIsUnknown() {
+        givenNewOptionsProperty(DB_MODE, PERSISTED);
+        givenNewOptionsProperty(DB_PATH, "foo");
+        givenNewOptionsProperty(KURA_SERVICE_PID, "foo");
+        givenNewOptionsProperty(DB_KEY, "first");
+        givenOldOptionsProperty(DB_KEY, "second");
+        givenCryptoServiceEntry(TEST_DB_CRYPTO_ENTRY_KEY, EncryptionKeyFormat.ASCII.name() + ":third");
+
+        givenEncryptedDatabase(new EncryptionKeySpec(TEST_ENCRYPTION_KEY, EncryptionKeyFormat.ASCII));
+
+        whenDataSourceIsCreated();
+
+        thenExceptionIsThrown(SQLException.class);
+    }
+
+    private final CryptoService cryptoService = mock(CryptoService.class);
+
+    private Map<String, Object> currentProperties = new HashMap<>();
+    private Optional<Map<String, Object>> oldProperties = Optional.empty();
+    private Map<String, String> cryptoServiceEntries = new HashMap<>();
+
+    private Optional<Exception> exception = Optional.empty();
+    private DatabaseLoader loader;
+
+    private Map<String, Optional<EncryptionKeySpec>> databaseEncryptionKeys = new HashMap<>();
+
+    private final List<SQLiteConfig> sqliteConfigs = new ArrayList<>();
+    private final List<SQLiteDataSource> dataSources = new ArrayList<>();
+    private final List<String> queries = new ArrayList<>();
+    private int cryptoServiceUpdateCount = 0;
+
+    public DatabaseLoaderTest() {
+        when(cryptoService.getKeyStorePassword(any())).thenAnswer(i -> Optional
+                .ofNullable(cryptoServiceEntries.get(i.getArgument(0))).map(String::toCharArray).orElse(null));
+
+        try {
+            when(cryptoService.decryptAes(any(char[].class))).then(i -> i.getArgument(0));
+
+            Mockito.doAnswer(i -> {
+                cryptoServiceUpdateCount++;
+                cryptoServiceEntries.put(i.getArgument(0), new String(i.getArgument(1, char[].class)));
+                return null;
+            }).when(cryptoService).setKeyStorePassword(any(), any(char[].class));
+        } catch (KuraException e) {
+            throw new IllegalStateException();
+        }
+    }
+
+    private void givenEncryptedDatabase(final EncryptionKeySpec encryptionKey) {
+        givenEncryptedDatabase(TEST_DB_URL, encryptionKey);
+    }
+
+    private void givenUnencryptedDatabase() {
+        givenUnencryptedDatabase(TEST_DB_URL);
+    }
+
+    private void givenEncryptedDatabase(final String path, final EncryptionKeySpec encryptionKey) {
+        this.databaseEncryptionKeys.put(path, Optional.of(encryptionKey));
+    }
+
+    private void givenUnencryptedDatabase(final String path) {
+        this.databaseEncryptionKeys.put(path, Optional.empty());
+    }
+
+    private void givenCryptoServiceEntry(final String key, final String value) {
+        this.cryptoServiceEntries.put(key, value);
+    }
+
+    private void givenNewOptionsProperty(final String key, final String value) {
+        currentProperties.put(key, value);
+    }
+
+    private void givenOldOptionsProperty(final String key, final String value) {
+
+        if (!oldProperties.isPresent()) {
+            oldProperties = Optional.of(new HashMap<>());
+        }
+
+        oldProperties.get().put(key, value);
+    }
+
+    private void givenDatabaseLoader() {
+
+        this.loader = new DatabaseLoader(new SqliteDbServiceOptions(currentProperties),
+                oldProperties.map(SqliteDbServiceOptions::new), cryptoService) {
+
+            @Override
+            protected void changeEncryptionKey(SQLiteDataSource dataSource, Optional<EncryptionKeySpec> encryptionKey)
+                    throws SQLException {
+                super.changeEncryptionKey(dataSource, encryptionKey);
+                databaseEncryptionKeys.put(dataSource.getUrl(), encryptionKey);
+            }
+
+            @Override
+            protected SQLiteDataSource buildDataSource(final SQLiteConfig config) {
+
+                try {
+                    sqliteConfigs.add(config);
+
+                    final Statement stmt = mock(Statement.class);
+
+                    when(stmt.execute(any())).thenAnswer(i -> {
+                        queries.add(i.getArgument(0));
+                        return false;
+                    });
+
+                    final Connection connection = mock(Connection.class);
+
+                    when(connection.createStatement()).thenReturn(stmt);
+
+                    final SQLiteDataSource dataSource = new SQLiteDataSource(config) {
+
+                        @Override
+                        public Connection getConnection() throws SQLException {
+
+                            final String url = getUrl();
+
+                            final Optional<EncryptionKeySpec> currentKey = databaseEncryptionKeys.get(url);
+
+                            if (url.contains("mode=memory") || Objects.equals(currentKey, fromSqliteConfig(config))) {
+                                return connection;
+                            } else {
+                                throw new SQLException();
+                            }
+                        }
+                    };
+
+                    dataSources.add(dataSource);
+
+                    return dataSource;
+                } catch (SQLException e) {
+                    throw new IllegalStateException();
+                }
+
+            }
+        };
+
+    }
+
+    private void whenDataSourceIsCreated() {
+        givenDatabaseLoader();
+        try {
+            this.loader.openDataSource();
+        } catch (Exception e) {
+            this.exception = Optional.of(e);
+        }
+    }
+
+    private void thenThereAreNoEntriesInCryptoService() {
+        assertTrue(this.cryptoServiceEntries.isEmpty());
+    }
+
+    private void thenCryptoServiceEntryIs(final String key, final String value) {
+        assertEquals(value, this.cryptoServiceEntries.get(key));
+    }
+
+    private void thenOpenDataSourceInvocationCountIs(final int count) {
+        assertEquals(count, this.sqliteConfigs.size());
+    }
+
+    private void thenOpenDataSourceInvocationUrlIs(final int index, final String path) {
+        assertEquals(path, this.dataSources.get(index).getUrl());
+    }
+
+    private void thenOpenDataSourceInvocationKeyIs(final int index, final Optional<EncryptionKeySpec> key) {
+        assertEquals(key, fromSqliteConfig(this.sqliteConfigs.get(index)));
+    }
+
+    private void thenOpenDataSourceInvocationJournalModeIs(final int index, final JournalMode journalMode) {
+        assertEquals(journalMode,
+                JournalMode.valueOf(this.sqliteConfigs.get(index).toProperties().getProperty("journal_mode")));
+    }
+
+    private void thenNoExceptionIsThrown() {
+        if (this.exception.isPresent()) {
+            this.exception.get().printStackTrace();
+        }
+
+        assertEquals(Optional.empty(), this.exception);
+    }
+
+    private void thenQueryIsExecuted(final int index, final String query) {
+        assertEquals(query, queries.get(index));
+    }
+
+    private void thenCryptoServiceUpdateCountIs(final int expectedCount) {
+        assertEquals(expectedCount, this.cryptoServiceUpdateCount);
+    }
+
+    private void thenExceptionIsThrown(final Class<? extends Exception> classz) {
+        if (!this.exception.isPresent()) {
+            fail("Exception expected");
+        }
+
+        assertEquals(classz, this.exception.get().getClass());
+    }
+
+    private Optional<EncryptionKeySpec> fromSqliteConfig(final SQLiteConfig config) {
+        final Properties properties = config.toProperties();
+
+        final Optional<String> key = Optional.ofNullable(properties.getProperty("password"));
+        final Optional<HexKeyMode> hexKeyMode = Optional.ofNullable(properties.getProperty("hexkey_mode"))
+                .map(HexKeyMode::valueOf);
+
+        if (key.isPresent() && hexKeyMode.isPresent()) {
+            EncryptionKeyFormat format;
+
+            if (hexKeyMode.get() == HexKeyMode.NONE) {
+                format = EncryptionKeyFormat.ASCII;
+            } else if (hexKeyMode.get() == HexKeyMode.SSE) {
+                format = EncryptionKeyFormat.HEX_SSE;
+            } else if (hexKeyMode.get() == HexKeyMode.SQLCIPHER) {
+                format = EncryptionKeyFormat.HEX_SQLCIPHER;
+            } else {
+                throw new IllegalStateException();
+            }
+
+            return Optional.of(new EncryptionKeySpec(key.get(), format));
+        } else {
+            return Optional.empty();
+        }
+
+    }
+}


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

* Adds options for configuring the encryption extensions supported by the `sqlite-jdbc` library.
* Using encryption extensions requires custom SQLite native libraries.
* Adds support for changing the encryption key and storing it in Kura `CryptoService` to mitigate possible issues caused by snapshot rollbacks with different keys.