### PR TITLE
fix: Wrong PKCS11KeystoreServiceImpl bind methods [backport release-5.3.0]

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/OSGI-INF/org.eclipse.kura.core.keystore.pkcs11KeystoreService.xml
+++ b/kura/org.eclipse.kura.core.keystore/OSGI-INF/org.eclipse.kura.core.keystore.pkcs11KeystoreService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2022 Eurotech and/or its affiliates and others
+   Copyright (c) 2022, 2023 Eurotech and/or its affiliates and others
 
    This program and the accompanying materials are made
    available under the terms of the Eclipse Public License 2.0
@@ -24,9 +24,11 @@
               bind="setCryptoService"
               cardinality="1..1"
               policy="static"/>
-    <reference name="ConfigurationService"
-              bind="setConfigurationService"
-              interface="org.eclipse.kura.configuration.ConfigurationService"/>
+    <reference name="SystemService"
+              bind="setSystemService"
+              interface="org.eclipse.kura.system.SystemService"
+              cardinality="1..1"
+              policy="static"/>
     <property name="kura.ui.factory.hide" type="String" value="true"/>
     <property name="kura.ui.service.hide" type="String" value="true"/>
     <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static"/>


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
