### PR TITLE
fix(web2): Fix cellular default values

### DIFF
--- a/kura/org.eclipse.kura.net.configuration/src/main/java/org/eclipse/kura/net/configuration/NetworkConfigurationServiceCommon.java
+++ b/kura/org.eclipse.kura.net.configuration/src/main/java/org/eclipse/kura/net/configuration/NetworkConfigurationServiceCommon.java
@@ -118,7 +118,7 @@ public class NetworkConfigurationServiceCommon {
         return tocd;
     }
 
-        public static ComponentConfiguration getConfiguration(final String pid, final Map<String, Object> properties,
+    public static ComponentConfiguration getConfiguration(final String pid, final Map<String, Object> properties,
             final Optional<List<UsbNetDevice>> usbNetDevices) throws KuraException {
         final Tocd definition = getDefinition(properties, usbNetDevices);
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -278,8 +278,8 @@ public class GwtNetInterfaceConfigBuilder {
             gwtModemConfig.setMaxFail(this.properties.getModemMaxFail(this.ifName));
             gwtModemConfig.setIdle(this.properties.getModemIdle(this.ifName));
             gwtModemConfig.setActiveFilter(this.properties.getModemActiveFilter(this.ifName));
-            gwtModemConfig.setLcpEchoInterval(this.properties.getModemIpcEchoInterval(this.ifName));
-            gwtModemConfig.setLcpEchoFailure(this.properties.getModemIpcEchoFailure(this.ifName));
+            gwtModemConfig.setLcpEchoInterval(this.properties.getModemLpcEchoInterval(this.ifName));
+            gwtModemConfig.setLcpEchoFailure(this.properties.getModemLpcEchoFailure(this.ifName));
             gwtModemConfig.setGpsEnabled(this.properties.getModemGpsEnabled(this.ifName));
             gwtModemConfig.setDiversityEnabled(this.properties.getModemDiversityEnabled(this.ifName));
             gwtModemConfig.setApn(this.properties.getModemApn(this.ifName));

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -501,9 +501,9 @@ public class NetworkConfigurationServiceProperties {
     private static final String NET_INTERFACE_CONFIG_PDP_TYPE = "net.interface.%s.config.pdpType";
     private static final String NET_INTERFACE_CONFIG_MAX_FAIL = "net.interface.%s.config.maxFail";
     private static final String NET_INTERFACE_CONFIG_AUTH_TYPE = "net.interface.%s.config.authType";
-    private static final String NET_INTERFACE_CONFIG_IPC_ECHO_INTERVAL = "net.interface.%s.config.lpcEchoInterval";
+    private static final String NET_INTERFACE_CONFIG_LPC_ECHO_INTERVAL = "net.interface.%s.config.lpcEchoInterval";
     private static final String NET_INTERFACE_CONFIG_ACTIVE_FILTER = "net.interface.%s.config.activeFilter";
-    private static final String NET_INTERFACE_CONFIG_ECHO_FAILURE = "net.interface.%s.config.lpcEchoFailure";
+    private static final String NET_INTERFACE_CONFIG_LPC_ECHO_FAILURE = "net.interface.%s.config.lpcEchoFailure";
     private static final String NET_INTERFACE_CONFIG_DIVERSITY_ENABLED = "net.interface.%s.config.diversityEnabled";
     private static final String NET_INTERFACE_CONFIG_RESET_TIMEOUT = "net.interface.%s.config.resetTimeout";
     private static final String NET_INTERFACE_CONFIG_GPS_ENABLED = "net.interface.%s.config.gpsEnabled";
@@ -563,7 +563,7 @@ public class NetworkConfigurationServiceProperties {
     }
 
     public int getModemMaxFail(String ifname) {
-        return (int) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_MAX_FAIL, ifname), 0);
+        return (int) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_MAX_FAIL, ifname), 1);
     }
 
     public void setModemMaxFail(String ifname, int maxFail) {
@@ -580,12 +580,12 @@ public class NetworkConfigurationServiceProperties {
         }
     }
 
-    public int getModemIpcEchoInterval(String ifname) {
-        return (int) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_IPC_ECHO_INTERVAL, ifname), 0);
+    public int getModemLpcEchoInterval(String ifname) {
+        return (int) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_LPC_ECHO_INTERVAL, ifname), 0);
     }
 
-    public void setModemIpcEchoInterval(String ifname, int echoInterval) {
-        this.properties.put(String.format(NET_INTERFACE_CONFIG_IPC_ECHO_INTERVAL, ifname), echoInterval);
+    public void setModemLpcEchoInterval(String ifname, int echoInterval) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_LPC_ECHO_INTERVAL, ifname), echoInterval);
     }
 
     public String getModemActiveFilter(String ifname) {
@@ -596,12 +596,12 @@ public class NetworkConfigurationServiceProperties {
         this.properties.put(String.format(NET_INTERFACE_CONFIG_ACTIVE_FILTER, ifname), activeFilter);
     }
 
-    public int getModemIpcEchoFailure(String ifname) {
-        return (int) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_ECHO_FAILURE, ifname), 0);
+    public int getModemLpcEchoFailure(String ifname) {
+        return (int) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_LPC_ECHO_FAILURE, ifname), 0);
     }
 
-    public void setModemIpcEchoFailure(String ifname, int echoFailure) {
-        this.properties.put(String.format(NET_INTERFACE_CONFIG_ECHO_FAILURE, ifname), echoFailure);
+    public void setModemLpcEchoFailure(String ifname, int echoFailure) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_LPC_ECHO_FAILURE, ifname), echoFailure);
     }
 
     public boolean getModemDiversityEnabled(String ifname) {
@@ -614,7 +614,7 @@ public class NetworkConfigurationServiceProperties {
     }
 
     public int getModemResetTimeout(String ifname) {
-        return (int) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_RESET_TIMEOUT, ifname), 0);
+        return (int) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_RESET_TIMEOUT, ifname), 5);
     }
 
     public void setModemResetTimeout(String ifname, int modemResetTimeout) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -230,8 +230,8 @@ public class NetworkConfigurationServicePropertiesBuilder {
             this.properties.setModemMaxFail(this.ifname, gwtModemConfig.getMaxFail());
             this.properties.setModemIdle(this.ifname, gwtModemConfig.getIdle());
             this.properties.setModemActiveFilter(this.ifname, gwtModemConfig.getActiveFilter());
-            this.properties.setModemIpcEchoInterval(ifname, gwtModemConfig.getLcpEchoInterval());
-            this.properties.setModemIpcEchoFailure(this.ifname, gwtModemConfig.getLcpEchoFailure());
+            this.properties.setModemLpcEchoInterval(ifname, gwtModemConfig.getLcpEchoInterval());
+            this.properties.setModemLpcEchoFailure(this.ifname, gwtModemConfig.getLcpEchoFailure());
             this.properties.setModemGpsEnabled(this.ifname, gwtModemConfig.isGpsEnabled());
             this.properties.setModemDiversityEnabled(this.ifname, gwtModemConfig.isDiversityEnabled());
             this.properties.setModemApn(this.ifname, gwtModemConfig.getApn());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -251,6 +251,7 @@ public class NetworkStatusServiceAdapter {
             gwtModemConfig.setHwBand(getModemBands(modemInterfaceInfo));
             gwtModemConfig.setModel(ellipsis(modemInterfaceInfo.getModel(), 40));
             gwtModemConfig.setManufacturer(ellipsis(modemInterfaceInfo.getManufacturer(), 20));
+            gwtModemConfig.setModemId(modemInterfaceInfo.getModel());
             gwtModemConfig.setGpsSupported(modemInterfaceInfo.isGpsSupported());
             gwtModemConfig.setHwFirmware(modemInterfaceInfo.getFirmwareVersion());
             gwtModemConfig.setConnectionType(modemInterfaceInfo.getConnectionType().toString());


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR set the correct default values in the cellular tab.

**Description of the solution adopted:** The following fields are set:

- Modem Reset Timeout (default 5)
- Connection Attempts Retry Delay (default 0)
- Connection Attempts (default 1)
- LPC Echo Interval/Failure (default 0)

Moreover, the modem identifier field is set to the modem model.
