### PR TITLE
docs: added dnsmasq dependency to generic profiles description

### DIFF
--- a/docs/getting-started/install-kura.md
+++ b/docs/getting-started/install-kura.md
@@ -54,7 +54,7 @@ To have all the Kura features working, the following dependencies are required:
 - Security: `polkit` or `policykit-1`, `ssh` or `openssh`, `openssl`, `busybox`, `openvpn`.
 - Bluetooth: `bluez` or `bluez5`, `bluez-hcidump` or `bluez5-noinst-tools`.
 - Time: `ntpdate`, `chrony`, `chronyc`, `cron` or `cronie`.
-- Networking: `network-manager` or `networkmanager`, `bind9` or `bind`, `isc-dhcp-server` or (`dhcp-server` and `dhcp-client`), `iw`, `iptables`, `modemmanager`.
+- Networking: `network-manager` or `networkmanager`, `bind9` or `bind`, `dnsmasq` or `isc-dhcp-server` or (`dhcp-server` and `dhcp-client`), `iw`, `iptables`, `modemmanager`.
 - Logs: `logrotate`.
 - Gps: `gpsd`.
 - Python: `python3`.


### PR DESCRIPTION
This PR adds `dnsmasq` to the listed dependencies in the documentation for the generic profiles.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
