### PR TITLE
fix(dnsmasq): added protections against wrong configurations

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -56,6 +56,8 @@ systemctl disable chrony
 systemctl enable NetworkManager
 systemctl start NetworkManager
 systemctl enable ModemManager
+systemctl stop dnsmasq
+systemctl disable dnsmasq
 
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -56,6 +56,8 @@ systemctl disable chrony
 systemctl enable NetworkManager
 systemctl start NetworkManager
 systemctl enable ModemManager
+systemctl stop dnsmasq
+systemctl disable dnsmasq
 
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -56,6 +56,8 @@ systemctl disable chrony
 systemctl enable NetworkManager
 systemctl start NetworkManager
 systemctl enable ModemManager
+systemctl stop dnsmasq
+systemctl disable dnsmasq
 
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
@@ -142,7 +142,9 @@ public class DnsmasqTool implements DhcpLinuxTool {
     private void writeGlobalConfig() {
         try {
             Path dnsmasqGlobalsPath = Paths.get(DNSMASQ_GLOBAL_CONFIG_FILE);
-            Files.write(dnsmasqGlobalsPath, GLOBAL_CONFIGURATION.getBytes(StandardCharsets.UTF_8));
+            if (Files.notExists(dnsmasqGlobalsPath)) {
+                Files.write(dnsmasqGlobalsPath, GLOBAL_CONFIGURATION.getBytes(StandardCharsets.UTF_8));
+            }
         } catch (IOException e) {
             logger.warn("DNSMASQ - Failed setting in DHCP-only mode.", e);
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -374,7 +374,7 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
     private void writeDhcpServerConfiguration(Set<String> interfaceNames) {
         interfaceNames.forEach(interfaceName -> {
             if (isDhcpServerValid(interfaceName)) {
-                DhcpServerConfigWriter dhcpServerConfigWriter = buildDhcpServerConfigWriter(interfaceName,
+                DhcpServerConfigWriter dhcpServerConfigWriter = new DhcpServerConfigWriter(interfaceName,
                         this.networkProperties);
                 try {
                     dhcpServerConfigWriter.writeConfiguration();
@@ -387,11 +387,6 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
                 this.dhcpServerMonitor.putDhcpServerInterfaceConfiguration(interfaceName, false);
             }
         });
-    }
-
-    protected DhcpServerConfigWriter buildDhcpServerConfigWriter(final String interfaceName,
-            final NetworkProperties properties) {
-        return new DhcpServerConfigWriter(interfaceName, properties);
     }
 
     private boolean isDhcpServerValid(String interfaceName) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -374,7 +374,7 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
     private void writeDhcpServerConfiguration(Set<String> interfaceNames) {
         interfaceNames.forEach(interfaceName -> {
             if (isDhcpServerValid(interfaceName)) {
-                DhcpServerConfigWriter dhcpServerConfigWriter = new DhcpServerConfigWriter(interfaceName,
+                DhcpServerConfigWriter dhcpServerConfigWriter = buildDhcpServerConfigWriter(interfaceName,
                         this.networkProperties);
                 try {
                     dhcpServerConfigWriter.writeConfiguration();
@@ -387,6 +387,11 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
                 this.dhcpServerMonitor.putDhcpServerInterfaceConfiguration(interfaceName, false);
             }
         });
+    }
+
+    protected DhcpServerConfigWriter buildDhcpServerConfigWriter(final String interfaceName,
+            final NetworkProperties properties) {
+        return new DhcpServerConfigWriter(interfaceName, properties);
     }
 
     private boolean isDhcpServerValid(String interfaceName) {


### PR DESCRIPTION
This PR includes checks in the piece of code that manages `dnsmasq` to prevent wrong configurations from being applied.

**Related Issue:** N/A.

**Description of the solution adopted:** Several changes are introduced in this PR:

- `dnsmasq` is disabled at installation so it won't start at system reboot causing conflicts with other DNS server tools.
- The global configuration is written only once.
- When a wrong configuration is written in `/etc/dnsmasq.d/`, `DnsmasqTool` detects the defect and removes it.

**Screenshots:** N/A.

**Manual Tests**: The following manual tests have been executed on a Raspberry Pi 4 - Raspbian 11 to validate the solution:

1. On fresh installation after Kura starts the `dnsmasq` service is not failing.
2. Applying a wrong snapshot with an unexisting interface configured in DHCP server mode does not keep a wrong configuration, the directory `/etc/dnsmasq.d/` will not contain the configuration for such interface.
3. `dnsmasq` does not fail and is running even if there is no interface configured in DHCP server mode; no specific configuration is present in `/etc/dnsmasq.d/`.
4. Configs creation and service reloading is done consistently with what is set on the UI (tried combinations of DHCP&NAT, only NAT, etc.).
5. `/etc/dnsmasq.d/dnsmasq-globals.conf` is rewritten at kura restart. Modifying it after Kura is started will trigger the monitor to rewrite it.
6. If after first installation there is already a configuration present, like `/etc/dnsmasq.d/dnsmasq-wlan0.conf`, such configuration is rewritten if configured from the UI.

Cases that we do not care about:

1. If an interface is disabled but a user manually puts a valid config in `/etc/dnsmasq.d/`, like `/etc/dnsmasq.d/dnsmasq-wlan0.conf`,  then the file `/etc/dnsmasq.d/dnsmasq-wlan0.conf` is not deteled and `dnsmasq` fails because the interface is not existent. This case is specular to the nr.1 of the previous list.
2. If a user removes a configuration inside `/etc/dnsmasq.d/` except for the global one, the monitor will detect the change but the configuration is not rewritten upon next configuration change. The `dnsmasq` service is not restarted in this case so it will keep running with the last configuration.

**Any side note on the changes made:** N/A.
