### PR TITLE
fix: Improved DataService validation

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/data/DataService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/data/DataService.java
@@ -132,6 +132,7 @@ public interface DataService {
      * messages that should be sent with the minimum latency.
      * For example Cloud life-cycle messages are published with priority 0
      * as soon the connection is established and just before disconnecting.
+     * Priority must be non-negative.
      * <br>
      * Data messages, tolerating an higher latency, may be published with a
      * lower priority. Within each priority level and each QoS level, messages
@@ -150,7 +151,8 @@ public interface DataService {
      * @param retain
      * @param priority
      * @return
-     * @throws KuraStoreException
+     * @throws KuraStoreException If the message cannot be stored.
+     * @throws IllegalArgumentException If the priority argument is negative.
      */
     public int publish(String topic, byte[] payload, int qos, boolean retain, int priority) throws KuraStoreException;
 

--- a/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.raw.mqtt.publisher.RawMqttPublisher.xml
+++ b/kura/org.eclipse.kura.cloudconnection.raw.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.raw.mqtt.publisher.RawMqttPublisher.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2023 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -54,6 +54,7 @@
             cardinality="0"
             required="true"
             default="7"
+            min="0"
             description='The priority of the messages. 0 is highest priority. This parameter is related to the DataService component of the cloud stack.'>
         </AD>
     </OCD>

--- a/kura/org.eclipse.kura.core.cloud/OSGI-INF/metatype/org.eclipse.kura.cloud.publisher.CloudPublisher.xml
+++ b/kura/org.eclipse.kura.core.cloud/OSGI-INF/metatype/org.eclipse.kura.cloud.publisher.CloudPublisher.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2023 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -72,6 +72,7 @@
             type="Integer"
             cardinality="0"
             required="true"
+            min="0"
             default="7"
             description='Message priority. Priority level 0 (highest) should be used sparingly and reserved for messages that should be sent with the minimum latency. Default is set to 7.'>
         </AD>

--- a/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.core/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -205,6 +205,15 @@
             min="1"
             description="Specifies an inactivity timeout in seconds. If the timeout expires, the cloud connection will be automatically closed. This parameter is only used if Enable Connection Schedule is set to true." />
 
+          <AD id="maximum.payload.size"
+            name="Maximum Payload Size"
+            type="Long"
+            cardinality="0"
+            required="true"
+            default="16777216"
+            min="0"
+            description="The maximum allowed size in bytes for the message payload."/>
+
     </OCD>
     <Designate pid="org.eclipse.kura.data.DataService" factoryPid="org.eclipse.kura.data.DataService">
         <Object ocdref="org.eclipse.kura.data.DataService"/>

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -638,6 +638,14 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
     @Override
     public int publish(String topic, byte[] payload, int qos, boolean retain, int priority) throws KuraStoreException {
 
+        if (priority < 0) {
+            throw new IllegalArgumentException("Priority cannot be negative");
+        }
+
+        if ((long) payload.length > this.dataServiceOptions.getMaximumPayloadSizeBytes()) {
+            throw new KuraStoreException("Payload size exceeds configured limit");
+        }
+
         if (this.autoConnectStrategy.isPresent()) {
             this.autoConnectStrategy.get().onPublishRequested(topic, payload, qos, retain, priority);
         }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -642,7 +642,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             throw new IllegalArgumentException("Priority cannot be negative");
         }
 
-        if ((long) payload.length > this.dataServiceOptions.getMaximumPayloadSizeBytes()) {
+        if (payload != null && (long) payload.length > this.dataServiceOptions.getMaximumPayloadSizeBytes()) {
             throw new KuraStoreException("Payload size exceeds configured limit");
         }
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
@@ -50,6 +50,7 @@ public class DataServiceOptions {
     private static final String CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS = "connection.schedule.inactivity.interval.seconds";
     private static final String CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE = "connection.schedule.priority.override.enable";
     private static final String CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD = "connection.schedule.priority.override.threshold";
+    private static final String MAXIMUM_PAYLOAD_SIZE = "maximum.payload.size";
 
     private static final boolean AUTOCONNECT_PROP_DEFAULT = false;
     private static final int CONNECT_DELAY_DEFAULT = 60;
@@ -71,6 +72,7 @@ public class DataServiceOptions {
     private static final long CONNECTION_SCHEDULE_INACTIVITY_INTERVAL_SECONDS_DEFAULT = 60;
     private static final boolean CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_ENABLE_DEFAULT = false;
     private static final int CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD_DEFAULT = 1;
+    private static final long MAXIMUM_PAYLOAD_SIZE_DEFAULT = 16777216;
 
     private static final int CONNECT_CRITICAL_COMPONENT_TIMEOUT_MULTIPLIER = 5000;
 
@@ -203,5 +205,13 @@ public class DataServiceOptions {
         return (Integer) this.properties.getOrDefault(CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD,
                 CONNECTION_SCHEDULE_PRIORITY_OVERRIDE_THRESHOLD_DEFAULT);
 
+    }
+
+    public long getMaximumPayloadSizeBytes() {
+        try {
+            return (long) this.properties.getOrDefault(MAXIMUM_PAYLOAD_SIZE, MAXIMUM_PAYLOAD_SIZE_DEFAULT);
+        } catch (final Exception e) {
+            return MAXIMUM_PAYLOAD_SIZE_DEFAULT;
+        }
     }
 }

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
@@ -12,7 +12,10 @@
  ******************************************************************************/
 package org.eclipse.kura.core.data;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
@@ -28,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -48,6 +52,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 
@@ -56,6 +61,10 @@ public class DataServiceImplTest {
     private DataServiceImpl dataServiceImpl;
     private DataTransportService dataTransportServiceMock;
     private Map<String, Object> properties;
+    private Optional<Exception> exception = Optional.empty();
+    private final MessageStoreProvider messageStoreProvider = Mockito.mock(MessageStoreProvider.class);
+    private final MessageStore messageStore = Mockito.mock(MessageStore.class);
+    private final List<StoredMessage> storedMessages = new ArrayList<>();
 
     @Before
     public void cleanUp() {
@@ -86,6 +95,82 @@ public class DataServiceImplTest {
         whenMessageStoreDisconnectionEventHappen();
 
         thenDataTrasportIsDisconnected();
+    }
+
+    @Test
+    public void shouldNotAllowNegativePriority() throws KuraStoreException {
+        givenDataService();
+        givenMessageStoreProvider();
+        givenDataTrasportServiceConnected();
+        givenIsActive();
+
+        whenMessageIsPublished("foo", new byte[4], 0, false, -1);
+
+        thenExceptionIsThrown(IllegalArgumentException.class);
+        thenStoredMessageCountIs(0);
+    }
+
+    @Test
+    public void shouldStoreMessagesWithPayloadSizeLessThanConfiguredThreshold() throws KuraStoreException {
+        givenDataService();
+        givenMessageStoreProvider();
+        givenDataTrasportServiceConnected();
+        givenConfigurationProperty("maximum.payload.size", 4L);
+        givenIsActive();
+
+        whenMessageIsPublished("foo", new byte[3], 0, false, 9);
+
+        thenNoExceptionIsTrown();
+        thenMessageIsStored(0, "foo", new byte[3], 0, false, 9);
+    }
+
+    @Test
+    public void shouldStoreMessagesWithPayloadSizeEqualThanConfiguredThreshold() throws KuraStoreException {
+        givenDataService();
+        givenMessageStoreProvider();
+        givenDataTrasportServiceConnected();
+        givenConfigurationProperty("maximum.payload.size", 4L);
+        givenIsActive();
+
+        whenMessageIsPublished("foo", new byte[4], 0, false, 9);
+
+        thenNoExceptionIsTrown();
+        thenMessageIsStored(0, "foo", new byte[4], 0, false, 9);
+    }
+
+    @Test
+    public void shouldNotStoreMessagesWithPayloadSizeGreaterThanConfiguredThreshold() throws KuraStoreException {
+        givenDataService();
+        givenMessageStoreProvider();
+        givenDataTrasportServiceConnected();
+        givenConfigurationProperty("maximum.payload.size", 4L);
+        givenIsActive();
+
+        whenMessageIsPublished("foo", new byte[5], 0, false, 9);
+
+        thenExceptionIsThrown(KuraStoreException.class);
+        thenExceptionMessageContains("size exceeds");
+    }
+
+    private void givenConfigurationProperty(final String key, final Object value) {
+        this.properties.put(key, value);
+    }
+
+    private void givenMessageStoreProvider() throws KuraStoreException {
+        Mockito.when(messageStoreProvider.openMessageStore(Mockito.any())).thenReturn(messageStore);
+        Mockito.when(messageStore.store(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyBoolean(),
+                Mockito.anyInt()))
+                .thenAnswer(i -> {
+                    this.storedMessages.add(new StoredMessage.Builder(0) //
+                            .withTopic(i.getArgument(0)) //
+                            .withPayload(i.getArgument(1)) //
+                            .withQos(i.getArgument(2)) //
+                            .withRetain(i.getArgument(3)) //
+                            .withPriority(i.getArgument(4)) //
+                            .build());
+                    return null;
+                });
+        this.dataServiceImpl.setMessageStoreProvider(messageStoreProvider);
     }
 
     private void givenIsActive() {
@@ -139,6 +224,15 @@ public class DataServiceImplTest {
 
     }
 
+    private void whenMessageIsPublished(final String topic, final byte[] payload, final int qos, final boolean retain,
+            final int priority) {
+        try {
+        this.dataServiceImpl.publish(topic, payload, qos, retain, priority);
+        } catch (final Exception e) {
+            this.exception = Optional.of(e);
+        }
+    }
+
     private void whenMessageStoreDisconnectionEventHappen() {
         this.dataServiceImpl.disconnected();
     }
@@ -161,6 +255,33 @@ public class DataServiceImplTest {
 
     private void thenStartConnectionTaskIsInvoked() {
         verify(this.dataServiceImpl, times(2)).startConnectionTask();
+    }
+
+    private void thenMessageIsStored(final int index, final String topic, final byte[] payload, final int qos, final boolean retain,
+            final int priority) {
+        final StoredMessage message = this.storedMessages.get(index);
+
+        assertEquals(topic, message.getTopic());
+        assertArrayEquals(payload, message.getPayload());
+        assertEquals(qos, message.getQos());
+        assertEquals(retain, message.isRetain());
+        assertEquals(priority, message.getPriority());
+    }
+
+    private void thenStoredMessageCountIs(final int expectedCount) {
+        assertEquals(expectedCount, this.storedMessages.size());
+    }
+
+    private void thenNoExceptionIsTrown() {
+        assertFalse(this.exception.isPresent());
+    }
+
+    private void thenExceptionIsThrown(final Class<?> classz) {
+        assertEquals(Optional.of(classz), this.exception.map(Object::getClass));
+    }
+
+    private void thenExceptionMessageContains(final String message) {
+        assertTrue(this.exception.filter(e -> e.getMessage().contains(message)).isPresent());
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.test/src/test/java/org/eclipse/kura/core/data/DataServiceImplTest.java
@@ -109,6 +109,20 @@ public class DataServiceImplTest {
         thenExceptionIsThrown(IllegalArgumentException.class);
         thenStoredMessageCountIs(0);
     }
+    
+    @Test
+    public void shouldStoreMessagesWithNullPayload() throws KuraStoreException {
+        givenDataService();
+        givenMessageStoreProvider();
+        givenDataTrasportServiceConnected();
+        givenConfigurationProperty("maximum.payload.size", 4L);
+        givenIsActive();
+
+        whenMessageIsPublished("foo", null, 0, false, 9);
+
+        thenNoExceptionIsTrown();
+        thenMessageIsStored(0, "foo", null, 0, false, 9);
+    }
 
     @Test
     public void shouldStoreMessagesWithPayloadSizeLessThanConfiguredThreshold() throws KuraStoreException {


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

* Added validation for rejecting messages with priority < 0
* Added option for configuring maximum allowed payload size
