### PR TITLE
chore: Modified NM configuration to use dhclient

### DIFF
--- a/kura/distrib/src/main/resources/common/99-kura-nm.conf
+++ b/kura/distrib/src/main/resources/common/99-kura-nm.conf
@@ -2,7 +2,7 @@
 ignore-carrier=*
 no-auto-default=*
 plugins=ifupdown,keyfile
-dhcp=internal
+dhcp=dhclient
 
 [ifupdown]
 managed=true


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR updates the `99-kura-nm.conf` file to use `dhclient` as DHCP client application instead of the internal one.

