### PR TITLE
fix(linux.net): dhcp server tool ordering

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
@@ -47,12 +47,12 @@ public class DhcpServerManager {
 
     public static DhcpServerTool getTool() {
         if (dhcpServerTool == DhcpServerTool.NONE) {
-            if (LinuxNetworkUtil.toolExists(DhcpServerTool.DNSMASQ.getValue())) {
-                dhcpServerTool = DhcpServerTool.DNSMASQ;
-            } else if (LinuxNetworkUtil.toolExists(DhcpServerTool.DHCPD.getValue())) {
+            if (LinuxNetworkUtil.toolExists(DhcpServerTool.DHCPD.getValue())) {
                 dhcpServerTool = DhcpServerTool.DHCPD;
             } else if (LinuxNetworkUtil.toolExists(DhcpServerTool.UDHCPD.getValue())) {
                 dhcpServerTool = DhcpServerTool.UDHCPD;
+            } else if (LinuxNetworkUtil.toolExists(DhcpServerTool.DNSMASQ.getValue())) {
+                dhcpServerTool = DhcpServerTool.DNSMASQ;
             }
         }
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
@@ -56,6 +56,8 @@ public class DhcpServerManager {
             }
         }
 
+        logger.info("Using {} as DHCP server.", dhcpServerTool.getValue());
+
         return dhcpServerTool;
     }
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -265,7 +265,7 @@ public class LinuxNetworkUtil {
 
     public static boolean toolExists(String tool) {
         boolean ret = false;
-        final String[] searchFolders = new String[] { "/sbin/", "/usr/sbin/", "/bin/" };
+        final String[] searchFolders = new String[] { "/sbin/", "/usr/sbin/", "/bin/", "/usr/bin/" };
 
         if (TOOLS.contains(tool)) {
             ret = true;

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,42 +13,166 @@
 package org.eclipse.kura.linux.net.dhcp;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.eclipse.kura.core.testutil.TestUtil;
+import org.eclipse.kura.executor.CommandExecutorService;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 public class DhcpServerManagerTest {
 
+    private static final String EXAMPLE_INTERFACE = "eth0";
+
+    private static final String EXPECTED_ETC_CONF_FILENAME = "/etc/%s-%s.conf";
+    private static final String EXPECTED_DNSMASQ_CONF_FILENAME = "/etc/dnsmasq.d/%s-%s.conf";
+    private static final String EXPECTED_PID_FILENAME = "/var/run/%s-%s.pid";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private DhcpServerManager dhcpServerManager;
+    private CommandExecutorService executorMock;
+    private String returnedFilename;
+    private Exception occurredException;
+
+    /*
+     * Scenarios
+     */
+
     @Test
-    public void testGetConfigFilename() throws NoSuchFieldException {
-        String interfaceName = "eth0";
-        TestUtil.setFieldValue(new DhcpServerManager(null), "dhcpServerTool", DhcpServerTool.NONE);
-        String fileName = DhcpServerManager.getConfigFilename(interfaceName);
-        assertEquals("/etc/", fileName);
+    public void shouldReturnConfigFilenameForDhcpd() throws NoSuchFieldException {
+        givenDhcpServerManager(DhcpServerTool.DHCPD);
 
-        TestUtil.setFieldValue(new DhcpServerManager(null), "dhcpServerTool", DhcpServerTool.DHCPD);
-        fileName = DhcpServerManager.getConfigFilename(interfaceName);
-        assertEquals("/etc/dhcpd-eth0.conf", fileName);
+        whenGetConfigFilename(EXAMPLE_INTERFACE);
 
-        TestUtil.setFieldValue(new DhcpServerManager(null), "dhcpServerTool", DhcpServerTool.UDHCPD);
-        fileName = DhcpServerManager.getConfigFilename(interfaceName);
-        assertEquals("/etc/udhcpd-eth0.conf", fileName);
+        thenNoExceptionsOccurred();
+        thenReturnedFilenameIs(
+                String.format(EXPECTED_ETC_CONF_FILENAME, DhcpServerTool.DHCPD.getValue(), EXAMPLE_INTERFACE));
     }
 
     @Test
-    public void testGetPidFilename() throws NoSuchFieldException {
-        String interfaceName = "eth0";
-        TestUtil.setFieldValue(new DhcpServerManager(null), "dhcpServerTool", DhcpServerTool.NONE);
-        String fileName = DhcpServerManager.getPidFilename(interfaceName);
-        assertEquals("/var/run/", fileName);
+    public void shouldReturnConfigFilenameForUdhcpd() throws NoSuchFieldException {
+        givenDhcpServerManager(DhcpServerTool.UDHCPD);
 
-        TestUtil.setFieldValue(new DhcpServerManager(null), "dhcpServerTool", DhcpServerTool.DHCPD);
-        fileName = DhcpServerManager.getPidFilename(interfaceName);
-        assertEquals("/var/run/dhcpd-eth0.pid", fileName);
+        whenGetConfigFilename(EXAMPLE_INTERFACE);
 
-        TestUtil.setFieldValue(new DhcpServerManager(null), "dhcpServerTool", DhcpServerTool.UDHCPD);
-        fileName = DhcpServerManager.getPidFilename(interfaceName);
-        assertEquals("/var/run/udhcpd-eth0.pid", fileName);
+        thenNoExceptionsOccurred();
+        thenReturnedFilenameIs(
+                String.format(EXPECTED_ETC_CONF_FILENAME, DhcpServerTool.UDHCPD.getValue(), EXAMPLE_INTERFACE));
+    }
+
+    @Test
+    public void shouldReturnConfigFilenameForDnsmasq() throws NoSuchFieldException {
+        givenDhcpServerManager(DhcpServerTool.DNSMASQ);
+
+        whenGetConfigFilename(EXAMPLE_INTERFACE);
+
+        thenNoExceptionsOccurred();
+        thenReturnedFilenameIs(
+                String.format(EXPECTED_DNSMASQ_CONF_FILENAME, DhcpServerTool.DNSMASQ.getValue(), EXAMPLE_INTERFACE));
+    }
+
+    @Test
+    public void shouldReturnConfigFilenameForNone() throws NoSuchFieldException {
+        givenDhcpServerManager(DhcpServerTool.NONE);
+
+        whenGetConfigFilename(EXAMPLE_INTERFACE);
+
+        thenNoExceptionsOccurred();
+        thenReturnedFilenameIs("/etc/");
+    }
+
+    @Test
+    public void shouldReturnPidFilenameForDhcpd() throws NoSuchFieldException {
+        givenDhcpServerManager(DhcpServerTool.DHCPD);
+
+        whenGetPidFilename(EXAMPLE_INTERFACE);
+
+        thenNoExceptionsOccurred();
+        thenReturnedFilenameIs(
+                String.format(EXPECTED_PID_FILENAME, DhcpServerTool.DHCPD.getValue(), EXAMPLE_INTERFACE));
+    }
+
+    @Test
+    public void shouldReturnPidFilenameForUdhcpd() throws NoSuchFieldException {
+        givenDhcpServerManager(DhcpServerTool.UDHCPD);
+
+        whenGetPidFilename(EXAMPLE_INTERFACE);
+
+        thenNoExceptionsOccurred();
+        thenReturnedFilenameIs(
+                String.format(EXPECTED_PID_FILENAME, DhcpServerTool.UDHCPD.getValue(), EXAMPLE_INTERFACE));
+    }
+
+    @Test
+    public void shouldReturnPidFilenameForDnsmasq() throws NoSuchFieldException {
+        givenDhcpServerManager(DhcpServerTool.DNSMASQ);
+
+        whenGetPidFilename(EXAMPLE_INTERFACE);
+
+        thenNoExceptionsOccurred();
+        thenReturnedFilenameIs("/var/run/");
+    }
+
+    @Test
+    public void shouldReturnPidFilenameForNone() throws NoSuchFieldException {
+        givenDhcpServerManager(DhcpServerTool.NONE);
+
+        whenGetPidFilename(EXAMPLE_INTERFACE);
+
+        thenNoExceptionsOccurred();
+        thenReturnedFilenameIs("/var/run/");
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenDhcpServerManager(DhcpServerTool dhcpServerTool) throws NoSuchFieldException {
+        this.executorMock = Mockito.mock(CommandExecutorService.class);
+
+        TestUtil.setFieldValue(new DhcpServerManager(null), "dhcpServerTool", dhcpServerTool);
+
+        this.dhcpServerManager = new DhcpServerManager(executorMock);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenGetConfigFilename(String interfaceName) {
+        try {
+            this.returnedFilename = DhcpServerManager.getConfigFilename(interfaceName);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenGetPidFilename(String interfaceName) {
+        try {
+            this.returnedFilename = DhcpServerManager.getPidFilename(interfaceName);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenNoExceptionsOccurred() {
+        assertNull(this.occurredException);
+    }
+
+    private void thenReturnedFilenameIs(String expectedFilename) {
+        assertEquals(expectedFilename, this.returnedFilename);
     }
 
 }


### PR DESCRIPTION
This PR will prioritize `dhcpd` over `dnsmasq` for selecting the appropriate dhcp server tool.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** Added `/usr/bin/` to the search paths for selecting the tool.