### PR TITLE
docs: Updated network status rest with signal strength value

### DIFF
--- a/docs/core-services/network-status-rest-v1.md
+++ b/docs/core-services/network-status-rest-v1.md
@@ -554,15 +554,13 @@ Object that contains specific properties to describe the status of a Modem inter
           * [AccessTechnology](#accesstechnology)
   
   * **signalQuality**: `number` 
-
+  
   * **signalStrength**: `number` 
   
   * **registrationStatus**: `string (enumerated)` 
       * [RegistrationStatus](#registrationstatus)
   
   * **operatorName**: `string` 
-  
-  * **rssi**: `number` 
   
 
 ```json
@@ -677,7 +675,6 @@ Object that contains specific properties to describe the status of a Modem inter
   "powerState": "ON",
   "primaryPort": "cdc-wdm0",
   "registrationStatus": "HOME",
-  "rssi": -113,
   "serialNumber": "111111111111111",
   "signalQuality": 55,
   "signalStrength": -80,
@@ -835,6 +832,8 @@ This object describes a Wifi Access Point. It can be used both for describing a 
 <br>**Properties**:
 
   * **ssid**: `string` 
+      The Service Set IDentifier of the WiFi network
+
   
   * **hardwareAddress**: `string` 
       * [HardwareAddress](#hardwareaddress)
@@ -846,16 +845,26 @@ This object describes a Wifi Access Point. It can be used both for describing a 
       * [WifiMode](#wifimode)
   
   * **maxBitrate**: `number` 
+      The maximum bitrate this access point is capable of.
+
   
   * **signalQuality**: `number` 
+      The current signal quality of the access point in percentage.
 
+  
   * **signalStrength**: `number` 
+      The current signal strength of the access point in dBm.
+
   
   * **wpaSecurity**: `array` 
+      The WPA capabilities of the access point
+
       * array element type: `string (enumerated)`
           * [WifiSecurity](#wifisecurity)
   
   * **rsnSecurity**: `array` 
+      The RSN capabilities of the access point
+
       * array element type: `string (enumerated)`
           * [WifiSecurity](#wifisecurity)
   

--- a/docs/core-services/network-status-rest-v1.md
+++ b/docs/core-services/network-status-rest-v1.md
@@ -283,6 +283,7 @@ Object that contains specific properties to describe the status of a WiFi interf
       "PAIR_CCMP"
     ],
     "signalQuality": 100,
+    "signalStrength": -20,
     "ssid": "MyAccessPoint",
     "wpaSecurity": [
       "NONE"
@@ -304,6 +305,7 @@ Object that contains specific properties to describe the status of a WiFi interf
         "PAIR_CCMP"
       ],
       "signalQuality": 100,
+      "signalStrength": -20,
       "ssid": "MyAccessPoint",
       "wpaSecurity": [
         "NONE"
@@ -323,6 +325,7 @@ Object that contains specific properties to describe the status of a WiFi interf
         "PAIR_CCMP"
       ],
       "signalQuality": 42,
+      "signalStrength": -69,
       "ssid": "OtherSSID",
       "wpaSecurity": [
         "NONE"
@@ -398,6 +401,7 @@ Object that contains specific properties to describe the status of a WiFi interf
       "PAIR_CCMP"
     ],
     "signalQuality": 0,
+    "signalStrength": -104,
     "ssid": "kura_gateway_raspberry_pi",
     "wpaSecurity": [
       "NONE"
@@ -419,6 +423,7 @@ Object that contains specific properties to describe the status of a WiFi interf
         "PAIR_CCMP"
       ],
       "signalQuality": 0,
+      "signalStrength": -104,
       "ssid": "kura_gateway_raspberry_pi",
       "wpaSecurity": [
         "NONE"
@@ -549,6 +554,8 @@ Object that contains specific properties to describe the status of a Modem inter
           * [AccessTechnology](#accesstechnology)
   
   * **signalQuality**: `number` 
+
+  * **signalStrength**: `number` 
   
   * **registrationStatus**: `string (enumerated)` 
       * [RegistrationStatus](#registrationstatus)
@@ -673,6 +680,7 @@ Object that contains specific properties to describe the status of a Modem inter
   "rssi": -113,
   "serialNumber": "111111111111111",
   "signalQuality": 55,
+  "signalStrength": -80,
   "simLocked": true,
   "softwareRevision": "EG25GGBR07A08M2G",
   "state": "ACTIVATED",
@@ -840,6 +848,8 @@ This object describes a Wifi Access Point. It can be used both for describing a 
   * **maxBitrate**: `number` 
   
   * **signalQuality**: `number` 
+
+  * **signalStrength**: `number` 
   
   * **wpaSecurity**: `array` 
       * array element type: `string (enumerated)`


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR updates the documentation about the network status rest apis with the new signal strength field.
