### PR TITLE
build(target-platform): added org.osgi.service.metatype.annotations

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -180,6 +180,7 @@ This project leverages the following third party content.
 * maven/mavencentral/org.jboss.logging/jboss-logging/3.3.2.Final, Apache-2.0, approved, CQ13843
 * maven/mavencentral/org.knowhowlab.osgi/monitoradmin/1.0.2, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/org.osgi/osgi.annotation/8.1.0, Apache-2.0, approved, #1985
+* maven/mavencentral/org.osgi/org.osgi.service.metatype.annotations/1.4.1, Apache-2.0, approved, #6910
 * maven/mavencentral/org.quartz-scheduler/quartz/2.3.2, Apache-2.0, approved, CQ22979
 * maven/mavencentral/org.slf4j/jcl-over-slf4j/1.7.36, Apache-2.0, approved, CQ12843
 * maven/mavencentral/org.slf4j/slf4j-api/1.7.36, MIT, approved, CQ13368

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -52,7 +52,10 @@ apache-qpid-proton-j.version=0.33.2
 mockito-core.version=4.8.1
 byte-buddy.version=1.12.18
 objenesis.version=3.3
+
 osgi.annotation.version=8.1.0
+org.osgi.service.metatype.annotations.version=1.4.1
+
 com.eclipsesource.jaxrs.jersey-min.version=2.22.2
 com.eclipsesource.jaxrs.publisher.version=5.3.1
 com.eclipsesource.jaxrs.publisher.jar.version=5.3.1.201602281253

--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -391,6 +391,11 @@
                                     <artifactId>osgi.annotation</artifactId>
                                     <version>${osgi.annotation.version}</version>
                                 </artifactItem>
+                                <dependency>
+                                    <groupId>org.osgi</groupId>
+                                    <artifactId>org.osgi.service.metatype.annotations</artifactId>
+                                    <version>${org.osgi.service.metatype.annotations.version}</version>
+                                </dependency>
                                 <artifactItem>
                                     <groupId>org.eclipse.kura</groupId>
                                     <artifactId>com.eclipsesource.jaxrs.jersey-min</artifactId>
@@ -706,6 +711,7 @@
                                 <move file="target/source/plugins/qpid-jms-client.jar" tofile="target/source/plugins/org.apache.qpid.jms.client_${apache-qpid-jms-client.version}.jar"/>
                                 <move file="target/source/plugins/minimal-json.jar" tofile="target/source/plugins/minimal-json_${com.eclipsesource.minimal-json.version}.jar"/>
                                 <move file="target/source/plugins/osgi.annotation.jar" tofile="target/source/plugins/osgi.annotation_${osgi.annotation.version}.jar"/>
+                                <move file="target/source/plugins/org.osgi.service.metatype.annotations.jar" tofile="target/source/plugins/org.osgi.service.metatype.annotations_${org.osgi.service.metatype.annotations.version}.jar" />
                                 <move file="target/source/plugins/org.moka7.jar" tofile="target/source/plugins/org.moka7_${org.moka7.version}.jar"/>
                                 <move file="target/source/plugins/com.eclipsesource.jaxrs.jersey-min.jar" tofile="target/source/plugins/com.eclipsesource.jaxrs.jersey-min_${com.eclipsesource.jaxrs.jersey-min.version}.jar"/>
                                 <move file="target/source/plugins/publisher.jar" tofile="target/source/plugins/com.eclipsesource.jaxrs.publisher_${com.eclipsesource.jaxrs.publisher.jar.version}.jar"/>


### PR DESCRIPTION
This PR adds the `org.osgi.service.metatype.annotations` to the target platform since not available by default in the Eclipse Equinox packages.

**Related Issue:** [This PR fixes/closes 4724](https://github.com/eclipse/kura/issues/4724).

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
