### PR TITLE
fix: password escaping issue with wifi passwords

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java
@@ -89,8 +89,6 @@ public class GwtNetworkServiceImpl {
             }
         }
 
-        logInterfaces("getConfigsAndStatuses", result);
-
         return result;
     }
 
@@ -260,41 +258,6 @@ public class GwtNetworkServiceImpl {
             return aps;
         } catch (KuraException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
-        }
-    }
-
-    private static void logInterfaces(String origin, List<GwtNetInterfaceConfig> configs) {
-        if (logger.isDebugEnabled()) {
-            for (GwtNetInterfaceConfig config : configs) {
-                Map<String, Object> ifProperties = config.getProperties();
-
-                if (config instanceof GwtWifiNetInterfaceConfig) {
-                    GwtWifiNetInterfaceConfig wifi = (GwtWifiNetInterfaceConfig) config;
-
-                    switch (wifi.getWirelessModeEnum()) {
-                    case netWifiWirelessModeAccessPoint:
-                        ifProperties.putAll(wifi.getAccessPointWifiConfigProps());
-                        break;
-                    case netWifiWirelessModeAdHoc:
-                        ifProperties.putAll(wifi.getAdhocWifiConfigProps());
-                        break;
-                    case netWifiWirelessModeStation:
-                        ifProperties.putAll(wifi.getStationWifiConfigProps());
-                        break;
-                    case netWifiWirelessModeDisabled:
-                    default:
-                        break;
-
-                    }
-                }
-
-                if (config instanceof GwtModemInterfaceConfig) {
-                    GwtModemInterfaceConfig modem = (GwtModemInterfaceConfig) config;
-                    ifProperties.putAll(modem.getProperties());
-                }
-
-                logger.debug("{} returned for interface {}:\n\n{}\n\n", origin, config.getName(), ifProperties);
-            }
         }
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -166,6 +166,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
             if (GwtServerUtil.PASSWORD_PLACEHOLDER.equals(gwtWifiConfig.getPassword())
                     && oldGwtNetInterfaceConfig instanceof GwtWifiNetInterfaceConfig) {
                 GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig = (GwtWifiNetInterfaceConfig) oldGwtNetInterfaceConfig;
+                gwtWifiNetInterfaceConfig.setUnescaped(true);
 
                 this.properties.setWifiMasterPassphrase(this.ifname,
                         gwtWifiNetInterfaceConfig.getAccessPointWifiConfig().getPassword());
@@ -205,6 +206,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
             if (GwtServerUtil.PASSWORD_PLACEHOLDER.equals(gwtWifiConfig.getPassword())
                     && oldGwtNetInterfaceConfig instanceof GwtWifiNetInterfaceConfig) {
                 GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig = (GwtWifiNetInterfaceConfig) oldGwtNetInterfaceConfig;
+                gwtWifiNetInterfaceConfig.setUnescaped(true);
                 this.properties.setWifiInfraPassphrase(this.ifname,
                         gwtWifiNetInterfaceConfig.getStationWifiConfig().getPassword());
             } else {
@@ -261,6 +263,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
                 if (GwtServerUtil.PASSWORD_PLACEHOLDER.equals(gwtModemConfig.getPassword())
                         && oldGwtNetInterfaceConfig instanceof GwtModemInterfaceConfig) {
                     GwtModemInterfaceConfig gwtModemInterfaceConfig = (GwtModemInterfaceConfig) oldGwtNetInterfaceConfig;
+                    gwtModemInterfaceConfig.setUnescaped(true);
                     this.properties.setModemPassword(this.ifname, gwtModemInterfaceConfig.getPassword());
                 } else {
                     this.properties.setModemPassword(this.ifname, gwtModemConfig.getPassword());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -168,8 +168,10 @@ public class NetworkConfigurationServicePropertiesBuilder {
                 GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig = (GwtWifiNetInterfaceConfig) oldGwtNetInterfaceConfig;
                 gwtWifiNetInterfaceConfig.setUnescaped(true);
 
-                this.properties.setWifiMasterPassphrase(this.ifname,
-                        gwtWifiNetInterfaceConfig.getAccessPointWifiConfig().getPassword());
+                GwtWifiConfig gwtApConfig =  gwtWifiNetInterfaceConfig.getAccessPointWifiConfig();
+                gwtApConfig.setUnescaped(true);
+                
+                this.properties.setWifiMasterPassphrase(this.ifname, gwtApConfig.getPassword());
             } else {
                 GwtServerUtil.validateUserPassword(gwtWifiConfig.getPassword());
                 this.properties.setWifiMasterPassphrase(this.ifname, gwtWifiConfig.getPassword());
@@ -207,8 +209,11 @@ public class NetworkConfigurationServicePropertiesBuilder {
                     && oldGwtNetInterfaceConfig instanceof GwtWifiNetInterfaceConfig) {
                 GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig = (GwtWifiNetInterfaceConfig) oldGwtNetInterfaceConfig;
                 gwtWifiNetInterfaceConfig.setUnescaped(true);
-                this.properties.setWifiInfraPassphrase(this.ifname,
-                        gwtWifiNetInterfaceConfig.getStationWifiConfig().getPassword());
+                
+                GwtWifiConfig gwtStationConfig =  gwtWifiNetInterfaceConfig.getStationWifiConfig();
+                gwtStationConfig.setUnescaped(true);
+                
+                this.properties.setWifiInfraPassphrase(this.ifname,gwtStationConfig.getPassword());
             } else {
                 this.properties.setWifiInfraPassphrase(this.ifname, gwtWifiConfig.getPassword());
             }
@@ -262,8 +267,10 @@ public class NetworkConfigurationServicePropertiesBuilder {
             if (gwtModemConfig.getPassword() != null) {
                 if (GwtServerUtil.PASSWORD_PLACEHOLDER.equals(gwtModemConfig.getPassword())
                         && oldGwtNetInterfaceConfig instanceof GwtModemInterfaceConfig) {
+                    
                     GwtModemInterfaceConfig gwtModemInterfaceConfig = (GwtModemInterfaceConfig) oldGwtNetInterfaceConfig;
                     gwtModemInterfaceConfig.setUnescaped(true);
+                    
                     this.properties.setModemPassword(this.ifname, gwtModemInterfaceConfig.getPassword());
                 } else {
                     this.properties.setModemPassword(this.ifname, gwtModemConfig.getPassword());


### PR DESCRIPTION
This PR is a general clean-up for NM-related issues.

1) password unescaping from the web UI to Kura backend sometimes breaks when applying an unchanged password.

2) Some network manager debug logs reveal the password. This must be removed.
https://github.com/eclipse/kura/blob/27bff99d61c414a5945f49a470fc5365ee4ee7fa/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/GwtNetworkServiceImpl.java#L296

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
