### PR TITLE
fix(core.crypto): UTF characters wrongly encoded/decoded with AES

### DIFF
--- a/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
+++ b/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
@@ -22,7 +22,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
@@ -74,9 +73,6 @@ public class CryptoServiceImpl implements CryptoService {
     private CharsetEncoder utf8Encoder;
     private CharsetDecoder utf8Decoder;
 
-    private CharsetEncoder platformEncoder;
-    private CharsetDecoder platformDecoder;
-
     public CryptoServiceImpl() {
         this.utf8Encoder = StandardCharsets.UTF_8.newEncoder();
         this.utf8Encoder.onMalformedInput(CodingErrorAction.REPORT);
@@ -85,14 +81,6 @@ public class CryptoServiceImpl implements CryptoService {
         this.utf8Decoder = StandardCharsets.UTF_8.newDecoder();
         this.utf8Decoder.onMalformedInput(CodingErrorAction.REPORT);
         this.utf8Decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
-
-        this.platformEncoder = Charset.defaultCharset().newEncoder();
-        this.platformEncoder.onMalformedInput(CodingErrorAction.REPLACE);
-        this.platformEncoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
-
-        this.platformDecoder = Charset.defaultCharset().newDecoder();
-        this.platformDecoder.onMalformedInput(CodingErrorAction.REPLACE);
-        this.platformDecoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
     }
 
     public void setSystemService(SystemService systemService) {
@@ -142,7 +130,7 @@ public class CryptoServiceImpl implements CryptoService {
             byteBuffer = this.utf8Encoder.encode(CharBuffer.wrap(value));
         } catch (CharacterCodingException e) {
             // fallback for backward compatibility
-            byteBuffer = this.platformEncoder.encode(CharBuffer.wrap(value));
+            byteBuffer = ByteBuffer.wrap(new String(value).getBytes());
         }
         byte[] encodedBytes = new byte[byteBuffer.limit()];
         byteBuffer.get(encodedBytes);
@@ -156,7 +144,7 @@ public class CryptoServiceImpl implements CryptoService {
             charBuffer = this.utf8Decoder.decode(ByteBuffer.wrap(value));
         } catch (CharacterCodingException e) {
             // fallback for backward compatibility
-            charBuffer = this.platformDecoder.decode(ByteBuffer.wrap(value));
+            charBuffer = CharBuffer.wrap(new String(value).toCharArray());
         }
         char[] decodedChar = new char[charBuffer.limit()];
         charBuffer.get(decodedChar);

--- a/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
+++ b/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
@@ -70,19 +70,6 @@ public class CryptoServiceImpl implements CryptoService {
     private final SecureRandom random = new SecureRandom();
     private SystemService systemService;
 
-    private CharsetEncoder utf8Encoder;
-    private CharsetDecoder utf8Decoder;
-
-    public CryptoServiceImpl() {
-        this.utf8Encoder = StandardCharsets.UTF_8.newEncoder();
-        this.utf8Encoder.onMalformedInput(CodingErrorAction.REPORT);
-        this.utf8Encoder.onUnmappableCharacter(CodingErrorAction.REPORT);
-
-        this.utf8Decoder = StandardCharsets.UTF_8.newDecoder();
-        this.utf8Decoder.onMalformedInput(CodingErrorAction.REPORT);
-        this.utf8Decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
-    }
-
     public void setSystemService(SystemService systemService) {
         this.systemService = systemService;
     }
@@ -123,11 +110,11 @@ public class CryptoServiceImpl implements CryptoService {
 
     }
 
-    private synchronized byte[] charArrayToByteArray(char[] value) throws CharacterCodingException {
+    private byte[] charArrayToByteArray(char[] value) throws CharacterCodingException {
 
         ByteBuffer byteBuffer;
         try {
-            byteBuffer = this.utf8Encoder.encode(CharBuffer.wrap(value));
+            byteBuffer = getUtf8Encoder().encode(CharBuffer.wrap(value));
         } catch (CharacterCodingException e) {
             // fallback for backward compatibility
             byteBuffer = ByteBuffer.wrap(new String(value).getBytes());
@@ -138,10 +125,10 @@ public class CryptoServiceImpl implements CryptoService {
         return encodedBytes;
     }
 
-    private synchronized char[] byteArrayToCharArray(byte[] value) throws CharacterCodingException {
+    private char[] byteArrayToCharArray(byte[] value) throws CharacterCodingException {
         CharBuffer charBuffer;
         try {
-            charBuffer = this.utf8Decoder.decode(ByteBuffer.wrap(value));
+            charBuffer = getUtf8Decoder().decode(ByteBuffer.wrap(value));
         } catch (CharacterCodingException e) {
             // fallback for backward compatibility
             charBuffer = CharBuffer.wrap(new String(value).toCharArray());
@@ -150,6 +137,22 @@ public class CryptoServiceImpl implements CryptoService {
         charBuffer.get(decodedChar);
 
         return decodedChar;
+    }
+
+    private CharsetEncoder getUtf8Encoder() {
+        CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
+        encoder.onMalformedInput(CodingErrorAction.REPORT);
+        encoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+
+        return encoder;
+    }
+
+    private CharsetDecoder getUtf8Decoder() {
+        CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+        decoder.onMalformedInput(CodingErrorAction.REPORT);
+        decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+
+        return decoder;
     }
 
     private byte[] base64Decode(String internalStringValue) {

--- a/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
+++ b/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
@@ -87,12 +87,12 @@ public class CryptoServiceImpl implements CryptoService {
         this.utf8Decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
 
         this.platformEncoder = Charset.defaultCharset().newEncoder();
-        this.platformEncoder.onMalformedInput(CodingErrorAction.REPORT);
-        this.platformEncoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+        this.platformEncoder.onMalformedInput(CodingErrorAction.REPLACE);
+        this.platformEncoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
 
         this.platformDecoder = Charset.defaultCharset().newDecoder();
-        this.platformDecoder.onMalformedInput(CodingErrorAction.REPORT);
-        this.platformDecoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+        this.platformDecoder.onMalformedInput(CodingErrorAction.REPLACE);
+        this.platformDecoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
     }
 
     public void setSystemService(SystemService systemService) {
@@ -135,7 +135,7 @@ public class CryptoServiceImpl implements CryptoService {
 
     }
 
-    private byte[] charArrayToByteArray(char[] value) throws CharacterCodingException {
+    private synchronized byte[] charArrayToByteArray(char[] value) throws CharacterCodingException {
 
         ByteBuffer byteBuffer;
         try {
@@ -150,7 +150,7 @@ public class CryptoServiceImpl implements CryptoService {
         return encodedBytes;
     }
 
-    private char[] byteArrayToCharArray(byte[] value) throws CharacterCodingException {
+    private synchronized char[] byteArrayToCharArray(byte[] value) throws CharacterCodingException {
         CharBuffer charBuffer;
         try {
             charBuffer = this.utf8Decoder.decode(ByteBuffer.wrap(value));

--- a/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
+++ b/kura/org.eclipse.kura.core.crypto/src/main/java/org/eclipse/kura/core/crypto/CryptoServiceImpl.java
@@ -19,6 +19,13 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -64,6 +71,30 @@ public class CryptoServiceImpl implements CryptoService {
     private final SecureRandom random = new SecureRandom();
     private SystemService systemService;
 
+    private CharsetEncoder utf8Encoder;
+    private CharsetDecoder utf8Decoder;
+
+    private CharsetEncoder platformEncoder;
+    private CharsetDecoder platformDecoder;
+
+    public CryptoServiceImpl() {
+        this.utf8Encoder = StandardCharsets.UTF_8.newEncoder();
+        this.utf8Encoder.onMalformedInput(CodingErrorAction.REPORT);
+        this.utf8Encoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+
+        this.utf8Decoder = StandardCharsets.UTF_8.newDecoder();
+        this.utf8Decoder.onMalformedInput(CodingErrorAction.REPORT);
+        this.utf8Decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+
+        this.platformEncoder = Charset.defaultCharset().newEncoder();
+        this.platformEncoder.onMalformedInput(CodingErrorAction.REPORT);
+        this.platformEncoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+
+        this.platformDecoder = Charset.defaultCharset().newDecoder();
+        this.platformDecoder.onMalformedInput(CodingErrorAction.REPORT);
+        this.platformDecoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+    }
+
     public void setSystemService(SystemService systemService) {
         this.systemService = systemService;
     }
@@ -89,19 +120,48 @@ public class CryptoServiceImpl implements CryptoService {
             byte[] iv = new byte[IV_SIZE];
             this.random.nextBytes(iv);
             c.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(AUTH_TAG_LENGTH_BIT, iv));
-            byte[] encryptedBytes = c.doFinal(new String(value).getBytes());
-
+            byte[] encryptedBytes = c.doFinal(charArrayToByteArray(value));
             String ivString = base64Encode(iv);
             String encryptedMessage = base64Encode(encryptedBytes);
+
             return (ivString + ENCRYPTED_STRING_SEPARATOR + encryptedMessage).toCharArray();
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
             throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED, "encrypt");
-        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException e) {
+        } catch (InvalidKeyException | IllegalBlockSizeException | BadPaddingException | CharacterCodingException e) {
             throw new KuraException(KuraErrorCode.ENCODE_ERROR, VALUE_EXCEPTION_CAUSE);
         } catch (InvalidAlgorithmParameterException e) {
             throw new KuraException(KuraErrorCode.ENCODE_ERROR, PARAMETER_EXCEPTION_CAUSE);
         }
 
+    }
+
+    private byte[] charArrayToByteArray(char[] value) throws CharacterCodingException {
+
+        ByteBuffer byteBuffer;
+        try {
+            byteBuffer = this.utf8Encoder.encode(CharBuffer.wrap(value));
+        } catch (CharacterCodingException e) {
+            // fallback for backward compatibility
+            byteBuffer = this.platformEncoder.encode(CharBuffer.wrap(value));
+        }
+        byte[] encodedBytes = new byte[byteBuffer.limit()];
+        byteBuffer.get(encodedBytes);
+
+        return encodedBytes;
+    }
+
+    private char[] byteArrayToCharArray(byte[] value) throws CharacterCodingException {
+        CharBuffer charBuffer;
+        try {
+            charBuffer = this.utf8Decoder.decode(ByteBuffer.wrap(value));
+        } catch (CharacterCodingException e) {
+            // fallback for backward compatibility
+            charBuffer = this.platformDecoder.decode(ByteBuffer.wrap(value));
+        }
+        char[] decodedChar = new char[charBuffer.limit()];
+        charBuffer.get(decodedChar);
+
+        return decodedChar;
     }
 
     private byte[] base64Decode(String internalStringValue) {
@@ -137,11 +197,11 @@ public class CryptoServiceImpl implements CryptoService {
             Cipher c = Cipher.getInstance(CIPHER);
             c.init(Cipher.DECRYPT_MODE, generateKey(), new GCMParameterSpec(AUTH_TAG_LENGTH_BIT, iv));
             byte[] decryptedBytes = c.doFinal(decodedValue);
-            String decryptedValue = new String(decryptedBytes);
-            return decryptedValue.toCharArray();
+
+            return byteArrayToCharArray(decryptedBytes);
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
             throw new KuraException(KuraErrorCode.OPERATION_NOT_SUPPORTED, DECRYPT_EXCEPTION_CAUSE);
-        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException e) {
+        } catch (InvalidKeyException | BadPaddingException | IllegalBlockSizeException | CharacterCodingException e) {
             throw new KuraException(KuraErrorCode.DECODER_ERROR, VALUE_EXCEPTION_CAUSE);
         } catch (InvalidAlgorithmParameterException e) {
             throw new KuraException(KuraErrorCode.ENCODE_ERROR, PARAMETER_EXCEPTION_CAUSE);


### PR DESCRIPTION
Different fix for the problem in #4481 but in this case we create encoders and decoders capable of raise exceptions to detect invalid UTF-8 characters and try to fallback to the default charset.