### PR TITLE
fix(nm): support for pass dns feature in dnsmasq

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/DhcpServerConfigWriter.java
@@ -108,11 +108,14 @@ public class DhcpServerConfigWriter {
                 pw.println("interface=" + dhcpServerConfig.getInterfaceName());
                 pw.println("bind-interfaces");
                 pw.println("dhcp-option=1," + NetworkUtil.getNetmaskStringForm(dhcpServerConfig.getPrefix()));
-                pw.println("dhcp-option=3," + dhcpServerConfig.getRouterAddress().toString());
 
                 if (dhcpServerConfig.isPassDns()) {
+                    // router property
+                    pw.println("dhcp-option=3," + dhcpServerConfig.getRouterAddress().toString());
                     // announce DNS servers on this device
                     pw.println("dhcp-option=6,0.0.0.0");
+                } else {
+                    pw.println("dhcp-ignore-names");
                 }
 
                 // all subnets are local


### PR DESCRIPTION
`dnsmasq` is currently configured to not allow to disable DNS server forwarding to DHCP clients: if the property `dhcp-server-option=6,` is not set then default of `dhp-server-option=6,0.0.0.0` is used which means "forward DNS found on localhost".

This PR adds the property `dhcp-ignore-names` when `passDns=false`. Such property without arguments allows to ignore DNS entries ([ref](https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html)).

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
