### PR TITLE
fix(wire.script.tools): readding deps that were lost during graaljs downgrade

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -197,6 +197,7 @@ This project leverages the following third party content.
 * maven/mavencentral/org.graalvm.truffle/truffle-api/21.3.5, UPL-1.0, approved, #6718
 * maven/mavencentral/org.graalvm.regex/regex/21.3.5, UPL-1.0 AND Unicode-TOU, approved, #6719
 * maven/mavencentral/org.graalvm.sdk/launcher-common/21.3.5, UPL-1.0, approved, #6720
+* maven/mavencentral/com.ibm.icu/icu4j/72.1, ICU, approved, #4354
 * maven/mavencentral/com.github.hypfvieh/dbus-java/3.3.2, MIT, approved, CQ23190
 * maven/mavencentral/com.github.jnr/jffi/1.3.9, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ23196
 * maven/mavencentral/com.github.jnr/jnr-a64asm/1.0.0, Apache-2.0, approved, CQ22814

--- a/kura/org.eclipse.kura.wire.script.tools/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.wire.script.tools/META-INF/MANIFEST.MF
@@ -24,4 +24,5 @@ Bundle-ClassPath: .,
  lib/js-scriptengine.jar,
  lib/launcher-common.jar,
  lib/truffle-api.jar,
- lib/regex.jar
+ lib/regex.jar,
+ lib/icu4j.jar

--- a/kura/org.eclipse.kura.wire.script.tools/build.properties
+++ b/kura/org.eclipse.kura.wire.script.tools/build.properties
@@ -10,5 +10,6 @@ bin.includes = META-INF/,\
                lib/js-scriptengine.jar,\
                lib/launcher-common.jar,\
                lib/regex.jar,\
-               lib/truffle-api.jar
+               lib/truffle-api.jar,\
+               lib/icu4j.jar
                

--- a/kura/org.eclipse.kura.wire.script.tools/pom.xml
+++ b/kura/org.eclipse.kura.wire.script.tools/pom.xml
@@ -81,6 +81,12 @@
                                     <artifactId>launcher-common</artifactId>
                                     <version>${graalvm.version}</version>
                                 </artifactItem>
+                                <!-- Transitive dependencies -->
+                                <artifactItem>
+                                    <groupId>com.ibm.icu</groupId>
+                                    <artifactId>icu4j</artifactId>
+                                    <version>72.1</version>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                         <goals>


### PR DESCRIPTION
The last downgrade of Graal JS set a version that had not embedded the [icu4j dependency](https://mvnrepository.com/artifact/com.ibm.icu/icu4j/72.1), causing the tool to fail at instatiation. This PR readds the dependency and updates the NOTICE file.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
