### PR TITLE
fix: Overriding NM unmanaged-devices policy  [Backport]

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -1558,8 +1558,8 @@
                                             </mapper>
                                         </data>
                                         <data>
-                                            <src>${project.basedir}/src/main/resources/common/99kura-nm.conf</src>
-                                            <dst>/etc/NetworkManager/conf.d/99kura-nm.conf</dst>
+                                            <src>${project.basedir}/src/main/resources/common/99-kura-nm.conf</src>
+                                            <dst>/etc/NetworkManager/conf.d/99-kura-nm.conf</dst>
                                             <type>file</type>
                                         </data>
                                     </dataSet>
@@ -1657,8 +1657,8 @@
                                             </mapper>
                                         </data>
                                         <data>
-                                            <src>${project.basedir}/src/main/resources/common/99kura-nm.conf</src>
-                                            <dst>/etc/NetworkManager/conf.d/99kura-nm.conf</dst>
+                                            <src>${project.basedir}/src/main/resources/common/99-kura-nm.conf</src>
+                                            <dst>/etc/NetworkManager/conf.d/99-kura-nm.conf</dst>
                                             <type>file</type>
                                         </data>
                                     </dataSet>
@@ -1756,8 +1756,8 @@
                                             </mapper>
                                         </data>
                                         <data>
-                                            <src>${project.basedir}/src/main/resources/common/99kura-nm.conf</src>
-                                            <dst>/etc/NetworkManager/conf.d/99kura-nm.conf</dst>
+                                            <src>${project.basedir}/src/main/resources/common/99-kura-nm.conf</src>
+                                            <dst>/etc/NetworkManager/conf.d/99-kura-nm.conf</dst>
                                             <type>file</type>
                                         </data>
                                     </dataSet>

--- a/kura/distrib/src/main/resources/common/99-kura-nm.conf
+++ b/kura/distrib/src/main/resources/common/99-kura-nm.conf
@@ -11,3 +11,6 @@ managed=true
 uri=http://network-test.debian.org/nm
 interval=60
 response="NetworkManager is online"
+
+[keyfile]
+unmanaged-devices=*,except:type:wifi,except:type:wwan,except:type:ethernet


### PR DESCRIPTION
* fix: Overriding NM unmanaged-devices policy



* refactor: Renamed kura-nm file to match general policy



---------

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
