### PR TITLE
build(installers-deb): added complete list of dependencies

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
@@ -18,7 +18,7 @@ Depends: openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temu
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
- ntpdate, chrony, chronyc, cron | cronie,
+ ntpdate, chrony, chronyc | chrony, cron | cronie,
  network-manager | networkmanager, bind9 | bind, isc-dhcp-server | dhcp-server, isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
  logrotate,
  gpsd
@@ -30,3 +30,4 @@ Description: Kura is an inclusive software framework that puts a layer
   standard interfaces that shorten custom development time, simplified coding
   and software that can be easily ported from one hardware platform
   to another.
+        

--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
@@ -15,11 +15,13 @@ Version: [[project.version]]
 Section: misc
 Priority: low
 Depends: openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
- network-manager, bind9, isc-dhcp-server, iw,
- bluez, bluez-hcidump,
- iptables,
- chrony, ntpdate, cron,
- telnet, dos2unix, unzip
+ setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
+ polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
+ bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
+ ntpdate, chrony, chronyc, cron | cronie,
+ network-manager | networkmanager, bind9 | bind, isc-dhcp-server | dhcp-server, isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
+ logrotate,
+ gpsd
 Recommends: python3
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/control
@@ -18,7 +18,7 @@ Depends: openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temu
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
- ntpdate, chrony, chronyc, cron | cronie,
+ ntpdate, chrony, chronyc | chrony, cron | cronie,
  network-manager | networkmanager, bind9 | bind, isc-dhcp-server | dhcp-server, isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
  logrotate,
  gpsd

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/control
@@ -15,11 +15,13 @@ Version: [[project.version]]
 Section: misc
 Priority: low
 Depends: openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
- network-manager, bind9, isc-dhcp-server, iw,
- bluez, bluez-hcidump,
- iptables,
- chrony, ntpdate, cron,
- telnet, dos2unix, unzip
+ setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
+ polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
+ bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
+ ntpdate, chrony, chronyc, cron | cronie,
+ network-manager | networkmanager, bind9 | bind, isc-dhcp-server | dhcp-server, isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
+ logrotate,
+ gpsd
 Recommends: python3
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
@@ -18,7 +18,7 @@ Depends: openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temu
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
- ntpdate, chrony, chronyc, cron | cronie,
+ ntpdate, chrony, chronyc | chrony, cron | cronie,
  network-manager | networkmanager, bind9 | bind, isc-dhcp-server | dhcp-server, isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
  logrotate,
  gpsd

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
@@ -15,11 +15,13 @@ Version: [[project.version]]
 Section: misc
 Priority: low
 Depends: openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temurin-17-jdk,
- network-manager, bind9, isc-dhcp-server, iw,
- bluez, bluez-hcidump,
- iptables,
- chrony, ntpdate, cron,
- telnet, dos2unix, unzip
+ setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
+ polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
+ bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
+ ntpdate, chrony, chronyc, cron | cronie,
+ network-manager | networkmanager, bind9 | bind, isc-dhcp-server | dhcp-server, isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
+ logrotate,
+ gpsd
 Recommends: python3
 Architecture: all
 Maintainer: support@eurotech.com


### PR DESCRIPTION
This PR completes the list of DEB dependencies needed for Kura. Documentation available here: https://github.com/eclipse/kura/pull/4472.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
