### PR TITLE
chore(protocol.can): Added libsocket-can to classpath

### DIFF
--- a/kura/org.eclipse.kura.protocol.can/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.protocol.can/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Import-Package: de.entropia.can;version="1.0",
 Export-Package: org.eclipse.kura.protocol.can;version="2.0.0"
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: .
+Bundle-ClassPath: .,
+ lib/libsocket-can-java-1.0.0.jar


### PR DESCRIPTION
Just to remove the annoying error messages in Eclipse IDE but maybe there's a reason why it was not added..