### PR TITLE
refactor(nm): NMDBusConnector class refactor

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMConfigurationEnforcementHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMConfigurationEnforcementHandler.java
@@ -47,7 +47,7 @@ public class NMConfigurationEnforcementHandler implements DBusSigHandler<Device.
         if (deviceIsConnectingToANewNetwork || deviceDisconnectedBecauseOfConfigurationEvent) {
             try {
                 logger.info("Network change detected on interface {}. Roll-back to cached configuration", s.getPath());
-                String deviceId = this.nm.getDeviceId(s.getPath());
+                String deviceId = this.nm.getDeviceIdByDBusPath(s.getPath());
                 this.nm.apply(deviceId);
             } catch (DBusException e) {
                 logger.error("Failed to handle network configuration change event for device: {}. Caused by:",

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMConfigurationEnforcementHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMConfigurationEnforcementHandler.java
@@ -47,7 +47,8 @@ public class NMConfigurationEnforcementHandler implements DBusSigHandler<Device.
         if (deviceIsConnectingToANewNetwork || deviceDisconnectedBecauseOfConfigurationEvent) {
             try {
                 logger.info("Network change detected on interface {}. Roll-back to cached configuration", s.getPath());
-                this.nm.apply();
+                String deviceId = this.nm.getDeviceId(s.getPath());
+                this.nm.apply(deviceId);
             } catch (DBusException e) {
                 logger.error("Failed to handle network configuration change event for device: {}. Caused by:",
                         s.getPath(), e);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -184,35 +184,35 @@ public class NMDbusConnector {
             }
 
             switch (deviceType) {
-                case NM_DEVICE_TYPE_ETHERNET:
-                    Wired wiredDevice = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.get().getObjectPath(),
-                            Wired.class);
-                    Properties wiredDeviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
-                            wiredDevice.getObjectPath(), Properties.class);
+            case NM_DEVICE_TYPE_ETHERNET:
+                Wired wiredDevice = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.get().getObjectPath(),
+                        Wired.class);
+                Properties wiredDeviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
+                        wiredDevice.getObjectPath(), Properties.class);
 
-                    DevicePropertiesWrapper ethernetPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
-                            Optional.of(wiredDeviceProperties), NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+                DevicePropertiesWrapper ethernetPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
+                        Optional.of(wiredDeviceProperties), NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
-                    networkInterfaceStatus = NMStatusConverter.buildEthernetStatus(interfaceId,
-                            ethernetPropertiesWrapper, ip4configProperties);
-                    break;
-                case NM_DEVICE_TYPE_LOOPBACK:
-                    DevicePropertiesWrapper loopbackPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
-                            Optional.empty(), NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
+                networkInterfaceStatus = NMStatusConverter.buildEthernetStatus(interfaceId,
+                        ethernetPropertiesWrapper, ip4configProperties);
+                break;
+            case NM_DEVICE_TYPE_LOOPBACK:
+                DevicePropertiesWrapper loopbackPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
+                        Optional.empty(), NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
 
-                    networkInterfaceStatus = NMStatusConverter.buildLoopbackStatus(interfaceId,
-                            loopbackPropertiesWrapper, ip4configProperties);
-                    break;
-                case NM_DEVICE_TYPE_WIFI:
-                    networkInterfaceStatus = createWirelessStatus(interfaceId, commandExecutorService, device.get(),
-                            deviceProperties, ip4configProperties);
-                    break;
-                case NM_DEVICE_TYPE_MODEM:
-                    networkInterfaceStatus = createModemStatus(interfaceId, device.get(), deviceProperties,
-                            ip4configProperties);
-                    break;
-                default:
-                    break;
+                networkInterfaceStatus = NMStatusConverter.buildLoopbackStatus(interfaceId,
+                        loopbackPropertiesWrapper, ip4configProperties);
+                break;
+            case NM_DEVICE_TYPE_WIFI:
+                networkInterfaceStatus = createWirelessStatus(interfaceId, commandExecutorService, device.get(),
+                        deviceProperties, ip4configProperties);
+                break;
+            case NM_DEVICE_TYPE_MODEM:
+                networkInterfaceStatus = createModemStatus(interfaceId, device.get(), deviceProperties,
+                        ip4configProperties);
+                break;
+            default:
+                break;
             }
         }
         return networkInterfaceStatus;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -400,6 +400,7 @@ public class NMDbusConnector {
                 modemResetHandlerEnable(deviceId, delayMinutes, device);
             }
         }
+
     }
 
     private void manageNonConfiguredInterface(Device device, String deviceId) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -581,8 +581,8 @@ public class NMDbusConnector {
         return deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_MANAGED);
     }
 
-    private NMDeviceType getDeviceType(String devicePath) throws DBusException {
-        Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, devicePath,
+    private NMDeviceType getDeviceType(String deviceDbusPath) throws DBusException {
+        Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, deviceDbusPath,
                 Properties.class);
 
         NMDeviceType deviceType = NMDeviceType
@@ -590,7 +590,7 @@ public class NMDbusConnector {
 
         // Workaround to identify Loopback interface for NM versions prior to 1.42
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_GENERIC) {
-            Generic genericDevice = this.dbusConnection.getRemoteObject(NM_BUS_NAME, devicePath,
+            Generic genericDevice = this.dbusConnection.getRemoteObject(NM_BUS_NAME, deviceDbusPath,
                     Generic.class);
             Properties genericDeviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
                     genericDevice.getObjectPath(), Properties.class);
@@ -754,10 +754,10 @@ public class NMDbusConnector {
         this.modemHandlers.clear();
     }
 
-    private String getDeviceIdFromNM(String devicePath) throws DBusException {
-        Properties nmModemProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, devicePath, Properties.class);
+    private String getDeviceIdFromNM(String deviceDbusPath) throws DBusException {
+        Properties nmModemProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, deviceDbusPath, Properties.class);
         String deviceId = (String) nmModemProperties.Get(NM_DEVICE_BUS_NAME + ".Modem", "DeviceId");
-        logger.debug("Found DeviceId {} for device {}", deviceId, devicePath);
+        logger.debug("Found DeviceId {} for device {}", deviceId, deviceDbusPath);
         return deviceId;
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -194,16 +194,14 @@ public class NMDbusConnector {
                             Optional.of(wiredDeviceProperties), NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
                     networkInterfaceStatus = NMStatusConverter.buildEthernetStatus(interfaceId,
-                            ethernetPropertiesWrapper,
-                            ip4configProperties);
+                            ethernetPropertiesWrapper, ip4configProperties);
                     break;
                 case NM_DEVICE_TYPE_LOOPBACK:
                     DevicePropertiesWrapper loopbackPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
                             Optional.empty(), NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
 
                     networkInterfaceStatus = NMStatusConverter.buildLoopbackStatus(interfaceId,
-                            loopbackPropertiesWrapper,
-                            ip4configProperties);
+                            loopbackPropertiesWrapper, ip4configProperties);
                     break;
                 case NM_DEVICE_TYPE_WIFI:
                     networkInterfaceStatus = createWirelessStatus(interfaceId, commandExecutorService, device.get(),

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceAddedHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceAddedHandler.java
@@ -33,7 +33,8 @@ public class NMDeviceAddedHandler implements DBusSigHandler<NetworkManager.Devic
     public void handle(NetworkManager.DeviceAdded s) {
         try {
             logger.info("New network device connected at {}", s.getDevicePath());
-            this.nm.apply();
+            String deviceId = this.nm.getDeviceIdByDBusPath(s.getPath());
+            this.nm.apply(deviceId);
         } catch (DBusException e) {
             logger.error("Failed to handle DeviceAdded event for device: {}. Caused by:", s.getDevicePath(), e);
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceAddedHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDeviceAddedHandler.java
@@ -33,7 +33,7 @@ public class NMDeviceAddedHandler implements DBusSigHandler<NetworkManager.Devic
     public void handle(NetworkManager.DeviceAdded s) {
         try {
             logger.info("New network device connected at {}", s.getDevicePath());
-            String deviceId = this.nm.getDeviceIdByDBusPath(s.getPath());
+            String deviceId = this.nm.getDeviceIdByDBusPath(s.getDevicePath().getPath());
             this.nm.apply(deviceId);
         } catch (DBusException e) {
             logger.error("Failed to handle DeviceAdded event for device: {}. Caused by:", s.getDevicePath(), e);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -692,7 +692,7 @@ public class NMDbusConnectorTest {
 
         givenApplyWasCalledOnceWith(this.netConfig);
 
-        whenDeviceStateChangeSignalAppearsWith("/org/freedesktop/NetworkManager/Devices/5",
+        whenDeviceStateChangeSignalAppearsWith("/mock/device/eth0",
                 NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED),
                 NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_CONFIG), new UInt32(1));
 
@@ -718,7 +718,7 @@ public class NMDbusConnectorTest {
 
         givenApplyWasCalledOnceWith(this.netConfig);
 
-        whenDeviceStateChangeSignalAppearsWith("/org/freedesktop/NetworkManager/Devices/5",
+        whenDeviceStateChangeSignalAppearsWith("/mock/device/eth0",
                 NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_DEACTIVATING),
                 NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED), new UInt32(1));
 
@@ -744,7 +744,7 @@ public class NMDbusConnectorTest {
 
         givenApplyWasCalledOnceWith(this.netConfig);
 
-        whenDeviceStateChangeSignalAppearsWith("/org/freedesktop/NetworkManager/Devices/5",
+        whenDeviceStateChangeSignalAppearsWith("/mock/device/eth0",
                 NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_FAILED),
                 NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_DISCONNECTED), new UInt32(1));
 
@@ -1001,8 +1001,8 @@ public class NMDbusConnectorTest {
             Settings settings = mock(Settings.class);
             when(settings.ListConnections()).thenReturn(this.mockedConnectionDbusPathList);
 
-            doReturn(settings).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-                    eq("/org/freedesktop/NetworkManager/Settings"), eq(Settings.class));
+            doReturn(settings).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
+                    "/org/freedesktop/NetworkManager/Settings", Settings.class);
 
             DBusPath mockUuidPath = mock(DBusPath.class);
             when(mockUuidPath.getPath()).thenReturn("/unused/connection/path");
@@ -1010,7 +1010,7 @@ public class NMDbusConnectorTest {
             when(settings.GetConnectionByUuid(any())).thenReturn(mockUuidPath);
 
             doThrow(DBusExecutionException.class).when(this.dbusConnection).getRemoteObject(
-                    eq("org.freedesktop.NetworkManager"), eq("/unused/connection/path"), eq(Connection.class));
+                    "org.freedesktop.NetworkManager", "/unused/connection/path", Connection.class);
         }
 
         DBusPath mockPath = mock(DBusPath.class);
@@ -1030,8 +1030,8 @@ public class NMDbusConnectorTest {
         when(mockNewConnection.GetSettings()).thenReturn(connectionSettings);
         when(mockNewConnection.getObjectPath()).thenReturn(connectionPath);
 
-        doReturn(mockNewConnection).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-                eq(connectionPath), eq(Connection.class));
+        doReturn(mockNewConnection).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
+                connectionPath, Connection.class);
 
         this.mockedConnections.put(connectionPath, mockNewConnection);
 
@@ -1046,8 +1046,8 @@ public class NMDbusConnectorTest {
             Settings settings = mock(Settings.class);
             when(settings.ListConnections()).thenReturn(this.mockedConnectionDbusPathList);
 
-            doReturn(settings).when(this.dbusConnection).getRemoteObject(eq("org.freedesktop.NetworkManager"),
-                    eq("/org/freedesktop/NetworkManager/Settings"), eq(Settings.class));
+            doReturn(settings).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
+                    "/org/freedesktop/NetworkManager/Settings", Settings.class);
 
             DBusPath mockUuidPath = mock(DBusPath.class);
             when(mockUuidPath.getPath()).thenReturn("/path/to/Associated/Connection");
@@ -1055,7 +1055,7 @@ public class NMDbusConnectorTest {
             when(settings.GetConnectionByUuid(any())).thenReturn(mockUuidPath);
 
             doReturn(mockAssociatedConnection).when(this.dbusConnection).getRemoteObject(
-                    eq("org.freedesktop.NetworkManager"), eq("/path/to/Associated/Connection"), eq(Connection.class));
+                    "org.freedesktop.NetworkManager", "/path/to/Associated/Connection", Connection.class);
         }
 
         DBusPath mockPath = mock(DBusPath.class);
@@ -1075,7 +1075,7 @@ public class NMDbusConnectorTest {
         when(mockAssociatedConnection.getObjectPath()).thenReturn(connectionPath);
 
         doReturn(mockAssociatedConnection).when(this.dbusConnection)
-                .getRemoteObject(eq("org.freedesktop.NetworkManager"), eq(connectionPath), eq(Connection.class));
+                .getRemoteObject("org.freedesktop.NetworkManager", connectionPath, Connection.class);
 
         this.mockedConnections.put(connectionPath, mockAssociatedConnection);
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR perform a refactor of the `NMDbusConnector` class. In particular, it adds the `apply(String deviceId)` method that is used by the `NMConfigurationEnforcementHandler` to apply the configuration to a single device/interface and it rewrites the `doApply` method in a simpler way.
