### PR TITLE
fix(installer): Added missing named files in generic installers

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -122,6 +122,18 @@ if command -v timedatectl > /dev/null ;
     timedatectl set-ntp false
 fi
 
+#set up bind/named
+mkdir -p /var/named
+chown -R bind /var/named
+cp ${INSTALL_DIR}/kura/install/named.ca /var/named/
+cp ${INSTALL_DIR}/kura/install/named.rfc1912.zones /etc/
+cp ${INSTALL_DIR}/kura/install/usr.sbin.named /etc/apparmor.d/
+if [ ! -f "/etc/bind/rndc.key" ] ; then
+    rndc-confgen -r /dev/urandom -a
+fi
+chown bind:bind /etc/bind/rndc.key
+chmod 600 /etc/bind/rndc.key
+
 # set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate-kura.conf
 

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -122,6 +122,18 @@ if command -v timedatectl > /dev/null ;
     timedatectl set-ntp false
 fi
 
+#set up bind/named
+mkdir -p /var/named
+chown -R bind /var/named
+cp ${INSTALL_DIR}/kura/install/named.ca /var/named/
+cp ${INSTALL_DIR}/kura/install/named.rfc1912.zones /etc/
+cp ${INSTALL_DIR}/kura/install/usr.sbin.named /etc/apparmor.d/
+if [ ! -f "/etc/bind/rndc.key" ] ; then
+    rndc-confgen -r /dev/urandom -a
+fi
+chown bind:bind /etc/bind/rndc.key
+chmod 600 /etc/bind/rndc.key
+
 # set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate-kura.conf
 

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -122,6 +122,18 @@ if command -v timedatectl > /dev/null ;
     timedatectl set-ntp false
 fi
 
+#set up bind/named
+mkdir -p /var/named
+chown -R bind /var/named
+cp ${INSTALL_DIR}/kura/install/named.ca /var/named/
+cp ${INSTALL_DIR}/kura/install/named.rfc1912.zones /etc/
+cp ${INSTALL_DIR}/kura/install/usr.sbin.named /etc/apparmor.d/
+if [ ! -f "/etc/bind/rndc.key" ] ; then
+    rndc-confgen -r /dev/urandom -a
+fi
+chown bind:bind /etc/bind/rndc.key
+chmod 600 /etc/bind/rndc.key
+
 # set up logrotate - no need to restart as it is a cronjob
 cp ${INSTALL_DIR}/kura/install/kura.logrotate /etc/logrotate-kura.conf
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

The #4582 added the support of the `bind` service as dns server for the generic profiles. This PR adds in the installers the copy on the configuration files needed to correctly start that service.