### PR TITLE
fix: Fixed unwanted inclusion of sqlite-jdbc jar in distrib

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -651,6 +651,7 @@ fi]]>
                 <exclude name="com.gwt.user_*" />
                 <exclude name="org.junit*" />
                 <exclude name="org.moka7*" />
+                <exclude name="org.xerial.sqlite-jdbc*" />
 
                 <!-- exclude source bundles -->
                 <exclude name="*.source_*.jar" />


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

* Fixed unwanted inclusion of `sqlite-jdbc` jar in distrib, the jar is currently intended to be distributed in a deployment package