### PR TITLE
fix: Removed deprecated named options

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxDnsServer.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dns/LinuxDnsServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -287,7 +287,7 @@ public abstract class LinuxDnsServer {
         sb.append("};\n");
         sb.append("\tmax-cache-ttl 30;\n");
         sb.append("\tmax-ncache-ttl 30;\n");
-        sb.append("\tdnssec-enable yes;\n").append("\tdnssec-validation yes;\n").append("\tdnssec-lookaside auto;\n");
+        sb.append("\tdnssec-validation no;\n");
         sb.append("};\n") //
                 .append("zone \".\" IN {\n") //
                 .append("\ttype hint;\n") //
@@ -322,9 +322,7 @@ public abstract class LinuxDnsServer {
                 .append("\n") //
                 .append("\tmax-cache-ttl 30;\n") //
                 .append("\tmax-ncache-ttl 30;\n") //
-                .append("\tdnssec-enable yes;\n") //
-                .append("\tdnssec-validation yes;\n") //
-                .append("\tdnssec-lookaside auto;\n") //
+                .append("\tdnssec-validation no;\n") //
                 .append("\n") //
                 .append("\t/* Path to ISC DLV key */\n") //
                 .append("\nbindkeys-file \"/etc/named.iscdlv.key\";\n") //


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

* Removes the `dnssec-enable `and `dnssec-lookaside` options which have been deprecated in bind 9.16 [1] and since 9.18   setting them is considered a configuration failure [2] that will prevent named from starting.

* Sets `dnssec-validation` to `no`, since it is equivalent to setting it to `yes` without including a  [trust-anchors](https://bind9.readthedocs.io/en/v9.18.13/reference.html#namedconf-statement-trust-anchors) statement (no dnssec validation is performed in both cases).

[1] https://bind9.readthedocs.io/en/v9.16.16/notes.html#notes-for-bind-9-16-0
[2] https://bind9.readthedocs.io/en/v9_18_6/notes.html?highlight=dnssec-enable#notes-for-bind-9-18-0
[3] https://bind9.readthedocs.io/en/v9.18.13/dnssec-guide.html#dnssec-validation-explained
