### PR TITLE
refactor(api): updated NetworkStatusService and implementation to use the newly introduced device ID

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/NetworkInterfaceStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/NetworkInterfaceStatus.java
@@ -25,11 +25,21 @@ import org.osgi.annotation.versioning.ProviderType;
  * network interface. Specific interfaces, like ethernet or wifi, must extend
  * this class.
  *
+ * A network interface is identified by Kura using the id field. It is used
+ * to internally manage the interface.
+ * The interfaceName, instead, is the IP interface as it may appear on the
+ * system.
+ * For Ethernet and WiFi interfaces the two values coincide (i.e. eth0, wlp1s0,
+ * ...).
+ * For modems, instead, the id is typically the usb or pci path, while the
+ * interfaceName is the IP interface created when they are connected.
+ * When the modem is disconnected the interfaceName can have a different value.
+ * 
  */
 @ProviderType
 public abstract class NetworkInterfaceStatus {
 
-    private final String name;
+    private final String id;
     private final String interfaceName;
     private final byte[] hardwareAddress;
     private final NetworkInterfaceType type;
@@ -44,7 +54,7 @@ public abstract class NetworkInterfaceStatus {
     private final Optional<NetworkInterfaceIpAddressStatus<IP6Address>> interfaceIp6Addresses;
 
     protected NetworkInterfaceStatus(NetworkInterfaceStatusBuilder<?> builder) {
-        this.name = builder.name;
+        this.id = builder.id;
         this.interfaceName = builder.interfaceName;
         this.hardwareAddress = builder.hardwareAddress;
         this.type = builder.type;
@@ -59,8 +69,8 @@ public abstract class NetworkInterfaceStatus {
         this.interfaceIp6Addresses = builder.interfaceIp6Addresses;
     }
 
-    public String getName() {
-        return this.name;
+    public String getId() {
+        return this.id;
     }
 
     public String getInterfaceName() {
@@ -119,7 +129,7 @@ public abstract class NetworkInterfaceStatus {
     public abstract static class NetworkInterfaceStatusBuilder<T extends NetworkInterfaceStatusBuilder<T>> {
 
         private static final String NA = "N/A";
-        private String name = NA;
+        private String id = NA;
         private String interfaceName = NA;
         private byte[] hardwareAddress = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
         private NetworkInterfaceType type = NetworkInterfaceType.UNKNOWN;
@@ -133,8 +143,8 @@ public abstract class NetworkInterfaceStatus {
         private Optional<NetworkInterfaceIpAddressStatus<IP4Address>> interfaceIp4Addresses = Optional.empty();
         private Optional<NetworkInterfaceIpAddressStatus<IP6Address>> interfaceIp6Addresses = Optional.empty();
 
-        public T withName(String name) {
-            this.name = name;
+        public T withId(String id) {
+            this.id = id;
             return getThis();
         }
 
@@ -213,7 +223,7 @@ public abstract class NetworkInterfaceStatus {
         result = prime * result
                 + Objects.hash(this.autoConnect, this.driver, this.driverVersion, this.firmwareVersion,
                         this.interfaceName,
-                        this.interfaceIp4Addresses, this.interfaceIp6Addresses, this.mtu, this.name, this.state,
+                        this.interfaceIp4Addresses, this.interfaceIp6Addresses, this.mtu, this.id, this.state,
                         this.type, this.virtual);
         return result;
     }
@@ -234,7 +244,7 @@ public abstract class NetworkInterfaceStatus {
                 && Objects.equals(this.interfaceName, other.interfaceName)
                 && Objects.equals(this.interfaceIp4Addresses, other.interfaceIp4Addresses)
                 && Objects.equals(this.interfaceIp6Addresses, other.interfaceIp6Addresses) && this.mtu == other.mtu
-                && Objects.equals(this.name, other.name) && this.state == other.state && this.type == other.type
+                && Objects.equals(this.id, other.id) && this.state == other.state && this.type == other.type
                 && this.virtual == other.virtual;
     }
 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/NetworkStatusService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/NetworkStatusService.java
@@ -36,18 +36,23 @@ public interface NetworkStatusService {
 
     /**
      * Return an optional {@link NetworkInterfaceStatus} of the given network
-     * interface. If the interface doesn't exist, an Empty value is returned.
+     * interface selected by its id. For Ethernet and WiFi interfaces, the
+     * identifier is typically the interface name. For the modems, instead,
+     * it is the usb or pci path.
+     * If the interface doesn't exist, an Empty value is returned.
      * 
-     * @param interfaceName the name of the network interface
+     * @param id the identifier of the network interface
      * @return the {@link NetworkInterfaceStatus}
      */
-    public Optional<NetworkInterfaceStatus> getNetworkStatus(String interfaceName);
+    public Optional<NetworkInterfaceStatus> getNetworkStatus(String id);
 
     /**
-     * Return the names of the network interfaces detected in the system.
+     * Return the identifiers of the network interfaces detected in the
+     * system. For Ethernet and WiFi interfaces, the identifier is typically
+     * the interface name. For the modems, instead, it is the usb or pci path.
      * 
-     * @return a list containing the network interface names
+     * @return a list containing the network interface identifiers
      */
-    public List<String> getInterfaceNames();
+    public List<String> getInterfaceIds();
 
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -228,7 +228,7 @@ public class NMDbusConnector {
             modemDeviceProperties = getModemProperties(modemPath.get());
             if (modemDeviceProperties.isPresent()) {
                 simProperties = getModemSimProperties(modemDeviceProperties.get());
-//                bearerProperties = getModemBearersProperties(modemPath.get(), modemDeviceProperties.get());
+                bearerProperties = getModemBearersProperties(modemPath.get(), modemDeviceProperties.get());
             }
         }
         DevicePropertiesWrapper modemPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -337,16 +337,16 @@ public class NMDbusConnector {
         }
     }
 
-    private void enableInterface(String iface, NetworkProperties properties, Device device,
-            NMDeviceType deviceType) throws DBusException {
+    private void enableInterface(String deviceId, NetworkProperties properties, Device device, NMDeviceType deviceType)
+            throws DBusException {
         if (Boolean.FALSE.equals(isDeviceManaged(device))) {
             setDeviceManaged(device, true);
         }
+        String interfaceName = getDeviceInterface(device);
 
         Optional<Connection> connection = getAppliedConnection(device);
-        Map<String, Map<String, Variant<?>>> newConnectionSettings = NMSettingsConverter.buildSettings(
-                properties,
-                connection, iface, deviceType);
+        Map<String, Map<String, Variant<?>>> newConnectionSettings = NMSettingsConverter.buildSettings(properties,
+                connection, deviceId, interfaceName, deviceType);
 
         logger.info("New settings: {}", newConnectionSettings);
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -436,19 +436,6 @@ public class NMDbusConnector {
         return devices;
     }
 
-    private List<String> getAllDeviceInterfaceNames() throws DBusException {
-        List<DBusPath> devicePaths = this.nm.GetAllDevices();
-
-        List<String> devices = new ArrayList<>();
-        for (DBusPath path : devicePaths) {
-            Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, path.getPath(),
-                    Properties.class);
-            devices.add(deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_INTERFACE));
-        }
-
-        return devices;
-    }
-
     private List<Properties> getAllAccessPoints(Wireless wirelessDevice) throws DBusException {
         List<DBusPath> accessPointPaths = wirelessDevice.GetAllAccessPoints();
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -133,7 +133,7 @@ public class NMDbusConnector {
         logger.info("NM Version: {}", nmVersion);
     }
 
-    public synchronized List<String> getInterfaces() throws DBusException {
+    public synchronized List<String> getDeviceIds() throws DBusException {
         List<Device> availableDevices = getAllDevices();
 
         List<String> supportedDeviceNames = new ArrayList<>();
@@ -290,7 +290,7 @@ public class NMDbusConnector {
 
     private synchronized void manageConfiguredInterfaces(List<String> configuredInterfaces,
             NetworkProperties properties) throws DBusException {
-        List<String> availableInterfaces = getInterfaces();
+        List<String> availableInterfaces = getDeviceIds();
 
         for (String iface : configuredInterfaces) {
             if (!availableInterfaces.contains(iface)) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -292,8 +292,6 @@ public class NMDbusConnector {
             NetworkProperties properties) throws DBusException {
         List<String> availableInterfaces = getInterfaces();
 
-        logger.info("Mbeh??? {}", availableInterfaces);
-
         for (String iface : configuredInterfaces) {
             if (!availableInterfaces.contains(iface)) {
                 logger.debug("Configured device \"{}\" not available on the system. Ignoring configuration.", iface);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -267,23 +267,23 @@ public class NMSettingsConverter {
     }
 
     private static void setAuthenticationType(String authenticationType, Map<String, Variant<?>> settings) {
-        if (authenticationType.equals("AUTO")) {
+        if (authenticationType.equals("netModemAuthAUTO")) {
             return;
         }
 
-        if (authenticationType.equals("NONE")) {
+        if (authenticationType.equals("netModemAuthNONE")) {
             settings.put(PPP_REFUSE_EAP, new Variant<>(true));
             settings.put(PPP_REFUSE_CHAP, new Variant<>(true));
             settings.put(PPP_REFUSE_PAP, new Variant<>(true));
             settings.put(PPP_REFUSE_MSCHAP, new Variant<>(true));
             settings.put(PPP_REFUSE_MSCHAPV2, new Variant<>(true));
-        } else if (authenticationType.equals("CHAP")) {
+        } else if (authenticationType.equals("netModemAuthCHAP")) {
             settings.put(PPP_REFUSE_EAP, new Variant<>(true));
             settings.put(PPP_REFUSE_CHAP, new Variant<>(false));
             settings.put(PPP_REFUSE_PAP, new Variant<>(true));
             settings.put(PPP_REFUSE_MSCHAP, new Variant<>(true));
             settings.put(PPP_REFUSE_MSCHAPV2, new Variant<>(true));
-        } else if (authenticationType.equals("PAP")) {
+        } else if (authenticationType.equals("netModemAuthPAP")) {
             settings.put(PPP_REFUSE_EAP, new Variant<>(true));
             settings.put(PPP_REFUSE_CHAP, new Variant<>(true));
             settings.put(PPP_REFUSE_PAP, new Variant<>(false));
@@ -397,8 +397,7 @@ public class NMSettingsConverter {
         case "SECURITY_WPA_WPA2":
             return Arrays.asList();
         default:
-            throw new IllegalArgumentException(
-                    String.format("Unsupported WiFi proto \"%s\"", kuraSecurityProto));
+            throw new IllegalArgumentException(String.format("Unsupported WiFi proto \"%s\"", kuraSecurityProto));
         }
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -51,26 +51,27 @@ public class NMSettingsConverter {
     }
 
     public static Map<String, Map<String, Variant<?>>> buildSettings(NetworkProperties properties,
-            Optional<Connection> oldConnection, String iface, NMDeviceType deviceType) {
+            Optional<Connection> oldConnection, String deviceId, String iface, NMDeviceType deviceType) {
         Map<String, Map<String, Variant<?>>> newConnectionSettings = new HashMap<>();
 
         Map<String, Variant<?>> connectionMap = buildConnectionSettings(oldConnection, iface, deviceType);
         newConnectionSettings.put(NM_SETTINGS_CONNECTION, connectionMap);
 
-        Map<String, Variant<?>> ipv4Map = NMSettingsConverter.buildIpv4Settings(properties, iface);
-        Map<String, Variant<?>> ipv6Map = NMSettingsConverter.buildIpv6Settings(properties, iface);
+        Map<String, Variant<?>> ipv4Map = NMSettingsConverter.buildIpv4Settings(properties, deviceId);
+        Map<String, Variant<?>> ipv6Map = NMSettingsConverter.buildIpv6Settings(properties, deviceId);
         newConnectionSettings.put("ipv4", ipv4Map);
         newConnectionSettings.put("ipv6", ipv6Map);
 
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_WIFI) {
-            Map<String, Variant<?>> wifiSettingsMap = NMSettingsConverter.build80211WirelessSettings(properties, iface);
+            Map<String, Variant<?>> wifiSettingsMap = NMSettingsConverter.build80211WirelessSettings(properties,
+                    deviceId);
             Map<String, Variant<?>> wifiSecuritySettingsMap = NMSettingsConverter
-                    .build80211WirelessSecuritySettings(properties, iface);
+                    .build80211WirelessSecuritySettings(properties, deviceId);
             newConnectionSettings.put("802-11-wireless", wifiSettingsMap);
             newConnectionSettings.put("802-11-wireless-security", wifiSecuritySettingsMap);
         } else if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {
-            Map<String, Variant<?>> gsmSettingsMap = NMSettingsConverter.buildGsmSettings(properties, iface);
-            Map<String, Variant<?>> pppSettingsMap = NMSettingsConverter.buildPPPSettings(properties, iface);
+            Map<String, Variant<?>> gsmSettingsMap = NMSettingsConverter.buildGsmSettings(properties, deviceId);
+            Map<String, Variant<?>> pppSettingsMap = NMSettingsConverter.buildPPPSettings(properties, deviceId);
             newConnectionSettings.put("gsm", gsmSettingsMap);
             newConnectionSettings.put("ppp", pppSettingsMap);
         }
@@ -78,26 +79,26 @@ public class NMSettingsConverter {
         return newConnectionSettings;
     }
 
-    public static Map<String, Variant<?>> buildIpv4Settings(NetworkProperties props, String iface) {
+    public static Map<String, Variant<?>> buildIpv4Settings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
-        Boolean dhcpClient4Enabled = props.get(Boolean.class, "net.interface.%s.config.dhcpClient4.enabled", iface);
+        Boolean dhcpClient4Enabled = props.get(Boolean.class, "net.interface.%s.config.dhcpClient4.enabled", deviceId);
 
         KuraIpStatus ip4Status = KuraIpStatus
-                .fromString(props.get(String.class, "net.interface.%s.config.ip4.status", iface));
+                .fromString(props.get(String.class, "net.interface.%s.config.ip4.status", deviceId));
 
         if (Boolean.FALSE.equals(dhcpClient4Enabled)) {
             settings.put(NM_SETTINGS_IPV4_METHOD, new Variant<>("manual"));
 
-            String address = props.get(String.class, "net.interface.%s.config.ip4.address", iface);
-            Short prefix = props.get(Short.class, "net.interface.%s.config.ip4.prefix", iface);
+            String address = props.get(String.class, "net.interface.%s.config.ip4.address", deviceId);
+            Short prefix = props.get(Short.class, "net.interface.%s.config.ip4.prefix", deviceId);
 
             Map<String, Variant<?>> addressEntry = new HashMap<>();
             addressEntry.put("address", new Variant<>(address));
             addressEntry.put("prefix", new Variant<>(new UInt32(prefix)));
 
             if (ip4Status.equals(KuraIpStatus.ENABLEDWAN)) {
-                Optional<String> gateway = props.getOpt(String.class, "net.interface.%s.config.ip4.gateway", iface);
+                Optional<String> gateway = props.getOpt(String.class, "net.interface.%s.config.ip4.gateway", deviceId);
                 gateway.ifPresent(gatewayAddress -> settings.put("gateway", new Variant<>(gatewayAddress)));
             }
 
@@ -111,14 +112,14 @@ public class NMSettingsConverter {
             settings.put("ignore-auto-dns", new Variant<>(true));
             settings.put("ignore-auto-routes", new Variant<>(true));
         } else if (ip4Status.equals(KuraIpStatus.ENABLEDWAN)) {
-            Optional<List<String>> dnsServers = props.getOptStringList("net.interface.%s.config.ip4.dnsServers", iface);
+            Optional<List<String>> dnsServers = props.getOptStringList("net.interface.%s.config.ip4.dnsServers", deviceId);
             if (dnsServers.isPresent()) {
                 settings.put("dns", new Variant<>(convertIp4(dnsServers.get()), "au"));
                 settings.put("ignore-auto-dns", new Variant<>(true));
             }
 
             Optional<Integer> wanPriority = props.getOpt(Integer.class, "net.interface.%s.config.ip4.wan.priority",
-                    iface);
+                    deviceId);
             if (wanPriority.isPresent()) {
                 Long supportedByNM = wanPriority.get().longValue();
                 settings.put("route-metric", new Variant<>(supportedByNM));
@@ -130,7 +131,7 @@ public class NMSettingsConverter {
         return settings;
     }
 
-    public static Map<String, Variant<?>> buildIpv6Settings(NetworkProperties props, String iface) {
+    public static Map<String, Variant<?>> buildIpv6Settings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
         // Disabled for now
@@ -139,60 +140,60 @@ public class NMSettingsConverter {
         return settings;
     }
 
-    public static Map<String, Variant<?>> build80211WirelessSettings(NetworkProperties props, String iface) {
+    public static Map<String, Variant<?>> build80211WirelessSettings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
-        String propMode = props.get(String.class, "net.interface.%s.config.wifi.mode", iface);
+        String propMode = props.get(String.class, "net.interface.%s.config.wifi.mode", deviceId);
 
         String mode = wifiModeConvert(propMode);
         settings.put("mode", new Variant<>(mode));
 
-        String ssid = props.get(String.class, "net.interface.%s.config.wifi.%s.ssid", iface, propMode.toLowerCase());
+        String ssid = props.get(String.class, "net.interface.%s.config.wifi.%s.ssid", deviceId, propMode.toLowerCase());
         settings.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
 
         short channel = Short.parseShort(
-                props.get(String.class, "net.interface.%s.config.wifi.%s.channel", iface, propMode.toLowerCase()));
+                props.get(String.class, "net.interface.%s.config.wifi.%s.channel", deviceId, propMode.toLowerCase()));
         settings.put("channel", new Variant<>(new UInt32(channel)));
 
         Optional<String> band = wifiBandConvert(
-                props.get(String.class, "net.interface.%s.config.wifi.%s.radioMode", iface, propMode.toLowerCase()),
+                props.get(String.class, "net.interface.%s.config.wifi.%s.radioMode", deviceId, propMode.toLowerCase()),
                 channel);
         band.ifPresent(bandString -> settings.put("band", new Variant<>(bandString)));
 
-        Optional<Boolean> hidden = props.getOpt(Boolean.class, "net.interface.%s.config.wifi.%s.ignoreSSID", iface,
+        Optional<Boolean> hidden = props.getOpt(Boolean.class, "net.interface.%s.config.wifi.%s.ignoreSSID", deviceId,
                 propMode.toLowerCase());
         hidden.ifPresent(hiddenString -> settings.put("hidden", new Variant<>(hiddenString)));
 
         return settings;
     }
 
-    public static Map<String, Variant<?>> build80211WirelessSecuritySettings(NetworkProperties props, String iface) {
+    public static Map<String, Variant<?>> build80211WirelessSecuritySettings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
-        String propMode = props.get(String.class, "net.interface.%s.config.wifi.mode", iface);
+        String propMode = props.get(String.class, "net.interface.%s.config.wifi.mode", deviceId);
 
         String psk = props
-                .get(Password.class, "net.interface.%s.config.wifi.%s.passphrase", iface, propMode.toLowerCase())
+                .get(Password.class, "net.interface.%s.config.wifi.%s.passphrase", deviceId, propMode.toLowerCase())
                 .toString();
         String keyMgmt = wifiKeyMgmtConvert(
-                props.get(String.class, "net.interface.%s.config.wifi.%s.securityType", iface, propMode.toLowerCase()));
+                props.get(String.class, "net.interface.%s.config.wifi.%s.securityType", deviceId, propMode.toLowerCase()));
         settings.put("psk", new Variant<>(psk));
         settings.put("key-mgmt", new Variant<>(keyMgmt));
 
         if ("wpa-psk".equals(keyMgmt)) {
             List<String> proto = wifiProtoConvert(props.get(String.class,
-                    "net.interface.%s.config.wifi.%s.securityType", iface, propMode.toLowerCase()));
+                    "net.interface.%s.config.wifi.%s.securityType", deviceId, propMode.toLowerCase()));
             settings.put("proto", new Variant<>(proto, "as"));
         }
 
-        Optional<String> group = props.getOpt(String.class, "net.interface.%s.config.wifi.%s.groupCiphers", iface,
+        Optional<String> group = props.getOpt(String.class, "net.interface.%s.config.wifi.%s.groupCiphers", deviceId,
                 propMode.toLowerCase());
         if (group.isPresent()) {
             List<String> nmGroup = wifiCipherConvert(group.get());
             settings.put("group", new Variant<>(nmGroup, "as"));
         }
 
-        Optional<String> pairwise = props.getOpt(String.class, "net.interface.%s.config.wifi.%s.pairwiseCiphers", iface,
+        Optional<String> pairwise = props.getOpt(String.class, "net.interface.%s.config.wifi.%s.pairwiseCiphers", deviceId,
                 propMode.toLowerCase());
         if (pairwise.isPresent()) {
             List<String> nmPairwise = wifiCipherConvert(pairwise.get());
@@ -202,34 +203,34 @@ public class NMSettingsConverter {
         return settings;
     }
 
-    public static Map<String, Variant<?>> buildGsmSettings(NetworkProperties props, String iface) {
+    public static Map<String, Variant<?>> buildGsmSettings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
-        String apn = props.get(String.class, "net.interface.%s.config.apn", iface);
+        String apn = props.get(String.class, "net.interface.%s.config.apn", deviceId);
         settings.put("apn", new Variant<>(apn));
 
-        Optional<String> username = props.getOpt(String.class, "net.interface.%s.config.username", iface);
+        Optional<String> username = props.getOpt(String.class, "net.interface.%s.config.username", deviceId);
         username.ifPresent(usernameString -> settings.put("username", new Variant<>(usernameString)));
 
-        Optional<Password> password = props.getOpt(Password.class, "net.interface.%s.config.password", iface);
+        Optional<Password> password = props.getOpt(Password.class, "net.interface.%s.config.password", deviceId);
         password.ifPresent(passwordString -> settings.put("password", new Variant<>(passwordString.toString())));
 
-        Optional<String> number = props.getOpt(String.class, "net.interface.%s.config.dialString", iface);
+        Optional<String> number = props.getOpt(String.class, "net.interface.%s.config.dialString", deviceId);
         number.ifPresent(numberString -> settings.put("number", new Variant<>(numberString)));
 
         return settings;
     }
 
-    public static Map<String, Variant<?>> buildPPPSettings(NetworkProperties props, String iface) {
+    public static Map<String, Variant<?>> buildPPPSettings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
         Optional<Integer> lcpEchoInterval = props.getOpt(Integer.class, "net.interface.%s.config.lcpEchoInterval",
-                iface);
+                deviceId);
         lcpEchoInterval.ifPresent(interval -> settings.put("lcp-echo-interval", new Variant<>(interval)));
-        Optional<Integer> lcpEchoFailure = props.getOpt(Integer.class, "net.interface.%s.config.lcpEchoFailure", iface);
+        Optional<Integer> lcpEchoFailure = props.getOpt(Integer.class, "net.interface.%s.config.lcpEchoFailure", deviceId);
         lcpEchoFailure.ifPresent(failure -> settings.put("lcp-echo-failure", new Variant<>(failure)));
 
-        Optional<String> authType = props.getOpt(String.class, "net.interface.%s.config.authType", iface);
+        Optional<String> authType = props.getOpt(String.class, "net.interface.%s.config.authType", deviceId);
         authType.ifPresent(authenticationType -> setAuthenticationType(authenticationType, settings));
 
         return settings;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -109,7 +109,7 @@ public class NMStatusConverter {
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties) {
 
         EthernetInterfaceStatusBuilder builder = EthernetInterfaceStatus.builder();
-        builder.withName(interfaceName).withInterfaceName(interfaceName).withVirtual(false);
+        builder.withId(interfaceName).withInterfaceName(interfaceName).withVirtual(false);
 
         NMDeviceState deviceState = NMDeviceState.fromUInt32(
                 devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, STATE));
@@ -126,7 +126,7 @@ public class NMStatusConverter {
     public static NetworkInterfaceStatus buildLoopbackStatus(String interfaceName,
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties) {
         LoopbackInterfaceStatusBuilder builder = LoopbackInterfaceStatus.builder();
-        builder.withName(interfaceName).withInterfaceName(interfaceName).withVirtual(true);
+        builder.withId(interfaceName).withInterfaceName(interfaceName).withVirtual(true);
 
         NMDeviceState deviceState = NMDeviceState.fromUInt32(
                 devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, STATE));
@@ -143,7 +143,7 @@ public class NMStatusConverter {
             AccessPointsProperties accessPointsProperties,
             SupportedChannelsProperties supportedChannelsProperties) {
         WifiInterfaceStatusBuilder builder = WifiInterfaceStatus.builder();
-        builder.withName(interfaceName).withInterfaceName(interfaceName).withVirtual(false);
+        builder.withId(interfaceName).withInterfaceName(interfaceName).withVirtual(false);
 
         NMDeviceState deviceState = NMDeviceState.fromUInt32(
                 devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, STATE));
@@ -207,10 +207,10 @@ public class NMStatusConverter {
             String modemDeviceProperty = ((String) properties.Get(MM_MODEM_BUS_NAME, "Device"));
             String modemDeviceResourcePath = modemDeviceProperty.substring(modemDeviceProperty.lastIndexOf("/") + 1);
             if (Objects.nonNull(modemDeviceResourcePath) && !modemDeviceResourcePath.isEmpty()) {
-                builder.withName(modemDeviceResourcePath);
+                builder.withId(modemDeviceResourcePath);
 
             } else {
-                builder.withName(interfaceName);
+                builder.withId(interfaceName);
             }
         });
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -105,11 +104,11 @@ public class NMStatusConverter {
         throw new IllegalStateException("Utility class");
     }
 
-    public static NetworkInterfaceStatus buildEthernetStatus(String interfaceName,
+    public static NetworkInterfaceStatus buildEthernetStatus(String interfaceId,
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties) {
 
         EthernetInterfaceStatusBuilder builder = EthernetInterfaceStatus.builder();
-        builder.withId(interfaceName).withInterfaceName(interfaceName).withVirtual(false);
+        builder.withId(interfaceId).withInterfaceName(interfaceId).withVirtual(false);
 
         NMDeviceState deviceState = NMDeviceState.fromUInt32(
                 devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, STATE));
@@ -123,10 +122,10 @@ public class NMStatusConverter {
 
     }
 
-    public static NetworkInterfaceStatus buildLoopbackStatus(String interfaceName,
+    public static NetworkInterfaceStatus buildLoopbackStatus(String interfaceId,
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties) {
         LoopbackInterfaceStatusBuilder builder = LoopbackInterfaceStatus.builder();
-        builder.withId(interfaceName).withInterfaceName(interfaceName).withVirtual(true);
+        builder.withId(interfaceId).withInterfaceName(interfaceId).withVirtual(true);
 
         NMDeviceState deviceState = NMDeviceState.fromUInt32(
                 devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, STATE));
@@ -138,12 +137,12 @@ public class NMStatusConverter {
         return builder.build();
     }
 
-    public static NetworkInterfaceStatus buildWirelessStatus(String interfaceName,
+    public static NetworkInterfaceStatus buildWirelessStatus(String interfaceId,
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties,
             AccessPointsProperties accessPointsProperties,
             SupportedChannelsProperties supportedChannelsProperties) {
         WifiInterfaceStatusBuilder builder = WifiInterfaceStatus.builder();
-        builder.withId(interfaceName).withInterfaceName(interfaceName).withVirtual(false);
+        builder.withId(interfaceId).withInterfaceName(interfaceId).withVirtual(false);
 
         NMDeviceState deviceState = NMDeviceState.fromUInt32(
                 devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, STATE));
@@ -172,15 +171,14 @@ public class NMStatusConverter {
         builder.withHardwareAddress(getMacAddressBytes(hwAddress));
     }
 
-    public static NetworkInterfaceStatus buildModemStatus(String interfaceName,
+    public static NetworkInterfaceStatus buildModemStatus(String interfaceId,
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties,
             List<Properties> simProperties, List<Properties> bearerProperties) {
         ModemInterfaceStatusBuilder builder = ModemInterfaceStatus.builder();
         Properties deviceProperties = devicePropertiesWrapper.getDeviceProperties();
         Optional<Properties> modemProperties = devicePropertiesWrapper.getDeviceSpecificProperties();
-        setModemName(interfaceName, modemProperties, builder);
-        setModemInterfaceName(interfaceName, deviceProperties, modemProperties, builder);
-        builder.withVirtual(false);
+        builder.withId(interfaceId).withVirtual(false);
+        setModemInterfaceName(interfaceId, deviceProperties, builder);
 
         NMDeviceState deviceState = NMDeviceState
                 .fromUInt32(deviceProperties.Get(NM_DEVICE_BUS_NAME, STATE));
@@ -200,45 +198,25 @@ public class NMStatusConverter {
         return builder.build();
     }
 
-    // Set the name as the path of the modem in the device (usb path, pci path, ...)
-    private static void setModemName(String interfaceName, Optional<Properties> modemProperties,
-            ModemInterfaceStatusBuilder builder) {
-        modemProperties.ifPresent(properties -> {
-            String modemDeviceProperty = ((String) properties.Get(MM_MODEM_BUS_NAME, "Device"));
-            String modemDeviceResourcePath = modemDeviceProperty.substring(modemDeviceProperty.lastIndexOf("/") + 1);
-            if (Objects.nonNull(modemDeviceResourcePath) && !modemDeviceResourcePath.isEmpty()) {
-                builder.withId(modemDeviceResourcePath);
-
-            } else {
-                builder.withId(interfaceName);
-            }
-        });
-    }
-
     // Set the interface name as the interface used for the connection if available
-    private static void setModemInterfaceName(String interfaceName, Properties deviceProperties,
-            Optional<Properties> modemProperties,
+    private static void setModemInterfaceName(String interfaceId, Properties deviceProperties,
             ModemInterfaceStatusBuilder builder) {
         try {
             String ipInterface = deviceProperties.Get(NM_DEVICE_BUS_NAME, "IpInterface");
             if (Objects.nonNull(ipInterface) && !ipInterface.isEmpty()) {
                 builder.withInterfaceName(ipInterface);
             } else {
-                modemProperties.ifPresent(properties -> {
-                    Map<String, ModemPortType> ports = getPorts(properties);
-                    Optional<Entry<String, ModemPortType>> netPort = ports.entrySet().stream()
-                            .filter(entry -> entry.getValue().equals(ModemPortType.NET)).findFirst();
-                    if (netPort.isPresent()) {
-                        builder.withInterfaceName(netPort.get().getKey());
-                    } else {
-                        builder.withInterfaceName(interfaceName);
-                    }
-                });
+                builder.withInterfaceName("");
             }
         } catch (DBusExecutionException e) {
-            logger.debug("Cannot retrieve IpInterface for " + interfaceName + " interface", e);
-            builder.withInterfaceName(interfaceName);
+            logger.debug("Cannot retrieve IpInterface for " + interfaceId + " interface", e);
+            builder.withInterfaceName("");
         }
+    }
+
+    public static String getModemDeviceHwPath(Properties modemProperties) {
+        String modemDeviceProperty = ((String) modemProperties.Get(MM_MODEM_BUS_NAME, "Device"));
+        return modemDeviceProperty.substring(modemDeviceProperty.lastIndexOf("/") + 1);
     }
 
     private static String getHwAddressFrom(DevicePropertiesWrapper devicePropertiesWrapper) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
@@ -100,7 +100,7 @@ public class NMStatusServiceImpl implements NetworkStatusService {
     public List<String> getInterfaceIds() {
         List<String> interfaces = new ArrayList<>();
         try {
-            interfaces = this.nmDbusConnector.getInterfaces();
+            interfaces = this.nmDbusConnector.getDeviceIds();
         } catch (DBusException e) {
             logger.warn("Could not retrieve interfaces from NM because: ", e);
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
@@ -66,21 +66,21 @@ public class NMStatusServiceImpl implements NetworkStatusService {
 
     @Override
     public List<NetworkInterfaceStatus> getNetworkStatus() {
-        List<String> availableInterfaces = getInterfaceNames();
+        List<String> availableInterfaces = getInterfaceIds();
 
         List<NetworkInterfaceStatus> interfaceStatuses = new ArrayList<>();
-        for (String iface : availableInterfaces) {
-            getNetworkStatus(iface).ifPresent(interfaceStatuses::add);
+        for (String id : availableInterfaces) {
+            getNetworkStatus(id).ifPresent(interfaceStatuses::add);
         }
 
         return interfaceStatuses;
     }
 
     @Override
-    public Optional<NetworkInterfaceStatus> getNetworkStatus(String interfaceName) {
+    public Optional<NetworkInterfaceStatus> getNetworkStatus(String id) {
         Optional<NetworkInterfaceStatus> networkInterfaceStatus = Optional.empty();
         try {
-            NetworkInterfaceStatus status = this.nmDbusConnector.getInterfaceStatus(interfaceName,
+            NetworkInterfaceStatus status = this.nmDbusConnector.getInterfaceStatus(id,
                     this.commandExecutorService);
             if (Objects.nonNull(status)) {
                 networkInterfaceStatus = Optional.of(status);
@@ -88,16 +88,16 @@ public class NMStatusServiceImpl implements NetworkStatusService {
         } catch (UnknownMethod e) {
             logger.warn(
                     "Could not retrieve status for \"{}\" interface from NM because the DBus object path references got invalidated.",
-                    interfaceName);
+                    id);
         } catch (DBusException | KuraException e) {
-            logger.warn("Could not retrieve status for \"{}\" interface from NM because: ", interfaceName, e);
+            logger.warn("Could not retrieve status for \"{}\" interface from NM because: ", id, e);
         }
 
         return networkInterfaceStatus;
     }
 
     @Override
-    public List<String> getInterfaceNames() {
+    public List<String> getInterfaceIds() {
         List<String> interfaces = new ArrayList<>();
         try {
             interfaces = this.nmDbusConnector.getInterfaces();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkInterfacesTableUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkInterfacesTableUi.java
@@ -13,6 +13,7 @@
 package org.eclipse.kura.web.client.ui.network;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.EntryClassUi;
@@ -150,9 +151,13 @@ public class NetworkInterfacesTableUi extends Composite {
             public String getValue(GwtNetInterfaceConfig object) {
                 if (object.getHwTypeEnum().equals(GwtNetIfType.MODEM) && object instanceof GwtModemInterfaceConfig) {
                     GwtModemInterfaceConfig modemObject = (GwtModemInterfaceConfig) object;
-                    return modemObject.getInterfaceName() + " (" + modemObject.getName() + ")";
+                    if (Objects.nonNull(modemObject.getInterfaceName()) && !modemObject.getInterfaceName().isEmpty()) {
+                        return modemObject.getName() + " (" + modemObject.getInterfaceName() + ")";
+                    } else {
+                        return object.getName();
+                    }
                 } else {
-                    return object.getInterfaceName();
+                    return object.getName();
                 }
             }
         };

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtStatusServiceImpl.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.kura.cloud.CloudService;
 import org.eclipse.kura.cloudconnection.CloudConnectionManager;
@@ -342,9 +343,11 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
                 }
             } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
                 String currentModemApn = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getApn();
+                String name = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getName();
                 String interfaceName = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getInterfaceName();
-                String name = interfaceName + " ("
-                        + gwtNetInterfaceConfig.getName() + ")";
+                if (Objects.nonNull(interfaceName) && !interfaceName.isEmpty()) {
+                    name = name + " (" + interfaceName + ")";
+                }
                 if (gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusDisabled
                         || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusUnmanaged
                         || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusL2Only) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -67,7 +67,7 @@ public class NetworkStatusServiceAdapter {
     }
 
     public List<String> getNetInterfaces() {
-        return this.networkStatusService.getInterfaceNames();
+        return this.networkStatusService.getInterfaceIds();
     }
 
     public void fillWithStatusProperties(String ifName, GwtNetInterfaceConfig gwtConfigToUpdate) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -176,12 +176,12 @@ public class NetworkStatusServiceAdapter {
     private void setCommonStateProperties(GwtNetInterfaceConfig gwtConfig,
             NetworkInterfaceStatus networkInterfaceStatus) {
 
-        gwtConfig.setName(networkInterfaceStatus.getName());
+        gwtConfig.setName(networkInterfaceStatus.getId());
         gwtConfig.setInterfaceName(networkInterfaceStatus.getInterfaceName());
         gwtConfig.setHwState(networkInterfaceStatus.getState().name());
         gwtConfig.setHwType(networkInterfaceStatus.getType().name());
         gwtConfig.setHwAddress(NetUtil.hardwareAddressToString(networkInterfaceStatus.getHardwareAddress()));
-        gwtConfig.setHwName(networkInterfaceStatus.getName());
+        gwtConfig.setHwName(networkInterfaceStatus.getId());
         gwtConfig.setHwDriver(networkInterfaceStatus.getDriver());
         gwtConfig.setHwDriverVersion(networkInterfaceStatus.getDriverVersion());
         gwtConfig.setHwFirmware(networkInterfaceStatus.getFirmwareVersion());

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -931,7 +931,7 @@ public class NMDbusConnectorTest {
 
     private void whenGetInterfacesIsCalled() {
         try {
-            this.internalStringList = this.instanceNMDbusConnector.getInterfaces();
+            this.internalStringList = this.instanceNMDbusConnector.getDeviceIds();
         } catch (DBusException e) {
             this.hasDBusExceptionBeenThrown = true;
         }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1068,7 +1068,7 @@ public class NMDbusConnectorTest {
     private void thenModemStatusHasCorrectValues(boolean hasBearers, boolean hasSims) {
         assertTrue(this.netInterface instanceof ModemInterfaceStatus);
         ModemInterfaceStatus modemStatus = (ModemInterfaceStatus) this.netInterface;
-        assertEquals("1-5", modemStatus.getName());
+        assertEquals("1-5", modemStatus.getId());
         assertEquals("wwan0", modemStatus.getInterfaceName());
         assertEquals("AwesomeModel", modemStatus.getModel());
         assertEquals("TheBestInTheWorld", modemStatus.getManufacturer());

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -485,11 +485,11 @@ public class NMDbusConnectorTest {
     @Test
     public void getModemInterfaceStatusShouldWork() throws DBusException, IOException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true, true,
+        givenMockedDevice("1-5", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true, true,
                 true);
         givenMockedDeviceList();
 
-        whenGetInterfaceStatus("wwan0", this.commandExecutorService);
+        whenGetInterfaceStatus("1-5", this.commandExecutorService);
 
         thenNoExceptionIsThrown();
         thenInterfaceStatusIsNotNull();
@@ -497,13 +497,14 @@ public class NMDbusConnectorTest {
         thenModemStatusHasCorrectValues(true, true);
     }
 
+    @Test
     public void getModemInterfaceStatusWithoutBearersShouldWork() throws DBusException, IOException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true, false,
+        givenMockedDevice("1-5", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true, false,
                 true);
         givenMockedDeviceList();
 
-        whenGetInterfaceStatus("wwan0", this.commandExecutorService);
+        whenGetInterfaceStatus("1-5", this.commandExecutorService);
 
         thenNoExceptionIsThrown();
         thenInterfaceStatusIsNotNull();
@@ -514,11 +515,11 @@ public class NMDbusConnectorTest {
     @Test
     public void getModemInterfaceStatusWithoutSimsShouldWork() throws DBusException, IOException {
         givenBasicMockedDbusConnector();
-        givenMockedDevice("wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true, true,
+        givenMockedDevice("1-5", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true, true,
                 false);
         givenMockedDeviceList();
 
-        whenGetInterfaceStatus("wwan0", this.commandExecutorService);
+        whenGetInterfaceStatus("1-5", this.commandExecutorService);
 
         thenNoExceptionIsThrown();
         thenInterfaceStatusIsNotNull();
@@ -672,19 +673,19 @@ public class NMDbusConnectorTest {
                 "/org/freedesktop/NetworkManager", Properties.class);
     }
 
-    private void givenMockedDevice(String interfaceName, NMDeviceType type, NMDeviceState state,
+    private void givenMockedDevice(String interfaceId, NMDeviceType type, NMDeviceState state,
             Boolean hasAssociatedConnection, boolean hasBearers, boolean hasSims) throws DBusException, IOException {
         Device mockedDevice1 = mock(Device.class);
 
-        this.mockDevices.put(interfaceName, mockedDevice1);
+        this.mockDevices.put(interfaceId, mockedDevice1);
 
-        when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/" + interfaceName);
+        when(mockedDevice1.getObjectPath()).thenReturn("/mock/device/" + interfaceId);
 
         Generic mockedDevice1Generic = mock(Generic.class);
-        when(mockedDevice1Generic.getObjectPath()).thenReturn("/mock/device/" + interfaceName);
+        when(mockedDevice1Generic.getObjectPath()).thenReturn("/mock/device/" + interfaceId);
 
         DBusPath mockedPath1 = mock(DBusPath.class);
-        when(mockedPath1.getPath()).thenReturn("/mock/device/" + interfaceName);
+        when(mockedPath1.getPath()).thenReturn("/mock/device/" + interfaceId);
 
         Map<String, Map<String, Variant<?>>> mockedDevice1ConnectionSetting = new HashMap<>();
         mockedDevice1ConnectionSetting.put("connection",
@@ -700,20 +701,20 @@ public class NMDbusConnectorTest {
 
         Properties mockedProperties1 = mock(Properties.class);
 
-        if (type == NMDeviceType.NM_DEVICE_TYPE_GENERIC && interfaceName.equals("lo")) {
+        if (type == NMDeviceType.NM_DEVICE_TYPE_GENERIC && interfaceId.equals("lo")) {
             when(mockedProperties1.Get(any(), any())).thenReturn("loopback");
         }
 
         if (type == NMDeviceType.NM_DEVICE_TYPE_WIFI) {
-            simulateIwCommandOutputs(interfaceName, mockedProperties1);
+            simulateIwCommandOutputs(interfaceId, mockedProperties1);
         }
 
         if (type == NMDeviceType.NM_DEVICE_TYPE_ETHERNET) {
             Wired wiredDevice = mock(Wired.class);
-            when(wiredDevice.getObjectPath()).thenReturn("/mock/device/" + interfaceName);
+            when(wiredDevice.getObjectPath()).thenReturn("/mock/device/" + interfaceId);
 
             doReturn(wiredDevice).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
-                    "/mock/device/" + interfaceName, Wired.class);
+                    "/mock/device/" + interfaceId, Wired.class);
         }
 
         when(mockedProperties1.Get("org.freedesktop.NetworkManager.Device", "DeviceType"))
@@ -721,35 +722,35 @@ public class NMDbusConnectorTest {
         when(mockedProperties1.Get("org.freedesktop.NetworkManager.Device", "State"))
                 .thenReturn(NMDeviceState.toUInt32(state));
         when(mockedProperties1.Get("org.freedesktop.NetworkManager.Device", "Interface"))
-                .thenReturn(interfaceName);
+                .thenReturn(interfaceId);
 
-        when(this.mockedNetworkManager.GetDeviceByIpIface(interfaceName)).thenReturn(mockedPath1);
+        when(this.mockedNetworkManager.GetDeviceByIpIface(interfaceId)).thenReturn(mockedPath1);
 
         doReturn(mockedDevice1).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
-                "/mock/device/" + interfaceName, Device.class);
+                "/mock/device/" + interfaceId, Device.class);
         doReturn(mockedDevice1Settings).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
                 "/org/freedesktop/NetworkManager/Settings", Settings.class);
         doReturn(mockedProperties1).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
-                "/mock/device/" + interfaceName, Properties.class);
+                "/mock/device/" + interfaceId, Properties.class);
         if (hasAssociatedConnection) {
             this.mockConnection = mock(Connection.class, RETURNS_SMART_NULLS);
             when(this.mockConnection.GetSettings()).thenReturn(mockedDevice1ConnectionSetting);
 
             doReturn(this.mockConnection).when(this.dbusConnection).getRemoteObject(
-                    "org.freedesktop.NetworkManager", "/mock/device/" + interfaceName, Connection.class);
+                    "org.freedesktop.NetworkManager", "/mock/device/" + interfaceId, Connection.class);
         } else {
             doThrow(new DBusExecutionException("initiate mocked throw")).when(this.dbusConnection).getRemoteObject(
-                    "org.freedesktop.NetworkManager", "/mock/device/" + interfaceName, Connection.class);
+                    "org.freedesktop.NetworkManager", "/mock/device/" + interfaceId, Connection.class);
         }
 
         doReturn(mockedDevice1Generic).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
                 "/mock/device/lo", Generic.class);
 
         Properties mockedProperties = this.dbusConnection.getRemoteObject("org.freedesktop.NetworkManager",
-                "/mock/device/" + interfaceName, Properties.class);
-        givenExtraStatusMocksFor(interfaceName, state, mockedProperties);
+                "/mock/device/" + interfaceId, Properties.class);
+        givenExtraStatusMocksFor(interfaceId, state, mockedProperties);
         if (type == NMDeviceType.NM_DEVICE_TYPE_MODEM) {
-            givenModemMocksFor(interfaceName, mockedProperties, hasBearers, hasSims);
+            givenModemMocksFor(interfaceId, mockedProperties, hasBearers, hasSims);
         }
     }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -955,6 +955,26 @@ public class NMSettingsConverterTest {
     }
 
     @Test
+    public void buildSettingsShouldWorkWithModemSettings() {
+        givenMapWith("net.interface.1-1.1.config.dhcpClient4.enabled", true);
+        givenMapWith("net.interface.1-1.1.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenMapWith("net.interface.1-1.1.config.apn", "mobile.test.com");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "1-1.1", "ttyACM0",
+                NMDeviceType.NM_DEVICE_TYPE_MODEM);
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
+        thenResultingBuildAllMapContains("ipv4", "method", "auto");
+        thenResultingBuildAllMapContains("connection", "id", "kura-ttyACM0-connection");
+        thenResultingBuildAllMapContains("connection", "interface-name", "ttyACM0");
+        thenResultingBuildAllMapContains("connection", "type", "gsm");
+        thenResultingBuildAllMapContains("connection", "autoconnect-retries", 1);
+        thenResultingBuildAllMapContains("gsm", "apn", "mobile.test.com");
+    }
+
+    @Test
     public void buildSettingsShouldThrowDhcpDisabledAndNullIp() {
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -443,7 +443,7 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("key-mgmt", "none");
         thenResultingMapNotContains("proto");
     }
-    
+
     @Test
     public void build80211WirelessSecuritySettingsShouldWorkWhenGivenSecurityTypeWep() {
 
@@ -460,7 +460,7 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("key-mgmt", "none");
         thenResultingMapNotContains("proto");
     }
-    
+
     @Test
     public void build80211WirelessSecuritySettingsShouldWorkWhenGivenSecurityTypeWpa() {
 
@@ -477,7 +477,7 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("key-mgmt", "wpa-psk");
         thenResultingMapContains("proto", new Variant<>(Arrays.asList("wpa"), "as").getValue());
     }
-    
+
     @Test
     public void build80211WirelessSecuritySettingsShouldWorkWhenGivenSecurityTypeWpa2() {
 
@@ -571,7 +571,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldWorkWithAuthTypeAuto() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "AUTO");
+        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthAUTO");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");
@@ -586,7 +586,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldWorkWithAuthTypeNone() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "NONE");
+        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthNONE");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");
@@ -601,7 +601,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldWorkWithAuthTypeChap() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "CHAP");
+        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthCHAP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");
@@ -616,7 +616,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldWorkWithAuthTypePap() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "PAP");
+        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthPAP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");
@@ -631,7 +631,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldThrowWithUnsupportedAuthType() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "ROFL");
+        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthROFL");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -54,7 +54,8 @@ public class NMSettingsConverterTest {
     @Test
     public void buildSettingsShouldThrowWhenGivenEmptyMap() {
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
         thenNoSuchElementExceptionThrown();
     }
 
@@ -696,7 +697,8 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
         thenNoExceptionsHaveBeenThrown();
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
@@ -737,7 +739,8 @@ public class NMSettingsConverterTest {
 
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
         thenNoExceptionsHaveBeenThrown();
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
@@ -777,7 +780,8 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
         thenNoExceptionsHaveBeenThrown();
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
@@ -818,7 +822,8 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
         thenNoExceptionsHaveBeenThrown();
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
@@ -860,7 +865,8 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
         thenNoExceptionsHaveBeenThrown();
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
@@ -892,7 +898,7 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0", "eth0",
                 NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
         thenNoExceptionsHaveBeenThrown();
@@ -914,7 +920,7 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0", "eth0",
                 NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
         thenNoExceptionsHaveBeenThrown();
@@ -936,7 +942,7 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0", "eth0",
                 NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
         thenNoExceptionsHaveBeenThrown();
@@ -958,7 +964,7 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0", "eth0",
                 NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
         thenNoSuchElementExceptionThrown();
@@ -974,7 +980,7 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0", "eth0",
                 NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
         thenNoSuchElementExceptionThrown();
@@ -990,7 +996,7 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0",
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0", "eth0",
                 NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
         thenNoSuchElementExceptionThrown();
@@ -1016,7 +1022,8 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
         thenNoSuchElementExceptionThrown();
     }
@@ -1041,7 +1048,8 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
         thenNoSuchElementExceptionThrown();
     }
@@ -1066,7 +1074,8 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
-        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", NMDeviceType.NM_DEVICE_TYPE_WIFI);
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
         thenNoSuchElementExceptionThrown();
     }
@@ -1141,9 +1150,10 @@ public class NMSettingsConverterTest {
      */
 
     public void whenBuildSettingsIsRunWith(NetworkProperties properties, Optional<Connection> oldConnection,
-            String iface, NMDeviceType deviceType) {
+            String deviceId, String iface, NMDeviceType deviceType) {
         try {
-            this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, iface, deviceType);
+            this.resultAllSettingsMap = NMSettingsConverter.buildSettings(properties, oldConnection, deviceId, iface,
+                    deviceType);
         } catch (NoSuchElementException e) {
             this.hasNoSuchElementExceptionBeenThrown = true;
         } catch (IllegalArgumentException e) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
@@ -277,7 +277,7 @@ public class NMStatusServiceImplTest {
 
     private void thenRetrievedEthernetInterfaceStatusHasFullProperties() throws UnknownHostException {
         EthernetInterfaceStatus ethStatus = (EthernetInterfaceStatus) this.status.get();
-        assertEquals("abcd0", ethStatus.getName());
+        assertEquals("abcd0", ethStatus.getId());
         assertCommonProperties(ethStatus);
         assertTrue(ethStatus.isLinkUp());
         assertEquals(buildEthernetInterfaceStatus("abcd0"), ethStatus);
@@ -291,7 +291,7 @@ public class NMStatusServiceImplTest {
 
     private void thenRetrievedWifiInterfaceStatusHasFullProperties() throws UnknownHostException {
         WifiInterfaceStatus wifiStatus = (WifiInterfaceStatus) this.status.get();
-        assertEquals("wlan0", wifiStatus.getName());
+        assertEquals("wlan0", wifiStatus.getId());
         assertCommonProperties(wifiStatus);
         assertEquals(2, wifiStatus.getCapabilities().size());
         assertEquals(EnumSet.of(WifiCapability.AP, WifiCapability.FREQ_2GHZ), wifiStatus.getCapabilities());
@@ -330,7 +330,7 @@ public class NMStatusServiceImplTest {
         assertFalse(this.statuses.isEmpty());
         assertEquals(2, this.statuses.size());
         this.statuses.forEach(status -> {
-            assertTrue(status.getName().equals("wlan0") || status.getName().equals("abcd0"));
+            assertTrue(status.getId().equals("wlan0") || status.getId().equals("abcd0"));
         });
     }
 
@@ -346,7 +346,7 @@ public class NMStatusServiceImplTest {
 
     private void thenRetrievedLoopbackInterfaceStatusHasFullProperties() throws UnknownHostException {
         LoopbackInterfaceStatus loStatus = (LoopbackInterfaceStatus) this.status.get();
-        assertEquals("lo", loStatus.getName());
+        assertEquals("lo", loStatus.getId());
         assertTrue(Arrays.equals(new byte[] { 0x00, 0x11, 0x02, 0x33, 0x44, 0x55 }, loStatus.getHardwareAddress()));
         assertEquals("EthDriver", loStatus.getDriver());
         assertEquals("EthDriverVersion", loStatus.getDriverVersion());
@@ -365,7 +365,7 @@ public class NMStatusServiceImplTest {
 
     private void thenRetrievedModemkInterfaceStatusHasFullProperties() throws UnknownHostException {
         ModemInterfaceStatus modemStatus = (ModemInterfaceStatus) this.status.get();
-        assertEquals("wwan0", modemStatus.getName());
+        assertEquals("wwan0", modemStatus.getId());
         assertTrue(Arrays.equals(new byte[] { 0x00, 0x11, 0x02, 0x33, 0x44, 0x55 }, modemStatus.getHardwareAddress()));
         assertEquals("EthDriver", modemStatus.getDriver());
         assertEquals("EthDriverVersion", modemStatus.getDriverVersion());
@@ -514,7 +514,7 @@ public class NMStatusServiceImplTest {
 
     private void buildCommonProperties(String interfaceName, NetworkInterfaceStatusBuilder<?> builder)
             throws UnknownHostException {
-        builder.withName(interfaceName);
+        builder.withId(interfaceName);
         builder.withHardwareAddress(new byte[] { 0x00, 0x11, 0x02, 0x33, 0x44, 0x55 });
         builder.withDriver("EthDriver").withDriverVersion("EthDriverVersion").withFirmwareVersion("1234");
         builder.withVirtual(false).withState(NetworkInterfaceState.ACTIVATED).withAutoConnect(true).withMtu(1500);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
@@ -222,12 +222,12 @@ public class NMStatusServiceImplTest {
 
     private void givenNMStatusServiceImplWithoutInterfaces() throws DBusException, UnknownHostException {
         createTestObjects();
-        when(this.nmDbusConnector.getInterfaces()).thenThrow(DBusException.class);
+        when(this.nmDbusConnector.getDeviceIds()).thenThrow(DBusException.class);
     }
 
     private void givenNMStatusServiceImplWithInterfaces() throws DBusException, UnknownHostException, KuraException {
         createTestObjects();
-        when(this.nmDbusConnector.getInterfaces()).thenReturn(Arrays.asList("abcd0", "wlan0"));
+        when(this.nmDbusConnector.getDeviceIds()).thenReturn(Arrays.asList("abcd0", "wlan0"));
         when(this.nmDbusConnector.getInterfaceStatus("abcd0", this.commandExecutorService))
                 .thenReturn(buildEthernetInterfaceStatus("abcd0"));
         when(this.nmDbusConnector.getInterfaceStatus("wlan0", this.commandExecutorService))

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
@@ -257,7 +257,7 @@ public class NMStatusServiceImplTest {
     }
 
     private void whenInterfaceNameListIsRetrived() {
-        this.interfaceNames = this.statusService.getInterfaceNames();
+        this.interfaceNames = this.statusService.getInterfaceIds();
     }
 
     private void thenInterfaceStatusIsEmpty() {


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

In order to correctly support modem devices, this PR updates the `NetworkStatusService` methods to use an `id` instead of an `interfaceName` to identify a network device. The `id` coincides with the `interfaceName` for ethernet and wifi interfaces, while for modems is the usb/pci path. The `interfaceName` for modems is the main port used for communication (i.e. ttyACM0, ttyUSB2, ...) and is used for identifying them by NetworkManager at configuration time.