### PR TITLE
refactor(api): Changed id field to interfaceId in network APIs

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/NetworkInterfaceStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/NetworkInterfaceStatus.java
@@ -25,12 +25,11 @@ import org.osgi.annotation.versioning.ProviderType;
  * network interface. Specific interfaces, like ethernet or wifi, must extend
  * this class.
  *
- * A network interface is identified by Kura using the id field. It is used
- * to internally manage the interface.
+ * A network interface is identified by Eclipse Kura using the interfaceId
+ * field. It is used to internally manage the interface.
  * The interfaceName, instead, is the IP interface as it may appear on the
- * system.
- * For Ethernet and WiFi interfaces the two values coincide (i.e. eth0, wlp1s0,
- * ...).
+ * system. For Ethernet and WiFi interfaces the two values coincide
+ * (i.e. eth0, wlp1s0, ...).
  * For modems, instead, the id is typically the usb or pci path, while the
  * interfaceName is the IP interface created when they are connected.
  * When the modem is disconnected the interfaceName can have a different value.
@@ -39,7 +38,7 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public abstract class NetworkInterfaceStatus {
 
-    private final String id;
+    private final String interfaceId;
     private final String interfaceName;
     private final byte[] hardwareAddress;
     private final NetworkInterfaceType type;
@@ -54,7 +53,7 @@ public abstract class NetworkInterfaceStatus {
     private final Optional<NetworkInterfaceIpAddressStatus<IP6Address>> interfaceIp6Addresses;
 
     protected NetworkInterfaceStatus(NetworkInterfaceStatusBuilder<?> builder) {
-        this.id = builder.id;
+        this.interfaceId = builder.interfaceId;
         this.interfaceName = builder.interfaceName;
         this.hardwareAddress = builder.hardwareAddress;
         this.type = builder.type;
@@ -69,8 +68,8 @@ public abstract class NetworkInterfaceStatus {
         this.interfaceIp6Addresses = builder.interfaceIp6Addresses;
     }
 
-    public String getId() {
-        return this.id;
+    public String getInterfaceId() {
+        return this.interfaceId;
     }
 
     public String getInterfaceName() {
@@ -129,7 +128,7 @@ public abstract class NetworkInterfaceStatus {
     public abstract static class NetworkInterfaceStatusBuilder<T extends NetworkInterfaceStatusBuilder<T>> {
 
         private static final String NA = "N/A";
-        private String id = NA;
+        private String interfaceId = NA;
         private String interfaceName = NA;
         private byte[] hardwareAddress = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
         private NetworkInterfaceType type = NetworkInterfaceType.UNKNOWN;
@@ -143,8 +142,8 @@ public abstract class NetworkInterfaceStatus {
         private Optional<NetworkInterfaceIpAddressStatus<IP4Address>> interfaceIp4Addresses = Optional.empty();
         private Optional<NetworkInterfaceIpAddressStatus<IP6Address>> interfaceIp6Addresses = Optional.empty();
 
-        public T withId(String id) {
-            this.id = id;
+        public T withInterfaceId(String interfaceId) {
+            this.interfaceId = interfaceId;
             return getThis();
         }
 
@@ -221,7 +220,7 @@ public abstract class NetworkInterfaceStatus {
         int result = 1;
         result = prime * result + Arrays.hashCode(this.hardwareAddress);
         result = prime * result + Objects.hash(this.autoConnect, this.driver, this.driverVersion, this.firmwareVersion,
-                this.interfaceName, this.interfaceIp4Addresses, this.interfaceIp6Addresses, this.mtu, this.id,
+                this.interfaceName, this.interfaceIp4Addresses, this.interfaceIp6Addresses, this.mtu, this.interfaceId,
                 this.state, this.type, this.virtual);
         return result;
     }
@@ -242,7 +241,8 @@ public abstract class NetworkInterfaceStatus {
                 && Objects.equals(this.interfaceName, other.interfaceName)
                 && Objects.equals(this.interfaceIp4Addresses, other.interfaceIp4Addresses)
                 && Objects.equals(this.interfaceIp6Addresses, other.interfaceIp6Addresses) && this.mtu == other.mtu
-                && Objects.equals(this.id, other.id) && this.state == other.state && this.type == other.type
+                && Objects.equals(this.interfaceId, other.interfaceId) && this.state == other.state
+                && this.type == other.type
                 && this.virtual == other.virtual;
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -108,7 +108,7 @@ public class NMStatusConverter {
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties) {
 
         EthernetInterfaceStatusBuilder builder = EthernetInterfaceStatus.builder();
-        builder.withId(interfaceId).withInterfaceName(interfaceId).withVirtual(false);
+        builder.withInterfaceId(interfaceId).withInterfaceName(interfaceId).withVirtual(false);
 
         NMDeviceState deviceState = NMDeviceState
                 .fromUInt32(devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, STATE));
@@ -125,7 +125,7 @@ public class NMStatusConverter {
     public static NetworkInterfaceStatus buildLoopbackStatus(String interfaceId,
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties) {
         LoopbackInterfaceStatusBuilder builder = LoopbackInterfaceStatus.builder();
-        builder.withId(interfaceId).withInterfaceName(interfaceId).withVirtual(true);
+        builder.withInterfaceId(interfaceId).withInterfaceName(interfaceId).withVirtual(true);
 
         NMDeviceState deviceState = NMDeviceState
                 .fromUInt32(devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, STATE));
@@ -141,7 +141,7 @@ public class NMStatusConverter {
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties,
             AccessPointsProperties accessPointsProperties, SupportedChannelsProperties supportedChannelsProperties) {
         WifiInterfaceStatusBuilder builder = WifiInterfaceStatus.builder();
-        builder.withId(interfaceId).withInterfaceName(interfaceId).withVirtual(false);
+        builder.withInterfaceId(interfaceId).withInterfaceName(interfaceId).withVirtual(false);
 
         NMDeviceState deviceState = NMDeviceState
                 .fromUInt32(devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, STATE));
@@ -176,7 +176,7 @@ public class NMStatusConverter {
         ModemInterfaceStatusBuilder builder = ModemInterfaceStatus.builder();
         Properties deviceProperties = devicePropertiesWrapper.getDeviceProperties();
         Optional<Properties> modemProperties = devicePropertiesWrapper.getDeviceSpecificProperties();
-        builder.withId(interfaceId).withVirtual(false);
+        builder.withInterfaceId(interfaceId).withVirtual(false);
         setModemInterfaceName(interfaceId, deviceProperties, builder);
 
         NMDeviceState deviceState = NMDeviceState.fromUInt32(deviceProperties.Get(NM_DEVICE_BUS_NAME, STATE));
@@ -231,16 +231,16 @@ public class NMStatusConverter {
         }
 
         switch (devicePropertiesWrapper.getDeviceType()) {
-        case NM_DEVICE_TYPE_ETHERNET:
-            return specificProperties.get().Get(NM_DEVICE_WIRED_BUS_NAME, NM_DEVICE_PROPERTY_HW_ADDRESS);
-        case NM_DEVICE_TYPE_WIFI:
-            return specificProperties.get().Get(NM_DEVICE_WIRELESS_BUS_NAME, NM_DEVICE_PROPERTY_HW_ADDRESS);
-        case NM_DEVICE_TYPE_MODEM:
-        case NM_DEVICE_TYPE_GENERIC:
-        case NM_DEVICE_TYPE_LOOPBACK:
-        default:
-            logger.debug("Setting HW Address to blank.");
-            return EMPTY_MAC_ADDRESS;
+            case NM_DEVICE_TYPE_ETHERNET:
+                return specificProperties.get().Get(NM_DEVICE_WIRED_BUS_NAME, NM_DEVICE_PROPERTY_HW_ADDRESS);
+            case NM_DEVICE_TYPE_WIFI:
+                return specificProperties.get().Get(NM_DEVICE_WIRELESS_BUS_NAME, NM_DEVICE_PROPERTY_HW_ADDRESS);
+            case NM_DEVICE_TYPE_MODEM:
+            case NM_DEVICE_TYPE_GENERIC:
+            case NM_DEVICE_TYPE_LOOPBACK:
+            default:
+                logger.debug("Setting HW Address to blank.");
+                return EMPTY_MAC_ADDRESS;
         }
     }
 
@@ -396,39 +396,39 @@ public class NMStatusConverter {
 
     private static WifiSecurity wifiSecurityFlagConvert(NM80211ApSecurityFlags nmFlag) {
         switch (nmFlag) {
-        case NM_802_11_AP_SEC_NONE:
-            return WifiSecurity.NONE;
-        case NM_802_11_AP_SEC_PAIR_WEP40:
-            return WifiSecurity.PAIR_WEP40;
-        case NM_802_11_AP_SEC_PAIR_WEP104:
-            return WifiSecurity.PAIR_WEP104;
-        case NM_802_11_AP_SEC_PAIR_TKIP:
-            return WifiSecurity.PAIR_TKIP;
-        case NM_802_11_AP_SEC_PAIR_CCMP:
-            return WifiSecurity.PAIR_CCMP;
-        case NM_802_11_AP_SEC_GROUP_WEP40:
-            return WifiSecurity.GROUP_WEP40;
-        case NM_802_11_AP_SEC_GROUP_WEP104:
-            return WifiSecurity.GROUP_WEP104;
-        case NM_802_11_AP_SEC_GROUP_TKIP:
-            return WifiSecurity.GROUP_TKIP;
-        case NM_802_11_AP_SEC_GROUP_CCMP:
-            return WifiSecurity.GROUP_CCMP;
-        case NM_802_11_AP_SEC_KEY_MGMT_PSK:
-            return WifiSecurity.KEY_MGMT_PSK;
-        case NM_802_11_AP_SEC_KEY_MGMT_802_1X:
-            return WifiSecurity.KEY_MGMT_802_1X;
-        case NM_802_11_AP_SEC_KEY_MGMT_SAE:
-            return WifiSecurity.KEY_MGMT_SAE;
-        case NM_802_11_AP_SEC_KEY_MGMT_OWE:
-            return WifiSecurity.KEY_MGMT_OWE;
-        case NM_802_11_AP_SEC_KEY_MGMT_OWE_TM:
-            return WifiSecurity.KEY_MGMT_OWE_TM;
-        case NM_802_11_AP_SEC_KEY_MGMT_EAP_SUITE_B_192:
-            return WifiSecurity.KEY_MGMT_EAP_SUITE_B_192;
-        default:
-            throw new IllegalArgumentException(
-                    String.format("Non convertible NM80211ApSecurityFlag \"%s\"", nmFlag));
+            case NM_802_11_AP_SEC_NONE:
+                return WifiSecurity.NONE;
+            case NM_802_11_AP_SEC_PAIR_WEP40:
+                return WifiSecurity.PAIR_WEP40;
+            case NM_802_11_AP_SEC_PAIR_WEP104:
+                return WifiSecurity.PAIR_WEP104;
+            case NM_802_11_AP_SEC_PAIR_TKIP:
+                return WifiSecurity.PAIR_TKIP;
+            case NM_802_11_AP_SEC_PAIR_CCMP:
+                return WifiSecurity.PAIR_CCMP;
+            case NM_802_11_AP_SEC_GROUP_WEP40:
+                return WifiSecurity.GROUP_WEP40;
+            case NM_802_11_AP_SEC_GROUP_WEP104:
+                return WifiSecurity.GROUP_WEP104;
+            case NM_802_11_AP_SEC_GROUP_TKIP:
+                return WifiSecurity.GROUP_TKIP;
+            case NM_802_11_AP_SEC_GROUP_CCMP:
+                return WifiSecurity.GROUP_CCMP;
+            case NM_802_11_AP_SEC_KEY_MGMT_PSK:
+                return WifiSecurity.KEY_MGMT_PSK;
+            case NM_802_11_AP_SEC_KEY_MGMT_802_1X:
+                return WifiSecurity.KEY_MGMT_802_1X;
+            case NM_802_11_AP_SEC_KEY_MGMT_SAE:
+                return WifiSecurity.KEY_MGMT_SAE;
+            case NM_802_11_AP_SEC_KEY_MGMT_OWE:
+                return WifiSecurity.KEY_MGMT_OWE;
+            case NM_802_11_AP_SEC_KEY_MGMT_OWE_TM:
+                return WifiSecurity.KEY_MGMT_OWE_TM;
+            case NM_802_11_AP_SEC_KEY_MGMT_EAP_SUITE_B_192:
+                return WifiSecurity.KEY_MGMT_EAP_SUITE_B_192;
+            default:
+                throw new IllegalArgumentException(
+                        String.format("Non convertible NM80211ApSecurityFlag \"%s\"", nmFlag));
         }
     }
 
@@ -445,37 +445,37 @@ public class NMStatusConverter {
 
     private static WifiCapability wifiCapabilitiesConvert(NMDeviceWifiCapabilities nmCapability) {
         switch (nmCapability) {
-        case NM_WIFI_DEVICE_CAP_NONE:
-            return WifiCapability.NONE;
-        case NM_WIFI_DEVICE_CAP_CIPHER_WEP40:
-            return WifiCapability.CIPHER_WEP40;
-        case NM_WIFI_DEVICE_CAP_CIPHER_WEP104:
-            return WifiCapability.CIPHER_WEP104;
-        case NM_WIFI_DEVICE_CAP_CIPHER_TKIP:
-            return WifiCapability.CIPHER_TKIP;
-        case NM_WIFI_DEVICE_CAP_CIPHER_CCMP:
-            return WifiCapability.CIPHER_CCMP;
-        case NM_WIFI_DEVICE_CAP_WPA:
-            return WifiCapability.WPA;
-        case NM_WIFI_DEVICE_CAP_RSN:
-            return WifiCapability.RSN;
-        case NM_WIFI_DEVICE_CAP_AP:
-            return WifiCapability.AP;
-        case NM_WIFI_DEVICE_CAP_ADHOC:
-            return WifiCapability.ADHOC;
-        case NM_WIFI_DEVICE_CAP_FREQ_VALID:
-            return WifiCapability.FREQ_VALID;
-        case NM_WIFI_DEVICE_CAP_FREQ_2GHZ:
-            return WifiCapability.FREQ_2GHZ;
-        case NM_WIFI_DEVICE_CAP_FREQ_5GHZ:
-            return WifiCapability.FREQ_5GHZ;
-        case NM_WIFI_DEVICE_CAP_MESH:
-            return WifiCapability.MESH;
-        case NM_WIFI_DEVICE_CAP_IBSS_RSN:
-            return WifiCapability.IBSS_RSN;
-        default:
-            throw new IllegalArgumentException(
-                    String.format("Non convertible NMDeviceWifiCapabilities \"%s\"", nmCapability));
+            case NM_WIFI_DEVICE_CAP_NONE:
+                return WifiCapability.NONE;
+            case NM_WIFI_DEVICE_CAP_CIPHER_WEP40:
+                return WifiCapability.CIPHER_WEP40;
+            case NM_WIFI_DEVICE_CAP_CIPHER_WEP104:
+                return WifiCapability.CIPHER_WEP104;
+            case NM_WIFI_DEVICE_CAP_CIPHER_TKIP:
+                return WifiCapability.CIPHER_TKIP;
+            case NM_WIFI_DEVICE_CAP_CIPHER_CCMP:
+                return WifiCapability.CIPHER_CCMP;
+            case NM_WIFI_DEVICE_CAP_WPA:
+                return WifiCapability.WPA;
+            case NM_WIFI_DEVICE_CAP_RSN:
+                return WifiCapability.RSN;
+            case NM_WIFI_DEVICE_CAP_AP:
+                return WifiCapability.AP;
+            case NM_WIFI_DEVICE_CAP_ADHOC:
+                return WifiCapability.ADHOC;
+            case NM_WIFI_DEVICE_CAP_FREQ_VALID:
+                return WifiCapability.FREQ_VALID;
+            case NM_WIFI_DEVICE_CAP_FREQ_2GHZ:
+                return WifiCapability.FREQ_2GHZ;
+            case NM_WIFI_DEVICE_CAP_FREQ_5GHZ:
+                return WifiCapability.FREQ_5GHZ;
+            case NM_WIFI_DEVICE_CAP_MESH:
+                return WifiCapability.MESH;
+            case NM_WIFI_DEVICE_CAP_IBSS_RSN:
+                return WifiCapability.IBSS_RSN;
+            default:
+                throw new IllegalArgumentException(
+                        String.format("Non convertible NMDeviceWifiCapabilities \"%s\"", nmCapability));
         }
     }
 
@@ -743,49 +743,49 @@ public class NMStatusConverter {
 
     private static WifiMode wifiModeConvert(NM80211Mode mode) {
         switch (mode) {
-        case NM_802_11_MODE_ADHOC:
-            return WifiMode.ADHOC;
-        case NM_802_11_MODE_INFRA:
-            return WifiMode.INFRA;
-        case NM_802_11_MODE_AP:
-            return WifiMode.MASTER;
-        case NM_802_11_MODE_MESH:
-            return WifiMode.MESH;
-        case NM_802_11_MODE_UNKNOWN:
-        default:
-            return WifiMode.UNKNOWN;
+            case NM_802_11_MODE_ADHOC:
+                return WifiMode.ADHOC;
+            case NM_802_11_MODE_INFRA:
+                return WifiMode.INFRA;
+            case NM_802_11_MODE_AP:
+                return WifiMode.MASTER;
+            case NM_802_11_MODE_MESH:
+                return WifiMode.MESH;
+            case NM_802_11_MODE_UNKNOWN:
+            default:
+                return WifiMode.UNKNOWN;
         }
     }
 
     private static NetworkInterfaceState deviceStateConvert(NMDeviceState state) {
         switch (state) {
-        case NM_DEVICE_STATE_UNMANAGED:
-            return NetworkInterfaceState.UNMANAGED;
-        case NM_DEVICE_STATE_UNAVAILABLE:
-            return NetworkInterfaceState.UNAVAILABLE;
-        case NM_DEVICE_STATE_DISCONNECTED:
-            return NetworkInterfaceState.DISCONNECTED;
-        case NM_DEVICE_STATE_PREPARE:
-            return NetworkInterfaceState.PREPARE;
-        case NM_DEVICE_STATE_CONFIG:
-            return NetworkInterfaceState.CONFIG;
-        case NM_DEVICE_STATE_NEED_AUTH:
-            return NetworkInterfaceState.NEED_AUTH;
-        case NM_DEVICE_STATE_IP_CONFIG:
-            return NetworkInterfaceState.IP_CONFIG;
-        case NM_DEVICE_STATE_IP_CHECK:
-            return NetworkInterfaceState.IP_CHECK;
-        case NM_DEVICE_STATE_SECONDARIES:
-            return NetworkInterfaceState.SECONDARIES;
-        case NM_DEVICE_STATE_ACTIVATED:
-            return NetworkInterfaceState.ACTIVATED;
-        case NM_DEVICE_STATE_DEACTIVATING:
-            return NetworkInterfaceState.DEACTIVATING;
-        case NM_DEVICE_STATE_FAILED:
-            return NetworkInterfaceState.FAILED;
-        case NM_DEVICE_STATE_UNKNOWN:
-        default:
-            return NetworkInterfaceState.UNKNOWN;
+            case NM_DEVICE_STATE_UNMANAGED:
+                return NetworkInterfaceState.UNMANAGED;
+            case NM_DEVICE_STATE_UNAVAILABLE:
+                return NetworkInterfaceState.UNAVAILABLE;
+            case NM_DEVICE_STATE_DISCONNECTED:
+                return NetworkInterfaceState.DISCONNECTED;
+            case NM_DEVICE_STATE_PREPARE:
+                return NetworkInterfaceState.PREPARE;
+            case NM_DEVICE_STATE_CONFIG:
+                return NetworkInterfaceState.CONFIG;
+            case NM_DEVICE_STATE_NEED_AUTH:
+                return NetworkInterfaceState.NEED_AUTH;
+            case NM_DEVICE_STATE_IP_CONFIG:
+                return NetworkInterfaceState.IP_CONFIG;
+            case NM_DEVICE_STATE_IP_CHECK:
+                return NetworkInterfaceState.IP_CHECK;
+            case NM_DEVICE_STATE_SECONDARIES:
+                return NetworkInterfaceState.SECONDARIES;
+            case NM_DEVICE_STATE_ACTIVATED:
+                return NetworkInterfaceState.ACTIVATED;
+            case NM_DEVICE_STATE_DEACTIVATING:
+                return NetworkInterfaceState.DEACTIVATING;
+            case NM_DEVICE_STATE_FAILED:
+                return NetworkInterfaceState.FAILED;
+            case NM_DEVICE_STATE_UNKNOWN:
+            default:
+                return NetworkInterfaceState.UNKNOWN;
         }
     }
 
@@ -796,7 +796,8 @@ public class NMStatusConverter {
      * and
      * https://github.com/torvalds/linux/blob/c9c3395d5e3dcc6daee66c6908354d47bf98cb0c/drivers/net/wireless/intel/ipw2x00/ipw2200.c#L11664
      * 
-     * signalQuality = (100 * DeltaRSSI^2 - (RSSIMax - RSSI)*(15*DeltaRSSI + 62*DeltaRSSI))/DeltaRSSI^2
+     * signalQuality = (100 * DeltaRSSI^2 - (RSSIMax - RSSI)*(15*DeltaRSSI +
+     * 62*DeltaRSSI))/DeltaRSSI^2
      */
     protected static int convertToWifiSignalStrength(int signalQuality) {
         int rssiMax = -20;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -231,16 +231,16 @@ public class NMStatusConverter {
         }
 
         switch (devicePropertiesWrapper.getDeviceType()) {
-            case NM_DEVICE_TYPE_ETHERNET:
-                return specificProperties.get().Get(NM_DEVICE_WIRED_BUS_NAME, NM_DEVICE_PROPERTY_HW_ADDRESS);
-            case NM_DEVICE_TYPE_WIFI:
-                return specificProperties.get().Get(NM_DEVICE_WIRELESS_BUS_NAME, NM_DEVICE_PROPERTY_HW_ADDRESS);
-            case NM_DEVICE_TYPE_MODEM:
-            case NM_DEVICE_TYPE_GENERIC:
-            case NM_DEVICE_TYPE_LOOPBACK:
-            default:
-                logger.debug("Setting HW Address to blank.");
-                return EMPTY_MAC_ADDRESS;
+        case NM_DEVICE_TYPE_ETHERNET:
+            return specificProperties.get().Get(NM_DEVICE_WIRED_BUS_NAME, NM_DEVICE_PROPERTY_HW_ADDRESS);
+        case NM_DEVICE_TYPE_WIFI:
+            return specificProperties.get().Get(NM_DEVICE_WIRELESS_BUS_NAME, NM_DEVICE_PROPERTY_HW_ADDRESS);
+        case NM_DEVICE_TYPE_MODEM:
+        case NM_DEVICE_TYPE_GENERIC:
+        case NM_DEVICE_TYPE_LOOPBACK:
+        default:
+            logger.debug("Setting HW Address to blank.");
+            return EMPTY_MAC_ADDRESS;
         }
     }
 
@@ -396,39 +396,39 @@ public class NMStatusConverter {
 
     private static WifiSecurity wifiSecurityFlagConvert(NM80211ApSecurityFlags nmFlag) {
         switch (nmFlag) {
-            case NM_802_11_AP_SEC_NONE:
-                return WifiSecurity.NONE;
-            case NM_802_11_AP_SEC_PAIR_WEP40:
-                return WifiSecurity.PAIR_WEP40;
-            case NM_802_11_AP_SEC_PAIR_WEP104:
-                return WifiSecurity.PAIR_WEP104;
-            case NM_802_11_AP_SEC_PAIR_TKIP:
-                return WifiSecurity.PAIR_TKIP;
-            case NM_802_11_AP_SEC_PAIR_CCMP:
-                return WifiSecurity.PAIR_CCMP;
-            case NM_802_11_AP_SEC_GROUP_WEP40:
-                return WifiSecurity.GROUP_WEP40;
-            case NM_802_11_AP_SEC_GROUP_WEP104:
-                return WifiSecurity.GROUP_WEP104;
-            case NM_802_11_AP_SEC_GROUP_TKIP:
-                return WifiSecurity.GROUP_TKIP;
-            case NM_802_11_AP_SEC_GROUP_CCMP:
-                return WifiSecurity.GROUP_CCMP;
-            case NM_802_11_AP_SEC_KEY_MGMT_PSK:
-                return WifiSecurity.KEY_MGMT_PSK;
-            case NM_802_11_AP_SEC_KEY_MGMT_802_1X:
-                return WifiSecurity.KEY_MGMT_802_1X;
-            case NM_802_11_AP_SEC_KEY_MGMT_SAE:
-                return WifiSecurity.KEY_MGMT_SAE;
-            case NM_802_11_AP_SEC_KEY_MGMT_OWE:
-                return WifiSecurity.KEY_MGMT_OWE;
-            case NM_802_11_AP_SEC_KEY_MGMT_OWE_TM:
-                return WifiSecurity.KEY_MGMT_OWE_TM;
-            case NM_802_11_AP_SEC_KEY_MGMT_EAP_SUITE_B_192:
-                return WifiSecurity.KEY_MGMT_EAP_SUITE_B_192;
-            default:
-                throw new IllegalArgumentException(
-                        String.format("Non convertible NM80211ApSecurityFlag \"%s\"", nmFlag));
+        case NM_802_11_AP_SEC_NONE:
+            return WifiSecurity.NONE;
+        case NM_802_11_AP_SEC_PAIR_WEP40:
+            return WifiSecurity.PAIR_WEP40;
+        case NM_802_11_AP_SEC_PAIR_WEP104:
+            return WifiSecurity.PAIR_WEP104;
+        case NM_802_11_AP_SEC_PAIR_TKIP:
+            return WifiSecurity.PAIR_TKIP;
+        case NM_802_11_AP_SEC_PAIR_CCMP:
+            return WifiSecurity.PAIR_CCMP;
+        case NM_802_11_AP_SEC_GROUP_WEP40:
+            return WifiSecurity.GROUP_WEP40;
+        case NM_802_11_AP_SEC_GROUP_WEP104:
+            return WifiSecurity.GROUP_WEP104;
+        case NM_802_11_AP_SEC_GROUP_TKIP:
+            return WifiSecurity.GROUP_TKIP;
+        case NM_802_11_AP_SEC_GROUP_CCMP:
+            return WifiSecurity.GROUP_CCMP;
+        case NM_802_11_AP_SEC_KEY_MGMT_PSK:
+            return WifiSecurity.KEY_MGMT_PSK;
+        case NM_802_11_AP_SEC_KEY_MGMT_802_1X:
+            return WifiSecurity.KEY_MGMT_802_1X;
+        case NM_802_11_AP_SEC_KEY_MGMT_SAE:
+            return WifiSecurity.KEY_MGMT_SAE;
+        case NM_802_11_AP_SEC_KEY_MGMT_OWE:
+            return WifiSecurity.KEY_MGMT_OWE;
+        case NM_802_11_AP_SEC_KEY_MGMT_OWE_TM:
+            return WifiSecurity.KEY_MGMT_OWE_TM;
+        case NM_802_11_AP_SEC_KEY_MGMT_EAP_SUITE_B_192:
+            return WifiSecurity.KEY_MGMT_EAP_SUITE_B_192;
+        default:
+            throw new IllegalArgumentException(
+                    String.format("Non convertible NM80211ApSecurityFlag \"%s\"", nmFlag));
         }
     }
 
@@ -445,37 +445,37 @@ public class NMStatusConverter {
 
     private static WifiCapability wifiCapabilitiesConvert(NMDeviceWifiCapabilities nmCapability) {
         switch (nmCapability) {
-            case NM_WIFI_DEVICE_CAP_NONE:
-                return WifiCapability.NONE;
-            case NM_WIFI_DEVICE_CAP_CIPHER_WEP40:
-                return WifiCapability.CIPHER_WEP40;
-            case NM_WIFI_DEVICE_CAP_CIPHER_WEP104:
-                return WifiCapability.CIPHER_WEP104;
-            case NM_WIFI_DEVICE_CAP_CIPHER_TKIP:
-                return WifiCapability.CIPHER_TKIP;
-            case NM_WIFI_DEVICE_CAP_CIPHER_CCMP:
-                return WifiCapability.CIPHER_CCMP;
-            case NM_WIFI_DEVICE_CAP_WPA:
-                return WifiCapability.WPA;
-            case NM_WIFI_DEVICE_CAP_RSN:
-                return WifiCapability.RSN;
-            case NM_WIFI_DEVICE_CAP_AP:
-                return WifiCapability.AP;
-            case NM_WIFI_DEVICE_CAP_ADHOC:
-                return WifiCapability.ADHOC;
-            case NM_WIFI_DEVICE_CAP_FREQ_VALID:
-                return WifiCapability.FREQ_VALID;
-            case NM_WIFI_DEVICE_CAP_FREQ_2GHZ:
-                return WifiCapability.FREQ_2GHZ;
-            case NM_WIFI_DEVICE_CAP_FREQ_5GHZ:
-                return WifiCapability.FREQ_5GHZ;
-            case NM_WIFI_DEVICE_CAP_MESH:
-                return WifiCapability.MESH;
-            case NM_WIFI_DEVICE_CAP_IBSS_RSN:
-                return WifiCapability.IBSS_RSN;
-            default:
-                throw new IllegalArgumentException(
-                        String.format("Non convertible NMDeviceWifiCapabilities \"%s\"", nmCapability));
+        case NM_WIFI_DEVICE_CAP_NONE:
+            return WifiCapability.NONE;
+        case NM_WIFI_DEVICE_CAP_CIPHER_WEP40:
+            return WifiCapability.CIPHER_WEP40;
+        case NM_WIFI_DEVICE_CAP_CIPHER_WEP104:
+            return WifiCapability.CIPHER_WEP104;
+        case NM_WIFI_DEVICE_CAP_CIPHER_TKIP:
+            return WifiCapability.CIPHER_TKIP;
+        case NM_WIFI_DEVICE_CAP_CIPHER_CCMP:
+            return WifiCapability.CIPHER_CCMP;
+        case NM_WIFI_DEVICE_CAP_WPA:
+            return WifiCapability.WPA;
+        case NM_WIFI_DEVICE_CAP_RSN:
+            return WifiCapability.RSN;
+        case NM_WIFI_DEVICE_CAP_AP:
+            return WifiCapability.AP;
+        case NM_WIFI_DEVICE_CAP_ADHOC:
+            return WifiCapability.ADHOC;
+        case NM_WIFI_DEVICE_CAP_FREQ_VALID:
+            return WifiCapability.FREQ_VALID;
+        case NM_WIFI_DEVICE_CAP_FREQ_2GHZ:
+            return WifiCapability.FREQ_2GHZ;
+        case NM_WIFI_DEVICE_CAP_FREQ_5GHZ:
+            return WifiCapability.FREQ_5GHZ;
+        case NM_WIFI_DEVICE_CAP_MESH:
+            return WifiCapability.MESH;
+        case NM_WIFI_DEVICE_CAP_IBSS_RSN:
+            return WifiCapability.IBSS_RSN;
+        default:
+            throw new IllegalArgumentException(
+                    String.format("Non convertible NMDeviceWifiCapabilities \"%s\"", nmCapability));
         }
     }
 
@@ -743,49 +743,49 @@ public class NMStatusConverter {
 
     private static WifiMode wifiModeConvert(NM80211Mode mode) {
         switch (mode) {
-            case NM_802_11_MODE_ADHOC:
-                return WifiMode.ADHOC;
-            case NM_802_11_MODE_INFRA:
-                return WifiMode.INFRA;
-            case NM_802_11_MODE_AP:
-                return WifiMode.MASTER;
-            case NM_802_11_MODE_MESH:
-                return WifiMode.MESH;
-            case NM_802_11_MODE_UNKNOWN:
-            default:
-                return WifiMode.UNKNOWN;
+        case NM_802_11_MODE_ADHOC:
+            return WifiMode.ADHOC;
+        case NM_802_11_MODE_INFRA:
+            return WifiMode.INFRA;
+        case NM_802_11_MODE_AP:
+            return WifiMode.MASTER;
+        case NM_802_11_MODE_MESH:
+            return WifiMode.MESH;
+        case NM_802_11_MODE_UNKNOWN:
+        default:
+            return WifiMode.UNKNOWN;
         }
     }
 
     private static NetworkInterfaceState deviceStateConvert(NMDeviceState state) {
         switch (state) {
-            case NM_DEVICE_STATE_UNMANAGED:
-                return NetworkInterfaceState.UNMANAGED;
-            case NM_DEVICE_STATE_UNAVAILABLE:
-                return NetworkInterfaceState.UNAVAILABLE;
-            case NM_DEVICE_STATE_DISCONNECTED:
-                return NetworkInterfaceState.DISCONNECTED;
-            case NM_DEVICE_STATE_PREPARE:
-                return NetworkInterfaceState.PREPARE;
-            case NM_DEVICE_STATE_CONFIG:
-                return NetworkInterfaceState.CONFIG;
-            case NM_DEVICE_STATE_NEED_AUTH:
-                return NetworkInterfaceState.NEED_AUTH;
-            case NM_DEVICE_STATE_IP_CONFIG:
-                return NetworkInterfaceState.IP_CONFIG;
-            case NM_DEVICE_STATE_IP_CHECK:
-                return NetworkInterfaceState.IP_CHECK;
-            case NM_DEVICE_STATE_SECONDARIES:
-                return NetworkInterfaceState.SECONDARIES;
-            case NM_DEVICE_STATE_ACTIVATED:
-                return NetworkInterfaceState.ACTIVATED;
-            case NM_DEVICE_STATE_DEACTIVATING:
-                return NetworkInterfaceState.DEACTIVATING;
-            case NM_DEVICE_STATE_FAILED:
-                return NetworkInterfaceState.FAILED;
-            case NM_DEVICE_STATE_UNKNOWN:
-            default:
-                return NetworkInterfaceState.UNKNOWN;
+        case NM_DEVICE_STATE_UNMANAGED:
+            return NetworkInterfaceState.UNMANAGED;
+        case NM_DEVICE_STATE_UNAVAILABLE:
+            return NetworkInterfaceState.UNAVAILABLE;
+        case NM_DEVICE_STATE_DISCONNECTED:
+            return NetworkInterfaceState.DISCONNECTED;
+        case NM_DEVICE_STATE_PREPARE:
+            return NetworkInterfaceState.PREPARE;
+        case NM_DEVICE_STATE_CONFIG:
+            return NetworkInterfaceState.CONFIG;
+        case NM_DEVICE_STATE_NEED_AUTH:
+            return NetworkInterfaceState.NEED_AUTH;
+        case NM_DEVICE_STATE_IP_CONFIG:
+            return NetworkInterfaceState.IP_CONFIG;
+        case NM_DEVICE_STATE_IP_CHECK:
+            return NetworkInterfaceState.IP_CHECK;
+        case NM_DEVICE_STATE_SECONDARIES:
+            return NetworkInterfaceState.SECONDARIES;
+        case NM_DEVICE_STATE_ACTIVATED:
+            return NetworkInterfaceState.ACTIVATED;
+        case NM_DEVICE_STATE_DEACTIVATING:
+            return NetworkInterfaceState.DEACTIVATING;
+        case NM_DEVICE_STATE_FAILED:
+            return NetworkInterfaceState.FAILED;
+        case NM_DEVICE_STATE_UNKNOWN:
+        default:
+            return NetworkInterfaceState.UNKNOWN;
         }
     }
 
@@ -796,8 +796,7 @@ public class NMStatusConverter {
      * and
      * https://github.com/torvalds/linux/blob/c9c3395d5e3dcc6daee66c6908354d47bf98cb0c/drivers/net/wireless/intel/ipw2x00/ipw2200.c#L11664
      * 
-     * signalQuality = (100 * DeltaRSSI^2 - (RSSIMax - RSSI)*(15*DeltaRSSI +
-     * 62*DeltaRSSI))/DeltaRSSI^2
+     * signalQuality = (100 * DeltaRSSI^2 - (RSSIMax - RSSI)*(15*DeltaRSSI + 62*DeltaRSSI))/DeltaRSSI^2
      */
     protected static int convertToWifiSignalStrength(int signalQuality) {
         int rssiMax = -20;

--- a/kura/org.eclipse.kura.rest.network.status.provider/src/main/java/org/eclipse/kura/network/status/provider/api/NetworkInterfaceStatusDTO.java
+++ b/kura/org.eclipse.kura.rest.network.status.provider/src/main/java/org/eclipse/kura/network/status/provider/api/NetworkInterfaceStatusDTO.java
@@ -37,7 +37,7 @@ public class NetworkInterfaceStatusDTO {
     private final NetworkInterfaceIpAddressStatusDTO interfaceIp6Addresses;
 
     protected NetworkInterfaceStatusDTO(final NetworkInterfaceStatus status) {
-        this.id = status.getId();
+        this.id = status.getInterfaceId();
         this.interfaceName = status.getInterfaceName();
         this.hardwareAddress = AddressUtil.formatHardwareAddress(status.getHardwareAddress());
         this.type = status.getType();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -180,12 +180,12 @@ public class NetworkStatusServiceAdapter {
     private void setCommonStateProperties(GwtNetInterfaceConfig gwtConfig,
             NetworkInterfaceStatus networkInterfaceStatus) {
 
-        gwtConfig.setName(networkInterfaceStatus.getId());
+        gwtConfig.setName(networkInterfaceStatus.getInterfaceId());
         gwtConfig.setInterfaceName(networkInterfaceStatus.getInterfaceName());
         gwtConfig.setHwState(networkInterfaceStatus.getState().name());
         gwtConfig.setHwType(networkInterfaceStatus.getType().name());
         gwtConfig.setHwAddress(NetUtil.hardwareAddressToString(networkInterfaceStatus.getHardwareAddress()));
-        gwtConfig.setHwName(networkInterfaceStatus.getId());
+        gwtConfig.setHwName(networkInterfaceStatus.getInterfaceId());
         gwtConfig.setHwDriver(networkInterfaceStatus.getDriver());
         gwtConfig.setHwDriverVersion(networkInterfaceStatus.getDriverVersion());
         gwtConfig.setHwFirmware(networkInterfaceStatus.getFirmwareVersion());

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1424,7 +1424,7 @@ public class NMDbusConnectorTest {
     private void thenModemStatusHasCorrectValues(boolean hasBearers, boolean hasSims) {
         assertTrue(this.netInterface instanceof ModemInterfaceStatus);
         ModemInterfaceStatus modemStatus = (ModemInterfaceStatus) this.netInterface;
-        assertEquals("1-5", modemStatus.getId());
+        assertEquals("1-5", modemStatus.getInterfaceId());
         assertEquals("wwan0", modemStatus.getInterfaceName());
         assertEquals("AwesomeModel", modemStatus.getModel());
         assertEquals("TheBestInTheWorld", modemStatus.getManufacturer());

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
@@ -301,7 +301,7 @@ public class NMStatusServiceImplTest {
 
     private void thenRetrievedEthernetInterfaceStatusHasFullProperties() throws UnknownHostException {
         EthernetInterfaceStatus ethStatus = (EthernetInterfaceStatus) this.status.get();
-        assertEquals("abcd0", ethStatus.getId());
+        assertEquals("abcd0", ethStatus.getInterfaceId());
         assertCommonProperties(ethStatus);
         assertTrue(ethStatus.isLinkUp());
         assertEquals(buildEthernetInterfaceStatus("abcd0"), ethStatus);
@@ -315,7 +315,7 @@ public class NMStatusServiceImplTest {
 
     private void thenRetrievedWifiInterfaceStatusHasFullProperties() throws UnknownHostException {
         WifiInterfaceStatus wifiStatus = (WifiInterfaceStatus) this.status.get();
-        assertEquals("wlan0", wifiStatus.getId());
+        assertEquals("wlan0", wifiStatus.getInterfaceId());
         assertCommonProperties(wifiStatus);
         assertEquals(2, wifiStatus.getCapabilities().size());
         assertEquals(EnumSet.of(WifiCapability.AP, WifiCapability.FREQ_2GHZ), wifiStatus.getCapabilities());
@@ -358,7 +358,7 @@ public class NMStatusServiceImplTest {
 
     private void thenRetrievedLoopbackInterfaceStatusHasFullProperties() throws UnknownHostException {
         LoopbackInterfaceStatus loStatus = (LoopbackInterfaceStatus) this.status.get();
-        assertEquals("lo", loStatus.getId());
+        assertEquals("lo", loStatus.getInterfaceId());
         assertTrue(Arrays.equals(new byte[] { 0x00, 0x11, 0x02, 0x33, 0x44, 0x55 }, loStatus.getHardwareAddress()));
         assertEquals("EthDriver", loStatus.getDriver());
         assertEquals("EthDriverVersion", loStatus.getDriverVersion());
@@ -377,7 +377,7 @@ public class NMStatusServiceImplTest {
 
     private void thenRetrievedModemkInterfaceStatusHasFullProperties() throws UnknownHostException {
         ModemInterfaceStatus modemStatus = (ModemInterfaceStatus) this.status.get();
-        assertEquals("wwan0", modemStatus.getId());
+        assertEquals("wwan0", modemStatus.getInterfaceId());
         assertTrue(Arrays.equals(new byte[] { 0x00, 0x11, 0x02, 0x33, 0x44, 0x55 }, modemStatus.getHardwareAddress()));
         assertEquals("EthDriver", modemStatus.getDriver());
         assertEquals("EthDriverVersion", modemStatus.getDriverVersion());
@@ -531,7 +531,7 @@ public class NMStatusServiceImplTest {
 
     private void buildCommonProperties(String interfaceName, NetworkInterfaceStatusBuilder<?> builder)
             throws UnknownHostException {
-        builder.withId(interfaceName);
+        builder.withInterfaceId(interfaceName);
         builder.withHardwareAddress(new byte[] { 0x00, 0x11, 0x02, 0x33, 0x44, 0x55 });
         builder.withDriver("EthDriver").withDriverVersion("EthDriverVersion").withFirmwareVersion("1234");
         builder.withVirtual(false).withState(NetworkInterfaceState.ACTIVATED).withAutoConnect(true).withMtu(1500);

--- a/kura/test/org.eclipse.kura.rest.network.status.provider.test/src/main/java/org/eclipse/kura/rest/network/status/provider/test/NetworkStatusRestServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.rest.network.status.provider.test/src/main/java/org/eclipse/kura/rest/network/status/provider/test/NetworkStatusRestServiceImplTest.java
@@ -237,7 +237,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
 
     @Test
     public void shouldEncodeLoopbackInterfaceStatusWithDefaultsById() {
-        givenNetworkStatus(LoopbackInterfaceStatus.builder().withId("lo0"));
+        givenNetworkStatus(LoopbackInterfaceStatus.builder().withInterfaceId("lo0"));
 
         whenRequestIsPerformed(new MethodSpec("POST"), NETWORK_STATUS_BY_INTERFACE_ID_PATH,
                 "{\"interfaceIds\":[\"lo0\"]}");
@@ -261,7 +261,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
 
     @Test
     public void shouldNotReturnMissingInterfaces() {
-        givenNetworkStatus(LoopbackInterfaceStatus.builder().withId("lo0"));
+        givenNetworkStatus(LoopbackInterfaceStatus.builder().withInterfaceId("lo0"));
 
         whenRequestIsPerformed(new MethodSpec("POST"), NETWORK_STATUS_BY_INTERFACE_ID_PATH,
                 "{\"interfaceIds\":[\"lo0\",\"foo\"]}");
@@ -287,7 +287,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
 
     @Test
     public void shouldReturnEmptyListIfNoInterfacesMatch() {
-        givenNetworkStatus(LoopbackInterfaceStatus.builder().withId("lo0"));
+        givenNetworkStatus(LoopbackInterfaceStatus.builder().withInterfaceId("lo0"));
 
         whenRequestIsPerformed(new MethodSpec("POST"), NETWORK_STATUS_BY_INTERFACE_ID_PATH,
                 "{\"interfaceIds\":[\"foo\"]}");
@@ -300,7 +300,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
     @Test
     public void shouldEncodeLoopbackInterfaceStatusWithCustomParams() {
         givenNetworkStatus(LoopbackInterfaceStatus.builder() //
-                .withId("lo0") //
+                .withInterfaceId("lo0") //
                 .withInterfaceName("lo1") //
                 .withHardwareAddress(new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, (byte) 0xff }) //
                 .withDriver("fooDriver") //
@@ -1068,7 +1068,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
     private void givenNetworkStatus(final NetworkInterfaceStatus.NetworkInterfaceStatusBuilder<?> builder) {
         final NetworkInterfaceStatus status = builder.build();
 
-        this.currentStatus.put(status.getId(), new Success(status));
+        this.currentStatus.put(status.getInterfaceId(), new Success(status));
     }
 
     private void givenExceptionRetrievingInterfaceStatus(final String interfaceId, final Exception exception) {
@@ -1078,7 +1078,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
 
     private void givenLoopbackInterfaceWithFilledIP4Address(final String id) throws UnknownHostException {
         givenNetworkStatus(
-                LoopbackInterfaceStatus.builder().withId(id)
+                LoopbackInterfaceStatus.builder().withInterfaceId(id)
                         .withInterfaceIp4Addresses(Optional.of(NetworkInterfaceIpAddressStatus.<IP4Address>builder()
                                 .withAddresses(Arrays.asList(
                                         new NetworkInterfaceIpAddress<>(ipV4Address(1, 2, 3, 4), (short) 16),
@@ -1089,7 +1089,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
     }
 
     private void givenLoopbackInterfaceWithFilledIP6Address(final String id) throws UnknownHostException {
-        givenNetworkStatus(LoopbackInterfaceStatus.builder().withId(id)
+        givenNetworkStatus(LoopbackInterfaceStatus.builder().withInterfaceId(id)
                 .withInterfaceIp6Addresses(Optional.of(NetworkInterfaceIpAddressStatus.<IP6Address>builder()
                         .withAddresses(Arrays.asList(
                                 new NetworkInterfaceIpAddress<>(ipV6Address(1, 2, 3, 4, 5, 0), (short) 16),
@@ -1101,12 +1101,12 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
     }
 
     private void givenLoopbackInterfaceWithUnFilledIP4Address(final String id) throws UnknownHostException {
-        givenNetworkStatus(LoopbackInterfaceStatus.builder().withId(id)
+        givenNetworkStatus(LoopbackInterfaceStatus.builder().withInterfaceId(id)
                 .withInterfaceIp4Addresses(Optional.of(NetworkInterfaceIpAddressStatus.<IP4Address>builder().build())));
     }
 
     private void givenLoopbackInterfaceWithUnFilledIP6Address(final String id) throws UnknownHostException {
-        givenNetworkStatus(LoopbackInterfaceStatus.builder().withId(id)
+        givenNetworkStatus(LoopbackInterfaceStatus.builder().withInterfaceId(id)
                 .withInterfaceIp6Addresses(Optional.of(NetworkInterfaceIpAddressStatus.<IP6Address>builder().build())));
     }
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR change the `id` field name to `interfaceId` in network APIs and implementation.