### PR TITLE
docs: removed not needed comment from REST API docs

### DIFF
--- a/docs/references/rest-apis/rest-inventory-api.md
+++ b/docs/references/rest-apis/rest-inventory-api.md
@@ -270,8 +270,6 @@
 --- 
 ## States
 
-%%We should probably unify these states to the same case.%%
-
 ### Bundle States
 ```
 -   `ACTIVE`: Container is running


### PR DESCRIPTION
Removed internal comment from API docs.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
