### PR TITLE
fix(installer): Added dnsmasq default configuration file

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -612,6 +612,9 @@ fi]]>
             <zipfileset file="src/main/resources/common/ifup-local.raspbian"
                 prefix="${build.output.name}/${install.folder}" />
 
+            <zipfileset file="src/main/resources/common/dnsmasq"
+                prefix="${build.output.name}/${install.folder}" />
+            	
             <zipfileset
                 file="${project.build.directory}/${build.output.name}/selinuxKura.pp"
                 prefix="${build.output.name}/${install.folder}" />

--- a/kura/distrib/src/main/resources/common/dnsmasq
+++ b/kura/distrib/src/main/resources/common/dnsmasq
@@ -1,3 +1,3 @@
 ENABLED=1
-CONFIG_DIR=/etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
+CONFIG_DIR=/etc/dnsmasq.d,*.conf
 DNSMASQ_EXCEPT="lo"

--- a/kura/distrib/src/main/resources/common/dnsmasq
+++ b/kura/distrib/src/main/resources/common/dnsmasq
@@ -1,0 +1,3 @@
+ENABLED=1
+CONFIG_DIR=/etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
+DNSMASQ_EXCEPT="lo"

--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/prerm
@@ -99,10 +99,15 @@ function preRemove {
     fi
 
     # restore /etc/network/interfaces.old
-    if test -f /etc/network/interfaces.old; then
+    if [ -f /etc/network/interfaces.old ]; then
         mv /etc/network/interfaces.old /etc/network/interfaces
     fi
 
+    # restore /etc/default/dnsmasq.old
+    if [ -f /etc/default/dnsmasq.old ]; then
+        mv /etc/default/dnsmasq.old /etc/default/dnsmasq
+    fi
+    
     echo ""
     echo "Uninstalling KURA... Done!"
 }

--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -103,6 +103,12 @@ if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     fi
 fi
 
+# install dnsmasq default configuration
+if [ -f /etc/default/dnsmasq ]; then
+    mv /etc/default/dnsmasq /etc/default/dnsmasq.old
+fi
+cp ${INSTALL_DIR}/kura/install/dnsmasq /etc/default/dnsmasq
+
 # disable NTP service
 if command -v timedatectl > /dev/null ;
   then

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/prerm
@@ -99,10 +99,15 @@ function preRemove {
     fi
 
     # restore /etc/network/interfaces.old
-    if test -f /etc/network/interfaces.old; then
+    if [ -f /etc/network/interfaces.old ]; then
         mv /etc/network/interfaces.old /etc/network/interfaces
     fi
 
+    # restore /etc/default/dnsmasq.old
+    if [ -f /etc/default/dnsmasq.old ]; then
+        mv /etc/default/dnsmasq.old /etc/default/dnsmasq
+    fi
+    
     echo ""
     echo "Uninstalling KURA... Done!"
 }

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -103,6 +103,12 @@ if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     fi
 fi
 
+# install dnsmasq default configuration
+if [ -f /etc/default/dnsmasq ]; then
+    mv /etc/default/dnsmasq /etc/default/dnsmasq.old
+fi
+cp ${INSTALL_DIR}/kura/install/dnsmasq /etc/default/dnsmasq
+
 # disable NTP service
 if command -v timedatectl > /dev/null ;
   then

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/prerm
@@ -99,8 +99,13 @@ function preRemove {
     fi
 
     # restore /etc/network/interfaces.old
-    if test -f /etc/network/interfaces.old; then
+    if [ -f /etc/network/interfaces.old ]; then
         mv /etc/network/interfaces.old /etc/network/interfaces
+    fi
+
+    # restore /etc/default/dnsmasq.old
+    if [ -f /etc/default/dnsmasq.old ]; then
+        mv /etc/default/dnsmasq.old /etc/default/dnsmasq
     fi
 
     echo ""

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -103,6 +103,12 @@ if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
     fi
 fi
 
+# install dnsmasq default configuration
+if [ -f /etc/default/dnsmasq ]; then
+    mv /etc/default/dnsmasq /etc/default/dnsmasq.old
+fi
+cp ${INSTALL_DIR}/kura/install/dnsmasq /etc/default/dnsmasq
+
 # disable NTP service
 if command -v timedatectl > /dev/null ;
   then


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds the `dnsmasq` default configuration file. The Kura installer will copy it in the `/etc/default/` folder.
