### PR TITLE
fix: Use autoincrement for Sqlite WireRecordStore ID column

### DIFF
--- a/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteQueryableWireRecordStoreImpl.java
+++ b/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteQueryableWireRecordStoreImpl.java
@@ -40,7 +40,7 @@ public class SqliteQueryableWireRecordStoreImpl extends AbstractJdbcQueryableWir
 
         if ("INT".equals(typeName)) {
             dbExtractedData = resultSet.getInt(columnIndex);
-        } else if ("BIGINT".equals(typeName)) {
+        } else if ("BIGINT".equals(typeName) || "INTEGER".equals(typeName)) {
             dbExtractedData = resultSet.getLong(columnIndex);
         } else if ("BOOLEAN".equals(typeName)) {
             dbExtractedData = resultSet.getBoolean(columnIndex);

--- a/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteWireRecordStoreImpl.java
+++ b/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteWireRecordStoreImpl.java
@@ -48,7 +48,7 @@ public class SqliteWireRecordStoreImpl extends AbstractJdbcWireRecordStoreImpl {
         return JdbcWireRecordStoreQueries.builder()
                 .withSqlAddColumn("ALTER TABLE " + super.escapedTableName + " ADD COLUMN {0} {1};")
                 .withSqlCreateTable("CREATE TABLE IF NOT EXISTS " + super.escapedTableName
-                        + " (ID INTEGER PRIMARY KEY, TIMESTAMP BIGINT);")
+                        + " (ID INTEGER PRIMARY KEY AUTOINCREMENT, TIMESTAMP BIGINT);")
                 .withSqlRowCount("SELECT COUNT(*) FROM " + super.escapedTableName + ";")
                 .withSqlDeleteRangeTable("DELETE FROM " + super.escapedTableName + " WHERE ID IN (SELECT ID FROM "
                         + super.escapedTableName + " ORDER BY ID ASC LIMIT {0});")

--- a/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/test/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteDbServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.db.sqlite.provider.test/src/test/java/org/eclipse/kura/internal/db/sqlite/provider/SqliteDbServiceOptionsTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.internal.db.sqlite.provider;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class SqliteDbServiceOptionsTest {
+
+    @Test
+    public void shouldSupportDefaultPath() {
+        givenConfigurationProperty("kura.service.pid", "foo");
+
+        whenOptionsAreCreated();
+
+        thenDbPathIs("/opt/mydb.sqlite");
+        thenDbUrlIs("jdbc:sqlite:file:foo?mode=memory&cache=shared");
+    }
+
+    @Test
+    public void shouldSupportPersistedMode() {
+        givenConfigurationProperty("kura.service.pid", "foo");
+        givenConfigurationProperty("db.mode", "PERSISTED");
+        givenConfigurationProperty("db.path", "/tmp/foo");
+
+        whenOptionsAreCreated();
+
+        thenDbPathIs("/tmp/foo");
+        thenDbUrlIs("jdbc:sqlite:file:/tmp/foo");
+    }
+
+    @Test
+    public void shouldIgnoreURIParameters() {
+        givenConfigurationProperty("kura.service.pid", "foo");
+        givenConfigurationProperty("db.mode", "PERSISTED");
+        givenConfigurationProperty("db.path", "/tmp/foo?baz=bar");
+
+        whenOptionsAreCreated();
+
+        thenDbPathIs("/tmp/foo");
+        thenDbUrlIs("jdbc:sqlite:file:/tmp/foo");
+    }
+
+    @Test
+    public void shouldIgnoreURIParametersDoubleQuestionMark() {
+        givenConfigurationProperty("kura.service.pid", "foo");
+        givenConfigurationProperty("db.mode", "PERSISTED");
+        givenConfigurationProperty("db.path", "/tmp/foo?baz=bar?foo");
+
+        whenOptionsAreCreated();
+
+        thenDbPathIs("/tmp/foo");
+        thenDbUrlIs("jdbc:sqlite:file:/tmp/foo");
+    }
+
+    private final Map<String, Object> properties = new HashMap<>();
+    private SqliteDbServiceOptions options;
+
+    private void givenConfigurationProperty(final String key, final Object value) {
+        properties.put(key, value);
+    }
+
+    private void whenOptionsAreCreated() {
+        this.options = new SqliteDbServiceOptions(properties);
+    }
+
+    private void thenDbPathIs(final String expectedPath) {
+        assertEquals(expectedPath, this.options.getPath());
+    }
+
+    private void thenDbUrlIs(final String expectedDbUrl) {
+        assertEquals(expectedDbUrl, this.options.getDbUrl());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.wire.db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/db/test/DbWireComponentsTest.java
+++ b/kura/test/org.eclipse.kura.wire.db.component.provider.test/src/main/java/org/eclipse/kura/internal/wire/db/test/DbWireComponentsTest.java
@@ -228,6 +228,19 @@ public class DbWireComponentsTest extends DbComponentsTestBase {
         thenFilterEmitsEnvelopeWithProperty("foo", TypedValues.newIntegerValue(24));
     }
 
+    @Test
+    public void shouldNotResetIdIfTableIsEmpty()
+            throws KuraException, InvalidSyntaxException, InterruptedException, ExecutionException, TimeoutException {
+        givenStoreWithConfig(this.wireComponentTestTarget.storeMaximumSizeKey(), 1);
+        givenAnEnvelopeReceivedByStore("foo", TypedValues.newIntegerValue(23));
+        givenAnEnvelopeReceivedByStore("foo", TypedValues.newIntegerValue(24));
+
+        whenQueryIsPerformed("SELECT * FROM \"" + tableName + "\";");
+
+        thenEnvelopeRecordCountIs(0, 1);
+        thenFilterEmitsEnvelopeWithProperty("ID", TypedValues.newLongValue(2));
+    }
+
     @Parameters(name = "{0} with {1}")
     public static Collection<Object[]> targets() {
         return Arrays.asList(new Object[][] {


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

* Use `AUTOINCREMENT` for WireRecordStore ID column
* Return `INTEGER` columns as long TypedValues in WireRecordQuery
* Added additional options test class
