### PR TITLE
fix(distrib): generic-aarch64 installer 'Description' field

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
@@ -30,4 +30,3 @@ Description: Kura is an inclusive software framework that puts a layer
   standard interfaces that shorten custom development time, simplified coding
   and software that can be easily ported from one hardware platform
   to another.
-        


### PR DESCRIPTION
Upon installation of the generic aarc64 profile I get the following error:

```
Unpacking socat (1.7.3.3-2) ...
dpkg: error processing archive /tmp/apt-dpkg-install-qyFjLc/34-kura_5.3.0-SNAPSHOT_generic-aarch64_installer.deb (--unpack):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 21 package 'kura':
 blank line in value of field 'Description'
Errors were encountered while processing:
 /tmp/apt-dpkg-install-qyFjLc/34-kura_5.3.0-SNAPSHOT_generic-aarch64_installer.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

This was due to the extra lines deleted in this PR.