### PR TITLE
fix(nm): actually delete connection upon device disconnection

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -536,7 +536,7 @@ public class NMDbusConnector {
     }
 
     private void disable(Device device) throws DBusException {
-        Optional<Connection> associatedConnection = getAssociatedConnection(device);
+        Optional<Connection> appliedConnection = getAppliedConnection(device);
 
         NMDeviceState deviceState = getDeviceState(device);
         if (Boolean.TRUE.equals(NMDeviceState.isConnected(deviceState))) {
@@ -547,8 +547,8 @@ public class NMDbusConnector {
         }
 
         // Housekeeping
-        if (associatedConnection.isPresent()) {
-            associatedConnection.get().Delete();
+        if (appliedConnection.isPresent()) {
+            appliedConnection.get().Delete();
         }
 
         List<Connection> availableConnections = getAvaliableConnections(device);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -536,6 +536,8 @@ public class NMDbusConnector {
     }
 
     private void disable(Device device) throws DBusException {
+        Optional<Connection> associatedConnection = getAssociatedConnection(device);
+
         NMDeviceState deviceState = getDeviceState(device);
         if (Boolean.TRUE.equals(NMDeviceState.isConnected(deviceState))) {
             DeviceStateLock dsLock = new DeviceStateLock(this.dbusConnection, device.getObjectPath(),
@@ -545,6 +547,10 @@ public class NMDbusConnector {
         }
 
         // Housekeeping
+        if (associatedConnection.isPresent()) {
+            associatedConnection.get().Delete();
+        }
+
         List<Connection> availableConnections = getAvaliableConnections(device);
         for (Connection connection : availableConnections) {
             connection.Delete();

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1462,7 +1462,7 @@ public class NMDbusConnectorTest {
     }
 
     private void thenConnectionIsDeleted(String path) {
-        verify(this.mockedConnections.get(path)).Delete();
+        verify(this.mockedConnections.get(path), atLeastOnce()).Delete();
     }
 
     private void thenConnectionIsNotDeleted(String path) {


### PR DESCRIPTION
**Bug description**

The scenario is the following: Kura configured with eth1 disabled. The configuration seems properly applied.
After a reboot, though the eth1 is active and working up until Kura boots and stops it.

**How to reproduce**

1. Stop Kura with systemctl stop kura
3. Delete a connection created by kura (for example `kura-wlan0-connection`) using the command `nmcli con del [connection-name]`
5. Create a new connection for the same interface for which you just deleted the connection (use `nmcli con edit` or `nmtui`) using a name different from the naming convention used by Kura. 
7. Activate the newly added connection
9. Restart Kura
11. Kura will now take over the connection, overwriting the settings
13. From the Web UI disable the interface for which you just created the connecition

You’ll see that the connection you created was not deleted but the device is disconnected.

If you reboot the connection will be activated for the time it will take for Kura to complete booting.

**Changelog**

This PR simply ensures to grab the current active connection for the device being disabled and deletes it after the device is issued a `Disconnect`. This ensures that the connection is deleted from the system.

@reviewer Please perform a test on a device with two eth interfaces to ensure everything works there.