### PR TITLE
fix(nm): cannot configure ethernet interfaces if the cable is disconnected

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -35,7 +35,6 @@ import org.eclipse.kura.nm.status.AccessPointsProperties;
 import org.eclipse.kura.nm.status.DevicePropertiesWrapper;
 import org.eclipse.kura.nm.status.NMStatusConverter;
 import org.eclipse.kura.nm.status.SupportedChannelsProperties;
-import org.freedesktop.AddAndActivateConnectionTuple;
 import org.freedesktop.NetworkManager;
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
@@ -395,10 +394,12 @@ public class NMDbusConnector {
             this.nm.ActivateConnection(new DBusPath(connection.get().getObjectPath()),
                     new DBusPath(device.getObjectPath()), new DBusPath("/"));
         } else {
-            AddAndActivateConnectionTuple createdConnectionTuple = this.nm.AddAndActivateConnection(
-                    newConnectionSettings, new DBusPath(device.getObjectPath()), new DBusPath("/"));
+            Settings settings = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_SETTINGS_BUS_PATH, Settings.class);
+            DBusPath createdConnectionPath = settings.AddConnection(newConnectionSettings);
+            this.nm.ActivateConnection(createdConnectionPath, new DBusPath(device.getObjectPath()), new DBusPath("/"));
+
             Connection createdConnection = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
-                    createdConnectionTuple.getPath().getPath(), Connection.class);
+                    createdConnectionPath.getPath(), Connection.class);
             connection = Optional.of(createdConnection);
         }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -265,7 +265,6 @@ public class NMSettingsConverter {
         String connectionName = String.format("kura-%s-connection", iface);
         connectionMap.put("id", new Variant<>(connectionName));
         connectionMap.put("interface-name", new Variant<>(iface));
-        connectionMap.put("autoconnect", new Variant<>(true));
 
         return connectionMap;
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -265,6 +265,7 @@ public class NMSettingsConverter {
         String connectionName = String.format("kura-%s-connection", iface);
         connectionMap.put("id", new Variant<>(connectionName));
         connectionMap.put("interface-name", new Variant<>(iface));
+        connectionMap.put("autoconnect", new Variant<>(true));
 
         return connectionMap;
     }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1328,13 +1328,10 @@ public class NMDbusConnectorTest {
         try {
             this.instanceNMDbusConnector.apply(networkConfig);
         } catch (DBusException e) {
-            e.printStackTrace();
             this.hasDBusExceptionBeenThrown = true;
         } catch (NoSuchElementException e) {
-            e.printStackTrace();
             this.hasNoSuchElementExceptionThrown = true;
         } catch (NullPointerException e) {
-            e.printStackTrace();
             this.hasNullPointerExceptionThrown = true;
         }
     }


### PR DESCRIPTION
When creating a new connection for an ethernet device without a connected cable the following exception was thrown:

```
Wed 2023-04-19 13:21:32.979015 UTC [s=c82f5507362a4bcabd3597251333b2c2;i=4e53c;b=3b9b181c4f434fb3a0649bc9d54ba0fd;m=3719928b;t=5f9b04d7a5f72;x=27124d60895e6d09]
    MESSAGE=Unable to apply configuration to the device path /org/freedesktop/NetworkManager/Devices/2
    STACKTRACE=org.freedesktop.dbus.exceptions.DBusExecutionException: Connection 'kura-eno1-connection' is not available on device eno1 because device has no carrier
                at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
                at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
...
```

which is correct.

Unfortunately, due to the fact that the connection was created using the `AddAndActivate` method, the connection was not created and saved on disk due to the above mentioned error.

To fix the issue I split the operation in two steps:
- I create and save on disk the connection using the `AddConnection` method of the `Settings` interface
- Then activate the connection using the `ActivateConnection` method of the `NetworkManager` interface

**Tests**: tested working on my RPi4 running Raspbian 64bit NM 1.30.6