### PR TITLE
fix(web2): fixed radio modes 2.4/5GHz erratic band assignment on BGN and A

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -617,11 +617,11 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private void setBandFromRadioMode(String radioModeValue) {
-        boolean isValue5GHz = radioModeValue.equals(WIFI_RADIO_ANAC_MESSAGE);
-        boolean isValue2GHz = radioModeValue.equals(WIFI_RADIO_B_MESSAGE)
-                || radioModeValue.equals(WIFI_RADIO_BG_MESSAGE)
-                || radioModeValue.equals(WIFI_RADIO_BGN_MESSAGE);
-        boolean isValueBoth = radioModeValue.equals(WIFI_RADIO_A_MESSAGE);
+        boolean isValue5GHz = radioModeValue.equals(WIFI_RADIO_ANAC_MESSAGE)
+                || radioModeValue.equals(WIFI_RADIO_A_MESSAGE);
+        boolean isValue2GHz = radioModeValue.equals(WIFI_RADIO_BG_MESSAGE)
+                || radioModeValue.equals(WIFI_RADIO_B_MESSAGE);
+        boolean isValueBoth = radioModeValue.equals(WIFI_RADIO_BGN_MESSAGE);
 
         for (int i = 0; i < this.radio.getItemCount(); i++) {
             String selectedText = this.radio.getItemText(i);
@@ -1827,9 +1827,9 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                 this.radio.addItem(MessageUtils.get(mode.name()));
             }
         } else {
-            this.radio.addItem(WIFI_BAND_2GHZ_MESSAGE, WIFI_RADIO_B_MESSAGE);
-            this.radio.addItem(WIFI_BAND_5GHZ_MESSAGE, WIFI_RADIO_ANAC_MESSAGE);
-            this.radio.addItem(WIFI_BAND_BOTH_MESSAGE, WIFI_RADIO_A_MESSAGE);
+            this.radio.addItem(WIFI_BAND_2GHZ_MESSAGE, WIFI_RADIO_BG_MESSAGE);
+            this.radio.addItem(WIFI_BAND_5GHZ_MESSAGE, WIFI_RADIO_A_MESSAGE);
+            this.radio.addItem(WIFI_BAND_BOTH_MESSAGE, WIFI_RADIO_BGN_MESSAGE);
         }
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -607,7 +607,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                 setBandFromRadioMode(radioModeValue);
             } else {
                 for (int i = 0; i < this.radio.getItemCount(); i++) {
-                    if (this.radio.getItemText(i).equals(MessageUtils.get(radioModeValue))) {
+                    if (this.radio.getItemText(i).equals(MessageUtils.get(radioModeValue))
+                            || this.radio.getItemText(i).equals(radioModeValue)) {
                         this.radio.setSelectedIndex(i);
                         break;
                     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -516,8 +516,10 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private void changeRadioModeToBand(boolean isNet2) {
-        this.radioHelp.setHelpText(MSGS.netWifiToolTipBand());
-        this.labelRadio.setText(MSGS.netWifiBand());
+        if (isNet2) {
+            this.radioHelp.setHelpText(MSGS.netWifiToolTipBand());
+            this.labelRadio.setText(MSGS.netWifiBand());
+        }
     }
 
     private void update() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtWifiRadioMode.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtWifiRadioMode.java
@@ -15,10 +15,10 @@ package org.eclipse.kura.web.shared.model;
 public enum GwtWifiRadioMode {
 
     netWifiRadioModeANAC("ac", false, true),
-    netWifiRadioModeBGN("n", true, false),
+    netWifiRadioModeBGN("n", true, true),
     netWifiRadioModeBG("g", true, false),
     netWifiRadioModeB("b", true, false),
-    netWifiRadioModeA("a", true, true);
+    netWifiRadioModeA("a", false, true);
 
     private final String radioMode;
     private final boolean twoDotFourGhz;


### PR DESCRIPTION
This PR fixes the follwing errors on the frequency band objects:

- `netWifiRadioModeBGN`: was set as not 5GHz, altough it is;
- `netWifiRadioModeA`: was set as 2.4GHz, but it is not.

Other complementary fixes to regressions are also implemented.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
