### PR TITLE
fix(nm): avoid error when `Modem.Location` interface is missing

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -460,7 +460,7 @@ public class NMDbusConnector {
             currentLocationSources = MMModemLocationSource
                     .toMMModemLocationSourceFromBitMask(modemLocationProperties.Get(MM_LOCATION_BUS_NAME, "Enabled"));
         } catch (DBusExecutionException e) {
-            logger.debug("Cannot retrive Modem.Location capabilities for {}. Caused by: ",
+            logger.warn("Cannot retrive Modem.Location capabilities for {}. Caused by: ",
                     modemLocationProperties.getObjectPath(), e);
             return;
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -460,7 +460,9 @@ public class NMDbusConnector {
             currentLocationSources = MMModemLocationSource
                     .toMMModemLocationSourceFromBitMask(modemLocationProperties.Get(MM_LOCATION_BUS_NAME, "Enabled"));
         } catch (DBusExecutionException e) {
-            logger.debug("Cannot retrive Modem.Location capabilities for {}.", modemLocationProperties.getObjectPath());
+            logger.debug("Cannot retrive Modem.Location capabilities for {}. Caused by: ",
+                    modemLocationProperties.getObjectPath(), e);
+            return;
         }
 
         EnumSet<MMModemLocationSource> managedLocationSources = EnumSet.of(
@@ -477,10 +479,7 @@ public class NMDbusConnector {
 
         logger.debug("Modem location setup {} for modem {}", currentLocationSources, modemDevicePath.get());
 
-        if (!currentLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE)) {
-            modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(currentLocationSources),
-                    false);
-        }
+        modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(currentLocationSources), false);
     }
 
     private String getDeviceId(Device device) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -479,7 +479,10 @@ public class NMDbusConnector {
 
         logger.debug("Modem location setup {} for modem {}", currentLocationSources, modemDevicePath.get());
 
-        modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(currentLocationSources), false);
+        if (!currentLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE)) {
+            modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(currentLocationSources),
+                    false);
+        }
     }
 
     private String getDeviceId(Device device) throws DBusException {


### PR DESCRIPTION
As per [ModemManager DBus API documentation](https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/gdbus-org.freedesktop.ModemManager1.Modem.Location.html), the `Modem.Location` interface:

>  ...allows devices to provide location information to client applications. **Not all devices can provide this information, or even if they do, they may not be able to provide it while a data session is active.**
>
> This interface will only be available once the modem is ready to be registered in the cellular network...

This meant that, it was possible to find this error during Modem configuration:

```
org.freedesktop.dbus.errors.UnknownMethod: No such interface “org.freedesktop.ModemManager1.Modem.Location” on object at path /org/freedesktop/ModemManager1/Modem/8
```

This PR add the required checks to avoid throwing errors due to the lack of the `Modem.Location` interface during Modem configuration.