### PR TITLE
fix: Fixed NetworkConfigurationService returning passwords as strings

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkConfigurationServiceImpl.java
@@ -33,7 +33,6 @@ import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.configuration.SelfConfiguringComponent;
-import org.eclipse.kura.core.configuration.ComponentConfigurationImpl;
 import org.eclipse.kura.core.net.EthernetInterfaceConfigImpl;
 import org.eclipse.kura.core.net.IpConfigurationInterpreter;
 import org.eclipse.kura.core.net.LoopbackInterfaceConfigImpl;
@@ -385,11 +384,10 @@ public class NetworkConfigurationServiceImpl implements NetworkConfigurationServ
     }
 
     @Override
+    @SuppressWarnings("restriction")
     public synchronized ComponentConfiguration getConfiguration() throws KuraException {
 
-        return new ComponentConfigurationImpl(PID,
-                NetworkConfigurationServiceCommon.getDefinition(this.properties, Optional.of(this.usbNetDevices)),
-                this.properties);
+        return NetworkConfigurationServiceCommon.getConfiguration(PID, properties, Optional.of(this.usbNetDevices));
     }
 
     @Override

--- a/kura/org.eclipse.kura.net.configuration/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.net.configuration/META-INF/MANIFEST.MF
@@ -7,6 +7,8 @@ Export-Package: org.eclipse.kura.net.configuration;version="1.0.0";x-internal:=t
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 Import-Package: org.eclipse.kura;version="[1.0,2.0)",
+ org.eclipse.kura.configuration;version="[1.2,2.0)",
+ org.eclipse.kura.configuration.metatype;version="[1.1,2.0)",
  org.eclipse.kura.core.configuration;version="[2.0,3.0)",
  org.eclipse.kura.core.configuration.metatype;version="[1.0,2.0)",
  org.eclipse.kura.net;version="[2.4,2.5)",

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -27,7 +27,6 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.configuration.SelfConfiguringComponent;
-import org.eclipse.kura.core.configuration.ComponentConfigurationImpl;
 import org.eclipse.kura.crypto.CryptoService;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.linux.net.util.LinuxNetworkUtil;
@@ -156,7 +155,7 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
             this.networkProperties = new NetworkProperties(discardModifiedNetworkInterfaces(new HashMap<>(properties)));
             update(this.networkProperties.getProperties());
         }
-        
+
         logger.info("Activate NetworkConfigurationService... Done.");
     }
 
@@ -271,12 +270,12 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
     }
 
     @Override
+    @SuppressWarnings("restriction")
     public synchronized ComponentConfiguration getConfiguration() throws KuraException {
 
-        return new ComponentConfigurationImpl(
-                NetworkConfigurationServiceCommon.PID, NetworkConfigurationServiceCommon
-                        .getDefinition(this.networkProperties.getProperties(), Optional.empty()),
-                this.networkProperties.getProperties());
+        return NetworkConfigurationServiceCommon.getConfiguration(NetworkConfigurationServiceCommon.PID,
+                this.networkProperties.getProperties(), Optional.empty());
+
     }
 
     private void mergeNetworkConfigurationProperties(final Map<String, Object> source, final Map<String, Object> dest) {


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

The NetworkConfigurationService is currently returning password fields as strings instead of Password objects for the configuration of the network interfaces that are present in the snapshot and not currently attached to the system.

This adds a check before its configuration is returned to wrap any string password property into a Password object.