### PR TITLE
fix: Aligned raspberry pi 64bits NN profile name

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -1260,7 +1260,7 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/kura_${project.version}_raspberry-pi-arm64_installer-nn.deb</deb>
+                                    <deb>${basedir}/target/kura_${project.version}_raspberry-pi-arm64-nn_installer.deb</deb>
                                     <controlDir>${basedir}/src/main/resources/raspberry-pi-arm64-nn/deb/control</controlDir>
                                     <dataSet>
                                         <data>


### PR DESCRIPTION
The previous name was *_raspberry-pi-arm64_installer-nn.deb. Aligned to the other profiles as *_raspberry-pi-arm64-nn_installer.deb