### PR TITLE
fix(installer): comment configured interfaces in interfaces file

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -577,6 +577,8 @@ fi]]>
                 prefix="${build.output.name}/${install.folder}" />
             <zipfileset file="src/main/resources/common/find-net-interfaces.py"
                 prefix="${build.output.name}/${install.folder}" />
+            <zipfileset file="src/main/resources/common/comment-interfaces-file.py"
+                prefix="${build.output.name}/${install.folder}" />
             <zipfileset file="src/main/resources/common/customize-installation.sh"
                 prefix="${build.output.name}/${install.folder}" />
             <zipfileset dir="src/main/resources/common/jdk-dio-properties"

--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -575,9 +575,9 @@ fi]]>
                 prefix="${build.output.name}/${install.folder}" />
             <zipfileset file="src/main/resources/common/patch_sysctl.sh"
                 prefix="${build.output.name}/${install.folder}" />
-            <zipfileset file="src/main/resources/common/find-net-interfaces.py"
+            <zipfileset file="src/main/resources/common/find_net_interfaces.py"
                 prefix="${build.output.name}/${install.folder}" />
-            <zipfileset file="src/main/resources/common/comment-interfaces-file.py"
+            <zipfileset file="src/main/resources/common/comment_interfaces_file.py"
                 prefix="${build.output.name}/${install.folder}" />
             <zipfileset file="src/main/resources/common/customize-installation.sh"
                 prefix="${build.output.name}/${install.folder}" />

--- a/kura/distrib/src/main/resources/common/comment-interfaces-file.py
+++ b/kura/distrib/src/main/resources/common/comment-interfaces-file.py
@@ -14,6 +14,7 @@
 import subprocess
 import sys
 import shutil
+import logging
 from os.path import exists
 
 ETHERNET_TYPES = ['ethernet', 'eth', 'wired']
@@ -21,15 +22,6 @@ WIRELESS_TYPES = ['wifi', 'wireless']
 INTERFACES_PATH = "/etc/network/interfaces"
 INTERFACES_OLD_PATH = INTERFACES_PATH + ".old"
 INTERFACES_TMP_PATH = INTERFACES_PATH + ".tmp"
-
-logging.basicConfig(
-    format='[comment_interfaces_file.py] %(asctime)s %(levelname)s %(message)s',
-    level=logging.INFO,
-    datefmt='%Y-%m-%d %H:%M:%S',
-    handlers=[
-        logging.StreamHandler()
-    ]
-)
 
 def get_eth_wlan_interfaces_names():
     """Reads the network interface names using 'nmcli dev' command.
@@ -81,6 +73,15 @@ def comment_paragraph(paragraph):
     return (commented)
 
 def main():
+    logging.basicConfig(
+        format='[comment_interfaces_file.py] %(asctime)s %(levelname)s %(message)s',
+        level=logging.INFO,
+        datefmt='%Y-%m-%d %H:%M:%S',
+        handlers=[
+            logging.StreamHandler()
+        ]
+    )
+
     if (not exists(INTERFACES_PATH)):
         logging.info("File %s does not exist.", INTERFACES_PATH)
         exit(0)

--- a/kura/distrib/src/main/resources/common/comment-interfaces-file.py
+++ b/kura/distrib/src/main/resources/common/comment-interfaces-file.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2023 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#  Eurotech
+#
+import subprocess
+import sys
+import shutil
+from os.path import exists
+
+LOG_MSG_PREFIX = "[comment_interfaces_file.py] "
+ETHERNET_TYPES = ['ethernet', 'eth', 'wired']
+WIRELESS_TYPES = ['wifi', 'wireless']
+INTERFACES_PATH = "/etc/network/interfaces"
+INTERFACES_OLD_PATH =  INTERFACES_PATH + ".old"
+INTERFACES_TMP_PATH = INTERFACES_PATH + ".tmp"
+
+def get_eth_wlan_interfaces_names():
+    """Reads the network interface names using 'nmcli dev' command.
+
+    It is assumed that at least one ethernet interface is present.
+
+    Returns:
+        tuple of lists (eth_names, wlan_names) where:
+            'eth_names' are the found ethernet interface names ordered by name;
+            'wlan_names' are the found wireless interface names ordered by name, might be an empty list.
+    """
+    cmd_output = subprocess.check_output(['nmcli', 'dev']).decode(sys.stdout.encoding).strip()
+    # list comprehension to remove empty items
+    lines = [x.strip() for x in cmd_output.split('\n') if len(x.strip()) > 0]
+
+    # removing header
+    del lines[0]
+
+    inteface_names = list()
+
+    for line in lines:
+        row = [x.strip() for x in line.split(' ') if len(x.strip()) > 0]
+        
+        interface_name = row[0].lower()
+        interface_type = row[1].lower()
+
+        if interface_type in ETHERNET_TYPES or interface_type in WIRELESS_TYPES:
+            inteface_names.append(interface_name)
+        
+    inteface_names.sort()
+
+    print(LOG_MSG_PREFIX + 'Found interfaces: ', inteface_names)
+
+    return (inteface_names)
+
+def commentParagraph(paragraph):
+    """Comment a paragraph
+
+    Returns:
+        a paragraph whose lines start with #
+    """
+    commented = ""
+    for line in paragraph.split("\n"):
+        if (not line.startswith("#")):
+            commented += "#" + line + "\n" 
+        else:
+            commented += line + "\n" 
+    commented += "\n"
+    return (commented)
+
+if (not exists(INTERFACES_PATH)):
+    print(LOG_MSG_PREFIX + "File " + INTERFACES_PATH + " does not exist.")
+    exit(1)
+
+print(LOG_MSG_PREFIX + "Backup " + INTERFACES_PATH + " file.")
+shutil.copyfile(INTERFACES_PATH, INTERFACES_OLD_PATH)
+shutil.copyfile(INTERFACES_PATH, INTERFACES_TMP_PATH)
+
+print(LOG_MSG_PREFIX + "Search for interfaces...");
+interface_names = get_eth_wlan_interfaces_names()
+
+for name in interface_names:
+    with open(INTERFACES_TMP_PATH, 'r+', encoding='utf-8') as file_to_edit:
+        contentParagraph = file_to_edit.read().split("\n\n")
+    output = ""
+    for paragraph in contentParagraph:
+        if name in paragraph:                
+            print(LOG_MSG_PREFIX + "Comment " + name + " configuration.");
+            output += commentParagraph(paragraph)
+        else:
+            output += paragraph + "\n\n"
+    file = open(INTERFACES_TMP_PATH, "w")
+    file.write(output)
+    file.close()
+
+print(LOG_MSG_PREFIX + "Replace " + INTERFACES_PATH + " file.");
+shutil.move(INTERFACES_TMP_PATH, INTERFACES_PATH)

--- a/kura/distrib/src/main/resources/common/comment-interfaces-file.py
+++ b/kura/distrib/src/main/resources/common/comment-interfaces-file.py
@@ -16,12 +16,20 @@ import sys
 import shutil
 from os.path import exists
 
-LOG_MSG_PREFIX = "[comment_interfaces_file.py] "
 ETHERNET_TYPES = ['ethernet', 'eth', 'wired']
 WIRELESS_TYPES = ['wifi', 'wireless']
 INTERFACES_PATH = "/etc/network/interfaces"
-INTERFACES_OLD_PATH =  INTERFACES_PATH + ".old"
+INTERFACES_OLD_PATH = INTERFACES_PATH + ".old"
 INTERFACES_TMP_PATH = INTERFACES_PATH + ".tmp"
+
+logging.basicConfig(
+    format='[comment_interfaces_file.py] %(asctime)s %(levelname)s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S',
+    handlers=[
+        logging.StreamHandler()
+    ]
+)
 
 def get_eth_wlan_interfaces_names():
     """Reads the network interface names using 'nmcli dev' command.
@@ -53,7 +61,7 @@ def get_eth_wlan_interfaces_names():
         
     inteface_names.sort()
 
-    print(LOG_MSG_PREFIX + 'Found interfaces: ', inteface_names)
+    logging.info("Found interfaces: %s", inteface_names)
 
     return (inteface_names)
 
@@ -74,14 +82,14 @@ def comment_paragraph(paragraph):
 
 def main():
     if (not exists(INTERFACES_PATH)):
-        print(LOG_MSG_PREFIX + "File " + INTERFACES_PATH + " does not exist.")
-        exit(1)
+        logging.info("File %s does not exist.", INTERFACES_PATH)
+        exit(0)
     
-    print(LOG_MSG_PREFIX + "Backup " + INTERFACES_PATH + " file.")
+    logging.info("Backup %s file.", INTERFACES_PATH)
     shutil.copyfile(INTERFACES_PATH, INTERFACES_OLD_PATH)
     shutil.copyfile(INTERFACES_PATH, INTERFACES_TMP_PATH)
     
-    print(LOG_MSG_PREFIX + "Search for interfaces...");
+    logging.info("Search for interfaces...")
     interface_names = get_eth_wlan_interfaces_names()
     
     for name in interface_names:
@@ -89,8 +97,8 @@ def main():
             content_paragraph = file_to_edit.read().split("\n\n")
         output = ""
         for paragraph in content_paragraph:
-            if name in paragraph:                
-                print(LOG_MSG_PREFIX + "Comment " + name + " configuration.");
+            if name in paragraph:
+                logging.info("Comment %s configuration.", name)
                 output += comment_paragraph(paragraph)
             else:
                 output += paragraph + "\n\n"
@@ -98,7 +106,7 @@ def main():
         f.write(output)
         f.close()
 
-    print(LOG_MSG_PREFIX + "Replace " + INTERFACES_PATH + " file.");
+    logging.info("Replace %s file.", INTERFACES_PATH)
     shutil.move(INTERFACES_TMP_PATH, INTERFACES_PATH)
     
 if __name__ == "__main__":

--- a/kura/distrib/src/main/resources/common/comment-interfaces-file.py
+++ b/kura/distrib/src/main/resources/common/comment-interfaces-file.py
@@ -57,7 +57,7 @@ def get_eth_wlan_interfaces_names():
 
     return (inteface_names)
 
-def commentParagraph(paragraph):
+def comment_paragraph(paragraph):
     """Comment a paragraph
 
     Returns:
@@ -72,30 +72,34 @@ def commentParagraph(paragraph):
     commented += "\n"
     return (commented)
 
-if (not exists(INTERFACES_PATH)):
-    print(LOG_MSG_PREFIX + "File " + INTERFACES_PATH + " does not exist.")
-    exit(1)
+def main():
+    if (not exists(INTERFACES_PATH)):
+        print(LOG_MSG_PREFIX + "File " + INTERFACES_PATH + " does not exist.")
+        exit(1)
+    
+    print(LOG_MSG_PREFIX + "Backup " + INTERFACES_PATH + " file.")
+    shutil.copyfile(INTERFACES_PATH, INTERFACES_OLD_PATH)
+    shutil.copyfile(INTERFACES_PATH, INTERFACES_TMP_PATH)
+    
+    print(LOG_MSG_PREFIX + "Search for interfaces...");
+    interface_names = get_eth_wlan_interfaces_names()
+    
+    for name in interface_names:
+        with open(INTERFACES_TMP_PATH, 'r+', encoding='utf-8') as file_to_edit:
+            content_paragraph = file_to_edit.read().split("\n\n")
+        output = ""
+        for paragraph in content_paragraph:
+            if name in paragraph:                
+                print(LOG_MSG_PREFIX + "Comment " + name + " configuration.");
+                output += comment_paragraph(paragraph)
+            else:
+                output += paragraph + "\n\n"
+        f = open(INTERFACES_TMP_PATH, "w")
+        f.write(output)
+        f.close()
 
-print(LOG_MSG_PREFIX + "Backup " + INTERFACES_PATH + " file.")
-shutil.copyfile(INTERFACES_PATH, INTERFACES_OLD_PATH)
-shutil.copyfile(INTERFACES_PATH, INTERFACES_TMP_PATH)
-
-print(LOG_MSG_PREFIX + "Search for interfaces...");
-interface_names = get_eth_wlan_interfaces_names()
-
-for name in interface_names:
-    with open(INTERFACES_TMP_PATH, 'r+', encoding='utf-8') as file_to_edit:
-        contentParagraph = file_to_edit.read().split("\n\n")
-    output = ""
-    for paragraph in contentParagraph:
-        if name in paragraph:                
-            print(LOG_MSG_PREFIX + "Comment " + name + " configuration.");
-            output += commentParagraph(paragraph)
-        else:
-            output += paragraph + "\n\n"
-    file = open(INTERFACES_TMP_PATH, "w")
-    file.write(output)
-    file.close()
-
-print(LOG_MSG_PREFIX + "Replace " + INTERFACES_PATH + " file.");
-shutil.move(INTERFACES_TMP_PATH, INTERFACES_PATH)
+    print(LOG_MSG_PREFIX + "Replace " + INTERFACES_PATH + " file.");
+    shutil.move(INTERFACES_TMP_PATH, INTERFACES_PATH)
+    
+if __name__ == "__main__":
+    main()

--- a/kura/distrib/src/main/resources/common/comment_interfaces_file.py
+++ b/kura/distrib/src/main/resources/common/comment_interfaces_file.py
@@ -16,46 +16,11 @@ import sys
 import shutil
 import logging
 from os.path import exists
+from find_net_interfaces import get_eth_wlan_interfaces_names
 
-ETHERNET_TYPES = ['ethernet', 'eth', 'wired']
-WIRELESS_TYPES = ['wifi', 'wireless']
 INTERFACES_PATH = "/etc/network/interfaces"
 INTERFACES_OLD_PATH = INTERFACES_PATH + ".old"
 INTERFACES_TMP_PATH = INTERFACES_PATH + ".tmp"
-
-def get_eth_wlan_interfaces_names():
-    """Reads the network interface names using 'nmcli dev' command.
-
-    It is assumed that at least one ethernet interface is present.
-
-    Returns:
-        tuple of lists (eth_names, wlan_names) where:
-            'eth_names' are the found ethernet interface names ordered by name;
-            'wlan_names' are the found wireless interface names ordered by name, might be an empty list.
-    """
-    cmd_output = subprocess.check_output(['nmcli', 'dev']).decode(sys.stdout.encoding).strip()
-    # list comprehension to remove empty items
-    lines = [x.strip() for x in cmd_output.split('\n') if len(x.strip()) > 0]
-
-    # removing header
-    del lines[0]
-
-    inteface_names = list()
-
-    for line in lines:
-        row = [x.strip() for x in line.split(' ') if len(x.strip()) > 0]
-        
-        interface_name = row[0].lower()
-        interface_type = row[1].lower()
-
-        if interface_type in ETHERNET_TYPES or interface_type in WIRELESS_TYPES:
-            inteface_names.append(interface_name)
-        
-    inteface_names.sort()
-
-    logging.info("Found interfaces: %s", inteface_names)
-
-    return (inteface_names)
 
 def comment_paragraph(paragraph):
     """Comment a paragraph
@@ -91,7 +56,8 @@ def main():
     shutil.copyfile(INTERFACES_PATH, INTERFACES_TMP_PATH)
     
     logging.info("Search for interfaces...")
-    interface_names = get_eth_wlan_interfaces_names()
+    (eth_names, wlan_names) = get_eth_wlan_interfaces_names()
+    interface_names = eth_names + wlan_names
     
     for name in interface_names:
         with open(INTERFACES_TMP_PATH, 'r+', encoding='utf-8') as file_to_edit:

--- a/kura/distrib/src/main/resources/common/customize-installation.sh
+++ b/kura/distrib/src/main/resources/common/customize-installation.sh
@@ -48,7 +48,7 @@ mv "/opt/eclipse/kura/install/iptables-${BOARD}" "/opt/eclipse/kura/.data/iptabl
 sed -i "s/device_name/${BOARD}/g" "/opt/eclipse/kura/framework/kura.properties"
 if python3 -V > /dev/null 2>&1
 then
-    python3 /opt/eclipse/kura/install/find-net-interfaces.py /opt/eclipse/kura/framework/kura.properties
+    python3 /opt/eclipse/kura/install/find_net_interfaces.py /opt/eclipse/kura/framework/kura.properties
 else
     echo "python3 not found. Could not edit the primary netowrk interface name in /opt/eclipse/kura/framework/kura.properties. Defaulted to eth0."
 fi
@@ -57,7 +57,7 @@ if [ ${BOARD} = "generic-device" ]; then
     # replace snapshot_0, iptables.init, and kura.properties with correct interface names
     if python3 -V > /dev/null 2>&1
     then
-        python3 /opt/eclipse/kura/install/find-net-interfaces.py /opt/eclipse/kura/user/snapshots/snapshot_0.xml /opt/eclipse/kura/.data/iptables
+        python3 /opt/eclipse/kura/install/find_net_interfaces.py /opt/eclipse/kura/user/snapshots/snapshot_0.xml /opt/eclipse/kura/.data/iptables
     else
         echo "python3 not found. snapshot_0.xml, and iptables.init files may have wrong interface names. Default is eth0 and wlan0. Please correct them manually if they mismatch."
     fi

--- a/kura/distrib/src/main/resources/common/customize-installation.sh
+++ b/kura/distrib/src/main/resources/common/customize-installation.sh
@@ -61,13 +61,4 @@ if [ ${BOARD} = "generic-device" ]; then
     else
         echo "python3 not found. snapshot_0.xml, and iptables.init files may have wrong interface names. Default is eth0 and wlan0. Please correct them manually if they mismatch."
     fi
-    
-    # comment network interface configurations in interfaces file
-    if python3 -V > /dev/null 2>&1
-    then
-        python3 /opt/eclipse/kura/install/comment-interfaces-file.py
-    else
-        echo "python3 not found. Please manually review the /etc/network/interfaces file and comment configured network interfaces."
-    fi
-    
 fi

--- a/kura/distrib/src/main/resources/common/customize-installation.sh
+++ b/kura/distrib/src/main/resources/common/customize-installation.sh
@@ -61,4 +61,13 @@ if [ ${BOARD} = "generic-device" ]; then
     else
         echo "python3 not found. snapshot_0.xml, and iptables.init files may have wrong interface names. Default is eth0 and wlan0. Please correct them manually if they mismatch."
     fi
+    
+    # comment network interface configurations in interfaces file
+    if python3 -V > /dev/null 2>&1
+    then
+        python3 /opt/eclipse/kura/install/comment-interfaces-file.py
+    else
+        echo "python3 not found. Please manually review the /etc/network/interfaces file and comment configured network interfaces."
+    fi
+    
 fi

--- a/kura/distrib/src/main/resources/common/find_net_interfaces.py
+++ b/kura/distrib/src/main/resources/common/find_net_interfaces.py
@@ -65,7 +65,7 @@ def get_eth_wlan_interfaces_names():
 
 def main():
     logging.basicConfig(
-        format='[find-net-interfaces.py] %(asctime)s %(levelname)s %(message)s',
+        format='[find_net_interfaces.py] %(asctime)s %(levelname)s %(message)s',
         level=logging.INFO,
         datefmt='%Y-%m-%d %H:%M:%S',
         handlers=[

--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -102,6 +102,13 @@ if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
         rm "${TO_REMOVE}"
     fi
 fi
+# comment network interface configurations in interfaces file
+if python3 -V > /dev/null 2>&1
+then
+    python3 /opt/eclipse/kura/install/comment-interfaces-file.py
+else
+    echo "python3 not found. Please manually review the /etc/network/interfaces file and comment configured network interfaces."
+fi
 
 # install dnsmasq default configuration
 if [ -f /etc/default/dnsmasq ]; then

--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -105,7 +105,7 @@ fi
 # comment network interface configurations in interfaces file
 if python3 -V > /dev/null 2>&1
 then
-    python3 /opt/eclipse/kura/install/comment-interfaces-file.py
+    python3 /opt/eclipse/kura/install/comment_interfaces_file.py
 else
     echo "python3 not found. Please manually review the /etc/network/interfaces file and comment configured network interfaces."
 fi

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -102,6 +102,13 @@ if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
         rm "${TO_REMOVE}"
     fi
 fi
+# comment network interface configurations in interfaces file
+if python3 -V > /dev/null 2>&1
+then
+    python3 /opt/eclipse/kura/install/comment-interfaces-file.py
+else
+    echo "python3 not found. Please manually review the /etc/network/interfaces file and comment configured network interfaces."
+fi
 
 # install dnsmasq default configuration
 if [ -f /etc/default/dnsmasq ]; then

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -105,7 +105,7 @@ fi
 # comment network interface configurations in interfaces file
 if python3 -V > /dev/null 2>&1
 then
-    python3 /opt/eclipse/kura/install/comment-interfaces-file.py
+    python3 /opt/eclipse/kura/install/comment_interfaces_file.py
 else
     echo "python3 not found. Please manually review the /etc/network/interfaces file and comment configured network interfaces."
 fi

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -102,6 +102,13 @@ if [ -d /usr/lib/NetworkManager/conf.d/ ]; then
         rm "${TO_REMOVE}"
     fi
 fi
+# comment network interface configurations in interfaces file
+if python3 -V > /dev/null 2>&1
+then
+    python3 /opt/eclipse/kura/install/comment-interfaces-file.py
+else
+    echo "python3 not found. Please manually review the /etc/network/interfaces file and comment configured network interfaces."
+fi
 
 # install dnsmasq default configuration
 if [ -f /etc/default/dnsmasq ]; then

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -105,7 +105,7 @@ fi
 # comment network interface configurations in interfaces file
 if python3 -V > /dev/null 2>&1
 then
-    python3 /opt/eclipse/kura/install/comment-interfaces-file.py
+    python3 /opt/eclipse/kura/install/comment_interfaces_file.py
 else
     echo "python3 not found. Please manually review the /etc/network/interfaces file and comment configured network interfaces."
 fi


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds a (python) script for commenting the configuration of some network interfaces in the `/etc/network/interfaces/` file. This is done only for generic profiles where the NM can conflict with the `ifupdown` scritps.