### PR TITLE
fix(api): Modem SIM representation

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/ModemInterfaceStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/ModemInterfaceStatus.java
@@ -48,7 +48,6 @@ public class ModemInterfaceStatus extends NetworkInterfaceStatus {
     private final Set<ModemBand> currentBands;
     private final boolean gpsSupported;
     private final List<Sim> availableSims;
-    private final int activeSimIndex;
     private final boolean simLocked;
     private final List<Bearer> bearers;
     private final ModemConnectionType connectionType;
@@ -77,7 +76,6 @@ public class ModemInterfaceStatus extends NetworkInterfaceStatus {
         this.currentBands = builder.currentBands;
         this.gpsSupported = builder.gpsSupported;
         this.availableSims = builder.availableSims;
-        this.activeSimIndex = builder.activeSimIndex;
         this.simLocked = builder.simLocked;
         this.bearers = builder.bearers;
         this.connectionType = builder.connectionType;
@@ -153,10 +151,6 @@ public class ModemInterfaceStatus extends NetworkInterfaceStatus {
         return this.availableSims;
     }
 
-    public int getActiveSimIndex() {
-        return this.activeSimIndex;
-    }
-
     public boolean isSimLocked() {
         return this.simLocked;
     }
@@ -216,7 +210,6 @@ public class ModemInterfaceStatus extends NetworkInterfaceStatus {
         private Set<ModemBand> currentBands = EnumSet.of(ModemBand.UNKNOWN);
         private boolean gpsSupported = false;
         private List<Sim> availableSims = Collections.emptyList();
-        private int activeSimIndex = 0;
         private boolean simLocked = false;
         private List<Bearer> bearers = Collections.emptyList();
         private ModemConnectionType connectionType = ModemConnectionType.DirectIP;
@@ -308,11 +301,6 @@ public class ModemInterfaceStatus extends NetworkInterfaceStatus {
             return getThis();
         }
 
-        public ModemInterfaceStatusBuilder withActiveSimIndex(int activeSimIndex) {
-            this.activeSimIndex = activeSimIndex;
-            return getThis();
-        }
-
         public ModemInterfaceStatusBuilder withSimLocked(boolean simLocked) {
             this.simLocked = simLocked;
             return getThis();
@@ -374,12 +362,12 @@ public class ModemInterfaceStatus extends NetworkInterfaceStatus {
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + Objects.hash(this.accessTechnologies, this.activeSimIndex, this.availableSims,
-                this.bearers, this.connectionStatus, this.connectionType, this.currentBands,
-                this.currentModemCapabilities, this.currentModes, this.gpsSupported, this.hardwareRevision,
-                this.manufacturer, this.model, this.operatorName, this.ports, this.powerState, this.primaryPort,
-                this.registrationStatus, this.signalStrength, this.serialNumber, this.signalQuality, this.simLocked,
-                this.softwareRevision, this.supportedBands, this.supportedModemCapabilities, this.supportedModes);
+        result = prime * result + Objects.hash(this.accessTechnologies, this.bearers, this.connectionStatus,
+                this.connectionType, this.currentBands, this.currentModemCapabilities, this.currentModes,
+                this.gpsSupported, this.hardwareRevision, this.manufacturer, this.model, this.operatorName, this.ports,
+                this.powerState, this.primaryPort, this.registrationStatus, this.signalStrength, this.serialNumber,
+                this.signalQuality, this.simLocked, this.softwareRevision, this.supportedBands,
+                this.supportedModemCapabilities, this.supportedModes);
         return result;
     }
 
@@ -393,7 +381,6 @@ public class ModemInterfaceStatus extends NetworkInterfaceStatus {
         }
         ModemInterfaceStatus other = (ModemInterfaceStatus) obj;
         return Objects.equals(this.accessTechnologies, other.accessTechnologies)
-                && this.activeSimIndex == other.activeSimIndex
                 && Objects.equals(this.availableSims, other.availableSims)
                 && Objects.equals(this.bearers, other.bearers) && this.connectionStatus == other.connectionStatus
                 && this.connectionType == other.connectionType && Objects.equals(this.currentBands, other.currentBands)

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/ModemInterfaceStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/ModemInterfaceStatus.java
@@ -362,12 +362,12 @@ public class ModemInterfaceStatus extends NetworkInterfaceStatus {
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + Objects.hash(this.accessTechnologies, this.bearers, this.connectionStatus,
-                this.connectionType, this.currentBands, this.currentModemCapabilities, this.currentModes,
-                this.gpsSupported, this.hardwareRevision, this.manufacturer, this.model, this.operatorName, this.ports,
-                this.powerState, this.primaryPort, this.registrationStatus, this.signalStrength, this.serialNumber,
-                this.signalQuality, this.simLocked, this.softwareRevision, this.supportedBands,
-                this.supportedModemCapabilities, this.supportedModes);
+        result = prime * result + Objects.hash(this.accessTechnologies, this.availableSims, this.bearers,
+                this.connectionStatus, this.connectionType, this.currentBands, this.currentModemCapabilities,
+                this.currentModes, this.gpsSupported, this.hardwareRevision, this.manufacturer, this.model,
+                this.operatorName, this.ports, this.powerState, this.primaryPort, this.registrationStatus,
+                this.signalStrength, this.serialNumber, this.signalQuality, this.simLocked, this.softwareRevision,
+                this.supportedBands, this.supportedModemCapabilities, this.supportedModes);
         return result;
     }
 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
@@ -134,6 +134,10 @@ public class Sim {
             return this;
         }
 
+        public Sim build() {
+            return new Sim(this);
+        }
+
     }
 
     @Override

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
@@ -25,6 +25,7 @@ import org.osgi.annotation.versioning.ProviderType;
 public class Sim {
 
     private final boolean active;
+    private final boolean primary;
     private final String iccid;
     private final String imsi;
     private final String eid;
@@ -32,9 +33,10 @@ public class Sim {
     private final SimType simType;
     private final ESimStatus eSimStatus;
 
-    public Sim(boolean active, String iccid, String imsi, String eid, String operatorName, SimType simType,
-            ESimStatus eSimStatus) {
+    public Sim(boolean active, boolean primary, String iccid, String imsi, String eid, String operatorName,
+            SimType simType, ESimStatus eSimStatus) {
         this.active = active;
+        this.primary = primary;
         this.iccid = iccid;
         this.imsi = imsi;
         this.eid = eid;
@@ -45,6 +47,10 @@ public class Sim {
 
     public boolean isActive() {
         return this.active;
+    }
+
+    public boolean isPrimary() {
+        return this.primary;
     }
 
     public String getIccid() {
@@ -73,8 +79,8 @@ public class Sim {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.active, this.eSimStatus, this.eid, this.iccid, this.imsi, this.operatorName,
-                this.simType);
+        return Objects.hash(this.active, this.primary, this.eSimStatus, this.eid, this.iccid, this.imsi,
+                this.operatorName, this.simType);
     }
 
     @Override
@@ -86,9 +92,10 @@ public class Sim {
             return false;
         }
         Sim other = (Sim) obj;
-        return this.active == other.active && this.eSimStatus == other.eSimStatus && Objects.equals(this.eid, other.eid)
-                && Objects.equals(this.iccid, other.iccid) && Objects.equals(this.imsi, other.imsi)
-                && Objects.equals(this.operatorName, other.operatorName) && this.simType == other.simType;
+        return this.active == other.active && this.primary == other.primary && this.eSimStatus == other.eSimStatus
+                && Objects.equals(this.eid, other.eid) && Objects.equals(this.iccid, other.iccid)
+                && Objects.equals(this.imsi, other.imsi) && Objects.equals(this.operatorName, other.operatorName)
+                && this.simType == other.simType;
     }
 
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
@@ -84,12 +84,12 @@ public class Sim {
 
         private boolean active;
         private boolean primary;
-        private String iccid;
-        private String imsi;
-        private String eid;
-        private String operatorName;
-        private SimType simType;
-        private ESimStatus eSimStatus;
+        private String iccid = "NA";
+        private String imsi = "NA";
+        private String eid = "NA";
+        private String operatorName = "NA";
+        private SimType simType = SimType.UNKNOWN;
+        private ESimStatus eSimStatus = ESimStatus.UNKNOWN;
 
         private SimBuilder() {
         }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
@@ -33,16 +33,15 @@ public class Sim {
     private final SimType simType;
     private final ESimStatus eSimStatus;
 
-    public Sim(boolean active, boolean primary, String iccid, String imsi, String eid, String operatorName,
-            SimType simType, ESimStatus eSimStatus) {
-        this.active = active;
-        this.primary = primary;
-        this.iccid = iccid;
-        this.imsi = imsi;
-        this.eid = eid;
-        this.operatorName = operatorName;
-        this.simType = simType;
-        this.eSimStatus = eSimStatus;
+    public Sim(SimBuilder builder) {
+        this.active = builder.active;
+        this.primary = builder.primary;
+        this.iccid = builder.iccid;
+        this.imsi = builder.imsi;
+        this.eid = builder.eid;
+        this.operatorName = builder.operatorName;
+        this.simType = builder.simType;
+        this.eSimStatus = builder.eSimStatus;
     }
 
     public boolean isActive() {
@@ -75,6 +74,66 @@ public class Sim {
 
     public ESimStatus geteSimStatus() {
         return this.eSimStatus;
+    }
+
+    public static SimBuilder builder() {
+        return new SimBuilder();
+    }
+
+    public static final class SimBuilder {
+
+        private boolean active;
+        private boolean primary;
+        private String iccid;
+        private String imsi;
+        private String eid;
+        private String operatorName;
+        private SimType simType;
+        private ESimStatus eSimStatus;
+
+        private SimBuilder() {
+        }
+
+        public SimBuilder withActive(boolean active) {
+            this.active = active;
+            return this;
+        }
+
+        public SimBuilder withPrimary(boolean primary) {
+            this.primary = primary;
+            return this;
+        }
+
+        public SimBuilder withIccid(String iccid) {
+            this.iccid = iccid;
+            return this;
+        }
+
+        public SimBuilder withImsi(String imsi) {
+            this.imsi = imsi;
+            return this;
+        }
+
+        public SimBuilder withEid(String eid) {
+            this.eid = eid;
+            return this;
+        }
+
+        public SimBuilder withOperatorName(String operatorName) {
+            this.operatorName = operatorName;
+            return this;
+        }
+
+        public SimBuilder withSimType(SimType simType) {
+            this.simType = simType;
+            return this;
+        }
+
+        public SimBuilder withESimStatus(ESimStatus eSimStatus) {
+            this.eSimStatus = eSimStatus;
+            return this;
+        }
+
     }
 
     @Override

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -809,13 +809,13 @@ public class NMDbusConnector {
             UInt32 primarySimSlot = modemProperties.Get(MM_MODEM_NAME, "PrimarySimSlot");
             List<DBusPath> simPaths = modemProperties.Get(MM_MODEM_NAME, "SimSlots");
             for (int index = 0; index < simPaths.size(); index++) {
-                String path = simPaths.get(index).getPath();
+                String dbusPath = simPaths.get(index).getPath();
 
-                if (path.equals("/")) {
+                if (dbusPath.equals("/")) {
                     continue;
                 }
 
-                Properties simProp = this.dbusConnection.getRemoteObject(MM_BUS_NAME, path, Properties.class);
+                Properties simProp = this.dbusConnection.getRemoteObject(MM_BUS_NAME, dbusPath, Properties.class);
                 boolean isActive = simProp.Get(MM_SIM_NAME, "Active");
                 boolean isPrimary = index == (primarySimSlot.intValue() - 1);
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -659,7 +659,9 @@ public class NMStatusConverter {
         } catch (DBusExecutionException e) {
             logger.warn("SimType property not found. Only physical sims are supported.");
         }
-        return new Sim(isActive, isPrimary, iccid, imsi, eid, operatorName, simType, eSimStatus);
+
+        return Sim.builder().withActive(isActive).withPrimary(isPrimary).withIccid(iccid).withImsi(imsi).withEid(eid)
+                .withOperatorName(operatorName).withSimType(simType).withESimStatus(eSimStatus).build();
     }
 
     private static List<Bearer> getBearers(List<Properties> properties) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -172,7 +172,7 @@ public class NMStatusConverter {
 
     public static NetworkInterfaceStatus buildModemStatus(String interfaceId,
             DevicePropertiesWrapper devicePropertiesWrapper, Optional<Properties> ip4configProperties,
-            List<Properties> simProperties, List<Properties> bearerProperties) {
+            List<SimProperties> simProperties, List<Properties> bearerProperties) {
         ModemInterfaceStatusBuilder builder = ModemInterfaceStatus.builder();
         Properties deviceProperties = devicePropertiesWrapper.getDeviceProperties();
         Optional<Properties> modemProperties = devicePropertiesWrapper.getDeviceSpecificProperties();
@@ -427,8 +427,7 @@ public class NMStatusConverter {
         case NM_802_11_AP_SEC_KEY_MGMT_EAP_SUITE_B_192:
             return WifiSecurity.KEY_MGMT_EAP_SUITE_B_192;
         default:
-            throw new IllegalArgumentException(
-                    String.format("Non convertible NM80211ApSecurityFlag \"%s\"", nmFlag));
+            throw new IllegalArgumentException(String.format("Non convertible NM80211ApSecurityFlag \"%s\"", nmFlag));
         }
     }
 
@@ -513,7 +512,7 @@ public class NMStatusConverter {
     }
 
     private static void setModemStatus(ModemInterfaceStatusBuilder builder, Optional<Properties> modemProperties,
-            List<Properties> simProperties, List<Properties> bearerProperties) {
+            List<SimProperties> simProperties, List<Properties> bearerProperties) {
         modemProperties.ifPresent(properties -> {
             builder.withModel(properties.Get(MM_MODEM_BUS_NAME, "Model"));
             builder.withManufacturer(properties.Get(MM_MODEM_BUS_NAME, "Manufacturer"));
@@ -531,7 +530,6 @@ public class NMStatusConverter {
             builder.withSupportedBands(getModemBands(properties, "SupportedBands"));
             builder.withCurrentBands(getModemBands(properties, "CurrentBands"));
             builder.withGpsSupported(isGpsSupported(properties));
-            builder.withActiveSimIndex(getActiveSimIndex(properties));
             builder.withSimLocked(isSimLocked(properties));
             builder.withConnectionStatus(MMModemState.toModemState(properties.Get(MM_MODEM_BUS_NAME, STATE)));
             builder.withAccessTechnologies(MMModemAccessTechnology
@@ -621,17 +619,6 @@ public class NMStatusConverter {
         return isSupported;
     }
 
-    private static int getActiveSimIndex(Properties properties) {
-        int simIndex = 0;
-        try {
-            UInt32 rawSimIndex = properties.Get(MM_MODEM_BUS_NAME, "PrimarySimSlot");
-            simIndex = rawSimIndex.intValue();
-        } catch (DBusExecutionException e) {
-            logger.warn("PrimarySimSlot property not found. Only a single SIM is supported");
-        }
-        return simIndex;
-    }
-
     private static boolean isSimLocked(Properties properties) {
         boolean simLocked = true;
         UInt32 simStatus = properties.Get(MM_MODEM_BUS_NAME, "UnlockRequired");
@@ -642,15 +629,11 @@ public class NMStatusConverter {
         return simLocked;
     }
 
-    private static List<Sim> getAvailableSims(List<Properties> properties) {
+    private static List<Sim> getAvailableSims(List<SimProperties> properties) {
         List<Sim> sims = new ArrayList<>();
-        for (Properties simProperties : properties) {
-            boolean active = true;
-            try {
-                active = simProperties.Get(MM_SIM_BUS_NAME, "Active");
-            } catch (DBusExecutionException e) {
-                logger.warn("Active property not found.");
-            }
+        for (SimProperties property : properties) {
+            Properties simProperties = property.getProperties();
+
             String iccid = simProperties.Get(MM_SIM_BUS_NAME, "SimIdentifier");
             String imsi = simProperties.Get(MM_SIM_BUS_NAME, "Imsi");
             String eid = "";
@@ -670,7 +653,8 @@ public class NMStatusConverter {
             } catch (DBusExecutionException e) {
                 logger.warn("SimType property not found. Only physical sims are supported.");
             }
-            sims.add(new Sim(active, iccid, imsi, eid, operatorName, simType, eSimStatus));
+            sims.add(new Sim(property.isActive(), property.isPrimary(), iccid, imsi, eid, operatorName, simType,
+                    eSimStatus));
         }
         return sims;
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -632,31 +632,34 @@ public class NMStatusConverter {
     private static List<Sim> getAvailableSims(List<SimProperties> properties) {
         List<Sim> sims = new ArrayList<>();
         for (SimProperties property : properties) {
-            Properties simProperties = property.getProperties();
-
-            String iccid = simProperties.Get(MM_SIM_BUS_NAME, "SimIdentifier");
-            String imsi = simProperties.Get(MM_SIM_BUS_NAME, "Imsi");
-            String eid = "";
-            try {
-                eid = simProperties.Get(MM_SIM_BUS_NAME, "Eid");
-            } catch (DBusExecutionException e) {
-                logger.warn("Eid property not found.");
-            }
-            String operatorName = simProperties.Get(MM_SIM_BUS_NAME, "OperatorName");
-            SimType simType = SimType.PHYSICAL;
-            ESimStatus eSimStatus = ESimStatus.UNKNOWN;
-            try {
-                simType = MMSimType.toSimType(simProperties.Get(MM_SIM_BUS_NAME, "SimType"));
-                if (simType.equals(SimType.ESIM)) {
-                    eSimStatus = MMSimEsimStatus.toESimStatus(simProperties.Get(MM_SIM_BUS_NAME, "EsimStatus"));
-                }
-            } catch (DBusExecutionException e) {
-                logger.warn("SimType property not found. Only physical sims are supported.");
-            }
-            sims.add(new Sim(property.isActive(), property.isPrimary(), iccid, imsi, eid, operatorName, simType,
-                    eSimStatus));
+            Sim sim = getAvailableSim(property.getProperties(), property.isActive(), property.isPrimary());
+            sims.add(sim);
         }
+
         return sims;
+    }
+
+    private static Sim getAvailableSim(Properties simProperties, boolean isActive, boolean isPrimary) {
+        String iccid = simProperties.Get(MM_SIM_BUS_NAME, "SimIdentifier");
+        String imsi = simProperties.Get(MM_SIM_BUS_NAME, "Imsi");
+        String eid = "";
+        try {
+            eid = simProperties.Get(MM_SIM_BUS_NAME, "Eid");
+        } catch (DBusExecutionException e) {
+            logger.warn("Eid property not found.");
+        }
+        String operatorName = simProperties.Get(MM_SIM_BUS_NAME, "OperatorName");
+        SimType simType = SimType.PHYSICAL;
+        ESimStatus eSimStatus = ESimStatus.UNKNOWN;
+        try {
+            simType = MMSimType.toSimType(simProperties.Get(MM_SIM_BUS_NAME, "SimType"));
+            if (simType.equals(SimType.ESIM)) {
+                eSimStatus = MMSimEsimStatus.toESimStatus(simProperties.Get(MM_SIM_BUS_NAME, "EsimStatus"));
+            }
+        } catch (DBusExecutionException e) {
+            logger.warn("SimType property not found. Only physical sims are supported.");
+        }
+        return new Sim(isActive, isPrimary, iccid, imsi, eid, operatorName, simType, eSimStatus);
     }
 
     private static List<Bearer> getBearers(List<Properties> properties) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/SimProperties.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/SimProperties.java
@@ -1,0 +1,29 @@
+package org.eclipse.kura.nm.status;
+
+import org.freedesktop.dbus.interfaces.Properties;
+
+public class SimProperties {
+
+    private final Properties properties;
+    private final boolean isActive;
+    private final boolean isPrimary;
+
+    public SimProperties(Properties properties, boolean isActive, boolean isPrimary) {
+        this.properties = properties;
+        this.isActive = isActive;
+        this.isPrimary = isPrimary;
+    }
+
+    public Properties getProperties() {
+        return this.properties;
+    }
+
+    public boolean isActive() {
+        return this.isActive;
+    }
+
+    public boolean isPrimary() {
+        return this.isPrimary;
+    }
+
+}

--- a/kura/org.eclipse.kura.rest.network.status.provider/src/main/java/org/eclipse/kura/network/status/provider/api/ModemInterfaceStatusDTO.java
+++ b/kura/org.eclipse.kura.rest.network.status.provider/src/main/java/org/eclipse/kura/network/status/provider/api/ModemInterfaceStatusDTO.java
@@ -46,7 +46,6 @@ public class ModemInterfaceStatusDTO extends NetworkInterfaceStatusDTO {
     private final Set<ModemBand> currentBands;
     private final boolean gpsSupported;
     private final List<SimDTO> availableSims;
-    private final int activeSimIndex;
     private final boolean simLocked;
     private final List<BearerDTO> bearers;
     private final ModemConnectionType connectionType;
@@ -77,7 +76,6 @@ public class ModemInterfaceStatusDTO extends NetworkInterfaceStatusDTO {
         this.currentBands = status.getCurrentBands();
         this.gpsSupported = status.isGpsSupported();
         this.availableSims = status.getAvailableSims().stream().map(SimDTO::new).collect(Collectors.toList());
-        this.activeSimIndex = status.getActiveSimIndex();
         this.simLocked = status.isSimLocked();
         this.bearers = status.getBearers().stream().map(BearerDTO::new).collect(Collectors.toList());
         this.connectionType = status.getConnectionType();

--- a/kura/org.eclipse.kura.rest.network.status.provider/src/main/java/org/eclipse/kura/network/status/provider/api/SimDTO.java
+++ b/kura/org.eclipse.kura.rest.network.status.provider/src/main/java/org/eclipse/kura/network/status/provider/api/SimDTO.java
@@ -20,6 +20,7 @@ import org.eclipse.kura.net.status.modem.SimType;
 public class SimDTO {
 
     private final boolean active;
+    private final boolean primary;
     private final String iccid;
     private final String imsi;
     private final String eid;
@@ -29,6 +30,7 @@ public class SimDTO {
 
     public SimDTO(final Sim sim) {
         this.active = sim.isActive();
+        this.primary = sim.isPrimary();
         this.iccid = sim.getIccid();
         this.imsi = sim.getImsi();
         this.eid = sim.getEid();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -233,11 +233,13 @@ public class NetworkStatusServiceAdapter {
         if (gwtConfig instanceof GwtModemInterfaceConfig && networkInterfaceInfo instanceof ModemInterfaceStatus) {
             GwtModemInterfaceConfig gwtModemConfig = (GwtModemInterfaceConfig) gwtConfig;
             ModemInterfaceStatus modemInterfaceInfo = (ModemInterfaceStatus) networkInterfaceInfo;
-            int activeSimIndex = modemInterfaceInfo.getActiveSimIndex();
             Sim activeSim = null;
+
             List<Sim> availableSims = modemInterfaceInfo.getAvailableSims();
-            if (Objects.nonNull(availableSims) && !availableSims.isEmpty()) {
-                activeSim = modemInterfaceInfo.getAvailableSims().get(activeSimIndex);
+            for (Sim sim : availableSims) {
+                if (sim.isActive() && sim.isPrimary()) {
+                    activeSim = sim;
+                }
             }
 
             gwtModemConfig.setHwState(modemInterfaceInfo.getState().toString());
@@ -372,6 +374,7 @@ public class NetworkStatusServiceAdapter {
     }
 
     private class ChannelsBuilder {
+
         List<WifiChannel> channels;
 
         public ChannelsBuilder() {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1056,8 +1056,8 @@ public class NMDbusConnectorTest {
 
             when(settings.GetConnectionByUuid(any())).thenReturn(mockUuidPath);
 
-            doThrow(DBusExecutionException.class).when(this.dbusConnection).getRemoteObject(
-                    "org.freedesktop.NetworkManager", "/unused/connection/path", Connection.class);
+            doThrow(DBusExecutionException.class).when(this.dbusConnection)
+                    .getRemoteObject("org.freedesktop.NetworkManager", "/unused/connection/path", Connection.class);
         }
 
         DBusPath mockPath = mock(DBusPath.class);
@@ -1121,8 +1121,8 @@ public class NMDbusConnectorTest {
         when(mockAssociatedConnection.GetSettings()).thenReturn(connectionSettings);
         when(mockAssociatedConnection.getObjectPath()).thenReturn(connectionPath);
 
-        doReturn(mockAssociatedConnection).when(this.dbusConnection)
-                .getRemoteObject("org.freedesktop.NetworkManager", connectionPath, Connection.class);
+        doReturn(mockAssociatedConnection).when(this.dbusConnection).getRemoteObject("org.freedesktop.NetworkManager",
+                connectionPath, Connection.class);
 
         this.mockedConnections.put(connectionPath, mockAssociatedConnection);
 
@@ -1521,7 +1521,6 @@ public class NMDbusConnectorTest {
         assertTrue(modemStatus.getCurrentBands().contains(ModemBand.EUTRAN_10));
         assertTrue(modemStatus.getCurrentBands().contains(ModemBand.EUTRAN_39));
         assertTrue(modemStatus.isGpsSupported());
-        assertEquals(0, modemStatus.getActiveSimIndex());
         assertFalse(modemStatus.isSimLocked());
         assertEquals(ModemConnectionStatus.REGISTERED, modemStatus.getConnectionStatus());
         assertEquals(1, modemStatus.getAccessTechnologies().size());
@@ -1532,7 +1531,7 @@ public class NMDbusConnectorTest {
         assertEquals("VeryCoolMobile", modemStatus.getOperatorName());
         if (hasSims) {
             assertEquals(1, modemStatus.getAvailableSims().size());
-            Sim sim = modemStatus.getAvailableSims().get(modemStatus.getActiveSimIndex());
+            Sim sim = modemStatus.getAvailableSims().get(0);
             assertTrue(sim.isActive());
             assertEquals("VeryExpensiveSim", sim.getIccid());
             assertEquals("1234567890", sim.getImsi());

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
@@ -264,8 +264,7 @@ public class NMStatusServiceImplTest {
     private void givenNMStatusServiceImplThrowingDBusExceptionOnGetInterfaces()
             throws UnknownHostException, DBusException, KuraException {
         createTestObjects();
-        when(this.nmDbusConnector.getDeviceIds())
-                .thenThrow(new DBusException("Cannot retrieve interface list."));
+        when(this.nmDbusConnector.getDeviceIds()).thenThrow(new DBusException("Cannot retrieve interface list."));
     }
 
     private void whenInterfaceStatusIsRetrieved(String interfaceName) {
@@ -465,7 +464,6 @@ public class NMStatusServiceImplTest {
         builder.withCurrentBands(getCurrentModemBands());
         builder.withGpsSupported(false);
         builder.withAvailableSims(getAvailableSims());
-        builder.withActiveSimIndex(1);
         builder.withSimLocked(false);
         builder.withBearers(getBearers());
         builder.withConnectionType(ModemConnectionType.DirectIP);
@@ -513,8 +511,12 @@ public class NMStatusServiceImplTest {
 
     private List<Sim> getAvailableSims() {
         List<Sim> sims = new ArrayList<>();
-        sims.add(new Sim(false, "1234", "5678", "90", "VeryCoolMobile", SimType.PHYSICAL, ESimStatus.UNKNOWN));
-        sims.add(new Sim(true, "ABCD", "DEFG", "HI", "UglyMobile", SimType.PHYSICAL, ESimStatus.UNKNOWN));
+        sims.add(Sim.builder().withActive(false).withPrimary(false).withIccid("1234").withImsi("5678").withEid("90")
+                .withOperatorName("VeryCoolMobile").withSimType(SimType.PHYSICAL).withESimStatus(ESimStatus.UNKNOWN)
+                .build());
+        sims.add(Sim.builder().withActive(true).withPrimary(true).withIccid("ABCD").withImsi("DEFG").withEid("HI")
+                .withOperatorName("UglyMobile").withSimType(SimType.PHYSICAL).withESimStatus(ESimStatus.UNKNOWN)
+                .build());
         return sims;
     }
 

--- a/kura/test/org.eclipse.kura.rest.network.status.provider.test/src/main/java/org/eclipse/kura/rest/network/status/provider/test/NetworkStatusRestServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.rest.network.status.provider.test/src/main/java/org/eclipse/kura/rest/network/status/provider/test/NetworkStatusRestServiceImplTest.java
@@ -756,7 +756,6 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
                 + "\"currentBands\":[\"UNKNOWN\"]," //
                 + "\"gpsSupported\":false," //
                 + "\"availableSims\":[]," //
-                + "\"activeSimIndex\":0," //
                 + "\"simLocked\":false," //
                 + "\"bearers\":[]," //
                 + "\"connectionType\":\"DirectIP\"," //
@@ -801,7 +800,6 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
                 .withSupportedBands(EnumSet.of(ModemBand.CDMA_BC1)) //
                 .withCurrentBands(EnumSet.of(ModemBand.UTRAN_9, ModemBand.CDMA_BC0)) //
                 .withGpsSupported(true) //
-                .withActiveSimIndex(2) //
                 .withSimLocked(true) //
                 .withConnectionType(ModemConnectionType.DirectIP) //
                 .withConnectionStatus(ModemConnectionStatus.DISCONNECTING) //
@@ -833,7 +831,6 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
                 + "\"supportedBands\":[\"CDMA_BC1\"]," //
                 + "\"currentBands\":[\"UTRAN_9\",\"CDMA_BC0\"]," //
                 + "\"gpsSupported\":true,\"availableSims\":[]," //
-                + "\"activeSimIndex\":2," //
                 + "\"simLocked\":true," //
                 + "\"bearers\":[]," //
                 + "\"connectionType\":\"DirectIP\"," //
@@ -885,7 +882,6 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
                 + "\"currentBands\":[\"UNKNOWN\"]," //
                 + "\"gpsSupported\":false," //
                 + "\"availableSims\":[]," //
-                + "\"activeSimIndex\":0," //
                 + "\"simLocked\":false," //
                 + "\"bearers\":[{" //
                 + "\"name\":\"foo\"," //
@@ -925,9 +921,26 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
 
     @Test
     public void shouldEncodeSim() {
-        givenNetworkStatus(ModemInterfaceStatus.builder().withAvailableSims(
-                Arrays.asList(new Sim(false, "abc", "imsi", "sed", "op", SimType.PHYSICAL, ESimStatus.UNKNOWN),
-                        new Sim(true, "ac", "isi", "se", "opp", SimType.ESIM, ESimStatus.WITH_PROFILES))));
+        givenNetworkStatus(ModemInterfaceStatus.builder().withAvailableSims(Arrays.asList( //
+                Sim.builder() //
+                        .withActive(true) //
+                        .withPrimary(true) //
+                        .withIccid("abc") //
+                        .withImsi("imsi") //
+                        .withEid("sed") //
+                        .withOperatorName("op") //
+                        .withSimType(SimType.PHYSICAL) //
+                        .withESimStatus(ESimStatus.UNKNOWN).build(), //
+                Sim.builder() //
+                        .withActive(false) //
+                        .withPrimary(false) //
+                        .withIccid("ac") //
+                        .withImsi("isi") //
+                        .withEid("se") //
+                        .withOperatorName("opp") //
+                        .withSimType(SimType.ESIM) //
+                        .withESimStatus(ESimStatus.WITH_PROFILES) //
+                        .build())));
 
         whenRequestIsPerformed(new MethodSpec("GET"), NETWORK_STATUS_PATH);
 
@@ -949,21 +962,22 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
                 + "\"currentBands\":[\"UNKNOWN\"]," //
                 + "\"gpsSupported\":false," //
                 + "\"availableSims\":[{" //
-                + "\"active\":false," //
+                + "\"active\":true," //
+                + "\"primary\":true," //
                 + "\"iccid\":\"abc\"," //
                 + "\"imsi\":\"imsi\"," //
                 + "\"eid\":\"sed\"," //
                 + "\"operatorName\":\"op\"," //
                 + "\"simType\":\"PHYSICAL\"," //
                 + "\"eSimStatus\":\"UNKNOWN\"}," //
-                + "{\"active\":true," //
+                + "{\"active\":false," //
+                + "\"primary\":false," //
                 + "\"iccid\":\"ac\"," //
                 + "\"imsi\":\"isi\"," //
                 + "\"eid\":\"se\"," //
                 + "\"operatorName\":\"opp\"," //
                 + "\"simType\":\"ESIM\"," //
                 + "\"eSimStatus\":\"WITH_PROFILES\"}]," //
-                + "\"activeSimIndex\":0," //
                 + "\"simLocked\":false," //
                 + "\"bearers\":[]," //
                 + "\"connectionType\":\"DirectIP\"," //


### PR DESCRIPTION
Due to a misinterpretation of the ModemManager DBus API documentation we were not representing the Modem SIMs correctly.

**Original issue**:

> After a SIM is inserted in internal modem supporting multiple SIMs, the Web UI does not load anymore. The exception [1] is visible in the log.
> The issue is probably caused by the fact that the value of the  PrimarySimSlot ([org.freedesktop.ModemManager1.Modem: ModemManager Reference Manual](https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/gdbus-org.freedesktop.ModemManager1.Modem.html#gdbus-property-org-freedesktop-ModemManager1-Modem.PrimarySimSlot)) property is being used as an array index.

<details>

<summary>See full stacktrace</summary>


```
STACKTRACE=com.google.gwt.user.server.rpc.UnexpectedException: Service method 'public abstract java.util.ArrayList org.eclipse.kura.web.shared.service.GwtStatusService.getDeviceConfig(org.eclipse.kura.web.shared.model.GwtXSRFToken,boolean,boolean) throws org.eclipse.kura.web.shared.GwtKuraException' threw an unexpected exception: java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
               	at com.google.gwt.user.server.rpc.RPC.encodeResponseForFailure(RPC.java:416)
               	at com.google.gwt.user.server.rpc.RPC.invokeAndEncodeResponse(RPC.java:605)
               	at com.google.gwt.user.server.rpc.RemoteServiceServlet.processCall(RemoteServiceServlet.java:333)
               	at org.eclipse.kura.web.server.OsgiRemoteServiceServlet.processCall(OsgiRemoteServiceServlet.java:208)
               	at com.google.gwt.user.server.rpc.RemoteServiceServlet.processCall(RemoteServiceServlet.java:303)
               	at com.google.gwt.user.server.rpc.RemoteServiceServlet.processPost(RemoteServiceServlet.java:373)
               	at com.google.gwt.user.server.rpc.AbstractRemoteServiceServlet.doPost(AbstractRemoteServiceServlet.java:62)
               	at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
               	at org.eclipse.kura.web.server.OsgiRemoteServiceServlet.service(OsgiRemoteServiceServlet.java:95)
               	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
               	at org.eclipse.equinox.http.servlet.internal.HttpServiceRuntimeImpl$LegacyServlet.service(HttpServiceRuntimeImpl.java:1459)
               	at org.eclipse.equinox.http.servlet.internal.registration.EndpointRegistration.service(EndpointRegistration.java:159)
               	at org.eclipse.equinox.http.servlet.internal.servlet.ResponseStateHandler.processRequest(ResponseStateHandler.java:67)
               	at org.eclipse.equinox.http.servlet.internal.context.DispatchTargets.doDispatch(DispatchTargets.java:117)
               	at org.eclipse.equinox.http.servlet.internal.servlet.ProxyServlet.dispatch(ProxyServlet.java:147)
               	at org.eclipse.equinox.http.servlet.internal.servlet.ProxyServlet.preprocess(ProxyServlet.java:115)
               	at org.eclipse.equinox.http.servlet.internal.servlet.ProxyServlet.service(ProxyServlet.java:104)
               	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
               	at org.eclipse.equinox.http.jetty.internal.HttpServerManager$InternalHttpServiceServlet.service(HttpServerManager.java:305)
               	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)
               	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:554)
               	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
               	at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:722)
               	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
               	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235)
               	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
               	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
               	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440)
               	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
               	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505)
               	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)
               	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
               	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355)
               	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
               	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
               	at org.eclipse.jetty.server.Server.handle(Server.java:516)
               	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487)
               	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732)
               	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479)
               	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
               	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
               	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
               	at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.onFillable(SslConnection.java:555)
               	at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:410)
               	at org.eclipse.jetty.io.ssl.SslConnection$2.succeeded(SslConnection.java:164)
               	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
               	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
               	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
               	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
               	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
               	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
               	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
               	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
               	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
               	at java.lang.Thread.run(Thread.java:750)
               Caused by: java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
               	at java.util.ArrayList.rangeCheck(ArrayList.java:659)
               	at java.util.ArrayList.get(ArrayList.java:435)
               	at org.eclipse.kura.web.server.net2.status.NetworkStatusServiceAdapter.setModemStateProperties(NetworkStatusServiceAdapter.java:240)
               	at org.eclipse.kura.web.server.net2.status.NetworkStatusServiceAdapter.fillWithStatusProperties(NetworkStatusServiceAdapter.java:79)
               	at org.eclipse.kura.web.server.net2.GwtNetworkServiceImpl.getConfigsAndStatuses(GwtNetworkServiceImpl.java:84)
               	at org.eclipse.kura.web.server.net2.GwtNetworkServiceImpl.findNetInterfaceConfigurations(GwtNetworkServiceImpl.java:57)
               	at org.eclipse.kura.web.server.GwtNetworkServiceImplFacade.findNetInterfaceConfigurations(GwtNetworkServiceImplFacade.java:42)
               	at org.eclipse.kura.web.server.GwtStatusServiceImpl.getNetworkStatus(GwtStatusServiceImpl.java:278)
               	at org.eclipse.kura.web.server.GwtStatusServiceImpl.getDeviceConfig(GwtStatusServiceImpl.java:92)
               	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
               	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
               	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
               	at java.lang.reflect.Method.invoke(Method.java:498)
               	at com.google.gwt.user.server.rpc.RPC.invokeAndEncodeResponse(RPC.java:587)
               	... 53 more
```

</details>

The UI code was using the `ActiveSimIndex` as 0-indexed, but it is not [as per the ModemManager documentation](https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/gdbus-org.freedesktop.ModemManager1.Modem.html#gdbus-property-org-freedesktop-ModemManager1-Modem.PrimarySimSlot). This issue unearthed some additional misinterpretation of the documentation (Active SIM != Primary SIM) and prompted this PR.

#### Relevant documentation

https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/gdbus-org.freedesktop.ModemManager1.Modem.html

![image](https://user-images.githubusercontent.com/22748355/234786170-e3d31b3a-b377-48e7-a51a-9a2ae9d3e696.png)

https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/gdbus-org.freedesktop.ModemManager1.Sim.html#gdbus-property-org-freedesktop-ModemManager1-Sim.Active

![image](https://user-images.githubusercontent.com/22748355/234786262-f02da93b-a668-4384-acf2-2b1c2584baaf.png)


## Changelog

- **API**:
  - Removed `activeSimIndex` attribute from the `ModemStatusInterface`: it was error-prone and not correctly used (we populated it with the *primary* slot index, not the *active* sim index).
  - Added `primary` attribute to the `Sim` class
  - Added a builder for the `Sim` class
- **NM implementation**:
  - Added `SimProperties` data structure so that we can carry around the `isActive` and `isPrimary` attribute informations
  - Leveraged the newly introduced data structure to populate the `Sim` class
- **UI**:
  - Leverage `isActive` and `isPrimary` attributes for determining the main SIM instead of relying on the `activeSimIndex`
- **RESTful API**:
  - Updated to leverage new builder and attributes of the `Sim` class

## Testing

#### 1. ModemManager 1.14.2 (Single SIM setup)


```
curl -k -u admin:eurotech https://$ADDRESS/services/networkStatus/v1/status

... "availableSims":[{"active":true,"primary":true,"iccid":"89REDACTED2","imsi":"2REDACTED191","eid":"","operatorName":"","simType":"PHYSICAL","eSimStatus":"UNKNOWN"}]
```

```
pi@raspberrypi:~ $ mmcli -i 0
  -------------------------------
  General    |         dbus path: /org/freedesktop/ModemManager1/SIM/0
  -------------------------------
  Properties |              imsi: 2REDACTED191
             |             iccid: 89REDACTED2
             |       operator id: 22210
```

#### 2. ModemManager 1.20.4 (Single SIM setup)

```
curl -k -u admin:eurotech https://$ADDRESS/services/networkStatus/v1/status

... "availableSims":[{"active":true,"primary":true,"iccid":"89REDACTED2","imsi":"2REDACTED191","eid":"","operatorName":"","simType":"PHYSICAL","eSimStatus":"UNKNOWN"}]
```

```
root@raspberrypi:/home/pi# mmcli -i 0
  -------------------------------
  General    |              path: /org/freedesktop/ModemManager1/SIM/0
  -------------------------------
  Properties |            active: yes
             |              imsi: 2REDACTED91
             |             iccid: 89REDACTED2
             |       operator id: 22210
             |              gid1: FF
             |              gid2: FF
```