### PR TITLE
fix(nm): avoid error on unavailable/corrupt MAC address

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -58,6 +58,8 @@ public class NMStatusConverter {
 
     private static final Logger logger = LoggerFactory.getLogger(NMStatusConverter.class);
 
+    private static final byte[] DEFAULT_MAC = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
     private static final String NM_DEVICE_BUS_NAME = "org.freedesktop.NetworkManager.Device";
     private static final String NM_DEVICE_WIRELESS_BUS_NAME = "org.freedesktop.NetworkManager.Device.Wireless";
     private static final String NM_ACCESSPOINT_BUS_NAME = "org.freedesktop.NetworkManager.AccessPoint";
@@ -414,14 +416,24 @@ public class NMStatusConverter {
     }
 
     private static byte[] getMacAddressBytes(String macAddress) {
-        String[] macAddressParts = macAddress.split(":");
-
-        byte[] macAddressBytes = new byte[6];
-        for (int i = 0; i < 6; i++) {
-            Integer hex = Integer.parseInt(macAddressParts[i], 16);
-            macAddressBytes[i] = hex.byteValue();
+        if (Objects.isNull(macAddress) || macAddress.isEmpty()) {
+            return DEFAULT_MAC;
         }
-
+        String[] macAddressParts = macAddress.split(":");
+        byte[] macAddressBytes = new byte[6];
+        try {
+            if (macAddressParts.length == 6) {
+                for (int i = 0; i < 6; i++) {
+                    Integer hex = Integer.parseInt(macAddressParts[i], 16);
+                    macAddressBytes[i] = hex.byteValue();
+                }
+            } else {
+                return DEFAULT_MAC;
+            }
+        } catch (NumberFormatException e) {
+            logger.warn("Cannot parse Hardware address", e);
+            return DEFAULT_MAC;
+        }
         return macAddressBytes;
     }
 


### PR DESCRIPTION
When scanning for nearby available Access Points the `NMStatusConverter` would throw:

``` 
java.lang.NumberFormatException: For input string: ""
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Integer.parseInt(Integer.java:592)
    at org.eclipse.kura.nm.status.NMStatusConverter.getMacAddressBytes(NMStatusConverter.java:421)
    at org.eclipse.kura.nm.status.NMStatusConverter.wifiAccessPointConvert(NMStatusConverter.java:244)
    at org.eclipse.kura.nm.status.NMStatusConverter.setWifiStatus(NMStatusConverter.java:175)
    at org.eclipse.kura.nm.status.NMStatusConverter.buildWirelessStatus(NMStatusConverter.java:120)
    at org.eclipse.kura.nm.NMDbusConnector.getInterfaceStatus(NMDbusConnector.java:188)
```

if one of the nearby AP is not advertising its MAC address.

This PR introduces a more reliable HW address conversion method that fixes the issue