### PR TITLE
fix: Updated named apparmor profile to include /usr/share/dns

### DIFF
--- a/kura/distrib/src/main/resources/common/named/usr.sbin.named
+++ b/kura/distrib/src/main/resources/common/named/usr.sbin.named
@@ -50,6 +50,9 @@
   /var/log/** rw,
   /varlog/named.log rw,
 
+  /usr/share/dns r,
+  /usr/share/dns/** r,
+
   /etc/named.rfc1912.zones r,
 
   # Site-specific additions and overrides. See local/README for details.


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Allows named to access `/usr/share/dns`, the default configuration provided by Ubuntu 22.04 references  `/usr/share/dns/root.hints`, without this change named will fail to start until Kura rewrites its configuration the first time it starts.
