### PR TITLE
fix(monitor.dns-server): added check for interface as LAN before starting DNS server

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/monitor/DnsMonitorServiceImpl.java
@@ -236,9 +236,10 @@ public class DnsMonitorServiceImpl implements DnsMonitorService, EventHandler {
             List<NetInterfaceConfig<? extends NetInterfaceAddressConfig>> netInterfaceConfigs = this.networkConfiguration
                     .getNetInterfaceConfigs();
             for (NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig : netInterfaceConfigs) {
-                if (netInterfaceConfig.getType() == NetInterfaceType.ETHERNET
+                if ((netInterfaceConfig.getType() == NetInterfaceType.ETHERNET
                         || netInterfaceConfig.getType() == NetInterfaceType.WIFI
-                        || netInterfaceConfig.getType() == NetInterfaceType.MODEM) {
+                        || netInterfaceConfig.getType() == NetInterfaceType.MODEM)
+                        && isEnabledForLan(netInterfaceConfig)) {
                     getAllowedNetworks(netInterfaceConfig);
                 }
             }
@@ -260,6 +261,7 @@ public class DnsMonitorServiceImpl implements DnsMonitorService, EventHandler {
 
         logger.debug("Getting DNS proxy config for {}", netInterfaceConfig.getName());
         List<NetConfig> netConfigs = ((AbstractNetInterface<?>) netInterfaceConfig).getNetConfigs();
+
         for (NetConfig netConfig : netConfigs) {
             if (netConfig instanceof DhcpServerConfig && ((DhcpServerConfig) netConfig).isPassDns()) {
                 logger.debug("Found an allowed network: {}/{}", ((DhcpServerConfig) netConfig).getRouterAddress(),
@@ -272,6 +274,11 @@ public class DnsMonitorServiceImpl implements DnsMonitorService, EventHandler {
                                 ((DhcpServerConfig) netConfig).getPrefix()));
             }
         }
+    }
+
+    private boolean isEnabledForLan(NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig) {
+        return ((AbstractNetInterface<?>) netInterfaceConfig).getInterfaceStatus()
+                .equals(NetInterfaceStatus.netIPv4StatusEnabledLAN);
     }
 
     private boolean isEnabledForWan(NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/monitor/DnsServerMonitor.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/monitor/DnsServerMonitor.java
@@ -32,6 +32,7 @@ import org.eclipse.kura.net.IPAddress;
 import org.eclipse.kura.net.NetConfig;
 import org.eclipse.kura.net.NetInterfaceAddressConfig;
 import org.eclipse.kura.net.NetInterfaceConfig;
+import org.eclipse.kura.net.NetInterfaceStatus;
 import org.eclipse.kura.net.NetInterfaceType;
 import org.eclipse.kura.net.NetworkPair;
 import org.eclipse.kura.net.dhcp.DhcpServerConfig;
@@ -121,6 +122,8 @@ public class DnsServerMonitor {
             logger.error("Could not get initial network configuration", e);
         }
 
+        this.enabled = false;
+
         Set<IPAddress> systemDnsServers = this.dnsUtil.getDnServers();
 
         Set<IP4Address> forwarders = getForwarders(systemDnsServers);
@@ -140,7 +143,7 @@ public class DnsServerMonitor {
                     .getNetInterfaceConfigs();
 
             for (NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig : netInterfaceConfigs) {
-                if (isSupportedInterfaceType(netInterfaceConfig)) {
+                if (isSupportedInterfaceType(netInterfaceConfig) && isEnabledForLan(netInterfaceConfig)) {
 
                     logger.debug("Getting DNS proxy config for {}", netInterfaceConfig.getName());
                     List<NetConfig> netConfigs = ((AbstractNetInterface<?>) netInterfaceConfig).getNetConfigs();
@@ -179,6 +182,11 @@ public class DnsServerMonitor {
         return netInterfaceConfig.getType() == NetInterfaceType.ETHERNET
                 || netInterfaceConfig.getType() == NetInterfaceType.WIFI
                 || netInterfaceConfig.getType() == NetInterfaceType.MODEM;
+    }
+
+    private boolean isEnabledForLan(NetInterfaceConfig<? extends NetInterfaceAddressConfig> netInterfaceConfig) {
+        return ((AbstractNetInterface<?>) netInterfaceConfig).getInterfaceStatus()
+                .equals(NetInterfaceStatus.netIPv4StatusEnabledLAN);
     }
 
     public boolean isPassDnsEnabled(NetConfig netConfig) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/monitor/DnsServerMonitor.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/monitor/DnsServerMonitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
This PR prevents the DNS server monitors from starting the DNS server when the `pass.dns` property is true but the interface is actually not set as LAN. This issue affected both the Kura networking profiles and the new NetworkManager-based ones.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: On `generic-arm32` and `raspberry-pi-armhf` it has been verified that:

1. Pass DNS functionality is still working: with the gateway set as AP with `passDNS=true` a laptop is able to obtain an IP address and DNS list. `named` is correctly running on gateway.
2. Setting the wireless interface from AP to DISABLED will shut down the `named` service. Prior this PR this was not the case. Re-enabling the interface as AP with `passDNS=true` will correctly restart `named` service and clients are able to connect.
3. Switching `passDNS` property whenin AP mode is correctly shutting down/starting `named` service.
4. Behaviour with multiple interfaces is consistent: if at least one interface is set in DHCP mode with pass DNS then `named` service keeps running. If both interfaces are disabled, then `named` will be stopped.

**Any side note on the changes made:** N/A.
