### PR TITLE
refactor(api): Added throw exception to NetworkStatusService APIs

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/NetworkStatusService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/NetworkStatusService.java
@@ -16,6 +16,7 @@ package org.eclipse.kura.net.status;
 import java.util.List;
 import java.util.Optional;
 
+import org.eclipse.kura.KuraException;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -27,14 +28,6 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface NetworkStatusService {
 
     /**
-     * Return the list of the {@link NetworkInterfaceStatus} of all network
-     * interfaces detected in the system.
-     * 
-     * @return a list containing the status of all the network interfaces
-     */
-    public List<NetworkInterfaceStatus> getNetworkStatus();
-
-    /**
      * Return an optional {@link NetworkInterfaceStatus} of the given network
      * interface selected by its id. For Ethernet and WiFi interfaces, the
      * identifier is typically the interface name. For the modems, instead,
@@ -43,8 +36,10 @@ public interface NetworkStatusService {
      * 
      * @param id the identifier of the network interface
      * @return the {@link NetworkInterfaceStatus}
+     * @throws KuraException when an error occurs while retrieving the status of the
+     *                       given interface
      */
-    public Optional<NetworkInterfaceStatus> getNetworkStatus(String id);
+    public Optional<NetworkInterfaceStatus> getNetworkStatus(String interfaceName) throws KuraException;
 
     /**
      * Return the identifiers of the network interfaces detected in the
@@ -53,6 +48,6 @@ public interface NetworkStatusService {
      * 
      * @return a list containing the network interface identifiers
      */
-    public List<String> getInterfaceIds();
+    public List<String> getInterfaceIds() throws KuraException;
 
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -215,7 +215,7 @@ public class NMStatusConverter {
     }
 
     public static String getModemDeviceHwPath(Properties modemProperties) {
-        String modemDeviceProperty = ((String) modemProperties.Get(MM_MODEM_BUS_NAME, "Device"));
+        String modemDeviceProperty = (String) modemProperties.Get(MM_MODEM_BUS_NAME, "Device");
         return modemDeviceProperty.substring(modemDeviceProperty.lastIndexOf("/") + 1);
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.kura.KuraException;
+import org.eclipse.kura.KuraIOException;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.net.status.NetworkInterfaceStatus;
 import org.eclipse.kura.net.status.NetworkStatusService;
@@ -74,11 +75,10 @@ public class NMStatusServiceImpl implements NetworkStatusService {
                 networkInterfaceStatus = Optional.of(status);
             }
         } catch (UnknownMethod e) {
-            logger.warn(
-                    "Could not retrieve status for \"{}\" interface from NM because the DBus object path references got invalidated.",
-                    id);
-        } catch (DBusException | KuraException e) {
-            logger.warn("Could not retrieve status for \"{}\" interface from NM because: ", id, e);
+            throw new KuraIOException(e, "Could not retrieve status for " + id
+                    + " interface from NM because the DBus object path references got invalidated.");
+        } catch (DBusException e) {
+            throw new KuraIOException(e, "Could not retrieve status for " + id + " interface from NM.");
         }
 
         return networkInterfaceStatus;
@@ -90,7 +90,7 @@ public class NMStatusServiceImpl implements NetworkStatusService {
         try {
             interfaces = this.nmDbusConnector.getDeviceIds();
         } catch (DBusException e) {
-            logger.warn("Could not retrieve interfaces from NM because: ", e);
+            throw new KuraIOException(e, "Could not retrieve interfaces from NM.");
         }
 
         return interfaces;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
@@ -65,19 +65,7 @@ public class NMStatusServiceImpl implements NetworkStatusService {
     }
 
     @Override
-    public List<NetworkInterfaceStatus> getNetworkStatus() {
-        List<String> availableInterfaces = getInterfaceIds();
-
-        List<NetworkInterfaceStatus> interfaceStatuses = new ArrayList<>();
-        for (String id : availableInterfaces) {
-            getNetworkStatus(id).ifPresent(interfaceStatuses::add);
-        }
-
-        return interfaceStatuses;
-    }
-
-    @Override
-    public Optional<NetworkInterfaceStatus> getNetworkStatus(String id) {
+    public Optional<NetworkInterfaceStatus> getNetworkStatus(String id) throws KuraException {
         Optional<NetworkInterfaceStatus> networkInterfaceStatus = Optional.empty();
         try {
             NetworkInterfaceStatus status = this.nmDbusConnector.getInterfaceStatus(id,
@@ -97,7 +85,7 @@ public class NMStatusServiceImpl implements NetworkStatusService {
     }
 
     @Override
-    public List<String> getInterfaceIds() {
+    public List<String> getInterfaceIds() throws KuraException {
         List<String> interfaces = new ArrayList<>();
         try {
             interfaces = this.nmDbusConnector.getDeviceIds();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -49,7 +49,7 @@ public class GwtNetworkServiceImpl {
     }
 
     private static final Logger logger = LoggerFactory.getLogger(GwtNetworkServiceImpl.class);
-    
+
     public static List<GwtNetInterfaceConfig> findNetInterfaceConfigurations(boolean recompute)
             throws GwtKuraException {
         try {
@@ -205,7 +205,7 @@ public class GwtNetworkServiceImpl {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
     }
-    
+
     public static List<GwtWifiChannelFrequency> findFrequencies(String interfaceName, GwtWifiRadioMode radioMode)
             throws GwtKuraException {
         try {
@@ -235,16 +235,16 @@ public class GwtNetworkServiceImpl {
             }
 
             return displayedChannels;
-        } catch (GwtKuraException e) {
+        } catch (KuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
     }
-    
+
     public static String getWifiCountryCode() throws GwtKuraException {
         try {
             NetworkStatusServiceAdapter status = new NetworkStatusServiceAdapter();
             return status.getWifiCountryCode();
-        } catch (GwtKuraException e) {
+        } catch (KuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
     }
@@ -254,7 +254,7 @@ public class GwtNetworkServiceImpl {
             List<GwtWifiHotspotEntry> aps = new NetworkStatusServiceAdapter().findWifiHotspots(interfaceName);
             logger.debug("Found APs: {}", aps);
             return aps;
-        } catch (GwtKuraException e) {
+        } catch (KuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2023 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -137,7 +137,7 @@ public class NetworkStatusServiceAdapter {
                     return ((WifiInterfaceStatus) ifaceStatus.get()).getCountryCode();
                 }
             } catch (KuraException e) {
-                logger.error("Cannot retrieve wifi country code", e);
+                this.logger.error("Cannot retrieve wifi country code", e);
             }
         }
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR refactors the `NetworkStatusService` APIs adding an exception throw to the get methods.

**Description of the solution adopted:** This PR does the following:

- removes the `getNetworkStatus` method from the `NetworkStatusService`
- add the exception throw to the `getNetworkStatus(String interfaceName)` and `getInterfaceNames()` methods
- the implementation and tests are updated accordingly

The rationale behind this modfications is to notify the user when an error occours. When the interface does not exist, an empty optional is returned and no exceptions are thrown. The retrival of the status of multiple interfaces should be managed at application level.
