### PR TITLE
fix(web2.server.net2): wrong enum default leaves wireless interface as station

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -181,8 +181,7 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setDriver(this.properties.getWifiMasterDriver(this.ifName));
         gwtWifiConfig.setIgnoreSSID(this.properties.getWifiMasterIgnoreSsid(this.ifName));
         gwtWifiConfig.setPassword(new String(this.properties.getWifiMasterPassphrase(this.ifName).getPassword()));
-        gwtWifiConfig.setWirelessMode(
-                EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiMasterMode(this.ifName)));
+        gwtWifiConfig.setWirelessMode(GwtWifiWirelessMode.netWifiWirelessModeAccessPoint.name());
         gwtWifiConfig.setSecurity(
                 EnumsParser.getGwtWifiSecurity(this.properties.getWifiMasterSecurityType(this.ifName)));
         gwtWifiConfig.setPairwiseCiphers(
@@ -210,8 +209,7 @@ public class GwtNetInterfaceConfigBuilder {
         gwtWifiConfig.setDriver(this.properties.getWifiInfraDriver(this.ifName));
         gwtWifiConfig.setIgnoreSSID(this.properties.getWifiInfraIgnoreSsid(this.ifName));
         gwtWifiConfig.setPassword(new String(this.properties.getWifiInfraPassphrase(this.ifName).getPassword()));
-        gwtWifiConfig
-                .setWirelessMode(EnumsParser.getGwtWifiWirelessMode(this.properties.getWifiInfraMode(this.ifName)));
+        gwtWifiConfig.setWirelessMode(GwtWifiWirelessMode.netWifiWirelessModeStation.name());
         gwtWifiConfig
                 .setSecurity(EnumsParser.getGwtWifiSecurity(this.properties.getWifiInfraSecurityType(this.ifName)));
         gwtWifiConfig.setPairwiseCiphers(

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
@@ -60,7 +60,7 @@ public class EnumsParser {
             }
         }
 
-        return GwtWifiWirelessMode.netWifiWirelessModeStation.name();
+        return GwtWifiWirelessMode.netWifiWirelessModeDisabled.name();
     }
 
     /**


### PR DESCRIPTION
This PR fixes the default case of an enum that sets the wireless interface as station while it should be disabled. This causes the client part of the UI to set a wrong validation state to the password property when the interface is disabled making it impossible to switch to AP mode.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.
