### PR TITLE
fix(web2): Fixed fileCountMax.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
@@ -858,7 +858,9 @@ class UploadRequest extends ServletFileUpload {
     public UploadRequest(DiskFileItemFactory diskFileItemFactory) {
         super(diskFileItemFactory);
         setSizeMax(FileServlet.getFileUploadSizeMax());
-        setFileCountMax(2L);
+        // contrary to what the name says, this method does not set the number of allowed files but the number of parts
+        // (files and fields)
+        setFileCountMax(10L);
         this.formFields = new HashMap<>();
         this.fileItems = new ArrayList<>();
     }


### PR DESCRIPTION
The value of  the max number of file was wrongly set.
As stated [here](https://github.com/apache/commons-fileupload/pull/203) the parameter refers to both files and fields so we needed to increase it.