### PR TITLE
fix(web2):  networking passwords replaced with placeholder, and html escaping and unescaping 

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net/GwtNetworkServiceImpl.java
@@ -75,6 +75,7 @@ import org.eclipse.kura.net.wifi.WifiSecurity;
 import org.eclipse.kura.system.SystemService;
 import org.eclipse.kura.usb.UsbDevice;
 import org.eclipse.kura.web.Console;
+import org.eclipse.kura.web.server.util.GwtServerUtil;
 import org.eclipse.kura.web.server.util.KuraExceptionHandler;
 import org.eclipse.kura.web.server.util.ServiceLocator;
 import org.eclipse.kura.web.shared.GwtKuraErrorCode;
@@ -119,24 +120,7 @@ public class GwtNetworkServiceImpl {
             throws GwtKuraException {
         List<GwtNetInterfaceConfig> result = privateFindNetInterfaceConfigurations(recompute);
 
-        for (GwtNetInterfaceConfig netConfig : result) {
-            if (netConfig instanceof GwtWifiNetInterfaceConfig) {
-                GwtWifiNetInterfaceConfig wifiConfig = (GwtWifiNetInterfaceConfig) netConfig;
-                GwtWifiConfig gwtAPWifiConfig = wifiConfig.getAccessPointWifiConfig();
-                if (gwtAPWifiConfig != null) {
-                    gwtAPWifiConfig.setPassword(PASSWORD_PLACEHOLDER);
-                }
-
-                GwtWifiConfig gwtStationWifiConfig = wifiConfig.getStationWifiConfig();
-                if (gwtStationWifiConfig != null) {
-                    gwtStationWifiConfig.setPassword(PASSWORD_PLACEHOLDER);
-                }
-            } else if (netConfig instanceof GwtModemInterfaceConfig) {
-                GwtModemInterfaceConfig modemConfig = (GwtModemInterfaceConfig) netConfig;
-                modemConfig.setPassword(PASSWORD_PLACEHOLDER);
-            }
-        }
-        return result;
+        return GwtServerUtil.replaceNetworkConfigListSensitivePasswordsWithPlaceholder(result);
     }
 
     private static List<GwtNetInterfaceConfig> privateFindNetInterfaceConfigurations(boolean recompute)

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net/GwtNetworkServiceImpl.java
@@ -1675,7 +1675,7 @@ public class GwtNetworkServiceImpl {
             oldGwtWifiConfig.ifPresent(config -> properties.put(wifiPassphrasePropName,
                     new Password(GwtSafeHtmlUtils.htmlUnescape(config.getPassword()))));
         } else if (passKey != null && mode.equals(GwtWifiWirelessMode.netWifiWirelessModeAccessPoint.name())) {
-            validateUserPassword(passKey);
+            GwtServerUtil.validateUserPassword(passKey);
             properties.put(wifiPassphrasePropName, new Password(passKey));
         } else if (passKey != null) {
             properties.put(wifiPassphrasePropName, new Password(passKey));
@@ -1839,22 +1839,6 @@ public class GwtNetworkServiceImpl {
             }
         }
         return false;
-    }
-
-    private static void validateUserPassword(final String password) throws GwtKuraException {
-        final List<Validator<String>> validators = PasswordStrengthValidators
-                .fromConfig(Console.getConsoleOptions().getUserOptions());
-
-        final List<String> errors = new ArrayList<>();
-
-        for (final Validator<String> validator : validators) {
-            validator.validate(password, errors::add);
-        }
-
-        if (!errors.isEmpty()) {
-            logger.warn("password strenght requirements not satisfied: {}", errors);
-            throw new GwtKuraException(GwtKuraErrorCode.ILLEGAL_ARGUMENT);
-        }
     }
 
     private static void appendNetwork(String address, StringBuilder stringBuilder) throws UnknownHostException {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kura.web.server.net2;
 
+import static org.eclipse.kura.web.server.util.GwtServerUtil.PASSWORD_PLACEHOLDER;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -36,6 +38,7 @@ import org.eclipse.kura.web.shared.model.GwtFirewallPortForwardEntry;
 import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiChannelFrequency;
+import org.eclipse.kura.web.shared.model.GwtWifiConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiHotspotEntry;
 import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiRadioMode;
@@ -53,7 +56,28 @@ public class GwtNetworkServiceImpl {
     public static List<GwtNetInterfaceConfig> findNetInterfaceConfigurations(boolean recompute)
             throws GwtKuraException {
         try {
-            return getConfigsAndStatuses();
+            List<GwtNetInterfaceConfig> result = getConfigsAndStatuses();
+            
+            for (GwtNetInterfaceConfig netConfig : result) {
+                if (netConfig instanceof GwtWifiNetInterfaceConfig) {
+                    GwtWifiNetInterfaceConfig wifiConfig = (GwtWifiNetInterfaceConfig) netConfig;
+                    GwtWifiConfig gwtAPWifiConfig = wifiConfig.getAccessPointWifiConfig();
+                    if (gwtAPWifiConfig != null) {
+                        gwtAPWifiConfig.setPassword(PASSWORD_PLACEHOLDER);
+                    }
+
+                    GwtWifiConfig gwtStationWifiConfig = wifiConfig.getStationWifiConfig();
+                    if (gwtStationWifiConfig != null) {
+                        gwtStationWifiConfig.setPassword(PASSWORD_PLACEHOLDER);
+                    }
+                } else if (netConfig instanceof GwtModemInterfaceConfig) {
+                    GwtModemInterfaceConfig modemConfig = (GwtModemInterfaceConfig) netConfig;
+                    modemConfig.setPassword(PASSWORD_PLACEHOLDER);
+                }
+            }
+            
+            return result;
+            
         } catch (KuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kura.web.server.net2;
 
-import static org.eclipse.kura.web.server.util.GwtServerUtil.PASSWORD_PLACEHOLDER;
-
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,6 +27,7 @@ import org.eclipse.kura.net.firewall.FirewallPortForwardConfigIP4;
 import org.eclipse.kura.net.status.NetworkInterfaceType;
 import org.eclipse.kura.web.server.net2.configuration.NetworkConfigurationServiceAdapter;
 import org.eclipse.kura.web.server.net2.status.NetworkStatusServiceAdapter;
+import org.eclipse.kura.web.server.util.GwtServerUtil;
 import org.eclipse.kura.web.server.util.ServiceLocator;
 import org.eclipse.kura.web.shared.GwtKuraErrorCode;
 import org.eclipse.kura.web.shared.GwtKuraException;
@@ -38,7 +37,6 @@ import org.eclipse.kura.web.shared.model.GwtFirewallPortForwardEntry;
 import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiChannelFrequency;
-import org.eclipse.kura.web.shared.model.GwtWifiConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiHotspotEntry;
 import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiRadioMode;
@@ -57,27 +55,9 @@ public class GwtNetworkServiceImpl {
             throws GwtKuraException {
         try {
             List<GwtNetInterfaceConfig> result = getConfigsAndStatuses();
-            
-            for (GwtNetInterfaceConfig netConfig : result) {
-                if (netConfig instanceof GwtWifiNetInterfaceConfig) {
-                    GwtWifiNetInterfaceConfig wifiConfig = (GwtWifiNetInterfaceConfig) netConfig;
-                    GwtWifiConfig gwtAPWifiConfig = wifiConfig.getAccessPointWifiConfig();
-                    if (gwtAPWifiConfig != null) {
-                        gwtAPWifiConfig.setPassword(PASSWORD_PLACEHOLDER);
-                    }
 
-                    GwtWifiConfig gwtStationWifiConfig = wifiConfig.getStationWifiConfig();
-                    if (gwtStationWifiConfig != null) {
-                        gwtStationWifiConfig.setPassword(PASSWORD_PLACEHOLDER);
-                    }
-                } else if (netConfig instanceof GwtModemInterfaceConfig) {
-                    GwtModemInterfaceConfig modemConfig = (GwtModemInterfaceConfig) netConfig;
-                    modemConfig.setPassword(PASSWORD_PLACEHOLDER);
-                }
-            }
-            
-            return result;
-            
+            return GwtServerUtil.replaceNetworkConfigListSensitivePasswordsWithPlaceholder(result);
+
         } catch (KuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
@@ -290,21 +270,21 @@ public class GwtNetworkServiceImpl {
 
                 if (config instanceof GwtWifiNetInterfaceConfig) {
                     GwtWifiNetInterfaceConfig wifi = (GwtWifiNetInterfaceConfig) config;
-                    
+
                     switch (wifi.getWirelessModeEnum()) {
-                        case netWifiWirelessModeAccessPoint:
-                            ifProperties.putAll(wifi.getAccessPointWifiConfigProps());
-                            break;
-                        case netWifiWirelessModeAdHoc:
-                            ifProperties.putAll(wifi.getAdhocWifiConfigProps());
-                            break;
-                        case netWifiWirelessModeStation:
-                            ifProperties.putAll(wifi.getStationWifiConfigProps());
-                            break;
-                        case netWifiWirelessModeDisabled:
-                        default:
-                            break;
-                        
+                    case netWifiWirelessModeAccessPoint:
+                        ifProperties.putAll(wifi.getAccessPointWifiConfigProps());
+                        break;
+                    case netWifiWirelessModeAdHoc:
+                        ifProperties.putAll(wifi.getAdhocWifiConfigProps());
+                        break;
+                    case netWifiWirelessModeStation:
+                        ifProperties.putAll(wifi.getStationWifiConfigProps());
+                        break;
+                    case netWifiWirelessModeDisabled:
+                    default:
+                        break;
+
                     }
                 }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
@@ -80,8 +80,9 @@ public class NetworkConfigurationServiceAdapter {
      * 
      * @param gwtConfig the configuration containing the properties to update
      * @throws KuraException
+     * @throws GwtKuraException 
      */
-    public void updateConfiguration(GwtNetInterfaceConfig gwtConfig) throws KuraException {
+    public void updateConfiguration(GwtNetInterfaceConfig gwtConfig) throws KuraException, GwtKuraException {
         NetworkConfigurationServicePropertiesBuilder builder = new NetworkConfigurationServicePropertiesBuilder(
                 gwtConfig);
         Map<String, Object> newProperties = builder.build();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
@@ -13,6 +13,7 @@
 package org.eclipse.kura.web.server.util;
 
 import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_PID;
+import static org.eclipse.kura.web.server.util.GwtServerUtil.PASSWORD_PLACEHOLDER;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -55,6 +56,10 @@ import org.eclipse.kura.web.shared.GwtKuraException;
 import org.eclipse.kura.web.shared.model.GwtComponentInstanceInfo;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter;
+import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
+import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
+import org.eclipse.kura.web.shared.model.GwtWifiConfig;
+import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter.GwtConfigParameterType;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
@@ -745,5 +750,27 @@ public final class GwtServerUtil {
             logger.error("Error exporting snapshot");
             throw new ServletException(e);
         }
+    }
+    
+    public static List<GwtNetInterfaceConfig> replaceNetworkConfigListSensitivePasswordsWithPlaceholder(List<GwtNetInterfaceConfig> gwtNetworkConfigList) {
+        for (GwtNetInterfaceConfig netConfig : gwtNetworkConfigList) {
+            if (netConfig instanceof GwtWifiNetInterfaceConfig) {
+                GwtWifiNetInterfaceConfig wifiConfig = (GwtWifiNetInterfaceConfig) netConfig;
+                GwtWifiConfig gwtAPWifiConfig = wifiConfig.getAccessPointWifiConfig();
+                if (gwtAPWifiConfig != null) {
+                    gwtAPWifiConfig.setPassword(PASSWORD_PLACEHOLDER);
+                }
+
+                GwtWifiConfig gwtStationWifiConfig = wifiConfig.getStationWifiConfig();
+                if (gwtStationWifiConfig != null) {
+                    gwtStationWifiConfig.setPassword(PASSWORD_PLACEHOLDER);
+                }
+            } else if (netConfig instanceof GwtModemInterfaceConfig) {
+                GwtModemInterfaceConfig modemConfig = (GwtModemInterfaceConfig) netConfig;
+                modemConfig.setPassword(PASSWORD_PLACEHOLDER);
+            }
+        }
+        
+        return gwtNetworkConfigList;
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
 package org.eclipse.kura.web.server.util;
 
 import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_PID;
-import static org.eclipse.kura.web.server.util.GwtServerUtil.PASSWORD_PLACEHOLDER;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -50,17 +49,20 @@ import org.eclipse.kura.marshalling.Marshaller;
 import org.eclipse.kura.rest.configuration.api.ComponentConfigurationList;
 import org.eclipse.kura.rest.configuration.api.DTOUtil;
 import org.eclipse.kura.util.service.ServiceUtil;
+import org.eclipse.kura.web.Console;
 import org.eclipse.kura.web.server.servlet.DeviceSnapshotsServlet;
 import org.eclipse.kura.web.shared.GwtKuraErrorCode;
 import org.eclipse.kura.web.shared.GwtKuraException;
 import org.eclipse.kura.web.shared.model.GwtComponentInstanceInfo;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter;
+import org.eclipse.kura.web.shared.model.GwtConfigParameter.GwtConfigParameterType;
 import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
-import org.eclipse.kura.web.shared.model.GwtConfigParameter.GwtConfigParameterType;
+import org.eclipse.kura.web.shared.validator.PasswordStrengthValidators;
+import org.eclipse.kura.web.shared.validator.Validator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
@@ -87,7 +89,9 @@ public final class GwtServerUtil {
     /** The Constant to check if configuration policy is set to require. */
     public static final String PATTERN_CONFIGURATION_REQUIRE = "configuration-policy=\"require\"";
 
-    /** The Constant to check if the provided interface is a configurable component. */
+    /**
+     * The Constant to check if the provided interface is a configurable component.
+     */
     public static final String PATTERN_SERVICE_PROVIDE_CONFIGURABLE_COMP = "provide interface=\"org.eclipse.kura.configuration.ConfigurableComponent\"";
 
     /** The Constant to check if provided interface is Wire Emitter. */
@@ -96,7 +100,10 @@ public final class GwtServerUtil {
     /** The Constant to check if provided interface is Wire Receiver. */
     public static final String PATTERN_SERVICE_PROVIDE_RECEIVER = "provide interface=\"org.eclipse.kura.wire.WireReceiver\"";
 
-    /** The Constant to check if the provided interface is a self configuring component. */
+    /**
+     * The Constant to check if the provided interface is a self configuring
+     * component.
+     */
     public static final String PATTERN_SERVICE_PROVIDE_SELF_CONFIGURING_COMP = "provide interface=\"org.eclipse.kura.configuration.SelfConfiguringComponent\"";
 
     private static final String DRIVER_PID = "driver.pid";
@@ -113,35 +120,35 @@ public final class GwtServerUtil {
         } else if (strValue != null && !strValue.trim().isEmpty()) {
             final String trimmedValue = strValue.trim();
             switch (gwtType) {
-            case LONG:
-                objValue = Long.parseLong(trimmedValue);
-                break;
-            case DOUBLE:
-                objValue = Double.parseDouble(trimmedValue);
-                break;
-            case FLOAT:
-                objValue = Float.parseFloat(trimmedValue);
-                break;
-            case INTEGER:
-                objValue = Integer.parseInt(trimmedValue);
-                break;
-            case SHORT:
-                objValue = Short.parseShort(trimmedValue);
-                break;
-            case BYTE:
-                objValue = Byte.parseByte(trimmedValue);
-                break;
-            case BOOLEAN:
-                objValue = Boolean.parseBoolean(trimmedValue);
-                break;
-            case PASSWORD:
-                objValue = new Password(trimmedValue);
-                break;
-            case CHAR:
-                objValue = Character.valueOf(trimmedValue.charAt(0));
-                break;
-            default:
-                break;
+                case LONG:
+                    objValue = Long.parseLong(trimmedValue);
+                    break;
+                case DOUBLE:
+                    objValue = Double.parseDouble(trimmedValue);
+                    break;
+                case FLOAT:
+                    objValue = Float.parseFloat(trimmedValue);
+                    break;
+                case INTEGER:
+                    objValue = Integer.parseInt(trimmedValue);
+                    break;
+                case SHORT:
+                    objValue = Short.parseShort(trimmedValue);
+                    break;
+                case BYTE:
+                    objValue = Byte.parseByte(trimmedValue);
+                    break;
+                case BOOLEAN:
+                    objValue = Boolean.parseBoolean(trimmedValue);
+                    break;
+                case PASSWORD:
+                    objValue = new Password(trimmedValue);
+                    break;
+                case CHAR:
+                    objValue = Character.valueOf(trimmedValue.charAt(0));
+                    break;
+                default:
+                    break;
             }
         }
         return objValue;
@@ -154,87 +161,87 @@ public final class GwtServerUtil {
         List<String> trimmedValues = Stream.of(defaultValues).map(String::trim).collect(Collectors.toList());
 
         switch (type) {
-        case BOOLEAN:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(Boolean.valueOf(value));
+            case BOOLEAN:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(Boolean.valueOf(value));
+                    }
                 }
-            }
-            return values.toArray(new Boolean[] {});
+                return values.toArray(new Boolean[] {});
 
-        case BYTE:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(Byte.valueOf(value));
+            case BYTE:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(Byte.valueOf(value));
+                    }
                 }
-            }
-            return values.toArray(new Byte[] {});
+                return values.toArray(new Byte[] {});
 
-        case CHAR:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(new Character(value.charAt(0)));
+            case CHAR:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(new Character(value.charAt(0)));
+                    }
                 }
-            }
-            return values.toArray(new Character[] {});
+                return values.toArray(new Character[] {});
 
-        case DOUBLE:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(Double.valueOf(value));
+            case DOUBLE:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(Double.valueOf(value));
+                    }
                 }
-            }
-            return values.toArray(new Double[] {});
+                return values.toArray(new Double[] {});
 
-        case FLOAT:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(Float.valueOf(value));
+            case FLOAT:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(Float.valueOf(value));
+                    }
                 }
-            }
-            return values.toArray(new Float[] {});
+                return values.toArray(new Float[] {});
 
-        case INTEGER:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(Integer.valueOf(value));
+            case INTEGER:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(Integer.valueOf(value));
+                    }
                 }
-            }
-            return values.toArray(new Integer[] {});
+                return values.toArray(new Integer[] {});
 
-        case LONG:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(Long.valueOf(value));
+            case LONG:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(Long.valueOf(value));
+                    }
                 }
-            }
-            return values.toArray(new Long[] {});
+                return values.toArray(new Long[] {});
 
-        case SHORT:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(Short.valueOf(value));
+            case SHORT:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(Short.valueOf(value));
+                    }
                 }
-            }
-            return values.toArray(new Short[] {});
+                return values.toArray(new Short[] {});
 
-        case PASSWORD:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(new Password(value));
+            case PASSWORD:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(new Password(value));
+                    }
                 }
-            }
-            return values.toArray(new Password[] {});
+                return values.toArray(new Password[] {});
 
-        case STRING:
-            for (String value : trimmedValues) {
-                if (!value.isEmpty()) {
-                    values.add(value);
+            case STRING:
+                for (String value : trimmedValues) {
+                    if (!value.isEmpty()) {
+                        values.add(value);
+                    }
                 }
-            }
-            return values.toArray(new String[] {});
-        default:
-            return null;
+                return values.toArray(new String[] {});
+            default:
+                return null;
         }
     }
 
@@ -751,8 +758,9 @@ public final class GwtServerUtil {
             throw new ServletException(e);
         }
     }
-    
-    public static List<GwtNetInterfaceConfig> replaceNetworkConfigListSensitivePasswordsWithPlaceholder(List<GwtNetInterfaceConfig> gwtNetworkConfigList) {
+
+    public static List<GwtNetInterfaceConfig> replaceNetworkConfigListSensitivePasswordsWithPlaceholder(
+            List<GwtNetInterfaceConfig> gwtNetworkConfigList) {
         for (GwtNetInterfaceConfig netConfig : gwtNetworkConfigList) {
             if (netConfig instanceof GwtWifiNetInterfaceConfig) {
                 GwtWifiNetInterfaceConfig wifiConfig = (GwtWifiNetInterfaceConfig) netConfig;
@@ -770,7 +778,23 @@ public final class GwtServerUtil {
                 modemConfig.setPassword(PASSWORD_PLACEHOLDER);
             }
         }
-        
+
         return gwtNetworkConfigList;
+    }
+
+    public static void validateUserPassword(final String password) throws GwtKuraException {
+        final List<Validator<String>> validators = PasswordStrengthValidators
+                .fromConfig(Console.getConsoleOptions().getUserOptions());
+
+        final List<String> errors = new ArrayList<>();
+
+        for (final Validator<String> validator : validators) {
+            validator.validate(password, errors::add);
+        }
+
+        if (!errors.isEmpty()) {
+            logger.warn("password strenght requirements not satisfied: {}", errors);
+            throw new GwtKuraException(GwtKuraErrorCode.ILLEGAL_ARGUMENT);
+        }
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtWifiConfig.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtWifiConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,9 +15,7 @@ package org.eclipse.kura.web.shared.model;
 import java.io.Serializable;
 import java.util.List;
 
-import org.eclipse.kura.web.shared.GwtSafeHtmlUtils;
-
-public class GwtWifiConfig extends GwtBaseModel implements Serializable {
+public class GwtWifiConfig extends KuraBaseModel implements Serializable {
 
     private static final long serialVersionUID = -7610506986073264800L;
 
@@ -43,15 +41,6 @@ public class GwtWifiConfig extends GwtBaseModel implements Serializable {
         setWirelessMode(GwtWifiWirelessMode.netWifiWirelessModeStation.name());
         setRadioMode(GwtWifiRadioMode.netWifiRadioModeBGN.name());
         setSecurity(GwtWifiSecurity.netWifiSecurityWPA2.name());
-    }
-
-    @Override
-    public void set(String name, Object value) {
-        Object escapedValue = value;
-        if (value instanceof String) {
-            escapedValue = GwtSafeHtmlUtils.htmlEscape((String) value);
-        }
-        super.set(name, escapedValue);
     }
 
     public String getWirelessMode() {


### PR DESCRIPTION
With the Net2 Web2 update, wifi passwords are being passed to the frontend when not supposed to.  This PR returns the placeholder replacement mechanism to the Net2 web code. 

This PR also refactors the code, moving the placeholder replacement to a general utility class.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped.

**Screenshots:** If applicable, add screenshots to help explain your solution

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
