### PR TITLE
fix(setups): Fix oomph setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ mvn -f kura/distrib/pom.xml clean install -DbuildAllContainers
 After this command runs, images can be found in your preferred container engine image list.
 
 ### Eclipse IDE
-The simplest way to start developing on Eclipse Kura is to use an [Eclipse Installer](https://www.eclipse.org/downloads/) based setup. A detailed installation and setup guide is available on the [official documentation](http://eclipse.github.io/kura/dev/kura-setup.html). Here you'll find a brief explaination of the required steps.
+The simplest way to start developing on Eclipse Kura is to use an [Eclipse Installer](https://www.eclipse.org/downloads/) based setup. A detailed installation and setup guide is available on the [official documentation](https://eclipse.github.io/kura/docs-develop/java-application-development/development-environment-setup). Here you'll find a brief explaination of the required steps.
 
 To correctly setup the environment, proceed as follows:
 - Install a jdk-8 distribution like [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=8) for your specific CPU architecture and OS.

--- a/README.md
+++ b/README.md
@@ -171,16 +171,16 @@ To correctly setup the environment, proceed as follows:
 - Install a jdk-8 distribution like [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=8) for your specific CPU architecture and OS.
 - Start the Eclipse Installer
 - Switch to advanced mode (top right hamburger menu > Advanced Mode)
-- Select "Eclipse IDE for Eclipse Committers" and configure the "Product Version" to be the version **2022-06 or older**.
-- Set the Java 1.8+ VM to the installed local jdk-8 VM, and press the Next button
+- Select "Eclipse IDE for Eclipse Committers" and configure the "Product Version" to be the version **2023-03 or newer**.
 - Select the Eclipse Kura installer from the list. If this is not available, add a new installer from https://raw.githubusercontent.com/eclipse/kura/develop/kura/setups/kura.setup, then check and press the Next button
 - Select the "Developer Type":
   - "User": if you want to develop applications or bundles running on Kura, select this option. It will install only the APIs and the examples.
   - "Developer" : if you are a framework developer, select this option. It will download and configure the Eclipse Kura framework.
 - Update Eclipse Kura Git repository username and customize further settings if you like (e.g. Root install folder, Installation folder name). To show these options, make sure that the "Show all variables" checkbox is enabled
+- Set the `JRE 1.8 location` value to the installed local jdk-8 VM
 - Leave all Bootstrap Tasks selected and press the Finish button
 - Accept all the licenses and wait for the installation to finish
-At first startup Eclipse IDE will checkout the code, perform a full build and configure a few Working Sets. 
+At first startup Eclipse IDE will checkout the code, perform a full build and configure a few Working Sets
 - When the tasks are completed. In the IDE open (double click) Target Platform > Target-Definition > Kura Target Platform Equinox 3.16.0, and press "Set as Target Platform" located at the top right of the window
 
 Now you are ready to develop on Eclipse Kura.

--- a/kura/setups/kura.setup
+++ b/kura/setups/kura.setup
@@ -88,7 +88,7 @@
     <repository
         url="http://mtoolkit-neon.s3-website-us-east-1.amazonaws.com"/>
     <repository
-        url="http://update.eclemma.org/"/>
+        url="https://download.eclipse.org/eclemma/releases/3.1.6/"/>
     <repository
         url="https://eclipse-uc.sonarlint.org/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>

--- a/kura/setups/kura.setup
+++ b/kura/setups/kura.setup
@@ -84,7 +84,7 @@
         name="org.sonarlint.eclipse.feature.feature.group"
         optional="true"/>
     <repository
-        url="https://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.9.0/N/LATEST/"/>
+        url="https://github.com/tesla/m2eclipse-tycho/releases/download/latest/"/>
     <repository
         url="http://mtoolkit-neon.s3-website-us-east-1.amazonaws.com"/>
     <repository

--- a/kura/setups/kura.setup
+++ b/kura/setups/kura.setup
@@ -67,8 +67,6 @@
     <requirement
         name="org.eclipse.m2e.feature.feature.group"/>
     <requirement
-        name="org.sonatype.tycho.m2e.feature.feature.group"/>
-    <requirement
         name="org.eclipse.m2e.wtp.feature.feature.group"/>
     <requirement
         name="org.eclipse.oomph.setup.projects.feature.group"/>
@@ -80,8 +78,6 @@
     <requirement
         name="org.sonarlint.eclipse.feature.feature.group"
         optional="true"/>
-    <repository
-        url="https://github.com/tesla/m2eclipse-tycho/releases/download/latest/"/>
     <repository
         url="https://download.eclipse.org/eclemma/releases/3.1.6/"/>
     <repository

--- a/kura/setups/kura.setup
+++ b/kura/setups/kura.setup
@@ -73,9 +73,6 @@
     <requirement
         name="org.eclipse.oomph.setup.projects.feature.group"/>
     <requirement
-        name="org.tigris.mtoolkit.feature.group"
-        optional="true"/>
-    <requirement
         name="org.eclipse.egit.gitflow.feature.feature.group"/>
     <requirement
         name="com.mountainminds.eclemma.feature.feature.group"
@@ -85,8 +82,6 @@
         optional="true"/>
     <repository
         url="https://github.com/tesla/m2eclipse-tycho/releases/download/latest/"/>
-    <repository
-        url="http://mtoolkit-neon.s3-website-us-east-1.amazonaws.com"/>
     <repository
         url="https://download.eclipse.org/eclemma/releases/3.1.6/"/>
     <repository

--- a/kura/setups/launchers/build-full.launch
+++ b/kura/setups/launchers/build-full.launch
@@ -4,7 +4,6 @@
 <stringAttribute key="M2_GOALS" value="-f pom.xml clean install"/>
 <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
 <booleanAttribute key="M2_OFFLINE" value="false"/>
-<stringAttribute key="M2_PROFILES" value="speedup"/>
 <listAttribute key="M2_PROPERTIES"/>
 <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
 <booleanAttribute key="M2_SKIP_TESTS" value="true"/>


### PR DESCRIPTION
Fix the oomph setup replacing m2e-tycho and eclemma repositories.

This eliminates the need to use older versions of Eclipse.

If merged the main README need an update