### PR TITLE
fix: check support for `GPS_UNMANAGED` in `isGpsSupported` method

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -605,12 +605,9 @@ public class NMStatusConverter {
         boolean isSupported = false;
         try {
             UInt32 locationSources = properties.Get(MM_MODEM_LOCATION_BUS_NAME, "Capabilities");
-            // Check if the location capability is MM_MODEM_LOCATION_SOURCE_GPS_RAW or
-            // MM_MODEM_LOCATION_SOURCE_GPS_NMEA
             Set<MMModemLocationSource> modemLocationSources = MMModemLocationSource
                     .toMMModemLocationSourceFromBitMask(locationSources);
-            if (modemLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW)
-                    || modemLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA)) {
+            if (modemLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED)) {
                 isSupported = true;
             }
         } catch (DBusExecutionException e) {


### PR DESCRIPTION
**Related Issue:** #4633 

**Description of the solution adopted:** With #4633 we switched from `NMEA` and `RAW` GPS location modes to `GPS_UNMANAGED`, but we never updated the `isGpsSupported` method to check for that capability instead of the old ones. This PR fixes that.

@MMaiero do we want this backported?