### PR TITLE
fix(nm): prevent connection retries from triggering configuration enforcement mechanism

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -199,6 +199,10 @@ public class NMSettingsConverter {
             }
         }
 
+        connectionMap.put("autoconnect-retries", new Variant<>(1)); // Prevent retries on failure to avoid
+                                                                    // triggering the configuration
+                                                                    // enforcement mechanism
+
         return connectionMap;
     }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -371,6 +371,7 @@ public class NMSettingsConverterTest {
 
         thenNoExceptionsHaveBeenThrown();
         thenResultingMapContains("type", "802-11-wireless");
+        thenResultingMapContains("autoconnect-retries", 1);
     }
 
     @Test
@@ -379,6 +380,7 @@ public class NMSettingsConverterTest {
 
         thenNoExceptionsHaveBeenThrown();
         thenResultingMapContains("type", "802-3-ethernet");
+        thenResultingMapContains("autoconnect-retries", 1);
     }
 
     @Test
@@ -398,6 +400,7 @@ public class NMSettingsConverterTest {
 
         thenNoExceptionsHaveBeenThrown();
         thenResultingMapContains("test", "test");
+        thenResultingMapContains("autoconnect-retries", 1);
     }
 
     @Test


### PR DESCRIPTION
**Behaviour**: when a device is misconfigured, NM attempt to perform a connection. Upon failure, by default, it performs 4 subsequent attempts to connect before giving up.

![image](https://user-images.githubusercontent.com/22748355/224930469-210ac7bb-7ca2-482e-8acf-6d071f604ac0.png)


The disconnection after failure (`NM_DEVICE_STATE_FAILED` → `NM_DEVICE_STATE_DISCONNECTED`) doesn't trigger the configuration enforcement mechanism but the subsequent connection attempt does (`*` → `NM_DEVICE_STATE_CONFIG`). This triggers an infinite configuration loop since the `autoconnect-retries` count is reset for each configuration roll-back.

https://github.com/eclipse/kura/blob/24093f6425bee99363281b9bcccac93b09d09fc7/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMConfigurationEnforcementHandler.java#L40-L47

**Steps to reproduce**:

- On a fresh Kura install configure the Wifi AP such as the configuration will fail (for example: set an invalid WiFi channel)
- Wait for the configuration to fail, when the autoconnect retry is performed you should see the configuration enforcement mechanism kick in.

**Solution**:

For now I just set the `autoconnect-retries` to `1` so that NM will attempt activation only once and the configuration enforcement mechanism will not be triggered.

This prevents the configuration enforcement loop to kick in but a more long-term solution should be searched for.