### PR TITLE
fix(web2): save configured wifi channel in GWT interface

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -188,6 +188,7 @@ public class GwtNetInterfaceConfigBuilder {
                 EnumsParser.getGwtWifiCiphers(this.properties.getWifiMasterPairwiseCiphers(this.ifName)));
         gwtWifiConfig.setGroupCiphers(
                 EnumsParser.getGwtWifiCiphers(this.properties.getWifiMasterGroupCiphers(this.ifName)));
+        gwtWifiConfig.setChannels(this.properties.getWifiMasterChannel(this.ifName));
 
         // wifi master specific properties
 
@@ -216,7 +217,8 @@ public class GwtNetInterfaceConfigBuilder {
                 EnumsParser.getGwtWifiCiphers(this.properties.getWifiInfraPairwiseCiphers(this.ifName)));
         gwtWifiConfig.setGroupCiphers(
                 EnumsParser.getGwtWifiCiphers(this.properties.getWifiInfraGroupCiphers(this.ifName)));
-
+        gwtWifiConfig.setChannels(this.properties.getWifiInfraChannel(this.ifName));
+        
         // wifi infra specific properties
 
         Optional<String> radioMode = EnumsParser


### PR DESCRIPTION
Prior this PR, the selected WiFi Channel was saved in the snapshot but not picked up when populating the channels list.

There is a convention that the element on position 0 of the integer list retuned by `gwtConfig.getChannels()` is considered from the UI the user-selected one.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.