### PR TITLE
test(linux.net.dhcp.server): added `DnsmasqToolTest` and `DhcpdToolTest`

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
@@ -39,12 +39,12 @@ public class DnsmasqTool implements DhcpLinuxTool {
 
     private static final Logger logger = LoggerFactory.getLogger(DnsmasqTool.class);
 
-    private static final String DNSMASQ_GLOBAL_CONFIG_FILE = "/etc/dnsmasq.d/dnsmasq-globals.conf";
+    private String globalConfigFilename = "/etc/dnsmasq.d/dnsmasq-globals.conf";
     private static final String GLOBAL_CONFIGURATION = "port=0\nbind-interfaces\n";
 
-    private static final Command IS_ACTIVE_COMMAND = new Command(new String[] { "systemctl", "is-active", "--quiet",
+    static final Command IS_ACTIVE_COMMAND = new Command(new String[] { "systemctl", "is-active", "--quiet",
             DhcpServerTool.DNSMASQ.getValue() });
-    private static final Command RESTART_COMMAND = new Command(new String[] { "systemctl", "restart",
+    static final Command RESTART_COMMAND = new Command(new String[] { "systemctl", "restart",
             DhcpServerTool.DNSMASQ.getValue() });
 
     private CommandExecutorService executorService;
@@ -115,6 +115,10 @@ public class DnsmasqTool implements DhcpLinuxTool {
         return isInterfaceDisabled;
     }
 
+    public void setDnsmasqGlobalConfigFile(String globalConfigFilename) {
+        this.globalConfigFilename = globalConfigFilename;
+    }
+
     private boolean isConfigFileAlteredOrNonExistent(String interfaceName)
             throws NoSuchAlgorithmException, IOException {
 
@@ -143,7 +147,7 @@ public class DnsmasqTool implements DhcpLinuxTool {
     }
 
     private void writeGlobalConfig() throws NoSuchAlgorithmException, IOException {
-        Path dnsmasqGlobalsPath = Paths.get(DNSMASQ_GLOBAL_CONFIG_FILE);
+        Path dnsmasqGlobalsPath = Paths.get(this.globalConfigFilename);
 
         if (shouldWriteGlobalConfig()) {
             Files.write(dnsmasqGlobalsPath, GLOBAL_CONFIGURATION.getBytes(StandardCharsets.UTF_8));
@@ -153,7 +157,7 @@ public class DnsmasqTool implements DhcpLinuxTool {
     }
 
     private boolean shouldWriteGlobalConfig() throws NoSuchAlgorithmException, IOException {
-        Path dnsmasqGlobalsPath = Paths.get(DNSMASQ_GLOBAL_CONFIG_FILE);
+        Path dnsmasqGlobalsPath = Paths.get(this.globalConfigFilename);
 
         if (Objects.isNull(this.globalConfigHash)) {
             return true;

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/server/DhcpdToolTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/server/DhcpdToolTest.java
@@ -1,0 +1,302 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.linux.net.dhcp.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.kura.KuraProcessExecutionErrorException;
+import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.executor.CommandStatus;
+import org.eclipse.kura.executor.ExitStatus;
+import org.eclipse.kura.executor.Pid;
+import org.eclipse.kura.linux.net.dhcp.DhcpServerManager;
+import org.eclipse.kura.linux.net.dhcp.DhcpServerTool;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.MockedStatic;
+
+@RunWith(Parameterized.class)
+public class DhcpdToolTest {
+
+    @Parameters
+    public static Collection<Object[]> SimTypeParams() {
+        List<Object[]> params = new ArrayList<>();
+        params.add(new Object[] { DhcpServerTool.DHCPD });
+        params.add(new Object[] { DhcpServerTool.UDHCPD });
+        return params;
+    }
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private CommandExecutorService mockExecutor;
+    private DhcpdTool tool;
+    private boolean isRunningResult;
+    private CommandStatus interfaceStartStatus;
+    private static MockedStatic<DhcpServerManager> mockServerManager;
+    private boolean isInterfaceDisabled;
+    private Exception occurredException;
+    private File tmpConfigFile;
+    private Map<String, Pid> runningPids;
+    private DhcpServerTool dhcpServerTool;
+
+    public DhcpdToolTest(DhcpServerTool dhcpServerTool) {
+        this.dhcpServerTool = dhcpServerTool;
+    }
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void shouldReturnIsRunningWhenToolSucceeds() {
+        givenExecutorReturnsExitStatus(0, true);
+        givenDhcpdTool(this.dhcpServerTool);
+
+        whenIsRunning("eth0");
+
+        thenToolReportedRunning();
+    }
+
+    @Test
+    public void shouldReturnNotRunningWhenToolFails() {
+        givenExecutorReturnsExitStatus(1, false);
+        givenDhcpdTool(this.dhcpServerTool);
+
+        whenIsRunning("eth0");
+
+        thenToolReportedNotRunning();
+    }
+
+    @Test
+    public void shouldStartInterfaceWhenToolSucceeds() {
+        givenExecutorReturnsExitStatus(0, true);
+        givenDhcpdTool(this.dhcpServerTool);
+
+        whenStartInterface("eth0");
+
+        thenInterfaceStarted();
+    }
+
+    @Test
+    public void shouldNotStartInterfaceWhenToolFails() {
+        givenExecutorReturnsExitStatus(1, false);
+        givenDhcpdTool(this.dhcpServerTool);
+
+        whenStartInterface("eth0");
+
+        thenInterfaceNotStarted();
+    }
+
+    @Test
+    public void shouldRemovePidFileWhenDisablingInterface() throws Exception {
+        givenExecutorReturnsExitStatus(0, true);
+        givenConfigFile("dhcpd-eth0.pid");
+        givenDhcpServerManagerReturn("eth0", this.tmpConfigFile.getAbsolutePath());
+        givenDhcpdTool(this.dhcpServerTool);
+        givenRunningPids();
+        givenExecutorCanStopToolSuccessfully();
+
+        whenDisableInterface("eth0");
+
+        thenFileWasDeleted("dhcpd-eth0.pid");
+        thenDisableInterfaceReturned(true);
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenDisablingInterfaceFails() throws Exception {
+        givenExecutorReturnsExitStatus(0, true);
+        givenConfigFile("dhcpd-eth0.pid");
+        givenDhcpServerManagerReturn("eth0", this.tmpConfigFile.getAbsolutePath());
+        givenDhcpdTool(this.dhcpServerTool);
+        givenRunningPids();
+        givenExecutorFailsStopTool();
+
+        whenDisableInterface("eth0");
+
+        thenKuraProcessExecutionErrorExceptionOccurred();
+        thenFileWasNotDeleted("dhcpd-eth0.pid");
+    }
+
+    @Test
+    public void shouldReturnFalseWhenDisablingInterfaceandNoRunningTool() throws Exception {
+        givenExecutorReturnsExitStatus(0, true);
+        givenConfigFile("dhcpd-eth0.pid");
+        givenDhcpServerManagerReturn("eth0", this.tmpConfigFile.getAbsolutePath());
+        givenDhcpdTool(this.dhcpServerTool);
+        givenNoRunningPids();
+        givenExecutorCanStopToolSuccessfully();
+
+        whenDisableInterface("eth0");
+
+        thenDisableInterfaceReturned(false);
+    }
+    
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenExecutorReturnsExitStatus(int exitCode, boolean isSuccessful) {
+        this.mockExecutor = mock(CommandExecutorService.class);
+
+        ExitStatus returnedExitStatus = new ExitStatus() {
+
+            @Override
+            public int getExitCode() {
+                return exitCode;
+            }
+
+            @Override
+            public boolean isSuccessful() {
+                return isSuccessful;
+            }
+            
+        };
+        CommandStatus returnedStatus = new CommandStatus(DnsmasqTool.IS_ACTIVE_COMMAND, returnedExitStatus);
+
+        when(this.mockExecutor.execute(any())).thenReturn(returnedStatus);
+        when(this.mockExecutor.isRunning(any(String[].class))).thenReturn(isSuccessful);
+    }
+
+    private void givenDhcpdTool(DhcpServerTool tool) {
+        this.tool = new DhcpdTool(mockExecutor, tool);
+    }
+
+    private void givenDhcpServerManagerReturn(String interfaceName, String returnedConfigFilename) {
+        mockServerManager = mockStatic(DhcpServerManager.class);
+        mockServerManager.when(() -> DhcpServerManager.getPidFilename(interfaceName)).thenReturn(returnedConfigFilename);
+    }
+
+    private void givenConfigFile(String filename) throws IOException {
+        this.tmpConfigFile = this.tmpFolder.newFile(filename);
+    }
+
+    private void givenRunningPids() {
+        this.runningPids = new HashMap<>();
+        this.runningPids.put("test", new Pid() {
+
+            @Override
+            public int getPid() {
+                return 1234;
+            }
+            
+        });
+
+        when(this.mockExecutor.getPids(any())).thenReturn(this.runningPids);
+    }
+
+    private void givenNoRunningPids() {
+        this.runningPids = new HashMap<>();
+
+        when(this.mockExecutor.getPids(any())).thenReturn(this.runningPids);
+    }
+
+    private void givenExecutorCanStopToolSuccessfully() {
+        when(this.mockExecutor.stop(any(), any())).thenReturn(true);
+    }
+
+    private void givenExecutorFailsStopTool() {
+        when(this.mockExecutor.stop(any(), any())).thenReturn(false);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenIsRunning(String interfaceName) {
+        this.isRunningResult = this.tool.isRunning(interfaceName);
+    }
+
+    private void whenStartInterface(String interfaceName) {
+        this.interfaceStartStatus = this.tool.startInterface(interfaceName);
+    }
+
+    private void whenDisableInterface(String interfaceName) {
+        try {
+            this.isInterfaceDisabled = this.tool.disableInterface(interfaceName);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenToolReportedRunning() {
+        assertTrue(this.isRunningResult);
+    }
+
+    private void thenToolReportedNotRunning() {
+        assertFalse(this.isRunningResult);
+    }
+
+    private void thenInterfaceStarted() {
+        assertTrue(this.interfaceStartStatus.getExitStatus().isSuccessful());
+    }
+
+    private void thenInterfaceNotStarted() {
+        assertFalse(this.interfaceStartStatus.getExitStatus().isSuccessful());
+    }
+
+    private void thenFileWasDeleted(String filename) {
+        assertFalse(this.tmpConfigFile.exists());
+    }
+
+    private void thenFileWasNotDeleted(String filename) {
+        assertTrue(this.tmpConfigFile.exists());
+    }
+
+    private void thenDisableInterfaceReturned(boolean expectedResult) {
+        assertEquals(expectedResult, this.isInterfaceDisabled);
+    }
+
+    private void thenKuraProcessExecutionErrorExceptionOccurred() {
+        assertTrue(this.occurredException instanceof KuraProcessExecutionErrorException);
+    }
+
+    /*
+     * Utilities
+     */
+
+    @After
+    public void closeStaticMock() {
+        if (mockServerManager != null && !mockServerManager.isClosed()) {
+            mockServerManager.close();
+        }
+    }
+
+}

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqToolTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqToolTest.java
@@ -1,0 +1,234 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.linux.net.dhcp.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.kura.KuraProcessExecutionErrorException;
+import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.executor.CommandStatus;
+import org.eclipse.kura.executor.ExitStatus;
+import org.eclipse.kura.linux.net.dhcp.DhcpServerManager;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
+
+public class DnsmasqToolTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private File tmpConfigFile;
+    private CommandExecutorService mockExecutor;
+    private static MockedStatic<DhcpServerManager> mockServerManager;
+    private DnsmasqTool tool;
+    private boolean isRunning;
+    private CommandStatus startInterfaceStatus;
+    private boolean interfaceDisabled;
+    private Exception occurredException;
+    
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void isRunningShouldReturnTrueIfAlreadyStarted() throws Exception {
+        givenExecutorReturnsExitStatus(0, true);
+        givenConfigFile("etc/dnsmasq.d/dnsmasq-eth0.conf");
+        givenDhcpServerManagerReturn("eth0", this.tmpConfigFile.getAbsolutePath());
+        givenDnsmasqTool();
+        givenStartInterface("eth0");
+
+        whenIsRunning("eth0");
+
+        thenIsRunningReturned(true);
+    }
+
+    @Test
+    public void isRunningShouldReturnFalseIfNeverStarted() throws Exception {
+        givenExecutorReturnsExitStatus(0, true);
+        givenConfigFile("etc/dnsmasq.d/dnsmasq-eth0.conf");
+        givenDhcpServerManagerReturn("eth0", this.tmpConfigFile.getAbsolutePath());
+        givenDnsmasqTool();
+
+        whenIsRunning("eth0");
+
+        thenIsRunningReturned(false);
+    }
+
+    @Test
+    public void isRunningShouldReturnFalseIfServiceIsNotActive() throws Exception {
+        givenExecutorReturnsExitStatus(1, false);
+        givenConfigFile("etc/dnsmasq.d/dnsmasq-eth0.conf");
+        givenDhcpServerManagerReturn("eth0", this.tmpConfigFile.getAbsolutePath());
+        givenDnsmasqTool();
+
+        whenIsRunning("eth0");
+
+        thenIsRunningReturned(false);
+    }
+
+    @Test
+    public void shouldRemoveInterfaceConfigIfStartFails() throws Exception {
+        givenExecutorReturnsExitStatus(1, false);
+        givenConfigFile("etc/dnsmasq.d/dnsmasq-eth0.conf");
+        givenDhcpServerManagerReturn("eth0", this.tmpConfigFile.getAbsolutePath());
+        givenDnsmasqTool();
+
+        whenStartInterface("eth0");
+
+        thenInterfaceNotStarted();
+        thenConfigFileNotPresent("eth0");
+    }
+
+    @Test
+    public void shouldRemoveInterfaceConfigIfInterfaceDisabled() throws Exception {
+        givenExecutorReturnsExitStatus(0, true);
+        givenConfigFile("etc/dnsmasq.d/dnsmasq-eth0.conf");
+        givenDhcpServerManagerReturn("eth0", this.tmpConfigFile.getAbsolutePath());
+        givenDnsmasqTool();
+        givenStartInterface("eth0");
+
+        whenDisableInterface("eth0");
+
+        thenConfigFileNotPresent("eth0");
+        thenDisableWasSuccessful();
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenFailToDisableInterface() throws Exception {
+        givenExecutorReturnsExitStatus(1, false);
+        givenConfigFile("etc/dnsmasq.d/dnsmasq-eth0.conf");
+        givenDhcpServerManagerReturn("eth0", this.tmpConfigFile.getAbsolutePath());
+        givenDnsmasqTool();
+
+        whenDisableInterface("eth0");
+
+        thenConfigFileNotPresent("eth0");
+        thenKuraProcessExecutionErrorExceptionOccurred();
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenExecutorReturnsExitStatus(int exitCode, boolean isSuccessful) {
+        this.mockExecutor = mock(CommandExecutorService.class);
+
+        ExitStatus returnedExitStatus = new ExitStatus() {
+
+            @Override
+            public int getExitCode() {
+                return exitCode;
+            }
+
+            @Override
+            public boolean isSuccessful() {
+                return isSuccessful;
+            }
+            
+        };
+        CommandStatus returnedStatus = new CommandStatus(DnsmasqTool.IS_ACTIVE_COMMAND, returnedExitStatus);
+
+        when(this.mockExecutor.execute(any())).thenReturn(returnedStatus);
+    }
+
+    private void givenDhcpServerManagerReturn(String interfaceName, String returnedConfigFilename) {
+        mockServerManager = mockStatic(DhcpServerManager.class);
+        mockServerManager.when(() -> DhcpServerManager.getConfigFilename(any())).thenReturn(returnedConfigFilename);
+    }
+
+    private void givenConfigFile(String filename) throws IOException {
+        try {
+            this.tmpFolder.newFolder("etc", "dnsmasq.d");
+        } catch (Exception e) {}
+        this.tmpConfigFile = this.tmpFolder.newFile(filename);
+    }
+
+    private void givenDnsmasqTool() throws Exception {
+        this.tool = new DnsmasqTool(this.mockExecutor);
+        this.tool.setDnsmasqGlobalConfigFile(this.tmpConfigFile.getAbsoluteFile().getParent() + "/dnsmasq-globals.conf");
+    }
+
+    private void givenStartInterface(String interfaceName) throws KuraProcessExecutionErrorException {
+        this.tool.startInterface(interfaceName);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenIsRunning(String interfaceName) throws KuraProcessExecutionErrorException {
+        this.isRunning = this.tool.isRunning(interfaceName);
+    }
+
+    private void whenStartInterface(String interfaceName) throws KuraProcessExecutionErrorException {
+        this.startInterfaceStatus = this.tool.startInterface(interfaceName);
+    }
+
+    private void whenDisableInterface(String interfaceName) throws KuraProcessExecutionErrorException {
+        try {
+            this.interfaceDisabled = this.tool.disableInterface(interfaceName);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }        
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenIsRunningReturned(boolean expectedResult) {
+        assertEquals(expectedResult, this.isRunning);
+    }
+
+    private void thenInterfaceNotStarted() {
+        assertFalse(this.startInterfaceStatus.getExitStatus().isSuccessful());
+    }
+
+    private void thenConfigFileNotPresent(String interfaceName) {
+        assertFalse(this.tmpConfigFile.exists());
+    }
+
+    private void thenDisableWasSuccessful() {
+        assertTrue(this.interfaceDisabled);
+    }
+
+    private void thenKuraProcessExecutionErrorExceptionOccurred() {
+        assertTrue(this.occurredException instanceof KuraProcessExecutionErrorException);
+    }
+
+    /*
+     * Utilities
+     */
+
+    @After
+    public void closeStaticMock() {
+        mockServerManager.close();
+    }
+}

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This PR adds some tests for the `linux.net.dhcp.server` package.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** Refactor of `DnsmasqTool` for better testability.