### PR TITLE
refactor(nm): `org.eclipse.kura.nm` log cleanup/update

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -387,14 +387,10 @@ public class NMDbusConnector {
         Map<String, Map<String, Variant<?>>> newConnectionSettings = NMSettingsConverter.buildSettings(properties,
                 connection, deviceId, interfaceName, deviceType);
 
-        logger.info("New settings parsed");
-
         DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
                 NMDeviceState.NM_DEVICE_STATE_CONFIG);
 
         if (connection.isPresent()) {
-            logger.info("Current settings available");
-
             connection.get().Update(newConnectionSettings);
             this.nm.ActivateConnection(new DBusPath(connection.get().getObjectPath()),
                     new DBusPath(device.getObjectPath()), new DBusPath("/"));
@@ -643,7 +639,7 @@ public class NMDbusConnector {
         if (appliedConnection.isPresent()) {
             return appliedConnection;
         } else {
-            logger.info("Active connection not found, looking for avaliable connections.");
+            logger.debug("Active connection not found, looking for avaliable connections.");
 
             List<Connection> availableConnections = getAvaliableConnections(dev);
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMModemResetHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMModemResetHandler.java
@@ -84,6 +84,7 @@ public class NMModemResetHandler implements DBusSigHandler<Device.StateChanged> 
 
     public void clearTimer() {
         if (timerAlreadyScheduled()) {
+            logger.info("Clearing timer for {}. Cancelling scheduled modem reset...", this.nmDevicePath);
             this.scheduledTasks.cancel();
             this.scheduledTasks = null;
         }


### PR DESCRIPTION
This PR:

- removes two logs in the `enableInterface` method that were not carrying much useful informations and cluttering the log
- lower the log entry for the `getAssociatedConnections` method from `info` to `debug`
- adds a log entry for when the scheduled timer is cancelled due to a `clearTimer` method call. This allows for a better understanding of the overall timer status on the system and is consistent with the rest of the code.

![image](https://user-images.githubusercontent.com/22748355/230080997-2896934e-53d5-4620-b114-a858bbedf372.png)

This is the resulting configuration log:

![image](https://user-images.githubusercontent.com/22748355/230100006-eca15932-0f46-4f53-a8e0-4114ceddfff8.png)
