### PR TITLE
fix(distrib): fix errors during network configuration on Jetson Nano

### DIFF
--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -81,6 +81,12 @@ if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
     chmod -x /etc/network/if-up.d/ntpdate
 fi
 
+#disable FAN protocol handling script to avoid
+#prmissions issues
+if [ -f "/etc/network/if-up.d/ubuntu-fan" ] ; then
+    chmod -x /etc/network/if-up.d/ubuntu-fan
+fi
+
 #disable asking NTP servers to the DHCP server
 sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
 

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -82,7 +82,7 @@ if [ -f "/etc/network/if-up.d/ntpdate" ] ; then
 fi
 
 #disable FAN protocol handling script to avoid
-#prmissions issues
+#permissions issues
 if [ -f "/etc/network/if-up.d/ubuntu-fan" ] ; then
     chmod -x /etc/network/if-up.d/ubuntu-fan
 fi


### PR DESCRIPTION
During testing we discovered that after configuring the a wlan interface as AP, the IP address is correcly set, I can see the AP from my laptop and the password is correct.

When I try to connect I cannot get an IP. This is because there's no `dhcpd` instance running in the background.

Furthermore we found a lot of errors in the log:
![image](https://user-images.githubusercontent.com/22748355/233572394-dcd40cf8-9f29-4fc1-a030-06a1e33cb7c6.png)

This exception was being thrown at line 726 and prevented the DHCP server to be brought up at line 728:

https://github.com/eclipse/kura/blob/31ef269ef081bedd72772b8508dcc98cc960ba37/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/WifiMonitorServiceImpl.java#L726-L729

This was due to the fact that the `ifup` command run by Kura was failing because:
![image](https://user-images.githubusercontent.com/22748355/233572828-04c0cb3f-8e78-4d37-97b0-e92596dc38ad.png)

The `ubuntu-fan` script relies on the `fanctl` script which *requires `root` privileges to be run*.

**Solution**: to fix this I disabled the `ubuntu-fan` script from being run during Kura installation. FAN protocol is used by Docker, this seems to not be an issue for simple docker container. It might break something if a container is created and configured to explicitly use the FAN protocol.