### PR TITLE
fix(core): Watchdog is not refreshed when connection to DB missing

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -253,7 +253,6 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
         } catch (KuraStoreException e) {
             logger.error("Failed to start store", e);
             DataServiceImpl.this.disconnectDataTransportAndLog(e);
-            DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
         }
     }
 
@@ -459,7 +458,6 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             } catch (KuraStoreException e) {
                 logger.error("Failed to unpublish in-flight messages", e);
                 DataServiceImpl.this.disconnectDataTransportAndLog(e);
-                DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
             }
         } else if (this.storeState.isPresent()) {
             logger.info("New session established. Dropping all in-flight messages.");
@@ -556,7 +554,6 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             } catch (KuraStoreException e) {
                 logger.error("Cannot confirm message to store", e);
                 disconnectDataTransportAndLog(e);
-                DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
             }
 
             // Notify the listeners
@@ -600,7 +597,6 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
         try {
             this.storeState.get().getOrOpenMessageStore();
         } catch (KuraStoreException e) {
-            DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
             throw new KuraConnectException(e, MESSAGE_STORE_NOT_CONNECTED_MESSAGE);
         }
 
@@ -687,7 +683,6 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
 
                 return messageId;
             } catch (KuraStoreException e) {
-                DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
                 disconnectDataTransportAndLog(e);
                 throw e;
             }
@@ -920,7 +915,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
                 connected = true;
             } catch (KuraConnectException | KuraStoreException e) {
                 logger.warn("DataService failure occured: ", e);
-
+                
                 if (e instanceof KuraStoreException) {
                     DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
                 }
@@ -1108,7 +1103,6 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
 
                 } catch (KuraStoreException e) {
                     DataServiceImpl.this.disconnectDataTransportAndLog(e);
-                    DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
                 }
 
             } else {
@@ -1161,8 +1155,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             } else {
                 throw new KuraStoreException(MESSAGE_STORE_NOT_CONNECTED_MESSAGE);
             }
-        } catch (KuraStoreException e) {
-            DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
+        } catch (Exception e) {
             DataServiceImpl.this.disconnectDataTransportAndLog(e);
             logger.error("Probably an unrecoverable exception", e);
         }

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -913,7 +913,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
                 }
                 connected = true;
             } catch (KuraConnectException | KuraStoreException e) {
-                logger.warn("Connection attempt failed with exception {}: {}", e.getClass().getSimpleName(), e);
+                logger.warn("Connection attempt failed with exception {}", e.getClass().getSimpleName(), e);
 
                 if (DataServiceImpl.this.dataServiceOptions.isConnectionRecoveryEnabled()) {
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -914,12 +914,13 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
                 connected = true;
             } catch (KuraConnectException | KuraStoreException e) {
                 logger.warn("Connection attempt failed with exception {}: {}", e.getClass().getSimpleName(), e);
-                
+
                 if (DataServiceImpl.this.dataServiceOptions.isConnectionRecoveryEnabled()) {
 
-                    if (isAuthenticationException(e) || DataServiceImpl.this.connectionAttempts
-                            .getAndIncrement() < DataServiceImpl.this.dataServiceOptions
-                                    .getRecoveryMaximumAllowedFailures() || e instanceof KuraStoreException) {
+                    if (isAuthenticationException(e) || e instanceof KuraStoreException
+                            || DataServiceImpl.this.connectionAttempts
+                                    .getAndIncrement() < DataServiceImpl.this.dataServiceOptions
+                                            .getRecoveryMaximumAllowedFailures()) {
                         logger.info("Checkin done.");
                         DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
                     } else {

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -920,9 +920,9 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
                 connected = true;
             } catch (KuraConnectException | KuraStoreException e) {
                 logger.warn("DataService failure occured: ", e);
-                
+
                 if (e instanceof KuraStoreException) {
-                    DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);                    
+                    DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
                 }
 
                 if (DataServiceImpl.this.dataServiceOptions.isConnectionRecoveryEnabled()) {

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -898,7 +898,8 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             try {
                 if (!DataServiceImpl.this.storeState.isPresent()) {
                     logger.warn(MESSAGE_STORE_NOT_CONNECTED_MESSAGE);
-                    return;
+                    DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
+                    throw new KuraStoreException(MESSAGE_STORE_NOT_CONNECTED_MESSAGE);
                 }
 
                 DataServiceImpl.this.storeState.get().getOrOpenMessageStore();

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -915,7 +915,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             } catch (KuraConnectException | KuraStoreException e) {
                 logger.warn("DataService failure occured: ", e);
                 
-                if (e instanceof KuraStoreException) {
+                if (DataServiceImpl.this.dataServiceOptions.isConnectionRecoveryEnabled() && e instanceof KuraStoreException) {
                     DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
                 }
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -919,7 +919,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
                 }
                 connected = true;
             } catch (KuraConnectException | KuraStoreException e) {
-                logger.warn("Connect failed", e);
+                logger.warn("DataService failure occured: ", e);
                 
                 if (e instanceof KuraStoreException) {
                     DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);                    

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -915,15 +915,11 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             } catch (KuraConnectException | KuraStoreException e) {
                 logger.warn("DataService failure occured: ", e);
                 
-                if (DataServiceImpl.this.dataServiceOptions.isConnectionRecoveryEnabled() && e instanceof KuraStoreException) {
-                    DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
-                }
-
                 if (DataServiceImpl.this.dataServiceOptions.isConnectionRecoveryEnabled()) {
 
                     if (isAuthenticationException(e) || DataServiceImpl.this.connectionAttempts
                             .getAndIncrement() < DataServiceImpl.this.dataServiceOptions
-                                    .getRecoveryMaximumAllowedFailures()) {
+                                    .getRecoveryMaximumAllowedFailures() || e instanceof KuraStoreException) {
                         logger.info("Checkin done.");
                         DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
                     } else {

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -913,7 +913,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
                 }
                 connected = true;
             } catch (KuraConnectException | KuraStoreException e) {
-                logger.warn("DataService failure occured: ", e);
+                logger.warn("Connection attempt failed with exception {}: {}", e.getClass().getSimpleName(), e);
                 
                 if (DataServiceImpl.this.dataServiceOptions.isConnectionRecoveryEnabled()) {
 

--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -467,7 +467,6 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
             } catch (KuraStoreException e) {
                 logger.error("Failed to drop in-flight messages", e);
                 DataServiceImpl.this.disconnectDataTransportAndLog(e);
-                DataServiceImpl.this.watchdogService.checkin(DataServiceImpl.this);
             }
         }
 


### PR DESCRIPTION
This PR fixes the following issue:

when the DB connection is misconfigured, and then the configuration is changed to be valid it is possible that the watchdog will still reboot the device. This PR added appropriate watchdog check-ins to the data service so that it will not erroneously restart the device. 

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
