### PR TITLE
fix(wire.component.conditional.provider): corrected unescaped metatype character

### DIFF
--- a/kura/org.eclipse.kura.wire.component.conditional.provider/OSGI-INF/metatype/org.eclipse.kura.wire.Conditional.xml
+++ b/kura/org.eclipse.kura.wire.component.conditional.provider/OSGI-INF/metatype/org.eclipse.kura.wire.Conditional.xml
@@ -17,7 +17,7 @@
     <OCD id="org.eclipse.kura.wire.Conditional"
          name="Conditional (deprecated)"
          description="A wire component that allows to forward the received envelopes to different ports depending on a boolean condition.
-         Deprecated component, available only if running on JRE with Nashorn (Java < 15).">
+         Deprecated component, available only if running on JRE with Nashorn (Java version lesser than 15).">
 
          <AD id="condition"
             name="condition"


### PR DESCRIPTION
N/A.

**Related Issue:** Without this PR, the Conditional component will not be usable since the metatype will not be loaded due to unescaped character. Similar issue was solved in https://github.com/eclipse/kura/pull/4323/ for the script filter.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
