### PR TITLE
fix(web2): GPS modem config is done independently of set IP status

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -63,6 +63,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
                 break;
         }
 
+        // Manage GPS independently of device ip status
+        setModemGpsProperties();
+
         return this.properties.getProperties();
     }
 
@@ -287,13 +290,20 @@ public class NetworkConfigurationServicePropertiesBuilder {
             this.properties.setModemActiveFilter(this.ifname, gwtModemConfig.getActiveFilter());
             this.properties.setModemLpcEchoInterval(ifname, gwtModemConfig.getLcpEchoInterval());
             this.properties.setModemLpcEchoFailure(this.ifname, gwtModemConfig.getLcpEchoFailure());
-            this.properties.setModemGpsEnabled(this.ifname, gwtModemConfig.isGpsEnabled());
             this.properties.setModemDiversityEnabled(this.ifname, gwtModemConfig.isDiversityEnabled());
             this.properties.setModemApn(this.ifname, gwtModemConfig.getApn());
             this.properties.setUsbProductName(this.ifname, gwtModemConfig.getModemId());
             this.properties.setUsbVendorName(this.ifname, gwtModemConfig.getManufacturer());
             this.properties.setUsbProductId(this.ifname, gwtModemConfig.getModel());
             this.properties.setUsbDevicePath(this.ifname, gwtModemConfig.getHwUsbDevice());
+        }
+    }
+
+    private void setModemGpsProperties() {
+        if (this.gwtConfig instanceof GwtModemInterfaceConfig) {
+            GwtModemInterfaceConfig gwtModemConfig = (GwtModemInterfaceConfig) this.gwtConfig;
+
+            this.properties.setModemGpsEnabled(this.ifname, gwtModemConfig.isGpsEnabled());
         }
     }
 


### PR DESCRIPTION
Prior this PR, the configuration of the **GPS enable** property was not performed if the device was set as _Disabled_ or _Unmanaged_. A user might want to enable GPS without wanting the modem as IP interface.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
