### PR TITLE
fix(nm): use UNMANAGED location source

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -468,6 +468,8 @@ public class NMDbusConnector {
                 .of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE);
         Set<MMModemLocationSource> currentLocationSources = EnumSet
                 .of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE);
+        Set<MMModemLocationSource> desiredLocationSources = EnumSet
+                .of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE);
 
         try {
             availableLocationSources = MMModemLocationSource.toMMModemLocationSourceFromBitMask(
@@ -480,22 +482,19 @@ public class NMDbusConnector {
             return;
         }
 
-        EnumSet<MMModemLocationSource> managedLocationSources = EnumSet.of(
-                MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW,
-                MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA);
-
-        for (MMModemLocationSource managedSource : managedLocationSources) {
-            if (isGPSSourceEnabled && availableLocationSources.contains(managedSource)) {
-                currentLocationSources.add(managedSource);
-            } else {
-                currentLocationSources.remove(managedSource);
+        if (isGPSSourceEnabled) {
+            if (!availableLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED)) {
+                logger.warn("Cannot setup Modem.Location, MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED not supported for {}",
+                        modemLocationProperties.getObjectPath());
+                return;
             }
+            desiredLocationSources = EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED);
         }
 
         logger.debug("Modem location setup {} for modem {}", currentLocationSources, modemDevicePath.get());
 
-        if (!currentLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE)) {
-            modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(currentLocationSources),
+        if (!currentLocationSources.equals(desiredLocationSources)) {
+            modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(desiredLocationSources),
                     false);
         }
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -80,8 +80,9 @@ public class NMDbusConnector {
     private static final String NM_DEVICE_PROPERTY_STATE = "State";
     private static final String NM_DEVICE_PROPERTY_IP4CONFIG = "Ip4Config";
     private static final String NM_SETTING_CONNECTION_KEY = "connection";
-
     private static final String NM_DEVICE_GENERIC_PROPERTY_TYPEDESCRIPTION = "TypeDescription";
+
+    private static final String MM_MODEM_PROPERTY_STATE = "State";
 
     private static final List<NMDeviceType> CONFIGURATION_SUPPORTED_DEVICE_TYPES = Arrays.asList(
             NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceType.NM_DEVICE_TYPE_MODEM);
@@ -506,7 +507,8 @@ public class NMDbusConnector {
         Properties modemProperties = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath,
                 Properties.class);
 
-        MMModemState currentModemState = MMModemState.toMMModemState(modemProperties.Get(MM_MODEM_NAME, "State"));
+        MMModemState currentModemState = MMModemState
+                .toMMModemState(modemProperties.Get(MM_MODEM_NAME, MM_MODEM_PROPERTY_STATE));
 
         if (currentModemState.getValue() < MMModemState.MM_MODEM_STATE_ENABLED.getValue()) {
             logger.info("Modem {} not enabled. Enabling modem...", modemDevicePath);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -457,6 +457,8 @@ public class NMDbusConnector {
             return;
         }
 
+        enableModem(modemDevicePath.get());
+
         boolean isGPSSourceEnabled = enableGPS.isPresent() && enableGPS.get();
 
         Location modemLocation = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath.get(),
@@ -496,6 +498,19 @@ public class NMDbusConnector {
         if (!currentLocationSources.equals(desiredLocationSources)) {
             modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(desiredLocationSources),
                     false);
+        }
+    }
+
+    private void enableModem(String modemDevicePath) throws DBusException {
+        Modem modem = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath, Modem.class);
+        Properties modemProperties = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath,
+                Properties.class);
+
+        MMModemState currentModemState = MMModemState.toMMModemState(modemProperties.Get(MM_MODEM_NAME, "State"));
+
+        if (currentModemState.getValue() < MMModemState.MM_MODEM_STATE_ENABLED.getValue()) {
+            logger.info("Modem {} not enabled. Enabling modem...", modemDevicePath);
+            modem.Enable(true);
         }
     }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -499,7 +499,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenDisconnectIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_3GPP_LAC_CI), false);
+        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
 
     @Test
@@ -518,9 +518,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenDisconnectIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_3GPP_LAC_CI,
-                MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW,
-                MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA), false);
+        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED), false);
     }
 
     @Test
@@ -542,7 +540,7 @@ public class NMDbusConnectorTest {
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_3GPP_LAC_CI), false);
+        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
 
     @Test
@@ -564,9 +562,7 @@ public class NMDbusConnectorTest {
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_3GPP_LAC_CI,
-                MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW,
-                MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA), false);
+        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED), false);
     }
 
     @Test
@@ -587,7 +583,7 @@ public class NMDbusConnectorTest {
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_3GPP_LAC_CI), false);
+        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
 
     @Test
@@ -1231,7 +1227,7 @@ public class NMDbusConnectorTest {
         doReturn("/org/freedesktop/ModemManager1/Modem/3").when(this.mockModemLocation).getObjectPath();
 
 
-        Set<MMModemLocationSource> availableSources = EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_3GPP_LAC_CI, MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW, MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA);
+        Set<MMModemLocationSource> availableSources = EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_3GPP_LAC_CI, MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW, MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA, MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED);
         Set<MMModemLocationSource> enabledSources = EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_3GPP_LAC_CI);
         when(modemProperties.Get("org.freedesktop.ModemManager1.Modem.Location", "Capabilities"))
                 .thenReturn(MMModemLocationSource.toBitMaskFromMMModemLocationSource(availableSources));


### PR DESCRIPTION
Currently [in the NMDbusConnector for the Modem+GPS combo we try to enable the `gps-raw` and `gps-nmea` location sources](https://github.com/eclipse/kura/blob/777c0b1591b0ed57fa18de4d64a2c6a256240469/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java#LL451C1-L451C1). This isn’t really helpful since ModemManager will then take control of the GPS serial ports of the modem and parse the location data on its own preventing any other service to access the port.

We want to give the control of the serial ports to `gpsd` as the location provider for Kura.

This can be done using the `gps-unmanaged` mode of ModemManager. 

> In recent ModemManager versions we support the “unmanaged GPS” location setting. When that is enabled, ModemManager takes care of telling the modem to enable GPS, but it will not try to read the NMEA GPS traces from the tty, that is left for other apps to do, like gpsd.

![image](https://github.com/eclipse/kura/assets/22748355/9d8fe502-1a46-4df0-9141-6caa842c185e)

This PR simply maps this mode to the "GPS enable" option of the modem tab.

**Note**: In the previous version of this code we tried to preserve the already existing settings for the location sources. This is not supported anymore since `gps-raw`/`gps-nmea` and `gps-unmanaged` are mutually exclusive. This also simplifies the code overall.

**Issues**: After some testing we found that Kura was throwing the following error:

![MicrosoftTeams-image](https://github.com/eclipse/kura/assets/22748355/700cf00a-d109-4375-a511-6840eb57c17c)

This was due to the fact that Kura was trying to configure the modem while ModemManager was still enabling it.

To avoid the issue I added a simple `enableModem` method that ensures the modem is actually **enabled** before attempting to configure it.

---

### Known issues

At reboot the `Setup` method for the modem location can fail with:

```
MESSAGE=Cannot setup Modem.Location, GPS data might not be available. Caused by:
    STACKTRACE=org.freedesktop.dbus.exceptions.DBusExecutionException: Couldn't enable location 'gps-unmanaged' gathering: Unknown mobile equipment error: 504
                at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
                at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
                at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
                at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
```

This is caused by the fact that, upon rebooting the device, the GNSS session was not properly cleaned and the error 504 ("Session is ongoing" [as per Quectel manual](https://sixfab.com/wp-content/uploads/2020/11/Quectel_LTE_Standard_GNSS_Application_Note_V1.2.pdf)) is reported.

The same error is reported by issuing the command through `mmcli`:

```bash
mmcli -m 0 --location-enable-gps-unmanaged
error: couldn't setup location gathering: 'GDBus.Error:org.freedesktop.ModemManager1.Error.MobileEquipment.Unknown: Couldn't enable location 'gps-unmanaged' gathering: Unknown mobile equipment error: 504'
```

This can be overcome by cleaning up the session issuing the following (**Note**: only available in debug mode)

```bash
mmcli -m 0 --command="AT+QGPSEND"
```

After some more experimentation we found that, even if the error is thrown, Kura is still able to grab the serial and parse the GPS location data.

![image](https://github.com/eclipse/kura/assets/22748355/c1294b81-c9e0-4007-9279-443dd9bd50fd)

For completeness we opened an issue in ModemManager repo and confirmed that this behaviour is not expected: [link to ModemManager issue](https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/734)

---

### Modem GPS setup instructions

#### 1. Go in the "Network" tab, select the modem and enable the GPS

![image](https://github.com/eclipse/kura/assets/22748355/4fd7f9c1-9bd9-44a2-bb38-fcfe48046303)

#### 2. On the command line check the GPS serial port reported by ModemManager

Find the available modems with:
```bash
mmcli -L
```

Once you find the number of your modem, request the info with:
```bash
mmcli -m 0
```
Look for the `(gps)` port in the output of the command

![Screenshot 2023-05-10 at 09 38 22](https://github.com/eclipse/kura/assets/22748355/c62ba05a-cf6d-4059-8145-29e66386ece6)

#### 3. Update the `/etc/default/gpsd` configuration file

Update the `DEVICES` field with the path you found at the step above. In this example we need to set it to `/dev/ttyUSB1`.

```bash
# Devices gpsd should collect to at boot time.
# They need to be read/writeable, either by user gpsd or the group dialout.
DEVICES="/dev/ttyUSB1" 

# Other options you want to pass to gpsd
GPSD_OPTIONS=""

# Automatically hot add/remove USB GPS devices via gpsdctl
USBAUTO="true"
```

#### 4. Enable and start the `gpsd` service

```bash
systemctl enable gpsd
```
```bash
systemctl start gpds
```

#### 5. Enable the Position service in the Kura UI

![Screenshot 2023-05-10 at 09 43 39](https://github.com/eclipse/kura/assets/22748355/c1341c99-fa97-429a-bdf9-9bf192dbc815)

... and you're done!