### PR TITLE
fix: Do not remove interface address while dhclient is running

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkAdminServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkAdminServiceImpl.java
@@ -1043,12 +1043,13 @@ public class NetworkAdminServiceImpl implements NetworkAdminService, EventHandle
                     renewDhcpLease(interfaceName);
                 } else {
                     this.linuxNetworkUtil.enableInterface(interfaceName);
+
+                    // if it isn't up - at least make sure the Ethernet controller is powered on
+                    if (!this.linuxNetworkUtil.hasAddress(interfaceName)) {
+                        this.linuxNetworkUtil.bringUpDeletingAddress(interfaceName);
+                    }
                 }
 
-                // if it isn't up - at least make sure the Ethernet controller is powered on
-                if (!this.linuxNetworkUtil.hasAddress(interfaceName)) {
-                    this.linuxNetworkUtil.bringUpDeletingAddress(interfaceName);
-                }
             } else {
                 logger.info("not bringing interface {} up because it is already up", interfaceName);
                 if (dhcp) {
@@ -1331,7 +1332,8 @@ public class NetworkAdminServiceImpl implements NetworkAdminService, EventHandle
                 wifiModeWait(ifaceName, WifiMode.INFRA, 10);
                 ret = isWifiConnectionCompleted(ifaceName, tout);
 
-                // Disable wifi interface again, previous configuration will be restored by WifiMonitorService
+                // Disable wifi interface again, previous configuration will be restored by
+                // WifiMonitorService
                 disableWifiInterface(ifaceName);
             } catch (Exception e) {
                 logger.warn("Exception while managing the temporary instance of the Wpa supplicant.", e);
@@ -1396,7 +1398,8 @@ public class NetworkAdminServiceImpl implements NetworkAdminService, EventHandle
     //
     // ----------------------------------------------------------------
 
-    // FIXME: simplify method signature. Probably we could take the mode from the wifiConfig.
+    // FIXME: simplify method signature. Probably we could take the mode from the
+    // wifiConfig.
     private void enableWifiInterface(String ifaceName, NetInterfaceStatus status, WifiMode wifiMode,
             WifiConfig wifiConfig) throws KuraException {
         // ignore mon.* interface
@@ -1443,7 +1446,8 @@ public class NetworkAdminServiceImpl implements NetworkAdminService, EventHandle
         this.wpaSupplicantManager.stop(ifaceName);
     }
 
-    // Submit new configuration, waiting for network configuration change event before returning
+    // Submit new configuration, waiting for network configuration change event
+    // before returning
     private void submitNetworkConfiguration(List<String> modifiedInterfaceNames,
             NetworkConfiguration networkConfiguration) throws KuraException {
         short timeout = 30000; // in milliseconds


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Currently line [1] is executed just after that `dhclient` is started for a particular interface, Kura passes the `-nw` option to `dhclient` causing it to fork and try to obtain an address asynchronously.
If condition [1] evaluates to true Kura will run `ifconfig <interface> 0.0.0.0` for the specific interface removing the configured address. This can cause a race condition if `dhclient` configures the interface after check [1] but before that `ifconfig <interface> 0.0.0.0` is run, in this case the address obtained by `dhclient` wold be dropped and the interface left without addresses.
This PR changes the code so that [1] is not executed if the interface is in DHCP client mode.

[1] https://github.com/eclipse/kura/blob/777c0b1591b0ed57fa18de4d64a2c6a256240469/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/NetworkAdminServiceImpl.java#L1049
