### PR TITLE
feat(dhcp-server): added dnsmasq support

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
@@ -19,7 +19,7 @@ Depends: openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temu
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
  ntpdate, chrony, chronyc | chrony, cron | cronie,
- network-manager | networkmanager, bind9 | bind, isc-dhcp-server | dhcp-server, isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
+ network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server | dhcp-server, dnsmasq | isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
  logrotate,
  gpsd
 Recommends: python3

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/control
@@ -19,7 +19,7 @@ Depends: openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temu
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
  ntpdate, chrony, chronyc | chrony, cron | cronie,
- network-manager | networkmanager, bind9 | bind, isc-dhcp-server | dhcp-server, isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
+ network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server | dhcp-server, dnsmasq | isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
  logrotate,
  gpsd
 Recommends: python3

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
@@ -19,7 +19,7 @@ Depends: openjdk-8-jre-headless | temurin-8-jdk | openjdk-17-jre-headless | temu
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
  ntpdate, chrony, chronyc | chrony, cron | cronie,
- network-manager | networkmanager, bind9 | bind, isc-dhcp-server | dhcp-server, isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
+ network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server | dhcp-server, dnsmasq | isc-dhcp-server | dhcp-client, iw, iptables, modemmanager,
  logrotate,
  gpsd
 Recommends: python3

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,17 +13,13 @@
 package org.eclipse.kura.linux.net.dhcp;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.KuraProcessExecutionErrorException;
-import org.eclipse.kura.core.linux.executor.LinuxSignal;
-import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.executor.CommandStatus;
-import org.eclipse.kura.executor.Pid;
+import org.eclipse.kura.linux.net.dhcp.server.DhcpLinuxTool;
+import org.eclipse.kura.linux.net.dhcp.server.DhcpdTool;
+import org.eclipse.kura.linux.net.dhcp.server.DnsmasqTool;
 import org.eclipse.kura.linux.net.util.LinuxNetworkUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,44 +31,49 @@ public class DhcpServerManager {
     private static final String FILE_DIR = "/etc/";
     private static final String PID_FILE_DIR = "/var/run/";
     private static DhcpServerTool dhcpServerTool = DhcpServerTool.NONE;
-    private final CommandExecutorService executorService;
+    private final DhcpLinuxTool linuxTool;
 
     static {
         dhcpServerTool = getTool();
     }
 
     public DhcpServerManager(CommandExecutorService service) {
-        this.executorService = service;
+        if (dhcpServerTool == DhcpServerTool.DNSMASQ) {
+            this.linuxTool = new DnsmasqTool(service);
+        } else {
+            this.linuxTool = new DhcpdTool(service, dhcpServerTool);
+        }
     }
 
     public static DhcpServerTool getTool() {
         if (dhcpServerTool == DhcpServerTool.NONE) {
-            if (LinuxNetworkUtil.toolExists(DhcpServerTool.DHCPD.getValue())) {
+            if (LinuxNetworkUtil.toolExists(DhcpServerTool.DNSMASQ.getValue())) {
+                dhcpServerTool = DhcpServerTool.DNSMASQ;
+            } else if (LinuxNetworkUtil.toolExists(DhcpServerTool.DHCPD.getValue())) {
                 dhcpServerTool = DhcpServerTool.DHCPD;
             } else if (LinuxNetworkUtil.toolExists(DhcpServerTool.UDHCPD.getValue())) {
                 dhcpServerTool = DhcpServerTool.UDHCPD;
             }
         }
+
         return dhcpServerTool;
     }
 
     public boolean isRunning(String interfaceName) {
-        // Check if DHCP server is running
-        return this.executorService.isRunning(DhcpServerManager.formDhcpdCommand(interfaceName));
+        return this.linuxTool.isRunning(interfaceName);
     }
 
     public boolean enable(String interfaceName) throws KuraException {
-        // Check if DHCP server is running
         if (isRunning(interfaceName)) {
-            // If so, disable it
             logger.error("DHCP server is already running for {}, bringing it down...", interfaceName);
             disable(interfaceName);
         }
-        // Start DHCP server
+
         File configFile = new File(DhcpServerManager.getConfigFilename(interfaceName));
         if (configFile.exists()) {
-            CommandStatus status = this.executorService
-                    .execute(new Command(DhcpServerManager.formDhcpdCommand(interfaceName)));
+
+            CommandStatus status = this.linuxTool.startInterface(interfaceName);
+
             if (status.getExitStatus().isSuccessful()) {
                 logger.debug("DHCP server started.");
                 return true;
@@ -86,26 +87,8 @@ public class DhcpServerManager {
 
     public boolean disable(String interfaceName) throws KuraException {
         logger.debug("Disable DHCP server for {}", interfaceName);
-
-        Map<String, Pid> pids = this.executorService.getPids(DhcpServerManager.formDhcpdCommand(interfaceName));
-        for (Pid pid : pids.values()) {
-            if (this.executorService.stop(pid, LinuxSignal.SIGTERM)) {
-                DhcpServerManager.removePidFile(interfaceName);
-            } else {
-                logger.debug("Failed to stop process...try to kill");
-                if (this.executorService.stop(pid, LinuxSignal.SIGKILL)) {
-                    DhcpServerManager.removePidFile(interfaceName);
-                } else {
-                    throw new KuraProcessExecutionErrorException("Failed to disable DHCP server");
-                }
-            }
-        }
-        if (pids.isEmpty()) {
-            logger.debug("tried to kill DHCP server for interface but it is not running");
-            return false;
-        }
-
-        return true;
+        
+        return this.linuxTool.disableInterface(interfaceName);
     }
 
     public static String getConfigFilename(String interfaceName) {
@@ -116,16 +99,12 @@ public class DhcpServerManager {
             sb.append(interfaceName);
             sb.append(".conf");
         }
-        return sb.toString();
-    }
 
-    private static boolean removePidFile(String interfaceName) {
-        boolean ret = true;
-        File pidFile = new File(DhcpServerManager.getPidFilename(interfaceName));
-        if (pidFile.exists()) {
-            ret = pidFile.delete();
+        if (dhcpServerTool == DhcpServerTool.DNSMASQ) {
+            sb.append("dnsmasq.d/dnsmasq-" + interfaceName + ".conf");
         }
-        return ret;
+
+        return sb.toString();
     }
 
     public static String getPidFilename(String interfaceName) {
@@ -137,22 +116,5 @@ public class DhcpServerManager {
             sb.append(".pid");
         }
         return sb.toString();
-    }
-
-    private static String[] formDhcpdCommand(String interfaceName) {
-        List<String> command = new ArrayList<>();
-        if (dhcpServerTool == DhcpServerTool.DHCPD) {
-            command.add(DhcpServerTool.DHCPD.getValue());
-            command.add("-cf");
-            command.add(DhcpServerManager.getConfigFilename(interfaceName));
-            command.add("-pf");
-            command.add(DhcpServerManager.getPidFilename(interfaceName));
-        } else if (dhcpServerTool == DhcpServerTool.UDHCPD) {
-            command.add(DhcpServerTool.UDHCPD.getValue());
-            command.add("-f");
-            command.add("-S");
-            command.add(DhcpServerManager.getConfigFilename(interfaceName));
-        }
-        return command.toArray(new String[0]);
     }
 }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerTool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,8 @@ package org.eclipse.kura.linux.net.dhcp;
 public enum DhcpServerTool {
     NONE("none"),
     DHCPD("dhcpd"),
-    UDHCPD("udhcpd");
+    UDHCPD("udhcpd"),
+    DNSMASQ("dnsmasq");
 
     private String toolName;
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DhcpLinuxTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DhcpLinuxTool.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.linux.net.dhcp.server;
+
+import org.eclipse.kura.KuraProcessExecutionErrorException;
+import org.eclipse.kura.executor.CommandStatus;
+
+public interface DhcpLinuxTool {
+
+    public boolean isRunning(String interfaceName);
+
+    public CommandStatus startInterface(String interfaceName);
+
+    public boolean disableInterface(String interfaceName) throws KuraProcessExecutionErrorException;
+
+}

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DhcpdTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DhcpdTool.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.linux.net.dhcp.server;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.kura.KuraProcessExecutionErrorException;
+import org.eclipse.kura.core.linux.executor.LinuxSignal;
+import org.eclipse.kura.executor.Command;
+import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.executor.CommandStatus;
+import org.eclipse.kura.executor.Pid;
+import org.eclipse.kura.linux.net.dhcp.DhcpServerManager;
+import org.eclipse.kura.linux.net.dhcp.DhcpServerTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DhcpdTool implements DhcpLinuxTool {
+
+    private static final Logger logger = LoggerFactory.getLogger(DhcpdTool.class);
+
+    private CommandExecutorService executorService;
+    private DhcpServerTool dhcpServerTool = DhcpServerTool.NONE;
+
+    public DhcpdTool(CommandExecutorService service, DhcpServerTool tool) {
+        this.executorService = service;
+        this.dhcpServerTool = tool;
+    }
+
+    @Override
+    public boolean isRunning(String interfaceName) {
+        return this.executorService.isRunning(getDhcpdCommand(interfaceName));
+    }
+
+    @Override
+    public CommandStatus startInterface(String interfaceName) {
+        return this.executorService.execute(new Command(getDhcpdCommand(interfaceName)));
+    }
+
+    @Override
+    public boolean disableInterface(String interfaceName) throws KuraProcessExecutionErrorException {
+        Map<String, Pid> pids = this.executorService.getPids(getDhcpdCommand(interfaceName));
+        for (Pid pid : pids.values()) {
+            if (this.executorService.stop(pid, LinuxSignal.SIGTERM)) {
+                removePidFile(interfaceName);
+            } else {
+                logger.debug("Failed to stop process...try to kill");
+                if (this.executorService.stop(pid, LinuxSignal.SIGKILL)) {
+                    removePidFile(interfaceName);
+                } else {
+                    throw new KuraProcessExecutionErrorException("Failed to disable DHCP server");
+                }
+            }
+        }
+        if (pids.isEmpty()) {
+            logger.debug("tried to kill DHCP server for interface but it is not running");
+            return false;
+        }
+
+        return true;
+    }
+
+    private String[] getDhcpdCommand(String interfaceName) {
+        List<String> command = new ArrayList<>();
+        if (dhcpServerTool == DhcpServerTool.DHCPD) {
+            command.add(DhcpServerTool.DHCPD.getValue());
+            command.add("-cf");
+            command.add(DhcpServerManager.getConfigFilename(interfaceName));
+            command.add("-pf");
+            command.add(DhcpServerManager.getPidFilename(interfaceName));
+        } else if (dhcpServerTool == DhcpServerTool.UDHCPD) {
+            command.add(DhcpServerTool.UDHCPD.getValue());
+            command.add("-f");
+            command.add("-S");
+            command.add(DhcpServerManager.getConfigFilename(interfaceName));
+        }
+        return command.toArray(new String[0]);
+    }
+
+    private boolean removePidFile(String interfaceName) {
+        boolean ret = true;
+        File pidFile = new File(DhcpServerManager.getPidFilename(interfaceName));
+        if (pidFile.exists()) {
+            ret = pidFile.delete();
+        }
+        return ret;
+    }
+
+}

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.linux.net.dhcp.server;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.kura.KuraProcessExecutionErrorException;
+import org.eclipse.kura.executor.Command;
+import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.executor.CommandStatus;
+import org.eclipse.kura.linux.net.dhcp.DhcpServerManager;
+import org.eclipse.kura.linux.net.dhcp.DhcpServerTool;
+
+public class DnsmasqTool implements DhcpLinuxTool {
+
+    private CommandExecutorService executorService;
+
+    public DnsmasqTool(CommandExecutorService service) {
+        this.executorService = service;
+    }
+
+    @Override
+    public boolean isRunning(String interfaceName) {
+        CommandStatus status = this.executorService.execute(
+                new Command(new String[] { "systemctl", "is-active", "--quiet", DhcpServerTool.DNSMASQ.getValue() }));
+        return status.getExitStatus().isSuccessful();
+    }
+
+    @Override
+    public CommandStatus startInterface(String interfaceName) {
+        List<String> command = new ArrayList<>();
+
+        command.add("systemctl");
+        command.add("start");
+        command.add(DhcpServerTool.DNSMASQ.getValue());
+
+        Command cmd = new Command(command.toArray(new String[0]));
+
+        return this.executorService.execute(cmd);
+    }
+
+    @Override
+    public boolean disableInterface(String interfaceName) throws KuraProcessExecutionErrorException {
+        File configFile = new File(DhcpServerManager.getConfigFilename(interfaceName));
+        configFile.delete();
+
+        CommandStatus status = this.executorService.execute(
+                new Command(new String[] { "systemctl", "restart", DhcpServerTool.DNSMASQ.getValue() }));
+        return status.getExitStatus().isSuccessful();
+    }
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
@@ -104,6 +104,17 @@ public class DhcpServerConfigWriter {
                 pw.println("opt lease " + dhcpServerConfig.getDefaultLeaseTime());
 
                 addDNSServersOption(dhcpServerConfig, pw);
+            } else if (dhcpServerTool == DhcpServerTool.DNSMASQ) {
+                pw.println("interface=" + dhcpServerConfig.getInterfaceName());
+                pw.println("dhcp-option=3,0.0.0.0");
+                pw.println("dhcp-option=6,0.0.0.0");
+                pw.println("port=0"); // disable DNS since managed by bind/bind9
+                
+                StringBuilder dhcpRangeProp = new StringBuilder("dhcp-range=")
+                    .append(dhcpServerConfig.getRangeStart())
+                    .append(",").append(dhcpServerConfig.getRangeEnd()).append(",")
+                    .append(dhcpServerConfig.getMaximumLeaseTime()).append("s");
+                pw.println(dhcpRangeProp.toString());
             }
             pw.flush();
             fos.getFD().sync();

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
@@ -106,8 +106,13 @@ public class DhcpServerConfigWriter {
                 addDNSServersOption(dhcpServerConfig, pw);
             } else if (dhcpServerTool == DhcpServerTool.DNSMASQ) {
                 pw.println("interface=" + dhcpServerConfig.getInterfaceName());
+                pw.println("bind-interfaces");
                 pw.println("dhcp-option=3,0.0.0.0");
-                pw.println("dhcp-option=6,0.0.0.0");
+
+                if (dhcpServerConfig.isPassDns()) {
+                    pw.println("dhcp-option=6,0.0.0.0");
+                }
+
                 pw.println("port=0"); // disable DNS since managed by bind/bind9
                 
                 StringBuilder dhcpRangeProp = new StringBuilder("dhcp-range=")

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
@@ -107,10 +107,12 @@ public class DhcpServerConfigWriter {
             } else if (dhcpServerTool == DhcpServerTool.DNSMASQ) {
                 pw.println("interface=" + dhcpServerConfig.getInterfaceName());
                 pw.println("bind-interfaces");
-                pw.println("dhcp-option=3,0.0.0.0");
+                pw.println("dhcp-authoritative");
+
+                pw.println("dhcp-option=3,0.0.0.0"); // default gateway
 
                 if (dhcpServerConfig.isPassDns()) {
-                    pw.println("dhcp-option=6,0.0.0.0");
+                    pw.println("dhcp-option=6,0.0.0.0"); // dns servers to announce
                 }
 
                 pw.println("port=0"); // disable DNS since managed by bind/bind9

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
@@ -107,20 +107,25 @@ public class DhcpServerConfigWriter {
             } else if (dhcpServerTool == DhcpServerTool.DNSMASQ) {
                 pw.println("interface=" + dhcpServerConfig.getInterfaceName());
                 pw.println("bind-interfaces");
-                pw.println("dhcp-authoritative");
-
-                pw.println("dhcp-option=3,0.0.0.0"); // default gateway
+                pw.println("dhcp-option=1," + NetworkUtil.getNetmaskStringForm(dhcpServerConfig.getPrefix()));
+                pw.println("dhcp-option=3," + dhcpServerConfig.getRouterAddress().toString());
 
                 if (dhcpServerConfig.isPassDns()) {
-                    pw.println("dhcp-option=6,0.0.0.0"); // dns servers to announce
+                    // announce DNS servers on this device
+                    pw.println("dhcp-option=6,0.0.0.0");
                 }
 
-                pw.println("port=0"); // disable DNS since managed by bind/bind9
+                // all subnets are local
+                pw.println("dhcp-option=27,1");
+                pw.println("dhcp-lease-max=" + dhcpServerConfig.getMaximumLeaseTime());
+                // disable DNS server since managed by NetworkManager
+                pw.println("port=0");
                 
                 StringBuilder dhcpRangeProp = new StringBuilder("dhcp-range=")
                     .append(dhcpServerConfig.getRangeStart())
-                    .append(",").append(dhcpServerConfig.getRangeEnd()).append(",")
-                    .append(dhcpServerConfig.getMaximumLeaseTime()).append("s");
+                    .append(",")
+                    .append(dhcpServerConfig.getRangeEnd()).append(",")
+                    .append(dhcpServerConfig.getDefaultLeaseTime()).append("s");
                 pw.println(dhcpRangeProp.toString());
             }
             pw.flush();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -139,7 +139,7 @@ public class GwtNetInterfaceConfigBuilder {
 
     private void setRouterMode() {
         boolean isDhcpServer = this.properties.getDhcpServer4Enabled(this.ifName);
-        boolean isNat = this.properties.getDhcpServer4PassDns(this.ifName);
+        boolean isNat = this.properties.getNatEnabled(this.ifName);
 
         if (isDhcpServer && isNat) {
             this.gwtConfig.setRouterMode(GwtNetRouterMode.netRouterDchpNat.name());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -67,7 +67,7 @@ public class NetworkConfigurationServiceProperties {
     }
 
     public boolean getNatEnabled(String ifname) {
-        return (boolean) this.properties.get(String.format(NET_INTERFACE_CONFIG_NAT_ENABLED, ifname));
+        return (boolean) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_NAT_ENABLED, ifname), false);
     }
 
     public void setNatEnabled(String ifname, boolean natEnabled) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -107,9 +107,16 @@ public class NetworkConfigurationServicePropertiesBuilder {
     }
 
     private void setIpv4DhcpServerProperties() {
-        boolean isDhcpServer = this.gwtConfig.getConfigMode().equals(GwtNetIfConfigMode.netIPv4ConfigModeManual.name())
-                && !this.gwtConfig.getRouterMode().equals(GwtNetRouterMode.netRouterOff.name());
+        boolean isManualAddress = this.gwtConfig.getConfigModeEnum() == GwtNetIfConfigMode.netIPv4ConfigModeManual;
+        boolean isDhcpServer = isManualAddress
+                && this.gwtConfig.getRouterModeEnum() != GwtNetRouterMode.netRouterOff
+                && this.gwtConfig.getRouterModeEnum() != GwtNetRouterMode.netRouterNat;
+        boolean isNatEnabled = isManualAddress
+                && (this.gwtConfig.getRouterModeEnum() == GwtNetRouterMode.netRouterNat
+                        || this.gwtConfig.getRouterModeEnum() == GwtNetRouterMode.netRouterDchpNat);
+
         this.properties.setDhcpServer4Enabled(this.ifname, isDhcpServer);
+        this.properties.setNatEnabled(this.ifname, isNatEnabled);
 
         if (isDhcpServer) {
             this.properties.setDhcpServer4RangeStart(this.ifname, this.gwtConfig.getRouterDhcpBeginAddress());


### PR DESCRIPTION
This PR adds support for _dnsmasq_, for devices that do not have dhcpd (installed by _isc-dhcp-server_ or _dhcpserver_).

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:**:

- Refactor of `DhcpServerManager` class to support tools that use systemd.
- UI fix on the router mode and NAT selection.
