### PR TITLE
feat(position): changed metatype default provider to gpsd

### DIFF
--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
@@ -365,6 +365,10 @@
             <esf:property name="bitsPerWord" array="false" encrypted="false" type="Integer">
                 <esf:value>8</esf:value>
             </esf:property>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="provider" type="String">
+                <esf:value>gpsd</esf:value>
+            </esf:property>
         </esf:properties>
     </esf:configuration>
     <esf:configuration pid="org.eclipse.kura.cloud.CloudService">

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
@@ -365,7 +365,6 @@
             <esf:property name="bitsPerWord" array="false" encrypted="false" type="Integer">
                 <esf:value>8</esf:value>
             </esf:property>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="provider" type="String">
                 <esf:value>gpsd</esf:value>
             </esf:property>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-intelup2
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-intelup2
@@ -320,6 +320,10 @@
             <esf:property name="bitsPerWord" array="false" encrypted="false" type="Integer">
                 <esf:value>8</esf:value>
             </esf:property>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="provider" type="String">
+                <esf:value>gpsd</esf:value>
+            </esf:property>
         </esf:properties>
     </esf:configuration>
     <esf:configuration pid="org.eclipse.kura.cloud.CloudService">

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-intelup2
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-intelup2
@@ -320,7 +320,6 @@
             <esf:property name="bitsPerWord" array="false" encrypted="false" type="Integer">
                 <esf:value>8</esf:value>
             </esf:property>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="provider" type="String">
                 <esf:value>gpsd</esf:value>
             </esf:property>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-jetson-nano
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-jetson-nano
@@ -287,7 +287,6 @@
             <esf:property name="bitsPerWord" array="false" encrypted="false" type="Integer">
                 <esf:value>8</esf:value>
             </esf:property>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="provider" type="String">
                 <esf:value>gpsd</esf:value>
             </esf:property>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-jetson-nano
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-jetson-nano
@@ -287,6 +287,10 @@
             <esf:property name="bitsPerWord" array="false" encrypted="false" type="Integer">
                 <esf:value>8</esf:value>
             </esf:property>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="provider" type="String">
+                <esf:value>gpsd</esf:value>
+            </esf:property>
         </esf:properties>
     </esf:configuration>
     <esf:configuration pid="org.eclipse.kura.cloud.CloudService">

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
@@ -365,6 +365,10 @@
             <esf:property name="bitsPerWord" array="false" encrypted="false" type="Integer">
                 <esf:value>8</esf:value>
             </esf:property>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="provider" type="String">
+                <esf:value>gpsd</esf:value>
+            </esf:property>
         </esf:properties>
     </esf:configuration>
     <esf:configuration pid="org.eclipse.kura.cloud.CloudService">

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
@@ -365,7 +365,6 @@
             <esf:property name="bitsPerWord" array="false" encrypted="false" type="Integer">
                 <esf:value>8</esf:value>
             </esf:property>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="provider" type="String">
                 <esf:value>gpsd</esf:value>
             </esf:property>

--- a/kura/org.eclipse.kura.linux.position/OSGI-INF/metatype/org.eclipse.kura.position.PositionService.xml
+++ b/kura/org.eclipse.kura.linux.position/OSGI-INF/metatype/org.eclipse.kura.position.PositionService.xml
@@ -41,7 +41,7 @@
             type="String"
             cardinality="0"
             required="true"
-            default="serial"
+            default="gpsd"
             description="Source for setting the position provider. Verify the availabiliy of the selected provider before activate it.">
             
             <Option label="serial" value="serial" />

--- a/kura/org.eclipse.kura.linux.position/OSGI-INF/metatype/org.eclipse.kura.position.PositionService.xml
+++ b/kura/org.eclipse.kura.linux.position/OSGI-INF/metatype/org.eclipse.kura.position.PositionService.xml
@@ -41,7 +41,7 @@
             type="String"
             cardinality="0"
             required="true"
-            default="gpsd"
+            default="serial"
             description="Source for setting the position provider. Verify the availabiliy of the selected provider before activate it.">
             
             <Option label="serial" value="serial" />


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Modified metatype for position service: provider default value is now `gpsd`.
