### PR TITLE
fix(distrib): let NetworkManager manage gsm type devices

### DIFF
--- a/kura/distrib/src/main/resources/common/99-kura-nm.conf
+++ b/kura/distrib/src/main/resources/common/99-kura-nm.conf
@@ -13,4 +13,4 @@ interval=60
 response="NetworkManager is online"
 
 [keyfile]
-unmanaged-devices=*,except:type:wifi,except:type:wwan,except:type:ethernet
+unmanaged-devices=*,except:type:wifi,except:type:gsm,except:type:wwan,except:type:ethernet


### PR DESCRIPTION
With #4497 we restricted the managed device of NM. This resulted in modems not showing up among managed devices:

![Screenshot 2023-03-28 at 15 53 45](https://user-images.githubusercontent.com/22748355/228260810-c1fc79e3-8f9d-4ccf-8d4e-00634b8c2ed5.png)

With this PR gsm devices are managed again:

![Screenshot 2023-03-28 at 15 54 50](https://user-images.githubusercontent.com/22748355/228261043-206e35ae-06e1-4ed5-bdb9-cebe015feb09.png)
