### PR TITLE
fix(distrib): add named.rfc file to apparmor exceptions

### DIFF
--- a/kura/distrib/src/main/resources/common/named/usr.sbin.named
+++ b/kura/distrib/src/main/resources/common/named/usr.sbin.named
@@ -49,7 +49,7 @@
   /var/log/named/ rw,
   /var/log/** rw,
   /varlog/named.log rw,
-  
+
   /etc/named.rfc1912.zones r,
 
   # Site-specific additions and overrides. See local/README for details.

--- a/kura/distrib/src/main/resources/common/named/usr.sbin.named
+++ b/kura/distrib/src/main/resources/common/named/usr.sbin.named
@@ -49,6 +49,8 @@
   /var/log/named/ rw,
   /var/log/** rw,
   /varlog/named.log rw,
+  
+  /etc/named.rfc1912.zones r,
 
   # Site-specific additions and overrides. See local/README for details.
   #include <local/usr.sbin.named>


### PR DESCRIPTION
After installing the latest `develop` build of Kura we were running into an issue with named on Ubuntu 20.04 systems:

![image](https://user-images.githubusercontent.com/22748355/236130044-11ededdf-68df-4afd-847f-7275fc844d12.png)

This issue was due to the fact that `apparmor` prevented `named` from reading the `named.rfc` file we install at Kura installation. This PR adds the `named.rfc` file we install in the `apparmor` exceptions so that `named` is allowed to read it.