### PR TITLE
fix(installer): Added ModemManager enable command in install script

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -61,7 +61,6 @@ systemctl disable chrony
 systemctl enable NetworkManager
 systemctl start NetworkManager
 systemctl enable ModemManager
-systemctl start ModemManager
 
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh

--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -60,6 +60,8 @@ systemctl stop chrony
 systemctl disable chrony
 systemctl enable NetworkManager
 systemctl start NetworkManager
+systemctl enable ModemManager
+systemctl start ModemManager
 
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -61,7 +61,6 @@ systemctl disable chrony
 systemctl enable NetworkManager
 systemctl start NetworkManager
 systemctl enable ModemManager
-systemctl start ModemManager
 
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -60,6 +60,8 @@ systemctl stop chrony
 systemctl disable chrony
 systemctl enable NetworkManager
 systemctl start NetworkManager
+systemctl enable ModemManager
+systemctl start ModemManager
 
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -61,7 +61,6 @@ systemctl disable chrony
 systemctl enable NetworkManager
 systemctl start NetworkManager
 systemctl enable ModemManager
-systemctl start ModemManager
 
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -60,6 +60,8 @@ systemctl stop chrony
 systemctl disable chrony
 systemctl enable NetworkManager
 systemctl start NetworkManager
+systemctl enable ModemManager
+systemctl start ModemManager
 
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds the enable and start command of the ModemManager service in the install scripts for the generic profiles.
