### PR TITLE
feat(nm): add automatic band selection support

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -134,20 +134,22 @@ public class NMSettingsConverter {
         String propMode = props.get(String.class, "net.interface.%s.config.wifi.mode", iface);
 
         String mode = wifiModeConvert(propMode);
+        settings.put("mode", new Variant<>(mode));
+
         String ssid = props.get(String.class, "net.interface.%s.config.wifi.%s.ssid", iface, propMode.toLowerCase());
-        String band = wifiBandConvert(
-                props.get(String.class, "net.interface.%s.config.wifi.%s.radioMode", iface, propMode.toLowerCase()));
-        Optional<String> channel = props.getOpt(String.class, "net.interface.%s.config.wifi.%s.channel", iface,
-                propMode.toLowerCase());
+        settings.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
+
+        short channel = Short.parseShort(
+                props.get(String.class, "net.interface.%s.config.wifi.%s.channel", iface, propMode.toLowerCase()));
+        settings.put("channel", new Variant<>(new UInt32(channel)));
+
+        Optional<String> band = wifiBandConvert(
+                props.get(String.class, "net.interface.%s.config.wifi.%s.radioMode", iface, propMode.toLowerCase()),
+                channel);
+        band.ifPresent(bandString -> settings.put("band", new Variant<>(band)));
+
         Optional<Boolean> hidden = props.getOpt(Boolean.class, "net.interface.%s.config.wifi.%s.ignoreSSID", iface,
                 propMode.toLowerCase());
-
-        settings.put("mode", new Variant<>(mode));
-        settings.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
-        settings.put("band", new Variant<>(band));
-        if (channel.isPresent()) {
-            settings.put("channel", new Variant<>(new UInt32(Short.parseShort(channel.get()))));
-        }
         if (hidden.isPresent()) {
             settings.put("hidden", new Variant<>(hidden.get()));
         }
@@ -249,18 +251,29 @@ public class NMSettingsConverter {
         }
     }
 
-    private static String wifiBandConvert(String kuraBand) {
+    private static Optional<String> wifiBandConvert(String kuraBand, short channel) {
+        List<String> bothFrequencyBands = Arrays.asList("RADIO_MODE_80211nHT20", "RADIO_MODE_80211nHT40below",
+                "RADIO_MODE_80211nHT40above");
+        boolean automaticChannelSelection = channel == 0;
+        boolean automaticBandSelection = bothFrequencyBands.contains(kuraBand);
+
+        if (automaticBandSelection && automaticChannelSelection) {
+            // Omit band if full-auto
+            return Optional.empty();
+        }
+
+        if (automaticBandSelection && !automaticChannelSelection) {
+            // Our own interpretation of the Wifi standard
+            return channel < 32 ? Optional.of("bg") : Optional.of("a");
+        }
+
         switch (kuraBand) {
         case "RADIO_MODE_80211a":
         case "RADIO_MODE_80211_AC":
-            return "a";
+            return Optional.of("a");
         case "RADIO_MODE_80211b":
         case "RADIO_MODE_80211g":
-            return "bg";
-        case "RADIO_MODE_80211nHT20":
-        case "RADIO_MODE_80211nHT40below":
-        case "RADIO_MODE_80211nHT40above":
-            return "bg"; // TBD
+            return Optional.of("bg");
         default:
             throw new IllegalArgumentException(String.format("Unsupported WiFi band \"%s\"", kuraBand));
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -146,13 +146,11 @@ public class NMSettingsConverter {
         Optional<String> band = wifiBandConvert(
                 props.get(String.class, "net.interface.%s.config.wifi.%s.radioMode", iface, propMode.toLowerCase()),
                 channel);
-        band.ifPresent(bandString -> settings.put("band", new Variant<>(band)));
+        band.ifPresent(bandString -> settings.put("band", new Variant<>(bandString)));
 
         Optional<Boolean> hidden = props.getOpt(Boolean.class, "net.interface.%s.config.wifi.%s.ignoreSSID", iface,
                 propMode.toLowerCase());
-        if (hidden.isPresent()) {
-            settings.put("hidden", new Variant<>(hidden.get()));
-        }
+        hidden.ifPresent(hiddenString -> settings.put("hidden", new Variant<>(hiddenString)));
 
         return settings;
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -134,56 +134,25 @@ public class NMSettingsConverter {
         String propMode = props.get(String.class, "net.interface.%s.config.wifi.mode", iface);
 
         String mode = wifiModeConvert(propMode);
-        settings.put("mode", new Variant<>(mode));
-
         String ssid = props.get(String.class, "net.interface.%s.config.wifi.%s.ssid", iface, propMode.toLowerCase());
-        settings.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
-
         String band = wifiBandConvert(
                 props.get(String.class, "net.interface.%s.config.wifi.%s.radioMode", iface, propMode.toLowerCase()));
-        String channel = props.get(String.class, "net.interface.%s.config.wifi.%s.channel", iface,
+        Optional<String> channel = props.getOpt(String.class, "net.interface.%s.config.wifi.%s.channel", iface,
                 propMode.toLowerCase());
-        setRadioSettings(band, channel, settings);
-
         Optional<Boolean> hidden = props.getOpt(Boolean.class, "net.interface.%s.config.wifi.%s.ignoreSSID", iface,
                 propMode.toLowerCase());
+
+        settings.put("mode", new Variant<>(mode));
+        settings.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
+        settings.put("band", new Variant<>(band));
+        if (channel.isPresent()) {
+            settings.put("channel", new Variant<>(new UInt32(Short.parseShort(channel.get()))));
+        }
         if (hidden.isPresent()) {
             settings.put("hidden", new Variant<>(hidden.get()));
         }
 
         return settings;
-    }
-
-    private static void setRadioSettings(String band, String channel, Map<String, Variant<?>> settings) {
-        boolean bandIsAuto = band.isEmpty();
-        boolean channelIsAuto = channel.equals("0");
-
-        if (bandIsAuto && channelIsAuto) {
-            // Full auto, don't set anything and let NM do its job
-            return;
-        }
-
-        if (!bandIsAuto && channelIsAuto) {
-            settings.put("band", new Variant<>(band));
-            settings.put("channel", new Variant<>(new UInt32(0)));
-        } else if (bandIsAuto && !channelIsAuto) {
-            String inferredBand = inferBandFrom(channel);
-            settings.put("band", new Variant<>(inferredBand));
-            settings.put("channel", new Variant<>(new UInt32(Short.parseShort(channel))));
-        } else { // !bandIsAuto && !channelIsAuto
-            settings.put("band", new Variant<>(band));
-            settings.put("channel", new Variant<>(new UInt32(Short.parseShort(channel))));
-        }
-    }
-
-    private static String inferBandFrom(String channel) {
-        int intChannel = Integer.parseInt(channel);
-
-        if (intChannel < 32) {
-            return "bg";
-        } else {
-            return "a";
-        }
     }
 
     public static Map<String, Variant<?>> build80211WirelessSecuritySettings(NetworkProperties props, String iface) {
@@ -281,7 +250,6 @@ public class NMSettingsConverter {
     }
 
     private static String wifiBandConvert(String kuraBand) {
-        logger.info("Band: {}", kuraBand);
         switch (kuraBand) {
         case "RADIO_MODE_80211a":
         case "RADIO_MODE_80211_AC":
@@ -292,7 +260,7 @@ public class NMSettingsConverter {
         case "RADIO_MODE_80211nHT20":
         case "RADIO_MODE_80211nHT40below":
         case "RADIO_MODE_80211nHT40above":
-            return ""; // leave empty
+            return "bg"; // TBD
         default:
             throw new IllegalArgumentException(String.format("Unsupported WiFi band \"%s\"", kuraBand));
         }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -263,6 +263,96 @@ public class NMSettingsConverterTest {
     }
 
     @Test
+    public void build80211WirelessSettingsShouldWorkWithChannel0And2Ghz() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211b");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "0");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("mode", "infrastructure");
+        thenResultingMapContainsBytes("ssid", "ssidtest");
+        thenResultingMapContains("band", "bg");
+        thenResultingMapContains("channel", new UInt32(0));
+    }
+
+    @Test
+    public void build80211WirelessSettingsShouldWorkWithChannel0And5Ghz() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "0");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("mode", "infrastructure");
+        thenResultingMapContainsBytes("ssid", "ssidtest");
+        thenResultingMapContains("band", "a");
+        thenResultingMapContains("channel", new UInt32(0));
+    }
+
+    @Test
+    public void build80211WirelessSettingsAutomaticBandSelectionShouldWorkWithChannel0() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211nHT20");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "0");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("mode", "infrastructure");
+        thenResultingMapContainsBytes("ssid", "ssidtest");
+        thenResultingMapContains("channel", new UInt32(0));
+        thenResultingMapNotContains("band");
+    }
+
+    @Test
+    public void build80211WirelessSettingsAutomaticBandSelectionShouldWorkWithChannel2Ghz() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211nHT20");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "1");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("mode", "infrastructure");
+        thenResultingMapContainsBytes("ssid", "ssidtest");
+        thenResultingMapContains("band", "bg");
+        thenResultingMapContains("channel", new UInt32(1));
+    }
+
+    @Test
+    public void build80211WirelessSettingsAutomaticBandSelectionShouldWorkWithChannel5Ghz() {
+
+        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211nHT20");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "44");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild80211WirelessSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("mode", "infrastructure");
+        thenResultingMapContainsBytes("ssid", "ssidtest");
+        thenResultingMapContains("band", "a");
+        thenResultingMapContains("channel", new UInt32(44));
+    }
+
+    @Test
     public void build80211WirelessSecuritySettingsShouldWorkWhenGivenExpectedMap() {
 
         givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");


### PR DESCRIPTION
This PR adds automatic band selection support.

**Detail**: To simplify current UX and better model the settings available from NetworkManager, we decided to introduce more automation in the band/channel selection for Wifi settings, leveraging the automation mechanism available from NetworkManager.

Instead of the old RadioMode we introduce in #4440  the “Band” settings selection allowing the following values:
- 2.4Ghz
- 5Ghz
- Both (2.4Ghz/5Ghz)

In the channel selection menu, in addition to the available channel, we’ll add the “Auto” channel option in #4448 

This PR adds the complementary support to the UI changes:
- Automatic channel (i.e. channel 0) is already supported and works as expected in Station Mode. In AP mode it defaults to the first channel in the band. Some more exploration is required.
- Automatic band selection, we infer the band from the selected channel.

**Access Point mode**

- In AP mode, setting the “Band” as “Both” and the “Channel” as “Auto” will result in NM setting the first channel in the band "bg".
- In AP mode, setting the “Band” and leaving the “Channel” as “Auto” will result in NM choosing the first channel within the chosen band.
- In AP mode, setting the “Channel” and leaving the “Band” as "Both" will result in Kura inferring the desired band from the channel using the algorithm reported below
- In AP mode, setting the “Channel” and the “Band” will result in NM setting all as expected.

From the implementation point of view:
- The `channel` parameter is always set.
- The `band` parameter is computed from the `radioMode` settings and the `channel` value.
  - radioMode 80211n + Channel Auto → NM: leave `band` settings as empty and `channel` as 0. NM will do its job → Note: NM will advertise the AP as 802.11n
  - radioMode 80211n + Channel selected → NM: Kura will infer the band from the channel number.
  - In any other case all settings are populated.

If the selected channel doesn’t belong to the selected band NM will throw a DBusException.

**Station mode**
The description for the AP mode still applies to the Station mode, but setting the channel as "Auto", will select the correct channel.

In case the AP selection uses the list of the available APs, band and channel are automatically populated.

In case a user manually populates all the fields, all the above cases still apply.

> ⚠️ Warning: Inferring band from channel number
> 
> Here we’re liberally interpreting the Wifi standard: channel numbers overlaps between bands so it wouldn’t allow us to select the band only from the channel number.
> 
> Given the fact that the channel overlapping between 2.4Ghz and 5Ghz are never used for the 5Ghz band we decided to use the following algorithm: if channel number < 32 → 2.4Ghz, 5Ghz otherwise.
> 
> See: [List of WLAN channels](https://en.wikipedia.org/wiki/List_of_WLAN_channels)