### PR TITLE
feat: Added option to delete database files on failure in SQLite

### DIFF
--- a/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/metatype/org.eclipse.kura.db.SQLiteDbService.xml
+++ b/kura/org.eclipse.kura.db.sqlite.provider/OSGI-INF/metatype/org.eclipse.kura.db.SQLiteDbService.xml
@@ -66,7 +66,7 @@
          </AD>
 
          <AD id="db.defrag.interval.seconds"
-            name="Defrag interval (seconds)"
+            name="Defrag Interval (seconds)"
             type="Long"
             cardinality="0" 
             required="true"
@@ -84,13 +84,21 @@
             description="SqliteDbService instances support running periodic periodic WAL checkpoints (https://www.sqlite.org/pragma.html#pragma_wal_checkpoint). Checkpoints will be performed in TRUNCATE mode. This parameter specifies the interval in seconds beetween two consecutive checkpoints, set to zero to disable. This parameter is only relevant for persisted databases in WAL Journal Mode."/>
 
          <AD id="db.connection.pool.max.size"
-            name="Connection pool max size"
+            name="Connection Pool Max Size"
             type="Integer"
             cardinality="0" 
             required="true"
             default="10"
             min="1"
             description="The SqliteDbService manages connections using a connection pool. This parameter defines the maximum number of connections for the pool. Only 1 connection is available in In Memory mode."/>
+
+        <AD id="delete.db.files.on.failure"
+            name="Delete Database Files On Failure"
+            type="Boolean"
+            cardinality="0" 
+            required="true"
+            default="true"
+            description="If set to true, the database files will be deleted in case of failure in opening a persisted database. This is intended as a last resort measure for keeping the database service operational, especially in the case when it is used as a cloud connection message store."/>
 
         <AD id="debug.shell.access.enabled"
             name="Debug Shell Access Enabled"

--- a/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/DatabaseLoader.java
+++ b/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/DatabaseLoader.java
@@ -56,7 +56,6 @@ public class DatabaseLoader {
 
             if (this.newOptions.isDeleteDbFilesOnFailure() && this.newOptions.getMode() != Mode.IN_MEMORY) {
                 logger.warn("failed to open database, deleting database files and retrying", e);
-                logger.warn("deleting database files");
                 deleteDbFiles(newOptions.getPath());
                 return openDataSourceInternal();
             }
@@ -210,7 +209,7 @@ public class DatabaseLoader {
 
         for (final String path : paths) {
             try {
-                logger.info("deleting database file: {}");
+                logger.info("deleting database file: {}", path);
                 deleteFile(new File(path));
             } catch (final Exception e) {
                 logger.warn("failed to delete database file", e);


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

* Added an option to SQLite db service to delete database files if database cannot be opened, enabled by default to match the behavior of the H2DbService implementation
* Added sanitization of Db url
* Fixed inconsistencies between metatype and options default parameter values