### PR TITLE
fix(nm): data race on status retrieval after configuration apply

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/DeviceStateLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/DeviceStateLock.java
@@ -40,7 +40,6 @@ public class DeviceStateLock {
             logger.warn("Wait interrupted because of:", e);
             Thread.currentThread().interrupt();
         } finally {
-            // Disarm signal handler
             this.dbusConnection.removeSigHandler(Device.StateChanged.class, stateHandler);
         }
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/DeviceStateLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/DeviceStateLock.java
@@ -14,7 +14,6 @@ public class DeviceStateLock {
 
     private static final Logger logger = LoggerFactory.getLogger(DeviceStateLock.class);
 
-    // Arm signal handler
     private final CountDownLatch latch = new CountDownLatch(1);
     private NMDeviceStateChangeHandler stateHandler;
     private final DBusConnection dbusConnection;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/DeviceStateLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/DeviceStateLock.java
@@ -1,0 +1,44 @@
+package org.eclipse.kura.nm;
+
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.networkmanager.Device;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeviceStateLock {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeviceStateLock.class);
+
+    // Arm signal handler
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private NMDeviceStateChangeHandler stateHandler;
+    private final DBusConnection dbusConnection;
+
+    public DeviceStateLock(DBusConnection dbusConnection, String dbusPath, NMDeviceState expectedNmDeviceState)
+            throws DBusException {
+        if (Objects.isNull(dbusPath) || dbusPath.isEmpty() || dbusPath.equals("/")) {
+            throw new IllegalArgumentException(String.format("Illegat DBus path for DeviceSateLock \"%s\"", dbusPath));
+        }
+        this.dbusConnection = Objects.requireNonNull(dbusConnection);
+        this.stateHandler = new NMDeviceStateChangeHandler(latch, dbusPath, expectedNmDeviceState);
+
+        this.dbusConnection.addSigHandler(Device.StateChanged.class, stateHandler);
+    }
+
+    public void waitForSignal() throws DBusException {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            logger.warn("Wait interrupted because of:", e);
+            Thread.currentThread().interrupt();
+        } finally {
+            // Disarm signal handler
+            this.dbusConnection.removeSigHandler(Device.StateChanged.class, stateHandler);
+        }
+    }
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/DeviceStateLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/DeviceStateLock.java
@@ -2,6 +2,7 @@ package org.eclipse.kura.nm;
 
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
@@ -31,7 +32,10 @@ public class DeviceStateLock {
 
     public void waitForSignal() throws DBusException {
         try {
-            latch.await();
+            boolean countdownCompleted = latch.await(5, TimeUnit.SECONDS);
+            if (!countdownCompleted) {
+                logger.warn("Timeout elapsed. Exiting anyway");
+            }
         } catch (InterruptedException e) {
             logger.warn("Wait interrupted because of:", e);
             Thread.currentThread().interrupt();

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -270,6 +270,7 @@ public class NMDbusConnector {
 
             logger.info("New settings: {}", newConnectionSettings);
 
+            // Arm signal handler
             CountDownLatch latch = new CountDownLatch(1);
             NMDeviceStateChangeHandler stateHandler = new NMDeviceStateChangeHandler(latch, device.getObjectPath());
             this.dbusConnection.addSigHandler(Device.StateChanged.class, stateHandler);
@@ -286,14 +287,17 @@ public class NMDbusConnector {
             }
 
             try {
+                // Wait for signal
                 latch.await();
             } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                logger.warn("Wait interrupted for {} interface because:", iface, e);
+                Thread.currentThread().interrupt();
+            } finally {
+                // Disarm signal handler
+                logger.info("Wait complete");
+                this.dbusConnection.removeSigHandler(Device.StateChanged.class, stateHandler);
             }
 
-            logger.info("Wait complete");
-            this.dbusConnection.removeSigHandler(Device.StateChanged.class, stateHandler);
         }
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -237,7 +237,7 @@ public class NMDbusConnector {
             // once the apply method returns, some status/config information can still change.
             // The correct way to fix this would be by handling a signal coming from the DBus
             // but this still work 99% of the time.
-            Thread.sleep(1500);
+            Thread.sleep(1500);  // NOSONAR
         } catch (InterruptedException e) {
             logger.warn("Wait interrupted because of:", e);
             Thread.currentThread().interrupt();

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -230,6 +230,17 @@ public class NMDbusConnector {
 
             List<Device> availableInterfaces = getAllDevices();
             manageNonConfiguredInterfaces(configuredInterfaces, availableInterfaces);
+
+            // TEMPORARY FIX!
+            // All NMDbusConnector client expect that the apply method return only when
+            // the configuration was applied. Unfortunately, due to the asynch nature of DBus,
+            // once the apply method returns, some status/config information can still change.
+            // The correct way to fix this would be by handling a signal coming from the DBus
+            // but this still work 99% of the time.
+            Thread.sleep(1500);
+        } catch (InterruptedException e) {
+            logger.warn("Wait interrupted because of:", e);
+            Thread.currentThread().interrupt();
         } finally {
             lock.unlock();
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -255,16 +255,10 @@ public class NMDbusConnector {
         logger.info("Settings iface \"{}\":{}", iface, deviceType);
 
         if (interfaceStatus == KuraInterfaceStatus.DISABLED) {
-            NMDeviceState currentState = getDeviceState(device);
-            if (currentState != NMDeviceState.NM_DEVICE_STATE_DISCONNECTED) {
-                DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
-                        NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
-                disable(device);
-                dsLock.waitForSignal();
-            }
+            disable(device);
         } else if (interfaceStatus == KuraInterfaceStatus.UNMANAGED) {
             logger.info("Iface \"{}\" set as Kura UNMANAGED. Skipping configuration.", iface);
-        } else { // NMDeviceEnable.ENABLED
+        } else { // KuraInterfaceStatus.ENABLED
             if (Boolean.FALSE.equals(isDeviceManaged(device))) {
                 setDeviceManaged(device, true);
             }
@@ -318,7 +312,10 @@ public class NMDbusConnector {
     private void disable(Device device) throws DBusException {
         NMDeviceState deviceState = getDeviceState(device);
         if (Boolean.TRUE.equals(NMDeviceState.isConnected(deviceState))) {
+            DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
+                    NMDeviceState.NM_DEVICE_STATE_DISCONNECTED);
             device.Disconnect();
+            dsLock.waitForSignal();
         }
 
         Optional<Connection> connection = getAppliedConnection(device);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceStateChangeHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceStateChangeHandler.java
@@ -38,8 +38,7 @@ public class NMDeviceStateChangeHandler implements DBusSigHandler<Device.StateCh
         NMDeviceState newState = NMDeviceState.fromUInt32(s.getNewState());
 
         logger.info("Device state change detected: {} -> {}, for {}", oldState, newState, s.getPath());
-        if (s.getPath().equals(path) && (newState == NMDeviceState.NM_DEVICE_STATE_ACTIVATED
-                || newState == NMDeviceState.NM_DEVICE_STATE_FAILED)) {
+        if (s.getPath().equals(path) && newState == NMDeviceState.NM_DEVICE_STATE_CONFIG) {
             logger.info("Notify waiting thread");
             latch.countDown();
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceStateChangeHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceStateChangeHandler.java
@@ -23,12 +23,14 @@ public class NMDeviceStateChangeHandler implements DBusSigHandler<Device.StateCh
 
     private static final Logger logger = LoggerFactory.getLogger(NMDeviceStateChangeHandler.class);
 
-    private CountDownLatch latch;
-    private String path;
+    private final CountDownLatch latch;
+    private final String path;
+    private final NMDeviceState expectedState;
 
-    public NMDeviceStateChangeHandler(CountDownLatch latch, String path) {
+    public NMDeviceStateChangeHandler(CountDownLatch latch, String path, NMDeviceState expectedNmDeviceState) {
         this.latch = latch;
         this.path = path;
+        this.expectedState = expectedNmDeviceState;
     }
 
     @Override
@@ -38,7 +40,7 @@ public class NMDeviceStateChangeHandler implements DBusSigHandler<Device.StateCh
         NMDeviceState newState = NMDeviceState.fromUInt32(s.getNewState());
 
         logger.info("Device state change detected: {} -> {}, for {}", oldState, newState, s.getPath());
-        if (s.getPath().equals(path) && newState == NMDeviceState.NM_DEVICE_STATE_CONFIG) {
+        if (s.getPath().equals(path) && newState == this.expectedState) {
             logger.info("Notify waiting thread");
             latch.countDown();
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceStateChangeHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceStateChangeHandler.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.nm;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.networkmanager.Device;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NMDeviceStateChangeHandler implements DBusSigHandler<Device.StateChanged> {
+
+    private static final Logger logger = LoggerFactory.getLogger(NMDeviceStateChangeHandler.class);
+
+    private CountDownLatch latch;
+    private String path;
+
+    public NMDeviceStateChangeHandler(CountDownLatch latch, String path) {
+        this.latch = latch;
+        this.path = path;
+    }
+
+    @Override
+    public void handle(Device.StateChanged s) {
+
+        NMDeviceState oldState = NMDeviceState.fromUInt32(s.getOldState());
+        NMDeviceState newState = NMDeviceState.fromUInt32(s.getNewState());
+
+        logger.info("Device state change detected: {} -> {}, for {}", oldState, newState, s.getPath());
+        if (s.getPath().equals(path) && (newState == NMDeviceState.NM_DEVICE_STATE_ACTIVATED
+                || newState == NMDeviceState.NM_DEVICE_STATE_FAILED)) {
+            logger.info("Notify waiting thread");
+            latch.countDown();
+        }
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceStateChangeHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceStateChangeHandler.java
@@ -39,7 +39,7 @@ public class NMDeviceStateChangeHandler implements DBusSigHandler<Device.StateCh
         NMDeviceState oldState = NMDeviceState.fromUInt32(s.getOldState());
         NMDeviceState newState = NMDeviceState.fromUInt32(s.getNewState());
 
-        logger.info("Device state change detected: {} -> {}, for {}", oldState, newState, s.getPath());
+        logger.trace("Device state change detected: {} -> {}, for {}", oldState, newState, s.getPath());
         if (s.getPath().equals(path) && newState == this.expectedState) {
             logger.info("Notify waiting thread");
             latch.countDown();

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
@@ -95,7 +95,6 @@ public class NMStatusServiceImpl implements NetworkStatusService {
             logger.warn(
                     "Could not retrieve status for \"{}\" interface from NM because the DBus object path references got invalidated.",
                     interfaceName);
-            return Optional.empty();
         } catch (DBusException | KuraException e) {
             logger.warn("Could not retrieve status for \"{}\" interface from NM because: ", interfaceName, e);
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.kura.net.NetworkService;
 import org.eclipse.kura.net.status.NetworkInterfaceStatus;
 import org.eclipse.kura.net.status.NetworkStatusService;
 import org.eclipse.kura.nm.NMDbusConnector;
+import org.freedesktop.dbus.errors.UnknownMethod;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.slf4j.Logger;
@@ -90,6 +91,11 @@ public class NMStatusServiceImpl implements NetworkStatusService {
             if (Objects.nonNull(status)) {
                 networkInterfaceStatus = Optional.of(status);
             }
+        } catch (UnknownMethod e) {
+            logger.warn(
+                    "Could not retrieve status for \"{}\" interface from NM because the DBus object path references got invalidated.",
+                    interfaceName);
+            return Optional.empty();
         } catch (DBusException | KuraException e) {
             logger.warn("Could not retrieve status for \"{}\" interface from NM because: ", interfaceName, e);
         }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
@@ -40,6 +40,7 @@ import org.eclipse.kura.net.status.wifi.WifiMode;
 import org.eclipse.kura.net.status.wifi.WifiSecurity;
 import org.eclipse.kura.nm.NMDbusConnector;
 import org.eclipse.kura.usb.UsbNetDevice;
+import org.freedesktop.dbus.errors.UnknownMethod;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.junit.Test;
 
@@ -57,6 +58,13 @@ public class NMStatusServiceImplTest {
     public void shouldReturnEmptyIfInterfaceDoesNotExist() throws DBusException, UnknownHostException, KuraException {
         givenNMStatusServiceImplWithNonExistingInterface();
         whenInterfaceStatusIsRetrieved("non-existing-interface");
+        thenInterfaceStatusIsEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyIfDBusObjectVanishes() throws DBusException, UnknownHostException, KuraException {
+        givenNMStatusServiceImplThrowingUnknownMethod();
+        whenInterfaceStatusIsRetrieved("wlan1");
         thenInterfaceStatusIsEmpty();
     }
 
@@ -143,6 +151,12 @@ public class NMStatusServiceImplTest {
         createTestObjects();
         when(this.nmDbusConnector.getInterfaceStatus("non-existing-interface", networkService,
                 this.commandExecutorService)).thenThrow(DBusException.class);
+    }
+
+    private void givenNMStatusServiceImplThrowingUnknownMethod() throws DBusException, KuraException {
+        createTestObjects();
+        when(this.nmDbusConnector.getInterfaceStatus("wlan0", networkService, this.commandExecutorService))
+                .thenThrow(UnknownMethod.class);
     }
 
     private void givenNMStatusServiceImplWithEthernetInterface()


### PR DESCRIPTION
All clients of the `NMDBusConnector` expect that, after the `apply` method returns, the network configuration was applied **and the system is in a stable condition**.

Due to the asynchronous nature of the DBus protocol this is not completely true, even though the `dbus-java` library implements some facilities to this end.

We discovered the unexpected behaviour in:
- #4412 : When the signal listener are re-activated after the configuration `apply` they immediately trigger in an infinite loop of `apply` calls. This is because, when the `apply` method returns, the "configuration roll-out" is still in progress on the NetworkManager's end.
- #4417 : When the GUI sends the configuration to the `ConfigurationService` it immediately asks the `NetworkStatusService` for the status. This meant that some DBus object references were getting invalidated due to the "configuration roll-out". Resulting in a lot of `Caused by: org.freedesktop.dbus.errors.UnknownMethod: No such interface “org.freedesktop.DBus.Properties” on object at path /org/freedesktop/NetworkManager/IP4Config/230`

---

### Test performed

System in stable condition (i.e. no pending "configuration roll-out"). Through `busctl` I checked the DBus object for the `wlan0` interface.

```bash
busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager/Devices/3 org.freedesktop.NetworkManager.Device Ip4Config
o "/org/freedesktop/NetworkManager/IP4Config/230"
```

When pressing the "Apply" button on the Network configuration UI I find an exception in the log:

```bash
Caused by: org.freedesktop.dbus.errors.UnknownMethod: No such interface “org.freedesktop.DBus.Properties” on object at path /org/freedesktop/NetworkManager/IP4Config/230
```

Re-checking the DBus object for the `wlan0` interface:

```bash
busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager/Devices/3 org.freedesktop.NetworkManager.Device Ip4Config
o "/org/freedesktop/NetworkManager/IP4Config/232"
```

This is because, after the apply took effect, the `Ip4Config` object associated to `wlan0` changed **while the `NetworkStatusService` was serving a request and handling a reference to the old object**.

---

This issue should be split in two different problems affecting the two already mentioned PRs

“Vanishing DBus objects”: which affects the GUI when trying to access the network status after applying the new network settings

“Spurious configuration roll-back”: which affects the Configuration enforcement behaviour based on DBus signal captures. When the network configuration is updated we generate a lot of DBus signals. We should ignore them when detecting for external network configuration changes.

---

### Solution

To avoid the issue we need to ensure that:
- Be resilient to the DBus object path getting invalidated.
- When the `apply` method returns, Kura doesn't trigger the Configuration Enforcement mechanism by itself.

The solution is split in 3 different changes:
- "_Object vanishing issue_": In `NMStatusServiceImpl` we catch `UnknownMethod` exceptions and return an `Optional.empty()` if they happen. This is similar to what the old networking was doing when it couldn't retrieve status informations.
- "_Spurious configuration roll-back_": In the `apply` methods we wait for the `NM_DEVICE_STATE_CONFIG` to trigger on the device we're currently configuring before returning.
- "_Configuration enforcement_": We trigger the configuration roll-back only on when `NM_DEVICE_STATE_CONFIG` signal appears on device that Kura manages.

The last two items combined should avoid having the configuration infinite loop issue found in #4412 