### PR TITLE
fix(web2): DHCP renew button is now disabled except in WAN/LAN mode using dhcp

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabTcpIpUi.java
@@ -700,8 +700,8 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
 
     private void showMultipleWanModal(List<GwtNetInterfaceConfig> configs) {
         for (GwtNetInterfaceConfig config : configs) {
-            if (config.getStatusEnum().equals(GwtNetIfStatus.netIPv4StatusEnabledWAN) && !config
-                    .getName().equals(TabTcpIpUi.this.selectedNetIfConfig.getName())) {
+            if (config.getStatusEnum().equals(GwtNetIfStatus.netIPv4StatusEnabledWAN)
+                    && !config.getName().equals(TabTcpIpUi.this.selectedNetIfConfig.getName())) {
                 logger.log(Level.SEVERE, "Error: Status Invalid");
                 TabTcpIpUi.this.wanModal.show();
                 break;
@@ -804,6 +804,7 @@ public class TabTcpIpUi extends Composite implements NetworkTab {
                 this.subnet.setText("");
                 this.gateway.setText("");
                 this.dns.setText("");
+                this.renew.setEnabled(false);
             } else {
                 String configureValue = this.configure.getSelectedValue();
                 if (configureValue.equals(IPV4_MODE_DHCP_MESSAGE)) {


### PR DESCRIPTION
DHCP renew button is now disabled except in WAN/LAN mode using dhcp.