### PR TITLE
fix(distrib): disabled ntp-servers dhclient config for /etc/dhclient.conf and /etc/dhcp/dhclient.conf

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -75,7 +75,15 @@ if command -v timedatectl > /dev/null ;
 fi
 
 #disable asking NTP servers to the DHCP server
-sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
+if [ -f /etc/dhcp/dhclient.conf ]; then
+    echo "Disabling ntp-servers in /etc/dhcp/dhclient.conf"
+    sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
+fi
+
+if [ -f /etc/dhclient.conf ]; then
+    echo "Disabling ntp-servers in /etc/dhclient.conf"
+    sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhclient.conf
+fi
 
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -88,7 +88,15 @@ if [ -f "/etc/network/if-up.d/ubuntu-fan" ] ; then
 fi
 
 #disable asking NTP servers to the DHCP server
-sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
+if [ -f /etc/dhcp/dhclient.conf ]; then
+    echo "Disabling ntp-servers in /etc/dhcp/dhclient.conf"
+    sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
+fi
+
+if [ -f /etc/dhclient.conf ]; then
+    echo "Disabling ntp-servers in /etc/dhclient.conf"
+    sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhclient.conf
+fi
 
 #prevent time sync services from starting
 systemctl stop systemd-timesyncd

--- a/kura/distrib/src/main/resources/raspberry-pi-arm64/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-arm64/kura_install.sh
@@ -75,7 +75,15 @@ if command -v timedatectl > /dev/null ;
 fi
 
 #disable asking NTP servers to the DHCP server
-sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
+if [ -f /etc/dhcp/dhclient.conf ]; then
+    echo "Disabling ntp-servers in /etc/dhcp/dhclient.conf"
+    sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
+fi
+
+if [ -f /etc/dhclient.conf ]; then
+    echo "Disabling ntp-servers in /etc/dhclient.conf"
+    sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhclient.conf
+fi
 
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd

--- a/kura/distrib/src/main/resources/raspberry-pi-armhf/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-armhf/kura_install.sh
@@ -72,7 +72,15 @@ if command -v timedatectl > /dev/null ;
 fi
 
 #disable asking NTP servers to the DHCP server
-sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
+if [ -f /etc/dhcp/dhclient.conf ]; then
+    echo "Disabling ntp-servers in /etc/dhcp/dhclient.conf"
+    sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhcp/dhclient.conf
+fi
+
+if [ -f /etc/dhclient.conf ]; then
+    echo "Disabling ntp-servers in /etc/dhclient.conf"
+    sed -i "s/\(, \?ntp-servers\)/; #\1/g" /etc/dhclient.conf
+fi
 
 # Prevent time sync services from starting
 systemctl stop systemd-timesyncd


### PR DESCRIPTION
This PR prevents `dhclient` asking for ntp-servers for the missing case `/etc/dhclient.conf`.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
