### PR TITLE
fix(core.deployment): dpa.properties is written even if package is already in persistence

### DIFF
--- a/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/download/DownloadFileUtilities.java
+++ b/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/download/DownloadFileUtilities.java
@@ -26,11 +26,11 @@ public class DownloadFileUtilities extends FileUtilities {
         String downloadDirectory = options.getDownloadDirectory();
         String packageFilename;
         if (!options.getSystemUpdate()) {
-            String dpName = FileUtilities.getFileName(options.getDpName(), options.getDpVersion(), ".dp");
+            String dpName = FileUtilities.getFileName(options.getDpName(), options.getDpVersion(), ".dp", "_");
             packageFilename = new StringBuilder().append(downloadDirectory).append(File.separator).append(dpName)
                     .toString();
         } else {
-            String shName = FileUtilities.getFileName(options.getDpName(), options.getDpVersion(), ".sh");
+            String shName = FileUtilities.getFileName(options.getDpName(), options.getDpVersion(), ".sh", "-");
             packageFilename = new StringBuilder().append(downloadDirectory).append(File.separator).append(shName)
                     .toString();
         }

--- a/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/download/impl/DownloadImpl.java
+++ b/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/download/impl/DownloadImpl.java
@@ -211,7 +211,8 @@ public class DownloadImpl implements ProgressListener {
             }
             s_logger.info("--> Going to verify hash signature!");
             try {
-                // these things should be checked beforehand, so that hash() has a chance to succeed
+                // these things should be checked beforehand, so that hash() has a chance to
+                // succeed
                 if (hashAlgorithm == null || "".equals(hashAlgorithm) || hashValue == null || "".equals(hashValue)) {
                     throw new KuraException(KuraErrorCode.INTERNAL_ERROR, null,
                             "Failed to verify checksum with empty algorithm: " + hashAlgorithm);
@@ -278,7 +279,7 @@ public class DownloadImpl implements ProgressListener {
 
     private File getDpVerifierFile(DeploymentPackageInstallOptions options) {
 
-        String shName = FileUtilities.getFileName(options.getDpName(), options.getDpVersion(), ".sh_verifier.sh");
+        String shName = FileUtilities.getFileName(options.getDpName(), options.getDpVersion(), ".sh_verifier.sh", "-");
         String packageFilename = new StringBuilder().append(this.verificationDirectory).append(File.separator)
                 .append(shName).toString();
 

--- a/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/util/FileUtilities.java
+++ b/kura/org.eclipse.kura.core.deployment/src/main/java/org/eclipse/kura/core/deployment/util/FileUtilities.java
@@ -16,8 +16,10 @@ package org.eclipse.kura.core.deployment.util;
 public class FileUtilities {
 
     public static String getFileName(String dpName, String dpVersion, String extension) {
-        String packageFilename = new StringBuilder().append(dpName).append("-").append(dpVersion).append(extension)
-                .toString();
-        return packageFilename;
+        return getFileName(dpName, dpVersion, extension, "-");
+    }
+
+    public static String getFileName(String dpName, String dpVersion, String extension, String separator) {
+        return dpName + separator + dpVersion + extension;
     }
 }

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -371,7 +371,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         try (InputStream dpInputStream = new FileInputStream(dpFile);) {
             dp = this.deploymentAdmin.installDeploymentPackage(dpInputStream);
 
-            String dpFsName = dp.getName() + "-" + dp.getVersion() + ".dp";
+            String dpFsName = dp.getName() + "_" + dp.getVersion() + ".dp";
             String dpPersistentFilePath = this.packagesPath + File.separator + dpFsName;
             dpPersistentFile = new File(dpPersistentFilePath);
 

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -371,7 +371,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         try (InputStream dpInputStream = new FileInputStream(dpFile);) {
             dp = this.deploymentAdmin.installDeploymentPackage(dpInputStream);
 
-            String dpFsName = dp.getName() + "_" + dp.getVersion() + ".dp";
+            String dpFsName = dp.getName() + "-" + dp.getVersion() + ".dp";
             String dpPersistentFilePath = this.packagesPath + File.separator + dpFsName;
             dpPersistentFile = new File(dpPersistentFilePath);
 
@@ -380,9 +380,11 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
             if (!dpFile.getCanonicalPath().equals(dpPersistentFile.getCanonicalPath())) {
                 logger.debug("dpFile.getCanonicalPath(): {}", dpFile.getCanonicalPath());
                 logger.debug("dpPersistentFile.getCanonicalPath(): {}", dpPersistentFile.getCanonicalPath());
-                FileUtils.copyFile(dpFile, dpPersistentFile);
-                addPackageToConfFile(dp.getName(), "file:" + dpPersistentFilePath);
+                Files.deleteIfExists(dpPersistentFile.toPath());
+                FileUtils.moveFile(dpFile, dpPersistentFile);
             }
+
+            addPackageToConfFile(dp.getName(), "file:" + dpPersistentFilePath);
         } finally {
             // The file from which we have installed the deployment package will be deleted
             // unless it's a persistent deployment package file.

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -388,7 +388,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         } finally {
             // The file from which we have installed the deployment package will be deleted
             // unless it's a persistent deployment package file.
-            if (dpPersistentFile != null && dpPersistentFile.exists()
+            if (dpPersistentFile != null && dpPersistentFile.exists() && dpFile.exists()
                     && !dpFile.getCanonicalPath().equals(dpPersistentFile.getCanonicalPath())) {
                 Files.delete(dpFile.toPath());
                 logger.debug("Deleted file: {}", dpFile.getName());

--- a/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
+++ b/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
@@ -48,6 +48,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.osgi.framework.Version;
 import org.osgi.service.deploymentadmin.DeploymentAdmin;
 import org.osgi.service.deploymentadmin.DeploymentException;
 import org.osgi.service.deploymentadmin.DeploymentPackage;
@@ -215,6 +216,7 @@ public class InstallImplTest {
 
         DeploymentPackage dpMock = mock(DeploymentPackage.class);
         when(dpMock.getName()).thenReturn("dp");
+        when(dpMock.getVersion()).thenReturn(new Version("1.0.0"));
         when(deploymentAdminMock.installDeploymentPackage(any())).thenReturn(dpMock);
 
         Object dp = TestUtil.invokePrivate(ii, "installDeploymentPackageInternal", dpFile);
@@ -256,6 +258,7 @@ public class InstallImplTest {
         when(deploymentAdminMock.installDeploymentPackage(any())).thenReturn(dpMock);
 
         when(dpMock.getName()).thenReturn("dpname");
+        when(dpMock.getVersion()).thenReturn(new Version("1.0.0"));
 
         ii.setDpaConfPath(null); // make sure this is null, so that we don't test too much
         ii.setPackagesPath(pkgDir.getCanonicalPath());

--- a/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
+++ b/kura/test/org.eclipse.kura.core.deployment.test/src/test/java/org/eclipse/kura/core/deployment/install/InstallImplTest.java
@@ -89,11 +89,18 @@ public class InstallImplTest {
     }
 
     @Test
-    public void testInstallDpSuccessMessage() throws KuraException {
+    public void testInstallDpSuccessMessage() throws KuraException, DeploymentException {
         CloudDeploymentHandlerV2 callbackMock = mock(CloudDeploymentHandlerV2.class);
         String kuraDataDir = "/tmp";
         InstallImpl ii = new InstallImpl(callbackMock, kuraDataDir, null);
         ii.setPackagesPath(kuraDataDir);
+
+        DeploymentAdmin mockDeploymentAdmin = mock(DeploymentAdmin.class);
+        DeploymentPackage dpMock = mock(DeploymentPackage.class);
+        when(dpMock.getName()).thenReturn("dpname");
+        when(mockDeploymentAdmin.installDeploymentPackage(Mockito.any())).thenReturn(dpMock);
+        ii.setDeploymentAdmin(mockDeploymentAdmin);
+        ii.setDpaConfPath("/tmp/dpa.properties");
 
         final String clientId = "clientid";
         final long jobid = 1234;
@@ -113,8 +120,8 @@ public class InstallImplTest {
                 KuraInstallPayload kp = (KuraInstallPayload) arguments[1];
 
                 assertEquals("", clientId, kp.getClientId());
-                assertEquals("", 100, kp.getInstallProgress());
                 assertEquals("", InstallStatus.COMPLETED.getStatusString(), kp.getInstallStatus());
+                assertEquals("", 100, kp.getInstallProgress());
                 assertEquals("", jobid, kp.getJobId().longValue());
 
                 return null;
@@ -195,6 +202,8 @@ public class InstallImplTest {
 
         ii.setPackagesPath(kuraDataDir);
 
+        ii.setDpaConfPath("/tmp/dpa.properties");
+
         File persDir = new File(kuraDataDir, "persistance");
         persDir.mkdirs();
         File veriDir = new File(persDir, "verification");
@@ -205,6 +214,7 @@ public class InstallImplTest {
         dpFile.createNewFile();
 
         DeploymentPackage dpMock = mock(DeploymentPackage.class);
+        when(dpMock.getName()).thenReturn("dp");
         when(deploymentAdminMock.installDeploymentPackage(any())).thenReturn(dpMock);
 
         Object dp = TestUtil.invokePrivate(ii, "installDeploymentPackageInternal", dpFile);


### PR DESCRIPTION
Forward-port of PR https://github.com/eclipse/kura/pull/4689 with the only effect to have the `dpa.properties` written even if package is already downloaded into `/opt/eclipse/kura/packages`.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
