### PR TITLE
fix: Extract sqlite native lib in bundle storage area

### DIFF
--- a/kura/org.eclipse.kura.db.sqlite.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.db.sqlite.provider/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.kura.internal.db.sqlite.provider.SqliteProviderActivator
 Import-Package: com.zaxxer.hikari;version="2.7.9",
  org.eclipse.kura;version="[1.7,2.0)",
  org.eclipse.kura.configuration;version="[1.2,2.0)",

--- a/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteProviderActivator.java
+++ b/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteProviderActivator.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.internal.db.sqlite.provider;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+public class SqliteProviderActivator implements BundleActivator {
+
+    private static final String SQLITE_TMPDIR_PROPERTY_KEY = "org.sqlite.tmpdir";
+
+    @Override
+    public void start(final BundleContext context) throws Exception {
+        if (System.getProperty(SQLITE_TMPDIR_PROPERTY_KEY) == null) {
+
+            final Optional<File> bundleStorageAreaLocation = Optional.ofNullable(context.getDataFile(""));
+
+            if (bundleStorageAreaLocation.isPresent()) {
+                System.setProperty(SQLITE_TMPDIR_PROPERTY_KEY, bundleStorageAreaLocation.get().getAbsolutePath());
+            }
+        }
+    }
+
+    @Override
+    public void stop(final BundleContext context) throws Exception {
+        // nothing to do
+    }
+
+}

--- a/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/main/java/org/eclipse/kura/db/sqlite/provider/test/SqliteDbServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/main/java/org/eclipse/kura/db/sqlite/provider/test/SqliteDbServiceImplTest.java
@@ -12,6 +12,9 @@
  ******************************************************************************/
 package org.eclipse.kura.db.sqlite.provider.test;
 
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
@@ -26,6 +29,16 @@ public class SqliteDbServiceImplTest extends SqliteDbServiceTestBase {
 
     public SqliteDbServiceImplTest() throws InterruptedException, ExecutionException, TimeoutException {
         super();
+    }
+
+    @Test
+    public void shouldNotExtractNativeLibrariesInJavaTempdir()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        givenSqliteDbService(Collections.emptyMap());
+
+        whenAConnectionIsRequested();
+
+        thenThereIsNoSqliteLibraryInJavaTempdir();
     }
 
     @Test
@@ -210,6 +223,13 @@ public class SqliteDbServiceImplTest extends SqliteDbServiceTestBase {
         whenAConnectionIsRequested();
 
         thenExceptionIsThrown();
+    }
+
+    private void thenThereIsNoSqliteLibraryInJavaTempdir() {
+        final File javaTempDir = new File(System.getProperty("java.io.tmpdir"));
+
+        assertArrayEquals(new String[] {}, javaTempDir.list((dir, name) -> name.startsWith("sqlite-")));
+
     }
 
 }

--- a/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/test/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteProviderActivatorTest.java
+++ b/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/test/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteProviderActivatorTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.internal.db.sqlite.provider;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
+
+public class SqliteProviderActivatorTest {
+
+    @Test
+    public void shouldSetSqliteTempDirIfUnset() {
+        givenBundleStorageAreaPath("/tmp/foo");
+
+        whenActivatorIsStarted();
+
+        thenNoExceptionIsThrown();
+        thenSystemPropertyValueIs("org.sqlite.tmpdir", "/tmp/foo");
+    }
+
+    @Test
+    public void shouldNotSetSqliteTempDirIfBundleStorageAreaIsNotAvailable() {
+        givenNoBundleStorageArea();
+
+        whenActivatorIsStarted();
+
+        thenNoExceptionIsThrown();
+        thenSystemPropertyValueIs("org.sqlite.tmpdir", null);
+    }
+
+    @Test
+    public void shouldNotChangeSqliteTempDirIfAlreadySet() {
+        givenSystemProperty("org.sqlite.tmpdir", "bar");
+        givenBundleStorageAreaPath("/tmp/foo");
+
+        whenActivatorIsStarted();
+
+        thenNoExceptionIsThrown();
+        thenSystemPropertyValueIs("org.sqlite.tmpdir", "bar");
+    }
+
+    private final BundleContext bundleContext = Mockito.mock(BundleContext.class);
+    private Optional<Exception> exception = Optional.empty();
+
+    private void givenBundleStorageAreaPath(String path) {
+        Mockito.when(bundleContext.getDataFile("")).thenReturn(new File(path));
+    }
+
+    private void givenNoBundleStorageArea() {
+        Mockito.when(bundleContext.getDataFile("")).thenReturn(null);
+    }
+
+    private void givenSystemProperty(final String key, final String value) {
+        System.setProperty(key, value);
+    }
+
+    private void whenActivatorIsStarted() {
+        try {
+            new SqliteProviderActivator().start(bundleContext);
+        } catch (Exception e) {
+            this.exception = Optional.of(e);
+        }
+
+    }
+
+    private void thenSystemPropertyValueIs(final String key, final String value) {
+        assertEquals(value, System.getProperty(key));
+    }
+
+    private void thenNoExceptionIsThrown() {
+        assertEquals(Optional.empty(), this.exception);
+
+    }
+}


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Currently sqlite-jdbc extracts the native libraries in the `/tmp` folder, this may cause problems for example if `/tmp` is cleaned up by `systemd-tmfiles`. This PR sets the `org.sqlite.tmpdir` system property to the bundle storage area (which is also in tmpfs in Kura by default), so that native libraries are extracted there. It should still be possible to override the `org.sqlite.tmpdir` property if needed.