### PR TITLE
fix(distrib): manage netplan configuration on installation

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -99,7 +99,6 @@ network:
   renderer: NetworkManager
 EOF
     netplan generate
-    netplan apply
 fi
 if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )

--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -100,7 +100,6 @@ network:
 EOF
     netplan generate
     netplan apply
-    systemctl restart NetworkManager
 fi
 if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )

--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -98,7 +98,6 @@ network:
   version: 2
   renderer: NetworkManager
 EOF
-    netplan generate
 fi
 if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -99,7 +99,6 @@ network:
   renderer: NetworkManager
 EOF
     netplan generate
-    netplan apply
 fi
 if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -100,7 +100,6 @@ network:
 EOF
     netplan generate
     netplan apply
-    systemctl restart NetworkManager
 fi
 if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -98,7 +98,6 @@ network:
   version: 2
   renderer: NetworkManager
 EOF
-    netplan generate
 fi
 if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -99,7 +99,6 @@ network:
   renderer: NetworkManager
 EOF
     netplan generate
-    netplan apply
 fi
 if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -100,7 +100,6 @@ network:
 EOF
     netplan generate
     netplan apply
-    systemctl restart NetworkManager
 fi
 if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -98,7 +98,6 @@ network:
   version: 2
   renderer: NetworkManager
 EOF
-    netplan generate
 fi
 if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     TO_REMOVE=$( find /usr/lib/NetworkManager/conf.d/ -type f -name  "*-globally-managed-devices.conf" | awk 'NR==1{print $1}' )


### PR DESCRIPTION
Upon installing Kura on Ubuntu Server 20.04 devices, the following exception was thrown:

```
Connection 'kura-enp3s0-connection' is not available on device enp3s0 because device is strictly unmanaged
```

This was due to the fact that for OSes using Netplan, the default network renderer was set to `networkd`. This PR changes the Netplan configuration so that NetworkManager is set as the default network renderer, allowing it to manage all the network interfaces.

~@MMaiero @marcellorinaldo This PR has only one issue: after configuring Netplan we perform a `systemctl reset NetworkManager`. This triggers the renewal of the DHCP lease and the IP changes. This means that the installation process looks like got stuck but in reality it **succeeds.**~ Updated: no longer an issue.

⚠️ **Note**: we rely on the user performing the reboot for all changes to be applied.