### PR TITLE
fix(web2): fixed authType and pdpType enums conversion on net2

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -270,23 +270,23 @@ public class NMSettingsConverter {
     }
 
     private static void setAuthenticationType(String authenticationType, Map<String, Variant<?>> settings) {
-        if (authenticationType.equals("netModemAuthAUTO")) {
+        if (authenticationType.equals("AUTO")) {
             return;
         }
 
-        if (authenticationType.equals("netModemAuthNONE")) {
+        if (authenticationType.equals("NONE")) {
             settings.put(PPP_REFUSE_EAP, new Variant<>(true));
             settings.put(PPP_REFUSE_CHAP, new Variant<>(true));
             settings.put(PPP_REFUSE_PAP, new Variant<>(true));
             settings.put(PPP_REFUSE_MSCHAP, new Variant<>(true));
             settings.put(PPP_REFUSE_MSCHAPV2, new Variant<>(true));
-        } else if (authenticationType.equals("netModemAuthCHAP")) {
+        } else if (authenticationType.equals("CHAP")) {
             settings.put(PPP_REFUSE_EAP, new Variant<>(true));
             settings.put(PPP_REFUSE_CHAP, new Variant<>(false));
             settings.put(PPP_REFUSE_PAP, new Variant<>(true));
             settings.put(PPP_REFUSE_MSCHAP, new Variant<>(true));
             settings.put(PPP_REFUSE_MSCHAPV2, new Variant<>(true));
-        } else if (authenticationType.equals("netModemAuthPAP")) {
+        } else if (authenticationType.equals("PAP")) {
             settings.put(PPP_REFUSE_EAP, new Variant<>(true));
             settings.put(PPP_REFUSE_CHAP, new Variant<>(true));
             settings.put(PPP_REFUSE_PAP, new Variant<>(false));

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -263,8 +263,6 @@ public class GwtNetInterfaceConfigBuilder {
             gwtModemConfig
                     .setAuthType(EnumsParser.getGwtModemAuthType(this.properties.getModemAuthType(this.ifName)));
             gwtModemConfig.setPdpType(EnumsParser.getGwtModemPdpType(this.properties.getModemPdpType(this.ifName)));
-            gwtModemConfig.setHwState(
-                    EnumsParser.getNetInterfaceState(this.properties.getModemConnectionStatus(this.ifName)));
 
             gwtModemConfig.setDialString(this.properties.getModemDialString(this.ifName));
             gwtModemConfig.setUsername(this.properties.getModemUsername(this.ifName));

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -558,10 +558,8 @@ public class NetworkConfigurationServiceProperties {
         return Optional.ofNullable((String) this.properties.get(String.format(NET_INTERFACE_CONFIG_PDP_TYPE, ifname)));
     }
 
-    public void setModemPdpType(String ifname, Optional<String> modemPdpType) {
-        if (modemPdpType.isPresent()) {
-            this.properties.put(String.format(NET_INTERFACE_CONFIG_PDP_TYPE, ifname), modemPdpType.get());
-        }
+    public void setModemPdpType(String ifname, String modemPdpType) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_PDP_TYPE, ifname), modemPdpType);
     }
 
     public int getModemMaxFail(String ifname) {
@@ -576,10 +574,8 @@ public class NetworkConfigurationServiceProperties {
         return getNonEmptyStringProperty(this.properties.get(String.format(NET_INTERFACE_CONFIG_AUTH_TYPE, ifname)));
     }
 
-    public void setModemAuthType(String ifname, Optional<String> authType) {
-        if (authType.isPresent()) {
-            this.properties.put(String.format(NET_INTERFACE_CONFIG_AUTH_TYPE, ifname), authType.get());
-        }
+    public void setModemAuthType(String ifname, String authType) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_AUTH_TYPE, ifname), authType);
     }
 
     public int getModemLpcEchoInterval(String ifname) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -514,7 +514,6 @@ public class NetworkConfigurationServiceProperties {
     private static final String NET_INTERFACE_CONFIG_DIAL_STRING = "net.interface.%s.config.dialString";
     private static final String NET_INTERFACE_CONFIG_HOLDOFF = "net.interface.%s.config.holdoff";
     private static final String NET_INTERFACE_CONFIG_PPP_NUM = "net.interface.%s.config.pppNum";
-    private static final String NET_INTERFACE_CONFIG_CONNECTION_STATUS = "net.interface.%s.config.connection.status";
     private static final String NET_INTERFACE_USB_PRODUCT_NAME = "net.interface.%s.usb.product.name";
     private static final String NET_INTERFACE_USB_VENDOR_ID = "net.interface.%s.usb.vendor.id";
     private static final String NET_INTERFACE_USB_VENDOR_NAME = "net.interface.%s.usb.vendor.name";
@@ -665,17 +664,6 @@ public class NetworkConfigurationServiceProperties {
 
     public void setModemPppNum(String ifname, int pppNum) {
         this.properties.put(String.format(NET_INTERFACE_CONFIG_PPP_NUM, ifname), pppNum);
-    }
-
-    public Optional<String> getModemConnectionStatus(String ifname) {
-        return getNonEmptyStringProperty(
-                this.properties.get(String.format(NET_INTERFACE_CONFIG_CONNECTION_STATUS, ifname)));
-    }
-
-    public void setModemConnectionStatus(String ifname, Optional<String> status) {
-        if (status.isPresent()) {
-            this.properties.put(String.format(NET_INTERFACE_CONFIG_CONNECTION_STATUS, ifname), status.get());
-        }
     }
 
     public String getUsbProductName(String ifname) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -259,9 +259,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
             GwtModemInterfaceConfig gwtModemConfig = (GwtModemInterfaceConfig) this.gwtConfig;
 
             this.properties.setModemAuthType(this.ifname,
-                    EnumsParser.getAuthType(Optional.ofNullable(gwtModemConfig.getAuthType().name())));
+                    EnumsParser.getAuthType(Optional.ofNullable(gwtModemConfig.getAuthType())));
             this.properties.setModemPdpType(this.ifname,
-                    EnumsParser.getPdpType(Optional.ofNullable(gwtModemConfig.getPdpType().name())));
+                    EnumsParser.getPdpType(Optional.ofNullable(gwtModemConfig.getPdpType())));
             this.properties.setModemConnectionStatus(this.ifname, Optional.ofNullable(gwtModemConfig.getHwState()));
             this.properties.setModemDialString(this.ifname, gwtModemConfig.getDialString());
             this.properties.setModemUsername(this.ifname, gwtModemConfig.getUsername());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -258,8 +258,10 @@ public class NetworkConfigurationServicePropertiesBuilder {
         if (this.gwtConfig instanceof GwtModemInterfaceConfig) {
             GwtModemInterfaceConfig gwtModemConfig = (GwtModemInterfaceConfig) this.gwtConfig;
 
-            this.properties.setModemAuthType(this.ifname, Optional.ofNullable(gwtModemConfig.getAuthType().name()));
-            this.properties.setModemPdpType(this.ifname, Optional.ofNullable(gwtModemConfig.getPdpType().name()));
+            this.properties.setModemAuthType(this.ifname,
+                    EnumsParser.getAuthType(Optional.ofNullable(gwtModemConfig.getAuthType().name())));
+            this.properties.setModemPdpType(this.ifname,
+                    EnumsParser.getPdpType(Optional.ofNullable(gwtModemConfig.getPdpType().name())));
             this.properties.setModemConnectionStatus(this.ifname, Optional.ofNullable(gwtModemConfig.getHwState()));
             this.properties.setModemDialString(this.ifname, gwtModemConfig.getDialString());
             this.properties.setModemUsername(this.ifname, gwtModemConfig.getUsername());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -262,7 +262,6 @@ public class NetworkConfigurationServicePropertiesBuilder {
                     EnumsParser.getAuthType(Optional.ofNullable(gwtModemConfig.getAuthType())));
             this.properties.setModemPdpType(this.ifname,
                     EnumsParser.getPdpType(Optional.ofNullable(gwtModemConfig.getPdpType())));
-            this.properties.setModemConnectionStatus(this.ifname, Optional.ofNullable(gwtModemConfig.getHwState()));
             this.properties.setModemDialString(this.ifname, gwtModemConfig.getDialString());
             this.properties.setModemUsername(this.ifname, gwtModemConfig.getUsername());
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -242,7 +242,7 @@ public class NetworkStatusServiceAdapter {
                 }
             }
 
-            gwtModemConfig.setHwState(modemInterfaceInfo.getState().toString());
+            gwtModemConfig.setHwState(modemInterfaceInfo.getConnectionStatus().name());
             gwtModemConfig.setHwSerial(modemInterfaceInfo.getSerialNumber());
             gwtModemConfig.setHwRssi(String.valueOf(modemInterfaceInfo.getSignalStrength()));
             gwtModemConfig.setHwICCID(activeSim != null ? activeSim.getIccid() : "NA");

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
@@ -328,18 +328,19 @@ public class EnumsParser {
      * Converts values of {@link GwtModemAuthType} to {@link AuthType.name()}
      * 
      */
-    public static String getAuthType(Optional<String> gwtModemAuthType) {
+    public static String getAuthType(Optional<GwtModemAuthType> gwtModemAuthType) {
         if (gwtModemAuthType.isPresent()) {
-            if (gwtModemAuthType.get().equals(GwtModemAuthType.netModemAuthAUTO.name())) {
-                return AuthType.AUTO.name();
-            }
+            switch (gwtModemAuthType.get()) {
+                case netModemAuthAUTO:
+                    return AuthType.AUTO.name();
+                case netModemAuthCHAP:
+                    return AuthType.CHAP.name();
 
-            if (gwtModemAuthType.get().equals(GwtModemAuthType.netModemAuthCHAP.name())) {
-                return AuthType.CHAP.name();
-            }
-
-            if (gwtModemAuthType.get().equals(GwtModemAuthType.netModemAuthPAP.name())) {
-                return AuthType.PAP.name();
+                case netModemAuthPAP:
+                    return AuthType.PAP.name();
+                case netModemAuthNONE:
+                default:
+                    break;
             }
         }
 
@@ -372,18 +373,18 @@ public class EnumsParser {
      * Converts values of {@link GwtModemPdpType} to {@link PdpType.name()}
      * 
      */
-    public static String getPdpType(Optional<String> gwtModemPdpType) {
+    public static String getPdpType(Optional<GwtModemPdpType> gwtModemPdpType) {
         if (gwtModemPdpType.isPresent()) {
-            if (gwtModemPdpType.get().equals(GwtModemPdpType.netModemPdpIP.name())) {
-                return PdpType.IP.name();
-            }
-
-            if (gwtModemPdpType.get().equals(GwtModemPdpType.netModemPdpIPv6.name())) {
-                return PdpType.IPv6.name();
-            }
-
-            if (gwtModemPdpType.get().equals(GwtModemPdpType.netModemPdpPPP.name())) {
-                return PdpType.PPP.name();
+            switch (gwtModemPdpType.get()) {
+                case netModemPdpIP:
+                    return PdpType.IP.name();
+                case netModemPdpIPv6:
+                    return PdpType.IPv6.name();
+                case netModemPdpPPP:
+                    return PdpType.PPP.name();
+                case netModemPdpUnknown:
+                default:
+                    break;
             }
         }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
@@ -14,11 +14,9 @@ package org.eclipse.kura.web.server.net2.utils;
 
 import java.util.Optional;
 
-import org.eclipse.kura.net.NetInterfaceState;
 import org.eclipse.kura.net.NetInterfaceStatus;
 import org.eclipse.kura.net.modem.ModemConfig.AuthType;
 import org.eclipse.kura.net.modem.ModemConfig.PdpType;
-import org.eclipse.kura.net.modem.ModemConnectionStatus;
 import org.eclipse.kura.net.wifi.WifiCiphers;
 import org.eclipse.kura.net.wifi.WifiMode;
 import org.eclipse.kura.net.wifi.WifiRadioMode;
@@ -389,52 +387,6 @@ public class EnumsParser {
         }
 
         return PdpType.UNKNOWN.name();
-    }
-
-    /**
-     * Converts values of {@link ModemConnectionStatus} to {@link NetInterfaceState}
-     * values
-     * 
-     */
-    public static String getNetInterfaceState(Optional<String> modemConnectionStatus) {
-        if (modemConnectionStatus.isPresent()) {
-            if (modemConnectionStatus.get().equals(ModemConnectionStatus.CONNECTED.name())) {
-                return NetInterfaceState.ACTIVATED.name();
-            }
-
-            if (modemConnectionStatus.get().equals(ModemConnectionStatus.CONNECTING.name())) {
-                return NetInterfaceState.IP_CONFIG.name();
-            }
-
-            if (modemConnectionStatus.get().equals(ModemConnectionStatus.DISCONNECTED.name())) {
-                return NetInterfaceState.DISCONNECTED.name();
-            }
-        }
-
-        return NetInterfaceState.UNKNOWN.name();
-    }
-
-    /**
-     * Converts values of {@link NetInterfaceState} to {@link ModemConnectionStatus}
-     * values
-     * 
-     */
-    public static String getModemConnectionStatus(Optional<String> netInterfaceState) {
-        if (netInterfaceState.isPresent()) {
-            if (netInterfaceState.get().equals(NetInterfaceState.ACTIVATED.name())) {
-                return ModemConnectionStatus.CONNECTED.name();
-            }
-
-            if (netInterfaceState.get().equals(NetInterfaceState.IP_CONFIG.name())) {
-                return ModemConnectionStatus.CONNECTING.name();
-            }
-
-            if (netInterfaceState.get().equals(NetInterfaceState.DISCONNECTED.name())) {
-                return ModemConnectionStatus.DISCONNECTED.name();
-            }
-        }
-
-        return ModemConnectionStatus.UNKNOWN.name();
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
@@ -325,25 +325,25 @@ public class EnumsParser {
     }
 
     /**
-     * Converts values of {@link GwtModemAuthType} to {@link AuthType}
+     * Converts values of {@link GwtModemAuthType} to {@link AuthType.name()}
      * 
      */
-    public static AuthType getAuthType(Optional<String> gwtModemAuthType) {
+    public static String getAuthType(Optional<String> gwtModemAuthType) {
         if (gwtModemAuthType.isPresent()) {
             if (gwtModemAuthType.get().equals(GwtModemAuthType.netModemAuthAUTO.name())) {
-                return AuthType.AUTO;
+                return AuthType.AUTO.name();
             }
 
             if (gwtModemAuthType.get().equals(GwtModemAuthType.netModemAuthCHAP.name())) {
-                return AuthType.CHAP;
+                return AuthType.CHAP.name();
             }
 
             if (gwtModemAuthType.get().equals(GwtModemAuthType.netModemAuthPAP.name())) {
-                return AuthType.PAP;
+                return AuthType.PAP.name();
             }
         }
 
-        return AuthType.NONE;
+        return AuthType.NONE.name();
     }
 
     /**
@@ -369,25 +369,25 @@ public class EnumsParser {
     }
 
     /**
-     * Converts values of {@link GwtModemPdpType} to {@link PdpType}
+     * Converts values of {@link GwtModemPdpType} to {@link PdpType.name()}
      * 
      */
-    public static PdpType getPdpType(Optional<String> gwtModemPdpType) {
+    public static String getPdpType(Optional<String> gwtModemPdpType) {
         if (gwtModemPdpType.isPresent()) {
             if (gwtModemPdpType.get().equals(GwtModemPdpType.netModemPdpIP.name())) {
-                return PdpType.IP;
+                return PdpType.IP.name();
             }
 
             if (gwtModemPdpType.get().equals(GwtModemPdpType.netModemPdpIPv6.name())) {
-                return PdpType.IPv6;
+                return PdpType.IPv6.name();
             }
 
             if (gwtModemPdpType.get().equals(GwtModemPdpType.netModemPdpPPP.name())) {
-                return PdpType.PPP;
+                return PdpType.PPP.name();
             }
         }
 
-        return PdpType.UNKNOWN;
+        return PdpType.UNKNOWN.name();
     }
 
     /**

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -587,7 +587,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldWorkWithAuthTypeAuto() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthAUTO");
+        givenMapWith("net.interface.ttyACM0.config.authType", "AUTO");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");
@@ -602,7 +602,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldWorkWithAuthTypeNone() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthNONE");
+        givenMapWith("net.interface.ttyACM0.config.authType", "NONE");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");
@@ -617,7 +617,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldWorkWithAuthTypeChap() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthCHAP");
+        givenMapWith("net.interface.ttyACM0.config.authType", "CHAP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");
@@ -632,7 +632,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldWorkWithAuthTypePap() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthPAP");
+        givenMapWith("net.interface.ttyACM0.config.authType", "PAP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");
@@ -647,7 +647,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldThrowWithUnsupportedAuthType() {
-        givenMapWith("net.interface.ttyACM0.config.authType", "netModemAuthROFL");
+        givenMapWith("net.interface.ttyACM0.config.authType", "ROFL");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");


### PR DESCRIPTION
This PR fixes the conversion between the enums held GWT-side `GwtModemAuthType`, `GwtModemPdpType` and the `AuthType`, `PdpType` enums used in the configuration service.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: Using a generic profile verify with a cellular connection:

1. Configure a modem with a Auth Type parameter value different than None
2. Save the configuration.
3. Refresh the web ui and go back to the network configuration section
4. No exceptions should appear on the logs.

**Any side note on the changes made:** N/A.
