### PR TITLE
feat(web2): added automatic channel selection support for WiFi on net2

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -107,12 +107,13 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     private static final String WIFI_CIPHERS_CCMP_TKIP_MESSAGE = MessageUtils
             .get(GwtWifiCiphers.netWifiCiphers_CCMP_TKIP.name());
 
-    private static final String WIFI_RADIO_BGN_MESSAGE = MessageUtils.get(GwtWifiRadioMode.netWifiRadioModeBGN.name());
-    private static final String WIFI_RADIO_ANAC_MESSAGE = MessageUtils
-            .get(GwtWifiRadioMode.netWifiRadioModeANAC.name());
-    private static final String WIFI_RADIO_BG_MESSAGE = MessageUtils.get(GwtWifiRadioMode.netWifiRadioModeBG.name());
-    private static final String WIFI_RADIO_B_MESSAGE = MessageUtils.get(GwtWifiRadioMode.netWifiRadioModeB.name());
-    private static final String WIFI_RADIO_A_MESSAGE = MessageUtils.get(GwtWifiRadioMode.netWifiRadioModeA.name());
+    private static final String WIFI_RADIO_BGN = GwtWifiRadioMode.netWifiRadioModeBGN.name();
+    private static final String WIFI_RADIO_ANAC = GwtWifiRadioMode.netWifiRadioModeANAC.name();
+    private static final String WIFI_RADIO_BG = GwtWifiRadioMode.netWifiRadioModeBG.name();
+    private static final String WIFI_RADIO_B = GwtWifiRadioMode.netWifiRadioModeB.name();
+    private static final String WIFI_RADIO_A = GwtWifiRadioMode.netWifiRadioModeA.name();
+
+    private static final String WIFI_RADIO_BGN_MESSAGE = MessageUtils.get(WIFI_RADIO_BGN);
 
     private static final String WIFI_BAND_5GHZ_MESSAGE = MessageUtils.get("netWifiBand5Ghz");
     private static final String WIFI_BAND_2GHZ_MESSAGE = MessageUtils.get("netWifiBand2Ghz");
@@ -421,18 +422,21 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
     @Override
     public void setNetInterface(GwtNetInterfaceConfig config) {
+        logger.info("Start setNetInterface");
+
         setDirty(true);
         if (this.tcpStatus == null || this.selectedNetIfConfig != config) {
             this.tcpStatus = this.tcpTab.getStatus();
         }
         if (config instanceof GwtWifiNetInterfaceConfig) {
             this.selectedNetIfConfig = (GwtWifiNetInterfaceConfig) config;
-            logger.info("config: " + selectedNetIfConfig);
+            logger.info("Selected ifconfig: " + selectedNetIfConfig.getProperties());
+
             this.activeConfig = this.selectedNetIfConfig.getActiveWifiConfig();
             if (Objects.nonNull(this.activeConfig)) {
-                logger.info("active config: " + this.activeConfig);
-                logger.info("wireless mode: " + this.activeConfig.getWirelessMode());
-                logger.info("channels " + this.activeConfig.getChannels());
+                logger.info("Active config: " + this.activeConfig.getProperties());
+                logger.info("Wireless mode: " + this.activeConfig.getWirelessMode());
+                logger.info("Channels " + this.activeConfig.getChannels());
                 if (this.activeConfig.getChannels() != null
                         && !TabWirelessUi.this.activeConfig.getChannels().isEmpty()) {
                     updateChanneList(TabWirelessUi.this.activeConfig);
@@ -441,7 +445,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             loadCountryCode();
         }
 
-        logger.info("setNetInterface done.");
+        logger.info("Finished setNetInterface");
     }
 
     private void updateChanneList(GwtWifiConfig config) {
@@ -529,6 +533,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private void setValues() {
+        logger.info("Start setValues");
+
         if (this.activeConfig == null) {
             return;
         }
@@ -548,7 +554,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         // select proper channels
         updateChanneList(this.activeConfig);
 
-        logger.info(MessageUtils.get(this.activeConfig.getSecurity()));
         String activeSecurity = this.activeConfig.getSecurity();
         if (activeSecurity != null) {
             for (int i = 0; i < this.security.getItemCount(); i++) {
@@ -599,7 +604,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         this.radio3.setValue(this.activeConfig.ignoreSSID());
         this.radio4.setValue(!this.activeConfig.ignoreSSID());
 
-        logger.info("set values done.");
+        logger.info("Finished setValues");
     }
 
     private void setRadioModeByValue(String radioModeValue) {
@@ -620,11 +625,11 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private void setBandFromRadioMode(String radioModeValue) {
-        boolean isValue5GHz = radioModeValue.equals(WIFI_RADIO_ANAC_MESSAGE)
-                || radioModeValue.equals(WIFI_RADIO_A_MESSAGE);
-        boolean isValue2GHz = radioModeValue.equals(WIFI_RADIO_BG_MESSAGE)
-                || radioModeValue.equals(WIFI_RADIO_B_MESSAGE);
-        boolean isValueBoth = radioModeValue.equals(WIFI_RADIO_BGN_MESSAGE);
+        boolean isValue5GHz = radioModeValue.equals(WIFI_RADIO_ANAC)
+                || radioModeValue.equals(WIFI_RADIO_A);
+        boolean isValue2GHz = radioModeValue.equals(WIFI_RADIO_BG)
+                || radioModeValue.equals(WIFI_RADIO_B);
+        boolean isValueBoth = radioModeValue.equals(WIFI_RADIO_BGN);
 
         for (int i = 0; i < this.radio.getItemCount(); i++) {
             String selectedText = this.radio.getItemText(i);
@@ -644,7 +649,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private void refreshForm() {
-        logger.info("refreshForm()");
+        logger.info("Start refreshForm");
+
         String tcpipStatus = this.tcpTab.getStatus();
 
         // Tcp/IP disabled
@@ -743,7 +749,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
         this.netTabs.adjustInterfaceTabs();
 
-        logger.info("refresh form done.");
+        logger.info("Finish refreshForm");
     }
 
     private void reset() {
@@ -827,6 +833,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private void initForm() {
+        logger.info("Start initForm");
+
         // Wireless Mode
 
         this.labelWireless.setText(MSGS.netWifiWirelessMode());
@@ -1169,7 +1177,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
         this.noChannelsText.setText(MSGS.netWifiAlertNoChannels());
 
-        logger.info("init done.");
+        logger.info("Finish initForm");
     }
 
     private void initRegDomErrorModal() {
@@ -1413,8 +1421,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
     private void addItemChannelList(GwtWifiChannelFrequency channelFrequency) {
 
-        logger.info("Adding channel: " + channelFrequency.getChannel());
-
         if (channelFrequency.getChannel() == 0 && channelFrequency.getFrequency() == 0) {
             this.channelList.addItem(AUTOMATIC_CHANNEL_DESCRIPTION);
             return;
@@ -1570,9 +1576,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
         gwtWifiConfig
                 .setChannels(Collections.singletonList(getChannelValueByIndex(this.channelList.getSelectedIndex())));
-
-        String freqValue = this.channelList.getSelectedItemText();
-        logger.info("Selected Frequency: " + freqValue);
 
         // security
         String secValue = this.security.getSelectedItemText();
@@ -1743,7 +1746,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                                 @Override
                                 public void onSuccess(List<GwtWifiChannelFrequency> freqChannels) {
                                     
-                                    logger.info("Processing result from findFrequencies...");
+                                    logger.info("Processing result from findFrequencies for "
+                                            + TabWirelessUi.this.selectedNetIfConfig.getName() + "/" + radioMode);
 
                                     TabWirelessUi.this.channelList.clear();
 
@@ -1761,7 +1765,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
                                     TabWirelessUi.this.noChannels.setVisible(!hasChannels);
 
-                                    logger.info("Processing result from findFrequencies... Done.");
+                                    logger.info("Finished processing result from findFrequencies for "
+                                            + TabWirelessUi.this.selectedNetIfConfig.getName() + "/" + radioMode);
 
                                 }
                             });
@@ -1829,9 +1834,9 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                 this.radio.addItem(MessageUtils.get(mode.name()));
             }
         } else {
-            this.radio.addItem(WIFI_BAND_2GHZ_MESSAGE, WIFI_RADIO_BG_MESSAGE);
-            this.radio.addItem(WIFI_BAND_5GHZ_MESSAGE, WIFI_RADIO_A_MESSAGE);
-            this.radio.addItem(WIFI_BAND_BOTH_MESSAGE, WIFI_RADIO_BGN_MESSAGE);
+            this.radio.addItem(WIFI_BAND_2GHZ_MESSAGE, WIFI_RADIO_BG);
+            this.radio.addItem(WIFI_BAND_5GHZ_MESSAGE, WIFI_RADIO_ANAC);
+            this.radio.addItem(WIFI_BAND_BOTH_MESSAGE, WIFI_RADIO_BGN);
         }
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1422,7 +1422,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     private void addItemChannelList(GwtWifiChannelFrequency channelFrequency) {
 
         if (channelFrequency.getChannel() == 0 && channelFrequency.getFrequency() == 0) {
-            this.channelList.addItem(AUTOMATIC_CHANNEL_DESCRIPTION);
+            this.channelList.addItem(AUTOMATIC_CHANNEL_DESCRIPTION, "0");
             return;
         }
 
@@ -1524,6 +1524,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         for (int i = 0; i < this.channelList.getItemCount(); i++) {
             String value = this.channelList.getItemText(i);
             String[] values = value.split(" ");
+
             int channel = Integer.parseInt(values[1]);
             if (channel == channelValue) {
                 return i;
@@ -1648,7 +1649,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     private GwtWifiRadioMode radioValueToRadioMode(String radioValue) {
 
         for (GwtWifiRadioMode mode : GwtWifiRadioMode.values()) {
-            if (MessageUtils.get(mode.name()).equals(radioValue)) {
+            if (mode.name().equals(radioValue)) {
                 return mode;
             }
         }
@@ -1734,6 +1735,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                 @Override
                 public void onSuccess(GwtXSRFToken token) {
                     GwtWifiRadioMode radioMode = radioValueToRadioMode(TabWirelessUi.this.radio.getSelectedValue());
+
                     TabWirelessUi.this.gwtNetworkService.findFrequencies(token,
                             TabWirelessUi.this.selectedNetIfConfig.getName(), radioMode,
                             new AsyncCallback<List<GwtWifiChannelFrequency>>() {
@@ -1799,7 +1801,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                             @Override
                             public void onSuccess(Boolean acSupported) {
 
-                                String selectedRadioModeText = TabWirelessUi.this.radio.getSelectedValue() != null
+                                String selectedRadioMode = TabWirelessUi.this.radio.getSelectedValue() != null
                                         ? TabWirelessUi.this.radio.getSelectedValue()
                                         : null;
 
@@ -1807,9 +1809,9 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
                                 fillRadioMode(acSupported);
 
-                                if (selectedRadioModeText != null) {
-                                    logger.info("selectedRadioModeText: " + selectedRadioModeText);
-                                    setRadioModeByValue(selectedRadioModeText);
+                                if (selectedRadioMode != null) {
+                                    logger.info("selectedRadioModeText: " + selectedRadioMode);
+                                    setRadioModeByValue(selectedRadioMode);
                                 } else {
                                     logger.info("TabWirelessUi.this.activeConfig.getRadioMode(): "
                                             + TabWirelessUi.this.activeConfig.getRadioMode());
@@ -1835,7 +1837,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             }
         } else {
             this.radio.addItem(WIFI_BAND_2GHZ_MESSAGE, WIFI_RADIO_BG);
-            this.radio.addItem(WIFI_BAND_5GHZ_MESSAGE, WIFI_RADIO_ANAC);
+            this.radio.addItem(WIFI_BAND_5GHZ_MESSAGE, WIFI_RADIO_A);
             this.radio.addItem(WIFI_BAND_BOTH_MESSAGE, WIFI_RADIO_BGN);
         }
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -367,7 +367,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             update();
         });
 
-        logger.severe("Constructor done.");
+        logger.info("Constructor done.");
     }
 
     @UiHandler(value = { "wireless", "ssid", "radio", "security", "password", "verify", "pairwise", "group", "bgscan",
@@ -427,12 +427,12 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         }
         if (config instanceof GwtWifiNetInterfaceConfig) {
             this.selectedNetIfConfig = (GwtWifiNetInterfaceConfig) config;
-            logger.severe("config: " + selectedNetIfConfig);
+            logger.info("config: " + selectedNetIfConfig);
             this.activeConfig = this.selectedNetIfConfig.getActiveWifiConfig();
             if (Objects.nonNull(this.activeConfig)) {
-                logger.severe("active config: " + this.activeConfig);
-                logger.severe("wireless mode: " + this.activeConfig.getWirelessMode());
-                logger.severe("channels " + this.activeConfig.getChannels());
+                logger.info("active config: " + this.activeConfig);
+                logger.info("wireless mode: " + this.activeConfig.getWirelessMode());
+                logger.info("channels " + this.activeConfig.getChannels());
                 if (this.activeConfig.getChannels() != null
                         && !TabWirelessUi.this.activeConfig.getChannels().isEmpty()) {
                     updateChanneList(TabWirelessUi.this.activeConfig);
@@ -441,7 +441,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             loadCountryCode();
         }
 
-        logger.severe("setNetInterface done.");
+        logger.info("setNetInterface done.");
     }
 
     private void updateChanneList(GwtWifiConfig config) {
@@ -599,7 +599,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         this.radio3.setValue(this.activeConfig.ignoreSSID());
         this.radio4.setValue(!this.activeConfig.ignoreSSID());
 
-        logger.severe("set values done.");
+        logger.info("set values done.");
     }
 
     private void setRadioModeByValue(String radioModeValue) {
@@ -743,7 +743,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
         this.netTabs.adjustInterfaceTabs();
 
-        logger.severe("refresh form done.");
+        logger.info("refresh form done.");
     }
 
     private void reset() {
@@ -1169,7 +1169,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
         this.noChannelsText.setText(MSGS.netWifiAlertNoChannels());
 
-        logger.severe("init done.");
+        logger.info("init done.");
     }
 
     private void initRegDomErrorModal() {
@@ -1413,7 +1413,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
     private void addItemChannelList(GwtWifiChannelFrequency channelFrequency) {
 
-        logger.fine("Adding channel: " + channelFrequency.getChannel());
+        logger.info("Adding channel: " + channelFrequency.getChannel());
 
         if (channelFrequency.getChannel() == 0 && channelFrequency.getFrequency() == 0) {
             this.channelList.addItem(AUTOMATIC_CHANNEL_DESCRIPTION);
@@ -1508,6 +1508,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private int getChannelIndexFromValue(int channelValue) {
+        
+        logger.info("getChannelIndexFromValue");
 
         if (channelValue == 0) {
             return 0;
@@ -1570,7 +1572,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                 .setChannels(Collections.singletonList(getChannelValueByIndex(this.channelList.getSelectedIndex())));
 
         String freqValue = this.channelList.getSelectedItemText();
-        logger.fine("Selected Frequency: " + freqValue);
+        logger.info("Selected Frequency: " + freqValue);
 
         // security
         String secValue = this.security.getSelectedItemText();
@@ -1642,20 +1644,13 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
     private GwtWifiRadioMode radioValueToRadioMode(String radioValue) {
 
-        GwtWifiRadioMode radioMode = null;
-
         for (GwtWifiRadioMode mode : GwtWifiRadioMode.values()) {
             if (MessageUtils.get(mode.name()).equals(radioValue)) {
-                radioMode = mode;
-                break;
+                return mode;
             }
         }
 
-        if (radioMode == null) {
-            radioMode = GwtWifiRadioMode.netWifiRadioModeBGN;
-        }
-
-        return radioMode;
+        return GwtWifiRadioMode.netWifiRadioModeBGN;
     }
 
     private void setForm(boolean visible) {
@@ -1747,6 +1742,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
                                 @Override
                                 public void onSuccess(List<GwtWifiChannelFrequency> freqChannels) {
+                                    
+                                    logger.info("Processing result from findFrequencies...");
 
                                     TabWirelessUi.this.channelList.clear();
 
@@ -1757,12 +1754,14 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                                     int selectedChannelIndex = getChannelIndexFromValue(channel);
                                     int channelIndex = selectedChannelIndex == -1 ? 0 : selectedChannelIndex;
 
-                                    logger.fine("Setting channel to: " + channel);
+                                    logger.info("Setting channel to: " + channel);
                                     TabWirelessUi.this.channelList.setSelectedIndex(channelIndex);
 
                                     boolean hasChannels = TabWirelessUi.this.channelList.getItemCount() > 0;
 
                                     TabWirelessUi.this.noChannels.setVisible(!hasChannels);
+
+                                    logger.info("Processing result from findFrequencies... Done.");
 
                                 }
                             });
@@ -1804,10 +1803,10 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                                 fillRadioMode(acSupported);
 
                                 if (selectedRadioModeText != null) {
-                                    logger.fine("selectedRadioModeText: " + selectedRadioModeText);
+                                    logger.info("selectedRadioModeText: " + selectedRadioModeText);
                                     setRadioModeByValue(selectedRadioModeText);
                                 } else {
-                                    logger.fine("TabWirelessUi.this.activeConfig.getRadioMode(): "
+                                    logger.info("TabWirelessUi.this.activeConfig.getRadioMode(): "
                                             + TabWirelessUi.this.activeConfig.getRadioMode());
                                     setRadioModeByValue(TabWirelessUi.this.activeConfig.getRadioMode());
                                 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1187,11 +1187,18 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private List<GwtWifiHotspotEntry> getChannelFrequencyByIndex(int selectedIndex) {
-        String[] itemtext = this.channelList.getItemText(selectedIndex).split(" ");
-        GwtWifiHotspotEntry frequencyEntry = new GwtWifiHotspotEntry();
+        String selectedItem = this.channelList.getItemText(selectedIndex);
 
-        frequencyEntry.setChannel(Integer.parseInt(itemtext[1]));
-        frequencyEntry.setFrequency(Integer.parseInt(itemtext[3]));
+        GwtWifiHotspotEntry frequencyEntry = new GwtWifiHotspotEntry();
+        
+        if (selectedItem.equals(AUTOMATIC_CHANNEL_DESCRIPTION)) {
+            frequencyEntry.setChannel(0);
+            frequencyEntry.setFrequency(0);
+        } else {
+            String[] itemtext = selectedItem.split(" ");
+            frequencyEntry.setChannel(Integer.parseInt(itemtext[1]));
+            frequencyEntry.setFrequency(Integer.parseInt(itemtext[3]));
+        }
 
         return Collections.singletonList(frequencyEntry);
     }
@@ -1422,7 +1429,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     private void addItemChannelList(GwtWifiChannelFrequency channelFrequency) {
 
         if (channelFrequency.getChannel() == 0 && channelFrequency.getFrequency() == 0) {
-            this.channelList.addItem(AUTOMATIC_CHANNEL_DESCRIPTION, "0");
+            this.channelList.addItem(AUTOMATIC_CHANNEL_DESCRIPTION);
             return;
         }
 
@@ -1515,19 +1522,21 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
     private int getChannelIndexFromValue(int channelValue) {
         
-        logger.info("getChannelIndexFromValue");
+        logger.info("getChannelIndexFromValue for channel: " + channelValue);
 
         if (channelValue == 0) {
             return 0;
         }
 
         for (int i = 0; i < this.channelList.getItemCount(); i++) {
-            String value = this.channelList.getItemText(i);
-            String[] values = value.split(" ");
+            String[] values = this.channelList.getItemText(i).split(" ");
 
-            int channel = Integer.parseInt(values[1]);
-            if (channel == channelValue) {
-                return i;
+            try {
+                int channel = Integer.parseInt(values[1]);
+                if (channel == channelValue) {
+                    return i;
+                }
+            } catch (NumberFormatException automaticChannel) {
             }
         }
         return -1;
@@ -1753,6 +1762,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
                                     TabWirelessUi.this.channelList.clear();
 
+                                    addAutomaticChannel(freqChannels);
+
                                     freqChannels.stream().forEach(TabWirelessUi.this::addItemChannelList);
 
                                     int channel = TabWirelessUi.this.activeConfig.getChannels().get(0);
@@ -1776,6 +1787,23 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             });
         }
 
+    }
+
+    private void addAutomaticChannel(List<GwtWifiChannelFrequency> freqs) {
+        if (!containsChannel0(freqs)) {
+            GwtWifiChannelFrequency automaticChannel = new GwtWifiChannelFrequency(0, 0);
+            freqs.add(0, automaticChannel);
+        }
+    }
+
+    private boolean containsChannel0(List<GwtWifiChannelFrequency> freqs) {
+        for (GwtWifiChannelFrequency freq : freqs) {
+            if (freq.getChannel() == 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void loadRadioMode() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.kura.web.server.net2;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.kura.KuraException;
@@ -32,9 +33,11 @@ import org.eclipse.kura.web.shared.GwtKuraException;
 import org.eclipse.kura.web.shared.model.GwtFirewallNatEntry;
 import org.eclipse.kura.web.shared.model.GwtFirewallOpenPortEntry;
 import org.eclipse.kura.web.shared.model.GwtFirewallPortForwardEntry;
+import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiChannelFrequency;
 import org.eclipse.kura.web.shared.model.GwtWifiHotspotEntry;
+import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiRadioMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,6 +84,8 @@ public class GwtNetworkServiceImpl {
                 }
             }
         }
+
+        logInterfaces("getConfigsAndStatuses", result);
 
         return result;
     }
@@ -225,7 +230,8 @@ public class GwtNetworkServiceImpl {
                     toDisplay.append(channel.getChannel());
                     toDisplay.append(" ");
                 }
-                logger.debug("Find frequencies for {}: {}", interfaceName, toDisplay.toString().trim());
+                logger.debug("Find frequencies for {}/{}: {}", interfaceName, radioMode.name(),
+                        toDisplay.toString().trim());
             }
 
             return displayedChannels;
@@ -250,6 +256,41 @@ public class GwtNetworkServiceImpl {
             return aps;
         } catch (GwtKuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
+        }
+    }
+
+    private static void logInterfaces(String origin, List<GwtNetInterfaceConfig> configs) {
+        if (logger.isDebugEnabled()) {
+            for (GwtNetInterfaceConfig config : configs) {
+                Map<String, Object> ifProperties = config.getProperties();
+
+                if (config instanceof GwtWifiNetInterfaceConfig) {
+                    GwtWifiNetInterfaceConfig wifi = (GwtWifiNetInterfaceConfig) config;
+                    
+                    switch (wifi.getWirelessModeEnum()) {
+                        case netWifiWirelessModeAccessPoint:
+                            ifProperties.putAll(wifi.getAccessPointWifiConfigProps());
+                            break;
+                        case netWifiWirelessModeAdHoc:
+                            ifProperties.putAll(wifi.getAdhocWifiConfigProps());
+                            break;
+                        case netWifiWirelessModeStation:
+                            ifProperties.putAll(wifi.getStationWifiConfigProps());
+                            break;
+                        case netWifiWirelessModeDisabled:
+                        default:
+                            break;
+                        
+                    }
+                }
+
+                if (config instanceof GwtModemInterfaceConfig) {
+                    GwtModemInterfaceConfig modem = (GwtModemInterfaceConfig) config;
+                    ifProperties.putAll(modem.getProperties());
+                }
+
+                logger.debug("{} returned for interface {}:\n\n{}\n\n", origin, config.getName(), ifProperties);
+            }
         }
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -219,6 +219,15 @@ public class GwtNetworkServiceImpl {
                 }
             }
 
+            if (logger.isDebugEnabled()) {
+                StringBuilder toDisplay = new StringBuilder();
+                for (GwtWifiChannelFrequency channel : displayedChannels) {
+                    toDisplay.append(channel.getChannel());
+                    toDisplay.append(" ");
+                }
+                logger.debug("Find frequencies for {}: {}", interfaceName, toDisplay.toString().trim());
+            }
+
             return displayedChannels;
         } catch (GwtKuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -211,8 +211,10 @@ public class GwtNetworkServiceImpl {
 
             for (GwtWifiChannelFrequency supportedChannel : allSupportedChannels) {
                 boolean channelIsfive5Ghz = supportedChannel.getFrequency() > 2501;
+                boolean isAutomaticChannelSelection = supportedChannel.getFrequency() == 0;
 
-                if (radioMode.isFiveGhz() && channelIsfive5Ghz || radioMode.isTwoDotFourGhz() && !channelIsfive5Ghz) {
+                if (radioMode.isFiveGhz() && channelIsfive5Ghz || radioMode.isTwoDotFourGhz() && !channelIsfive5Ghz
+                        || isAutomaticChannelSelection) {
                     displayedChannels.add(supportedChannel);
                 }
             }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -27,12 +27,9 @@ import org.eclipse.kura.web.shared.model.GwtWifiBgscanModule;
 import org.eclipse.kura.web.shared.model.GwtWifiConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiWirelessMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class GwtNetInterfaceConfigBuilder {
 
-    private static final Logger logger = LoggerFactory.getLogger(GwtNetInterfaceConfigBuilder.class);
     private static final String NA = "N/A";
 
     private final NetworkConfigurationServiceProperties properties;
@@ -202,8 +199,6 @@ public class GwtNetInterfaceConfigBuilder {
         }
 
         ((GwtWifiNetInterfaceConfig) this.gwtConfig).setAccessPointWifiConfig(gwtWifiConfig);
-        logger.debug("GWT Wifi Master Configuration for interface {}:\n{}\n", this.ifName,
-                gwtWifiConfig.getProperties());
     }
 
     private void setWifiInfraProperties() {
@@ -236,8 +231,6 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setPingAccessPoint(this.properties.getWifiInfraPingAP(this.ifName));
 
         ((GwtWifiNetInterfaceConfig) this.gwtConfig).setStationWifiConfig(gwtWifiConfig);
-        logger.debug("GWT Wifi Infra Configuration for interface {}:\n{}\n", this.ifName,
-                gwtWifiConfig.getProperties());
     }
 
     private void setBgScanProperties(GwtWifiConfig gwtWifiConfig, Optional<String> bgScan) {
@@ -295,9 +288,6 @@ public class GwtNetInterfaceConfigBuilder {
             gwtModemConfig.setModel(this.properties.getUsbProductId(this.ifName));
             gwtModemConfig.setHwUsbDevice(this.properties.getUsbDevicePath(this.ifName));
             gwtModemConfig.setConfigMode(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
-
-            logger.debug("GWT Modem Configuration for interface {}:\n{}\n", this.ifName,
-                    gwtModemConfig.getProperties());
         }
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
@@ -57,10 +57,8 @@ public class NetworkConfigurationServiceAdapter {
      * @return a new {@link GwtNetInterfaceConfig}
      */
     public GwtNetInterfaceConfig getGwtNetInterfaceConfig(String ifName) {
-        GwtNetInterfaceConfig gwtConfig = new GwtNetInterfaceConfigBuilder(this.netConfServProperties)
+        return new GwtNetInterfaceConfigBuilder(this.netConfServProperties)
                 .forInterface(ifName).build();
-        logger.debug("Got GWT Network Configuration for interface {}:\n{}\n", ifName, gwtConfig.getProperties());
-        return gwtConfig;
     }
 
     /**
@@ -72,10 +70,8 @@ public class NetworkConfigurationServiceAdapter {
      * @return a new {@link GwtNetInterfaceConfig}
      */
     public GwtNetInterfaceConfig getDefaultGwtNetInterfaceConfig(String ifName, NetworkInterfaceType ifType) {
-        GwtNetInterfaceConfig gwtConfig = new GwtNetInterfaceConfigBuilder()
+        return new GwtNetInterfaceConfigBuilder()
                 .forInterface(ifName).forType(ifType).build();
-        logger.debug("Created GWT Network Configuration for interface {} and type {}", ifName, ifType);
-        return gwtConfig;
     }
 
     /**

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -102,6 +102,9 @@ public class NetworkStatusServiceAdapter {
 
         List<GwtWifiChannelFrequency> gwtChannels = new ArrayList<>();
 
+        GwtWifiChannelFrequency autoChannel = new GwtWifiChannelFrequency(0, 0);
+        gwtChannels.add(autoChannel);
+
         for (WifiChannel channel : channels) {
             GwtWifiChannelFrequency gwtChannel = new GwtWifiChannelFrequency(channel.getChannel(),
                     channel.getFrequency());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -48,8 +48,6 @@ import org.eclipse.kura.web.shared.model.GwtWifiConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiHotspotEntry;
 import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiSecurity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Adapter to convert status-related properties to a
@@ -57,8 +55,6 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class NetworkStatusServiceAdapter {
-
-    private static final Logger logger = LoggerFactory.getLogger(NetworkStatusServiceAdapter.class);
 
     private final NetworkStatusService networkStatusService;
 
@@ -186,9 +182,6 @@ public class NetworkStatusServiceAdapter {
         gwtConfig.setHwDriverVersion(networkInterfaceStatus.getDriverVersion());
         gwtConfig.setHwFirmware(networkInterfaceStatus.getFirmwareVersion());
         gwtConfig.setHwMTU(networkInterfaceStatus.getMtu());
-
-        logger.debug("GWT common state properties for interface {}:\n{}\n", gwtConfig.getName(),
-                gwtConfig.getProperties());
     }
 
     private void setIpv4DhcpClientProperties(GwtNetInterfaceConfig gwtConfig,

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -102,9 +102,6 @@ public class NetworkStatusServiceAdapter {
 
         List<GwtWifiChannelFrequency> gwtChannels = new ArrayList<>();
 
-        GwtWifiChannelFrequency autoChannel = new GwtWifiChannelFrequency(0, 0);
-        gwtChannels.add(autoChannel);
-
         for (WifiChannel channel : channels) {
             GwtWifiChannelFrequency gwtChannel = new GwtWifiChannelFrequency(channel.getChannel(),
                     channel.getFrequency());


### PR DESCRIPTION
This PR allows to select `Automatic` in the channel field; which corresponds to channel 0 with frequency 0. This makes it compatible with [NM](https://networkmanager.dev/docs/api/latest/nm-settings-dbus.html), which allows ACS by setting channel to 0.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** ACS:
<img width="729" alt="Screenshot 2023-03-14 at 11 52 24" src="https://user-images.githubusercontent.com/39562568/224979048-7448dedd-4599-4655-b12b-3c4c0a480810.png">

**Any side note on the changes made:** N/A.
