### PR TITLE
fix: Improved the way netplan is disabled on Kura install

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/prerm
@@ -61,6 +61,27 @@ function stopWatchdog {
     fi
 }
 
+function restore_backup_files {
+    SUFFIX="${1}"
+
+    shift
+
+    for file in "${@}"
+    do
+        if [ -f "${file}" ] && expr "${file}" : ".*[.]${SUFFIX}$" > /dev/null; then
+            mv "${file}" "${file%."${SUFFIX}"}"
+        fi
+    done
+}
+
+function restore_netplan {
+  if [ -f /etc/netplan/zz-kura-use-nm.yaml ]; then
+    rm -f /etc/netplan/zz-kura-use-nm.yaml
+  fi
+
+  restore_backup_files kurasave /lib/netplan/* /etc/netplan/*
+}
+
 # Pre-remove script
 function preRemove {
     #Remove INIT scripts
@@ -107,6 +128,8 @@ function preRemove {
     if [ -f /etc/default/dnsmasq.old ]; then
         mv /etc/default/dnsmasq.old /etc/default/dnsmasq
     fi
+
+    restore_netplan
     
     echo ""
     echo "Uninstalling KURA... Done!"

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/prerm
@@ -61,6 +61,27 @@ function stopWatchdog {
     fi
 }
 
+function restore_backup_files {
+    SUFFIX="${1}"
+
+    shift
+
+    for file in "${@}"
+    do
+        if [ -f "${file}" ] && expr "${file}" : ".*[.]${SUFFIX}$" > /dev/null; then
+            mv "${file}" "${file%."${SUFFIX}"}"
+        fi
+    done
+}
+
+function restore_netplan {
+  if [ -f /etc/netplan/zz-kura-use-nm.yaml ]; then
+    rm -f /etc/netplan/zz-kura-use-nm.yaml
+  fi
+
+  restore_backup_files kurasave /lib/netplan/* /etc/netplan/*
+}
+
 # Pre-remove script
 function preRemove {
     #Remove INIT scripts
@@ -107,6 +128,8 @@ function preRemove {
     if [ -f /etc/default/dnsmasq.old ]; then
         mv /etc/default/dnsmasq.old /etc/default/dnsmasq
     fi
+
+    restore_netplan
     
     echo ""
     echo "Uninstalling KURA... Done!"

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/prerm
@@ -61,6 +61,27 @@ function stopWatchdog {
     fi
 }
 
+function restore_backup_files {
+    SUFFIX="${1}"
+
+    shift
+
+    for file in "${@}"
+    do
+        if [ -f "${file}" ] && expr "${file}" : ".*[.]${SUFFIX}$" > /dev/null; then
+            mv "${file}" "${file%."${SUFFIX}"}"
+        fi
+    done
+}
+
+function restore_netplan {
+  if [ -f /etc/netplan/zz-kura-use-nm.yaml ]; then
+    rm -f /etc/netplan/zz-kura-use-nm.yaml
+  fi
+
+  restore_backup_files kurasave /lib/netplan/* /etc/netplan/*
+}
+
 # Pre-remove script
 function preRemove {
     #Remove INIT scripts
@@ -107,6 +128,8 @@ function preRemove {
     if [ -f /etc/default/dnsmasq.old ]; then
         mv /etc/default/dnsmasq.old /etc/default/dnsmasq
     fi
+
+    restore_netplan
 
     echo ""
     echo "Uninstalling KURA... Done!"


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Modifies generic profiles to:

* Renames all yaml files in netplan configuration folders to avoid netplan interfering with NM, the files are restored un uninstall
* Adds a netplan configuration file to configure netplan to use the NM backend, the file is removed on uninstall
* Explicitly disables systemd-networkd
