### PR TITLE
docs: add REST command apis

### DIFF
--- a/docs/references/rest-apis/rest-command-api.md
+++ b/docs/references/rest-apis/rest-command-api.md
@@ -1,0 +1,55 @@
+# Rest Command v1 API
+
+#### Execute Command
+- Method: POST
+- API PATH: `/services/command/v1/command/`
+##### Request Body
+``` JSON
+{
+	//Command to be excuted on gateway
+    "command":"printenv TextEnvVarName1",
+
+    //Service Password for command Service
+    "password":"s3curePassw0rd",
+
+    //String base64 encoding of a zip file to transfer to gateway
+    "zipBytes": "UEsDBAoACAAAAIyD1lYAA AAAAAAAAAAAAAAJACAAdGVzdGZpbGUxVVQNAAfprpRk6a6UZOmulGR1eAsAAQT1AQAABBQAAABQSwcIAAAAAAAAAAAAAAAAUEsBAgoDCgAIAAAAjIPWVgAAAAAAAAAAAAAAAAkAIAAAAAAAAAAAAKSBAAAAAHRlc3RmaWxlMVVUDQAH6a6UZOmulGTprpRkdXgLAAEE9QEAAAQUAAAAUEsFBgAAAAABAAEAVwAAAFcAAAAAAA==",
+
+    //Command argument String array
+    "arguments":["arg 1"],
+
+    //Shell environment Pairs Map
+    "environmentPairs": 
+    {
+        "TextEnvVarName1":"TextEnvVarValue1",
+        "TextEnvVarName2":"TextEnvVarValue2"
+    },
+    //Working directory of command to be executed
+    "workingDirectory":"/tmp",
+    
+    //Run command synchronously/asynchronously
+    "isRunAsync":false
+}
+```
+
+##### Responses
+- 200 OK status
+
+```JSON
+{
+    "stdout": "Command error output is displayed in this field",
+    "stderr": "Command output is displayed in this field",
+    "exitCode": 0,
+    "isTimeOut": false
+}
+```
+
+- 400 Bad Request (Malformed Client JSON)
+- 404 Resource Not Found
+- 500 Internal Server Error
+
+
+
+!!! note
+
+    Use the following command to retrieve the base64 representation of a zip file. `base64 -i <filename.zip>`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
       - Javadoc: references/javadoc.md
       - REST-APIs:
         - REST Inventory API: references/rest-apis/rest-inventory-api.md
+        - REST Command API: references/rest-apis/rest-command-api.md
     - Tutorials:
       - Anomaly Detection: tutorials/AD-EdgeAI.ipynb
 


### PR DESCRIPTION
this PR adds new REST command apis to docs-develop.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).


**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:**  n/a

**Screenshots:** <img width="1155" alt="image" src="https://github.com/eclipse/kura/assets/29900100/df318412-da84-46e5-9f9b-4be1cc4613f5">

**Manual Tests**:  n/a

**Any side note on the changes made:** n/a
