### PR TITLE
docs: requests for tests added to the contributing and pr docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ The Gherkin reference: https://cucumber.io/docs/gherkin/reference/
 
 ### Manual Tests
 
-Before submitting a new Pull Request, please check the correct functioning of your changes in a real environment. If you are not fully convinced of your attempts, in the pull request you can ask the reviewer to perform some tests, but we encourage you to always check the changes personally before publishing the contribution, and to limit these demands to what is strictly necessary.
+Before you submit a Pull Request, ensure that your changes have been tested and are functional in a live environment. If you require additional validation, kindly request your reviewer to perform the necessary tests. It is strongly recommended that you personally verify your changes before submission and only seek further testing when absolutely necessary.
 
 ## Submitting the Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,10 @@ Since step and scenario methods are not allowed to return any value, it is somet
 
 The Gherkin reference: https://cucumber.io/docs/gherkin/reference/ 
 
+### Manual Tests
+
+Before submitting any changes, you are invited to check the correct functioning of the variations in a real environment. If you are not fully convinced of your attempts, in the pull request you can ask the reviewer to perform some tests, but we encourage you to always check the changes personally before publishing the contribution, and to limit these demands to what is strictly necessary.
+
 ## Submitting the Changes
 
 Submit a pull request via the normal GitHub UI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ The Gherkin reference: https://cucumber.io/docs/gherkin/reference/
 
 ### Manual Tests
 
-Before submitting any changes, you are invited to check the correct functioning of the variations in a real environment. If you are not fully convinced of your attempts, in the pull request you can ask the reviewer to perform some tests, but we encourage you to always check the changes personally before publishing the contribution, and to limit these demands to what is strictly necessary.
+Before submitting a new Pull Request, please check the correct functioning of your changes in a real environment. If you are not fully convinced of your attempts, in the pull request you can ask the reviewer to perform some tests, but we encourage you to always check the changes personally before publishing the contribution, and to limit these demands to what is strictly necessary.
 
 ## Submitting the Changes
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@ Brief description of the PR. [e.g. Added `null` check on `object` to avoid `Null
 
 **Screenshots:** If applicable, add screenshots to help explain your solution
 
-**Tests required of the reviewer**: Optional description of the tests that the reviewer is asked to do, in addition to the static revision of the code. These tests should have already been done by the committer, so please limit the requests
+**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review
 
 **Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,10 @@ Brief description of the PR. [e.g. Added `null` check on `object` to avoid `Null
 
 **Related Issue:** This PR fixes/closes {issue number}
 
-**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped.
+**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped
 
 **Screenshots:** If applicable, add screenshots to help explain your solution
+
+**Tests required of the reviewer**: Optional description of the tests that the reviewer is asked to do, in addition to the static revision of the code. These tests should have already been done by the committer, so please limit the requests
 
 **Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds in the **CONTRIBUTING.md** file few lines to urge the contributor to run some manual tests before publishing a pull request. It also adds a field in the **PULL_REQUEST_TEMPLATE.md** to ask the reviewer which tests to perform.

**Related Issue:** N/A

**Description of the solution adopted:** N/A

**Screenshots:** N/A

**Any side note on the changes made:** N/A
