### PR TITLE
fix(nm): do not set `gsm.password` if property is empty

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
@@ -20,6 +20,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import org.eclipse.kura.configuration.Password;
+
 public class NetworkProperties {
 
     private final Map<String, Object> properties;
@@ -44,8 +46,16 @@ public class NetworkProperties {
             throw new NoSuchElementException(String.format("The \"%s\" key contains a null value.", formattedKey));
         }
 
-        if (clazz == String.class) {
-            String value = String.class.cast(rawValue);
+        if (clazz == String.class || clazz == Password.class) {
+            String value = "";
+
+            if (clazz == String.class) {
+                value = String.class.cast(rawValue);
+            } else {
+                Password pwValue = Password.class.cast(rawValue);
+                value = pwValue.toString();
+            }
+
             if (value.isEmpty()) {
                 throw new NoSuchElementException(
                         String.format("The \"%s\" key contains an empty string value.", formattedKey));
@@ -67,8 +77,16 @@ public class NetworkProperties {
             return Optional.empty();
         }
 
-        if (clazz == String.class) {
-            String value = String.class.cast(rawValue);
+        if (clazz == String.class || clazz == Password.class) {
+            String value = "";
+
+            if (clazz == String.class) {
+                value = String.class.cast(rawValue);
+            } else {
+                Password pwValue = Password.class.cast(rawValue);
+                value = pwValue.toString();
+            }
+
             if (value.isEmpty()) {
                 return Optional.empty();
             }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -549,6 +549,21 @@ public class NMSettingsConverterTest {
     }
 
     @Test
+    public void buildGsmSettingsShouldWorkWithEmptyUsernamePassword() {
+        givenMapWith("net.interface.ttyACM0.config.apn", "mobile.provider.com");
+        givenMapWith("net.interface.ttyACM0.config.username", "");
+        givenMapWith("net.interface.ttyACM0.config.password", new Password(""));
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildGsmSettingsIsRunWith(this.networkProperties, "ttyACM0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("apn", "mobile.provider.com");
+        thenResultingMapNotContains("username");
+        thenResultingMapNotContains("password");
+    }
+
+    @Test
     public void buildPPPSettingsShouldNotThrowWithEmptyMap() {
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 


### PR DESCRIPTION
When configuring a modem the following exception frequently appeared:

```
2023-03-31T09:20:39,971 [Start Level: Equinox Container: 5ec28f70-bbd5-437e-9d7f-593d8e6ae69d] ERROR o.e.k.n.NMDbusConnector - Unable to configure iface 1-1.2, skipping
org.freedesktop.dbus.exceptions.DBusExecutionException: gsm.password: property is empty
```

This was due to the fact that the UI was sending an empty `Password` field to the NM bundle, and this was not treated properly by the `NetworkProperties`.

This PR changes the behaviour of `NetworkProperties` such that it treats an empty `Password` as it treats an empty `String`:
- If it is an optional parameter (requested using `getOpt` method) it will return `Optional.empty`
- If ti is a mandatory parameter (requested using `get` method) it will throw an exception.