### PR TITLE
fix: Simplified SQLite db service factory pid

### DIFF
--- a/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/metatype/org.eclipse.kura.db.SQLiteDbService.xml
+++ b/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/metatype/org.eclipse.kura.db.SQLiteDbService.xml
@@ -11,9 +11,9 @@
 
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
-    <OCD id="org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl" 
+    <OCD id="org.eclipse.kura.db.SQLiteDbService" 
          name="SqliteDbService" 
-         description="Sqlite based database service.">
+         description="SQLite based database service.">
 
         <AD id="db.mode"
             name="Database Mode"
@@ -101,7 +101,7 @@
             description="Enables or disables the interaction with this database instance using the sqlitedbg OSGi console command"/>
 
         </OCD>
-    <Designate pid="org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl" factoryPid="org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl">
-        <Object ocdref="org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl"/>
+    <Designate factoryPid="org.eclipse.kura.db.SQLiteDbService">
+        <Object ocdref="org.eclipse.kura.db.SQLiteDbService"/>
     </Designate>
 </MetaData>

--- a/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/org.eclipse.kura.db.SQLiteDbService.xml
+++ b/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/org.eclipse.kura.db.SQLiteDbService.xml
@@ -10,7 +10,7 @@
     SPDX-License-Identifier: EPL-2.0
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" enabled="true" activate="activate" configuration-policy="require" deactivate="deactivate" modified="updated" name="org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" enabled="true" activate="activate" configuration-policy="require" deactivate="deactivate" modified="updated" name="org.eclipse.kura.db.SQLiteDbService">
    <implementation class="org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl"/>
    <service>
       <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
@@ -19,7 +19,6 @@
       <provide interface="org.eclipse.kura.wire.store.provider.WireRecordStoreProvider"/>
       <provide interface="org.eclipse.kura.wire.store.provider.QueryableWireRecordStoreProvider"/>
    </service>
-   <property name="service.pid" value="org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl"/>
    <reference bind="setDebugShell" cardinality="1..1" interface="org.eclipse.kura.internal.db.sqlite.provider.SqliteDebugShell" name="SqliteDebugShell" policy="static"/>
    <reference bind="setCryptoService" cardinality="1..1" interface="org.eclipse.kura.crypto.CryptoService" name="CryptoService" policy="static"/>
 </scr:component>

--- a/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/main/java/org/eclipse/kura/db/sqlite/provider/test/SqliteDbServiceTestBase.java
+++ b/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/main/java/org/eclipse/kura/db/sqlite/provider/test/SqliteDbServiceTestBase.java
@@ -43,7 +43,7 @@ import org.osgi.framework.InvalidSyntaxException;
 
 public class SqliteDbServiceTestBase {
 
-    private static final String SQLITE_DB_SERVICE_FACTORY_PID = "org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl";
+    private static final String SQLITE_DB_SERVICE_FACTORY_PID = "org.eclipse.kura.db.SQLiteDbService";
     private static final AtomicInteger currentId = new AtomicInteger(0);
 
     private final ConfigurationService configurationService;

--- a/kura/test/org.eclipse.kura.message.store.provider.test/src/main/java/org/eclipse/kura/message/store/provider/test/TestTarget.java
+++ b/kura/test/org.eclipse.kura.message.store.provider.test/src/main/java/org/eclipse/kura/message/store/provider/test/TestTarget.java
@@ -81,7 +81,7 @@ public interface TestTarget {
         @Override
         public String storeFactoryPid() {
 
-            return "org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl";
+            return "org.eclipse.kura.db.SQLiteDbService";
         }
 
         @Override

--- a/kura/test/org.eclipse.kura.wire.db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/db/test/StoreTestTarget.java
+++ b/kura/test/org.eclipse.kura.wire.db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/db/test/StoreTestTarget.java
@@ -52,7 +52,7 @@ public interface StoreTestTarget {
 
         @Override
         public String factoryPid() {
-            return "org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl";
+            return "org.eclipse.kura.db.SQLiteDbService";
         }
 
         @Override


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Changes the currently not user friendly SQLite db service factory pid (`org.eclipse.kura.internal.db.sqlite.provider.SqliteDbServiceImpl`) to the more simple `org.eclipse.kura.db.SQLiteDbService`.
