### PR TITLE
fix: Manage Ubuntu cloud-init

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -85,6 +85,14 @@ sed -i "s|/bin/sh KURA_DIR|/bin/bash ${INSTALL_DIR}/kura|" /lib/systemd/system/f
 systemctl daemon-reload
 systemctl enable firewall
 
+# disables cloud-init if exists and allows interface management to network-manager
+if [ -d /etc/cloud/cloud.cfg.d ]; then
+    echo "network: {config: disabled}" | sudo tee -a /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg > /dev/null
+fi
+if [ -f /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf ]; then
+    rm /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf
+fi
+
 # disable NTP service
 if command -v timedatectl > /dev/null ;
   then

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -85,6 +85,14 @@ sed -i "s|/bin/sh KURA_DIR|/bin/bash ${INSTALL_DIR}/kura|" /lib/systemd/system/f
 systemctl daemon-reload
 systemctl enable firewall
 
+# disables cloud-init if exists and allows interface management to network-manager
+if [ -d /etc/cloud/cloud.cfg.d ]; then
+    echo "network: {config: disabled}" | sudo tee -a /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg > /dev/null
+fi
+if [ -f /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf ]; then
+    rm /usr/lib/NetworkManager/conf.d/10-globally-managed-devices.conf
+fi
+
 # disable NTP service
 if command -v timedatectl > /dev/null ;
   then

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -85,6 +85,18 @@ sed -i "s|/bin/sh KURA_DIR|/bin/bash ${INSTALL_DIR}/kura|" /lib/systemd/system/f
 systemctl daemon-reload
 systemctl enable firewall
 
+# disables cloud-init if exists and allows interface management to network-manager
+if [ -d /etc/cloud/cloud.cfg.d ]; then
+    echo "network: {config: disabled}" | sudo tee -a /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg > /dev/null
+fi
+if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
+    TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )
+    
+    if [ -f "${TO_REMOVE}" ]; then
+        rm "${TO_REMOVE}"
+    fi
+fi
+
 # disable NTP service
 if command -v timedatectl > /dev/null ;
   then


### PR DESCRIPTION
The PR introduces a couple of checks to identify and disable cloud-init (installed by default in Ubuntu server) and to give permissions to Kura to manage the networking interfaces via network-manager
