### PR TITLE
fix: added correct permissions to docker file

### DIFF
--- a/kura/distrib/src/main/resources/docker-alpine-x86_64-nn/Dockerfile
+++ b/kura/distrib/src/main/resources/docker-alpine-x86_64-nn/Dockerfile
@@ -25,7 +25,8 @@ RUN chmod a+x -R /usr/local/bin && \
     apk --no-cache add dos2unix openssl net-tools which busybox-extras && \
     apk --no-cache add bluez bluez-deprecated chrony eudev glib psmisc socat && \
     /kura-install/kura_*_docker-x86_64-nn_installer.sh && \
-    chmod a+rw -R /opt/eclipse && \
+    chmod -R go-rwx /opt/eclipse  && \
+    chmod a+rx /opt/eclipse  && \
     find /opt/eclipse -type d | xargs chmod a+x && \
     chmod a+rwx /var/log && \
     `# Test for the existence of the entry point` \

--- a/kura/distrib/src/main/resources/docker-ubi8-x86_64-nn/Dockerfile
+++ b/kura/distrib/src/main/resources/docker-ubi8-x86_64-nn/Dockerfile
@@ -39,7 +39,8 @@ RUN true && \
     && \
     microdnf -y clean all && rm -rf /var/cache/yum && \
     /kura-install/kura_*_docker-x86_64-nn_installer.sh && rm -rf /kura-install/ && \
-    chmod a+rw -R /opt/eclipse && \
+    chmod -R go-rwx /opt/eclipse  && \
+    chmod a+rx /opt/eclipse  && \
     find /opt/eclipse -type d | xargs chmod a+x && \
     chmod a+rwx /var/log && \
     `# Test for the existence of the entry point` \


### PR DESCRIPTION
Fixed the way the dockerfile applies permissions to the Kura folder. 
before things were set to 777.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** <img width="1906" alt="image" src="https://github.com/eclipse/kura/assets/29900100/badba534-f003-40f4-b688-8d2a0d4ff98f">
**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
