### PR TITLE
fix: Fixed possible deadlock with SQLite

### DIFF
--- a/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/ConnectionPoolManager.java
+++ b/kura/org.eclipse.kura.db.sqlite.provider/src/main/java/org/eclipse/kura/internal/db/sqlite/provider/ConnectionPoolManager.java
@@ -51,14 +51,13 @@ public class ConnectionPoolManager {
         this.hikariDatasource = new HikariDataSource(config);
     }
 
-    public synchronized Connection getConnection() throws SQLException {
+    public Connection getConnection() throws SQLException {
         logger.debug("getting connection");
 
         return this.hikariDatasource.getConnection();
-
     }
 
-    synchronized void withExclusiveConnection(final Consumer<Connection> consumer) {
+    void withExclusiveConnection(final Consumer<Connection> consumer) {
 
         HikariPoolMXBean hikariPoolMXBean = this.hikariDatasource.getHikariPoolMXBean();
 
@@ -82,7 +81,7 @@ public class ConnectionPoolManager {
         waitCondition(() -> hikariPoolMXBean.getActiveConnections() <= 0, timeoutMs);
     }
 
-    public synchronized void shutdown(final Optional<Long> waitIdleTimeoutMs) {
+    public void shutdown(final Optional<Long> waitIdleTimeoutMs) {
 
         HikariPoolMXBean hikariPoolMXBean = this.hikariDatasource.getHikariPoolMXBean();
 
@@ -97,7 +96,7 @@ public class ConnectionPoolManager {
         this.hikariDatasource.close();
     }
 
-    private synchronized boolean waitCondition(final BooleanSupplier condition, final Optional<Long> timeoutMs) {
+    private boolean waitCondition(final BooleanSupplier condition, final Optional<Long> timeoutMs) {
 
         final long end = timeoutMs.map(t -> System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(t))
                 .orElse(Long.MAX_VALUE);
@@ -109,7 +108,7 @@ public class ConnectionPoolManager {
             }
 
             try {
-                this.wait(100);
+                Thread.sleep(100);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

The existing synchronization logic in ConnectionPoolManager might cause a deadlock interacting with the synchronization logic provided by the Hikari pool. This PR removes the synchronization logic from ConnectionPoolManager to rely only on Hikari pool synchronization.

