### PR TITLE
fix(linux.net): Replaced timestamp check for dnsmasq configuration files with a hash check.

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
@@ -61,7 +61,7 @@ public class DhcpServerManager {
         return dhcpServerTool;
     }
 
-    public boolean isRunning(String interfaceName) {
+    public boolean isRunning(String interfaceName) throws KuraException {
         return this.linuxTool.isRunning(interfaceName);
     }
 
@@ -89,7 +89,7 @@ public class DhcpServerManager {
 
     public boolean disable(String interfaceName) throws KuraException {
         logger.debug("Disable DHCP server for {}", interfaceName);
-        
+
         return this.linuxTool.disableInterface(interfaceName);
     }
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DhcpLinuxTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DhcpLinuxTool.java
@@ -18,9 +18,9 @@ import org.eclipse.kura.executor.CommandStatus;
 
 public interface DhcpLinuxTool {
 
-    public boolean isRunning(String interfaceName);
+    public boolean isRunning(String interfaceName) throws KuraProcessExecutionErrorException;
 
-    public CommandStatus startInterface(String interfaceName);
+    public CommandStatus startInterface(String interfaceName) throws KuraProcessExecutionErrorException;
 
     public boolean disableInterface(String interfaceName) throws KuraProcessExecutionErrorException;
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/monitor/DhcpServerMonitor.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/monitor/DhcpServerMonitor.java
@@ -69,10 +69,14 @@ public class DhcpServerMonitor {
         this.dhcpServerInterfaceConfiguration.entrySet().forEach(entry -> {
             String interfaceName = entry.getKey();
             boolean enable = entry.getValue();
-            if (enable && !this.dhcpServerManager.isRunning(interfaceName)) {
-                startDhcpServer(interfaceName);
-            } else if (!enable && this.dhcpServerManager.isRunning(interfaceName)) {
-                stopDhcpServer(interfaceName);
+            try {
+                if (enable && !this.dhcpServerManager.isRunning(interfaceName)) {
+                    startDhcpServer(interfaceName);
+                } else if (!enable && this.dhcpServerManager.isRunning(interfaceName)) {
+                    stopDhcpServer(interfaceName);
+                }
+            } catch (KuraException e) {
+                logger.warn("Failed to chech DHCP server status for the interface " + interfaceName, e);
             }
         });
     }


### PR DESCRIPTION
Replaced timestamp check for dnsmasq configuration files with a hash check.
This change will make the check clock indipendent.