### PR TITLE
fix(distrib): do not rename /etc/network/interface file on installation

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -14,11 +14,6 @@
 
 INSTALL_DIR=/opt/eclipse
 
-# NetworkManager cannot modify connection settings that are from /etc/network/interfaces
-if test -f /etc/network/interfaces; then
-    mv /etc/network/interfaces /etc/network/interfaces.old
-fi
-
 # create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -14,11 +14,6 @@
 
 INSTALL_DIR=/opt/eclipse
 
-# NetworkManager cannot modify connection settings that are from /etc/network/interfaces
-if test -f /etc/network/interfaces; then
-    mv /etc/network/interfaces /etc/network/interfaces.old
-fi
-
 # create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -14,11 +14,6 @@
 
 INSTALL_DIR=/opt/eclipse
 
-# NetworkManager cannot modify connection settings that are from /etc/network/interfaces
-if test -f /etc/network/interfaces; then
-    mv /etc/network/interfaces /etc/network/interfaces.old
-fi
-
 # create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 


### PR DESCRIPTION
As per #4363 we suggested removing the `/etc/network/interfaces` file. This is wrong because that file is needed to manage CAN interfaces.

The new installers already take care of configuring NetworkManager for managing the devices, even though they're listed in the `/etc/network/interfaces` file. 

https://github.com/eclipse/kura/blob/06e60aec3dfbce666bf2e82b5c5b5ac6257e844b/kura/distrib/src/main/resources/common/99-kura-nm.conf#L7-L8

Therefore we shouldn't have issues on that front.

## Tests

I tested the arm64 installer on a Raspebby Pi running:
- [X] Raspberry Pi OS
- [X] Ubuntu Server 20.04
- [X] Ubuntu Server 22.04

and it seems to be working.