### PR TITLE
refactor(api): use newly introduced WifiChannel data structure for reporting supported channels information

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiAccessPoint.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiAccessPoint.java
@@ -162,7 +162,7 @@ public class WifiAccessPoint {
             return false;
         }
         WifiAccessPoint other = (WifiAccessPoint) obj;
-        return this.channel == other.channel && Arrays.equals(this.hardwareAddress, other.hardwareAddress)
+        return Objects.equals(channel, other.channel) && Arrays.equals(this.hardwareAddress, other.hardwareAddress)
                 && this.maxBitrate == other.maxBitrate && this.mode == other.mode
                 && Objects.equals(this.rsnSecurity, other.rsnSecurity) && this.signalQuality == other.signalQuality
                 && Objects.equals(this.ssid, other.ssid) && Objects.equals(this.wpaSecurity, other.wpaSecurity);

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiAccessPoint.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiAccessPoint.java
@@ -30,8 +30,7 @@ public class WifiAccessPoint {
 
     private final String ssid;
     private final byte[] hardwareAddress;
-    private final long frequency;
-    private final int channel;
+    private final WifiChannel channel;
     private final WifiMode mode;
     private final long maxBitrate;
     private final int signalQuality;
@@ -41,7 +40,6 @@ public class WifiAccessPoint {
     private WifiAccessPoint(WifiAccessPointBuilder builder) {
         this.ssid = builder.ssid;
         this.hardwareAddress = builder.hardwareAddress;
-        this.frequency = builder.frequency;
         this.channel = builder.channel;
         this.mode = builder.mode;
         this.maxBitrate = builder.maxBitrate;
@@ -58,11 +56,7 @@ public class WifiAccessPoint {
         return this.hardwareAddress;
     }
 
-    public long getFrequency() {
-        return this.frequency;
-    }
-
-    public int getChannel() {
+    public WifiChannel getChannel() {
         return this.channel;
     }
 
@@ -94,8 +88,7 @@ public class WifiAccessPoint {
 
         private String ssid;
         private byte[] hardwareAddress;
-        private long frequency;
-        private int channel;
+        private WifiChannel channel;
         private WifiMode mode;
         private long maxBitrate;
         private int signalQuality;
@@ -115,12 +108,7 @@ public class WifiAccessPoint {
             return this;
         }
 
-        public WifiAccessPointBuilder withFrequency(long frequency) {
-            this.frequency = frequency;
-            return this;
-        }
-
-        public WifiAccessPointBuilder withChannel(int channel) {
+        public WifiAccessPointBuilder withChannel(WifiChannel channel) {
             this.channel = channel;
             return this;
         }
@@ -160,9 +148,8 @@ public class WifiAccessPoint {
         final int prime = 31;
         int result = 1;
         result = prime * result + Arrays.hashCode(this.hardwareAddress);
-        result = prime * result
-                + Objects.hash(this.channel, this.frequency, this.maxBitrate, this.mode, this.rsnSecurity,
-                        this.signalQuality, this.ssid, this.wpaSecurity);
+        result = prime * result + Objects.hash(this.channel, this.maxBitrate, this.mode, this.rsnSecurity,
+                this.signalQuality, this.ssid, this.wpaSecurity);
         return result;
     }
 
@@ -175,11 +162,10 @@ public class WifiAccessPoint {
             return false;
         }
         WifiAccessPoint other = (WifiAccessPoint) obj;
-        return this.channel == other.channel && this.frequency == other.frequency
-                && Arrays.equals(this.hardwareAddress, other.hardwareAddress) && this.maxBitrate == other.maxBitrate
-                && this.mode == other.mode && Objects.equals(this.rsnSecurity, other.rsnSecurity)
-                && this.signalQuality == other.signalQuality && Objects.equals(this.ssid, other.ssid)
-                && Objects.equals(this.wpaSecurity, other.wpaSecurity);
+        return this.channel == other.channel && Arrays.equals(this.hardwareAddress, other.hardwareAddress)
+                && this.maxBitrate == other.maxBitrate && this.mode == other.mode
+                && Objects.equals(this.rsnSecurity, other.rsnSecurity) && this.signalQuality == other.signalQuality
+                && Objects.equals(this.ssid, other.ssid) && Objects.equals(this.wpaSecurity, other.wpaSecurity);
     }
 
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiChannel.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiChannel.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.net.status.wifi;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * This class represent a WiFi channel, providing the channel number, frequency,
+ * status and other useful informations.
+ *
+ * @noextend This class is not intended to be subclassed by clients.
+ */
+@ProviderType
+public class WifiChannel {
+
+    private final int channel;
+    private final int frequency;
+    private Optional<Boolean> disabled;
+    private Optional<Float> attenuation;
+    private Optional<Boolean> noInitiatingRadiation;
+    private Optional<Boolean> radarDetection;
+
+    public WifiChannel(int channel, int frequency) {
+        this.channel = channel;
+        this.frequency = frequency;
+        this.attenuation = Optional.empty();
+        this.noInitiatingRadiation = Optional.empty();
+        this.radarDetection = Optional.empty();
+        this.disabled = Optional.empty();
+    }
+
+    public Integer getChannel() {
+        return this.channel;
+    }
+
+    public Integer getFrequency() {
+        return this.frequency;
+    }
+
+    public Optional<Float> getAttenuation() {
+        return this.attenuation;
+    }
+
+    public void setAttenuation(Float attenuation) {
+        this.attenuation = Optional.of(attenuation);
+    }
+
+    public Optional<Boolean> getNoInitiatingRadiation() {
+        return this.noInitiatingRadiation;
+    }
+
+    public void setNoInitiatingRadiation(Boolean noInitiatingRadiation) {
+        this.noInitiatingRadiation = Optional.of(noInitiatingRadiation);
+    }
+
+    public Optional<Boolean> getRadarDetection() {
+        return this.radarDetection;
+    }
+
+    public void setRadarDetection(Boolean radarDetection) {
+        this.radarDetection = Optional.of(radarDetection);
+    }
+
+    public Optional<Boolean> getDisabled() {
+        return this.disabled;
+    }
+
+    public void setDisabled(Boolean disabled) {
+        this.disabled = Optional.of(disabled);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.attenuation, this.channel, this.disabled, this.frequency, this.noInitiatingRadiation,
+                this.radarDetection);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        WifiChannel other = (WifiChannel) obj;
+        return Objects.equals(this.attenuation, other.attenuation) && this.channel == other.channel
+                && Objects.equals(this.disabled, other.disabled) && this.frequency == other.frequency
+                && Objects.equals(this.noInitiatingRadiation, other.noInitiatingRadiation)
+                && Objects.equals(this.radarDetection, other.radarDetection);
+    }
+
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiInterfaceStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/WifiInterfaceStatus.java
@@ -32,10 +32,7 @@ import org.osgi.annotation.versioning.ProviderType;
 public class WifiInterfaceStatus extends NetworkInterfaceStatus {
 
     private final Set<WifiCapability> capabilities;
-    private final List<Long> supportedBitrates;
-    private final Set<WifiRadioMode> supportedRadioModes;
-    private final List<Integer> supportedChannels;
-    private final List<Long> supportedFrequencies;
+    private final List<WifiChannel> channels;
     private final String countryCode;
     private final WifiMode mode;
     private final Optional<WifiAccessPoint> activeWifiAccessPoint;
@@ -44,10 +41,7 @@ public class WifiInterfaceStatus extends NetworkInterfaceStatus {
     private WifiInterfaceStatus(WifiInterfaceStatusBuilder builder) {
         super(builder);
         this.capabilities = builder.capabilities;
-        this.supportedBitrates = builder.supportedBitrates;
-        this.supportedRadioModes = builder.supportedRadioModes;
-        this.supportedChannels = builder.supportedChannels;
-        this.supportedFrequencies = builder.supportedFrequencies;
+        this.channels = builder.channels;
         this.countryCode = builder.countryCode;
         this.mode = builder.mode;
         this.activeWifiAccessPoint = builder.currentWifiAccessPoint;
@@ -58,20 +52,8 @@ public class WifiInterfaceStatus extends NetworkInterfaceStatus {
         return this.capabilities;
     }
 
-    public List<Long> getSupportedBitrates() {
-        return this.supportedBitrates;
-    }
-
-    public Set<WifiRadioMode> getSupportedRadioModes() {
-        return this.supportedRadioModes;
-    }
-
-    public List<Integer> getSupportedChannels() {
-        return this.supportedChannels;
-    }
-
-    public List<Long> getSupportedFrequencies() {
-        return this.supportedFrequencies;
+    public List<WifiChannel> getChannels() {
+        return this.channels;
     }
 
     public String getCountryCode() {
@@ -97,10 +79,7 @@ public class WifiInterfaceStatus extends NetworkInterfaceStatus {
     public static class WifiInterfaceStatusBuilder extends NetworkInterfaceStatusBuilder<WifiInterfaceStatusBuilder> {
 
         private Set<WifiCapability> capabilities = EnumSet.of(WifiCapability.NONE);
-        private List<Long> supportedBitrates = Collections.emptyList();
-        private Set<WifiRadioMode> supportedRadioModes = EnumSet.of(WifiRadioMode.UNKNOWN);
-        private List<Integer> supportedChannels = Collections.emptyList();
-        private List<Long> supportedFrequencies = Collections.emptyList();
+        private List<WifiChannel> channels = Collections.emptyList();
         private String countryCode = "00";
         private WifiMode mode = WifiMode.UNKNOWN;
         private Optional<WifiAccessPoint> currentWifiAccessPoint = Optional.empty();
@@ -111,23 +90,8 @@ public class WifiInterfaceStatus extends NetworkInterfaceStatus {
             return this;
         }
 
-        public WifiInterfaceStatusBuilder withSupportedBitrates(List<Long> supportedBitrates) {
-            this.supportedBitrates = supportedBitrates;
-            return this;
-        }
-
-        public WifiInterfaceStatusBuilder withSupportedRadioModes(Set<WifiRadioMode> supportedRadioModes) {
-            this.supportedRadioModes = supportedRadioModes;
-            return this;
-        }
-
-        public WifiInterfaceStatusBuilder withSupportedChannels(List<Integer> supportedChannels) {
-            this.supportedChannels = supportedChannels;
-            return this;
-        }
-
-        public WifiInterfaceStatusBuilder withSupportedFrequencies(List<Long> supportedFrequencies) {
-            this.supportedFrequencies = supportedFrequencies;
+        public WifiInterfaceStatusBuilder withWifiChannels(List<WifiChannel> channels) {
+            this.channels = channels;
             return this;
         }
 
@@ -170,8 +134,7 @@ public class WifiInterfaceStatus extends NetworkInterfaceStatus {
         int result = super.hashCode();
         result = prime * result
                 + Objects.hash(this.activeWifiAccessPoint, this.availableWifiAccessPoints, this.capabilities,
-                        this.countryCode, this.mode, this.supportedBitrates, this.supportedChannels,
-                        this.supportedFrequencies, this.supportedRadioModes);
+                        this.countryCode, this.mode, this.channels);
         return result;
     }
 
@@ -188,10 +151,7 @@ public class WifiInterfaceStatus extends NetworkInterfaceStatus {
                 && Objects.equals(this.availableWifiAccessPoints, other.availableWifiAccessPoints)
                 && Objects.equals(this.capabilities, other.capabilities)
                 && Objects.equals(this.countryCode, other.countryCode)
-                && this.mode == other.mode && Objects.equals(this.supportedBitrates, other.supportedBitrates)
-                && Objects.equals(this.supportedChannels, other.supportedChannels)
-                && Objects.equals(this.supportedFrequencies, other.supportedFrequencies)
-                && Objects.equals(this.supportedRadioModes, other.supportedRadioModes);
+                && this.mode == other.mode && Objects.equals(this.channels, other.channels);
     }
 
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -220,7 +220,6 @@ public class NMStatusConverter {
         UInt32 uintFrequency = nmAccessPoint.Get(NM_ACCESSPOINT_BUS_NAME, "Frequency");
         int frequency = uintFrequency.intValue();
         int channel = channelFrequencyConvert(frequency);
-
         builder.withChannel(new org.eclipse.kura.net.status.wifi.WifiChannel(channel, frequency));
 
         UInt32 maxBitrate = nmAccessPoint.Get(NM_ACCESSPOINT_BUS_NAME, "MaxBitrate");

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.kura.net.IP4Address;
 import org.eclipse.kura.net.IPAddress;
 import org.eclipse.kura.net.status.NetworkInterfaceIpAddress;
@@ -40,7 +39,6 @@ import org.eclipse.kura.net.status.wifi.WifiCapability;
 import org.eclipse.kura.net.status.wifi.WifiInterfaceStatus;
 import org.eclipse.kura.net.status.wifi.WifiInterfaceStatus.WifiInterfaceStatusBuilder;
 import org.eclipse.kura.net.status.wifi.WifiMode;
-import org.eclipse.kura.net.status.wifi.WifiRadioMode;
 import org.eclipse.kura.net.status.wifi.WifiSecurity;
 import org.eclipse.kura.net.wifi.WifiChannel;
 import org.eclipse.kura.nm.NM80211ApSecurityFlags;
@@ -161,11 +159,10 @@ public class NMStatusConverter {
         List<NMDeviceWifiCapabilities> capabilities = NMDeviceWifiCapabilities
                 .fromUInt32(wirelessDeviceProperties.Get(NM_DEVICE_WIRELESS_BUS_NAME, "WirelessCapabilities"));
         builder.withCapabilities(wifiCapabilitiesConvert(capabilities));
-        builder.withSupportedRadioModes(wifiRadioModesConvert(capabilities));
 
-        Pair<List<Integer>, List<Long>> kuraSupportedChannels = wifiChannelsConvert(supportedChannels);
-        builder.withSupportedChannels(kuraSupportedChannels.getLeft());
-        builder.withSupportedFrequencies(kuraSupportedChannels.getRight());
+        List<org.eclipse.kura.net.status.wifi.WifiChannel> kuraSupportedChannels = wifiChannelsConvert(
+                supportedChannels);
+        builder.withWifiChannels(kuraSupportedChannels);
 
         builder.withCountryCode(countryCode);
 
@@ -179,45 +176,22 @@ public class NMStatusConverter {
         builder.withAvailableWifiAccessPoints(wifiAccessPointConvert(accessPoints));
     }
 
-    private static Pair<List<Integer>, List<Long>> wifiChannelsConvert(List<WifiChannel> supportedChannels) {
-        List<Integer> kuraChannels = new ArrayList<>();
-        List<Long> kuraFrequencies = new ArrayList<>();
+    private static List<org.eclipse.kura.net.status.wifi.WifiChannel> wifiChannelsConvert(
+            List<WifiChannel> supportedChannels) {
+        List<org.eclipse.kura.net.status.wifi.WifiChannel> kuraChannels = new ArrayList<>();
 
         for (WifiChannel channel : supportedChannels) {
-            kuraChannels.add(channel.getChannel());
-            kuraFrequencies.add(channel.getFrequency().longValue());
+            org.eclipse.kura.net.status.wifi.WifiChannel kuraChannel = new org.eclipse.kura.net.status.wifi.WifiChannel(
+                    channel.getChannel(), channel.getFrequency());
+            kuraChannel.setAttenuation(channel.getAttenuation());
+            kuraChannel.setDisabled(channel.isDisabled());
+            kuraChannel.setNoInitiatingRadiation(channel.isNoInitiatingRadiation());
+            kuraChannel.setRadarDetection(channel.isRadarDetection());
+
+            kuraChannels.add(kuraChannel);
         }
 
-        return Pair.of(kuraChannels, kuraFrequencies);
-    }
-
-    private static Set<WifiRadioMode> wifiRadioModesConvert(List<NMDeviceWifiCapabilities> capabilities) {
-        List<WifiRadioMode> kuraRadioModes = new ArrayList<>();
-
-        if (!capabilities.contains(NMDeviceWifiCapabilities.NM_WIFI_DEVICE_CAP_FREQ_VALID)) {
-            // Device doesn't report frequency capabilities
-            kuraRadioModes.add(WifiRadioMode.UNKNOWN);
-            return new HashSet<>(kuraRadioModes);
-        }
-
-        if (capabilities.contains(NMDeviceWifiCapabilities.NM_WIFI_DEVICE_CAP_FREQ_2GHZ)) {
-            kuraRadioModes.add(WifiRadioMode.RADIO_MODE_80211B);
-            kuraRadioModes.add(WifiRadioMode.RADIO_MODE_80211G);
-        }
-
-        if (capabilities.contains(NMDeviceWifiCapabilities.NM_WIFI_DEVICE_CAP_FREQ_5GHZ)) {
-            kuraRadioModes.add(WifiRadioMode.RADIO_MODE_80211A);
-            kuraRadioModes.add(WifiRadioMode.RADIO_MODE_80211_AC);
-        }
-
-        if (capabilities.contains(NMDeviceWifiCapabilities.NM_WIFI_DEVICE_CAP_FREQ_2GHZ)
-                && capabilities.contains(NMDeviceWifiCapabilities.NM_WIFI_DEVICE_CAP_FREQ_5GHZ)) {
-            kuraRadioModes.add(WifiRadioMode.RADIO_MODE_80211NHT20);
-            kuraRadioModes.add(WifiRadioMode.RADIO_MODE_80211NHT40_ABOVE);
-            kuraRadioModes.add(WifiRadioMode.RADIO_MODE_80211NHT40_BELOW);
-        }
-
-        return new HashSet<>(kuraRadioModes);
+        return kuraChannels;
     }
 
     private static List<WifiAccessPoint> wifiAccessPointConvert(List<Properties> nmAccessPoints) {
@@ -243,9 +217,11 @@ public class NMStatusConverter {
         String rawHwAddress = nmAccessPoint.Get(NM_ACCESSPOINT_BUS_NAME, "HwAddress");
         builder.withHardwareAddress(getMacAddressBytes(rawHwAddress));
 
-        UInt32 frequency = nmAccessPoint.Get(NM_ACCESSPOINT_BUS_NAME, "Frequency");
-        builder.withFrequency(frequency.longValue());
-        builder.withChannel(channelFrequencyConvert(frequency));
+        UInt32 uintFrequency = nmAccessPoint.Get(NM_ACCESSPOINT_BUS_NAME, "Frequency");
+        int frequency = uintFrequency.intValue();
+        int channel = channelFrequencyConvert(frequency);
+
+        builder.withChannel(new org.eclipse.kura.net.status.wifi.WifiChannel(channel, frequency));
 
         UInt32 maxBitrate = nmAccessPoint.Get(NM_ACCESSPOINT_BUS_NAME, "MaxBitrate");
         builder.withMaxBitrate(maxBitrate.longValue());
@@ -264,9 +240,7 @@ public class NMStatusConverter {
         return builder.build();
     }
 
-    private static int channelFrequencyConvert(UInt32 frequency) {
-        int fMHz = frequency.intValue();
-
+    private static int channelFrequencyConvert(int fMHz) {
         /* see 802.11 17.3.8.3.2 and Annex J */
         if (fMHz == 2484) {
             return 14;
@@ -396,12 +370,10 @@ public class NMStatusConverter {
 
     private static void setIP4DnsServers(Properties ip4configProperties,
             NetworkInterfaceIpAddressStatus<IP4Address> ip4AddressStatus) throws UnknownHostException {
-        List<Map<String, Variant<?>>> nameserverData = ip4configProperties.Get(NM_IP4CONFIG_BUS_NAME,
-                "NameserverData");
+        List<Map<String, Variant<?>>> nameserverData = ip4configProperties.Get(NM_IP4CONFIG_BUS_NAME, "NameserverData");
         for (Map<String, Variant<?>> dns : nameserverData) {
-            ip4AddressStatus
-                    .addDnsServerAddress(
-                            (IP4Address) IPAddress.parseHostAddress(String.class.cast(dns.get("address").getValue())));
+            ip4AddressStatus.addDnsServerAddress(
+                    (IP4Address) IPAddress.parseHostAddress(String.class.cast(dns.get("address").getValue())));
         }
     }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
@@ -33,10 +33,10 @@ import org.eclipse.kura.net.status.loopback.LoopbackInterfaceStatus.LoopbackInte
 import org.eclipse.kura.net.status.wifi.WifiAccessPoint;
 import org.eclipse.kura.net.status.wifi.WifiAccessPoint.WifiAccessPointBuilder;
 import org.eclipse.kura.net.status.wifi.WifiCapability;
+import org.eclipse.kura.net.status.wifi.WifiChannel;
 import org.eclipse.kura.net.status.wifi.WifiInterfaceStatus;
 import org.eclipse.kura.net.status.wifi.WifiInterfaceStatus.WifiInterfaceStatusBuilder;
 import org.eclipse.kura.net.status.wifi.WifiMode;
-import org.eclipse.kura.net.status.wifi.WifiRadioMode;
 import org.eclipse.kura.net.status.wifi.WifiSecurity;
 import org.eclipse.kura.nm.NMDbusConnector;
 import org.eclipse.kura.usb.UsbNetDevice;
@@ -230,15 +230,9 @@ public class NMStatusServiceImplTest {
                 wifiStatus.getUsbNetDevice().get());
         assertEquals(2, wifiStatus.getCapabilities().size());
         assertEquals(EnumSet.of(WifiCapability.AP, WifiCapability.FREQ_2GHZ), wifiStatus.getCapabilities());
-        assertEquals(2, wifiStatus.getSupportedBitrates().size());
-        assertEquals(Arrays.asList(54L, 1000L), wifiStatus.getSupportedBitrates());
-        assertEquals(2, wifiStatus.getSupportedRadioModes().size());
-        assertEquals(EnumSet.of(WifiRadioMode.RADIO_MODE_80211A, WifiRadioMode.RADIO_MODE_80211G),
-                wifiStatus.getSupportedRadioModes());
-        assertEquals(4, wifiStatus.getSupportedChannels().size());
-        assertEquals(Arrays.asList(1, 2, 3, 4), wifiStatus.getSupportedChannels());
-        assertEquals(2, wifiStatus.getSupportedFrequencies().size());
-        assertEquals(Arrays.asList(900L, 2400L), wifiStatus.getSupportedFrequencies());
+        assertEquals(4, wifiStatus.getChannels().size());
+        assertEquals(Arrays.asList(new WifiChannel(1, 2412), new WifiChannel(2, 2417), new WifiChannel(3, 2422),
+                new WifiChannel(4, 2432)), wifiStatus.getChannels());
         assertEquals("IT", wifiStatus.getCountryCode());
         assertEquals(WifiMode.INFRA, wifiStatus.getMode());
         assertTrue(wifiStatus.getActiveWifiAccessPoint().isPresent());
@@ -334,10 +328,8 @@ public class NMStatusServiceImplTest {
         builder.withUsbNetDevice(
                 Optional.of(new UsbNetDevice("1234", "5678", "CoolManufacturer", "VeryCoolModem", "1", "3", "wlan0")));
         builder.withCapabilities(EnumSet.of(WifiCapability.AP, WifiCapability.FREQ_2GHZ));
-        builder.withSupportedBitrates(Arrays.asList(54L, 1000L));
-        builder.withSupportedRadioModes(EnumSet.of(WifiRadioMode.RADIO_MODE_80211A, WifiRadioMode.RADIO_MODE_80211G));
-        builder.withSupportedChannels(Arrays.asList(1, 2, 3, 4));
-        builder.withSupportedFrequencies(Arrays.asList(900L, 2400L));
+        builder.withWifiChannels(Arrays.asList(new WifiChannel(1, 2412), new WifiChannel(2, 2417),
+                new WifiChannel(3, 2422), new WifiChannel(4, 2432)));
         builder.withCountryCode("IT");
         builder.withMode(WifiMode.INFRA);
         builder.withActiveWifiAccessPoint(Optional.of(buildAP()));
@@ -389,8 +381,7 @@ public class NMStatusServiceImplTest {
         WifiAccessPointBuilder builder = WifiAccessPoint.builder();
         builder.withSsid("MyCoolAP");
         builder.withHardwareAddress(new byte[] { 0x00, 0x11, 0x02, 0x33, 0x44, 0x55 });
-        builder.withFrequency(5000L);
-        builder.withChannel(7);
+        builder.withChannel(new WifiChannel(7, 2442));
         builder.withMode(WifiMode.INFRA);
         builder.withMaxBitrate(54);
         builder.withSignalQuality(78);
@@ -402,8 +393,7 @@ public class NMStatusServiceImplTest {
     private void assertEqualAPProperties(WifiAccessPoint ap) {
         assertEquals("MyCoolAP", ap.getSsid());
         assertArrayEquals(new byte[] { 0x00, 0x11, 0x02, 0x33, 0x44, 0x55 }, ap.getHardwareAddress());
-        assertEquals(5000L, ap.getFrequency());
-        assertEquals(7, ap.getChannel());
+        assertEquals(new WifiChannel(7, 2442), ap.getChannel());
         assertEquals(WifiMode.INFRA, ap.getMode());
         assertEquals(54, ap.getMaxBitrate());
         assertEquals(78, ap.getSignalQuality());


### PR DESCRIPTION
We decided to provide the channel informations with a more comprehensive data structure than the already merged `List`s of integers.

This PR introduces the `WifiChannel` data structure which carries informations about:
- Channel
- Frequency
- (Optional) disabled
- (Optional) attenuation
- (Optional) initialiting radiation
- (Optional) radar detection

This PR also updates the consumers of the original data structures.