### PR TITLE
fix: check if schedule is enabled before parsing

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -750,7 +750,11 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             return;
         }
 
-        final Optional<CronExpression> schedule = this.dataServiceOptions.getConnectionScheduleExpression();
+        Optional<CronExpression> schedule = Optional.empty();
+        
+        if (this.dataServiceOptions.isConnectionScheduleEnabled()) {
+            schedule = this.dataServiceOptions.getConnectionScheduleExpression();
+        }
 
         final AutoConnectStrategy strategy;
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -750,11 +750,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             return;
         }
 
-        Optional<CronExpression> schedule = Optional.empty();
-        
-        if (this.dataServiceOptions.isConnectionScheduleEnabled()) {
-            schedule = this.dataServiceOptions.getConnectionScheduleExpression();
-        }
+        final Optional<CronExpression> schedule = this.dataServiceOptions.getConnectionScheduleExpression();
 
         final AutoConnectStrategy strategy;
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceOptions.java
@@ -181,6 +181,11 @@ public class DataServiceOptions {
     }
 
     public Optional<CronExpression> getConnectionScheduleExpression() {
+        
+        if (!this.isConnectionScheduleEnabled()) {
+            return Optional.empty();
+        }
+        
         try {
             return Optional.of(new CronExpression((String) this.properties.get(CONNECTION_SCHECULE_EXPRESSION)));
         } catch (final Exception e) {


### PR DESCRIPTION
a minor change suggested by @marcellorinaldo  that prevents the parsing of the connection schedule cron string unless the feature is enabled. With this change, if you have a bad string, the error will not show when you are not using the connection schedule.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
