### PR TITLE
refactor: use `Device.Udi` to retrieve ModemManager device dbus path

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -49,7 +49,6 @@ import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
-import org.freedesktop.dbus.interfaces.ObjectManager;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.Variant;
@@ -817,41 +816,24 @@ public class NMDbusConnector {
         }
     }
 
-    private String getDeviceIdFromNM(String deviceDbusPath) throws DBusException {
-        Properties nmModemProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, deviceDbusPath,
-                Properties.class);
-        String deviceId = (String) nmModemProperties.Get(NM_DEVICE_BUS_NAME + ".Modem", "DeviceId");
-        logger.debug("Found DeviceId {} for device {}", deviceId, deviceDbusPath);
-        return deviceId;
-    }
-
-    private Map<DBusPath, Map<String, Map<String, Variant<?>>>> getManagedObjectsFromMM() throws DBusException {
-        ObjectManager objectManager = this.dbusConnection.getRemoteObject(MM_BUS_NAME, MM_BUS_PATH,
-                ObjectManager.class);
-        Map<DBusPath, Map<String, Map<String, Variant<?>>>> managedObjects = objectManager.GetManagedObjects();
-        logger.debug("Found Managed Objects {}", managedObjects.keySet());
-        return managedObjects;
-    }
-
-    private Optional<String> getModemPathFromManagedObjects(
-            Map<DBusPath, Map<String, Map<String, Variant<?>>>> managedObjects, String deviceId) {
-        Optional<String> modemPath = Optional.empty();
-        Optional<Entry<DBusPath, Map<String, Map<String, Variant<?>>>>> modemEntry = managedObjects.entrySet().stream()
-                .filter(entry -> {
-                    String modemDeviceId = (String) entry.getValue().get(MM_MODEM_NAME).get("DeviceIdentifier")
-                            .getValue();
-                    return modemDeviceId.equals(deviceId);
-                }).findFirst();
-        if (modemEntry.isPresent()) {
-            modemPath = Optional.of(modemEntry.get().getKey().getPath());
-        }
-        return modemPath;
-    }
-
     private Optional<String> getModemPathFromMM(String devicePath) throws DBusException {
-        String deviceId = getDeviceIdFromNM(devicePath);
-        Map<DBusPath, Map<String, Map<String, Variant<?>>>> managedObjects = getManagedObjectsFromMM();
-        return getModemPathFromManagedObjects(managedObjects, deviceId);
+        Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, devicePath, Properties.class);
+        NMDeviceType deviceType = NMDeviceType
+                .fromUInt32(deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_DEVICETYPE));
+
+        if (deviceType != NMDeviceType.NM_DEVICE_TYPE_MODEM) {
+            logger.warn("Device {} is not a modem", devicePath);
+            return Optional.empty();
+        }
+
+        String modemDbusPath = (String) deviceProperties.Get(NM_DEVICE_BUS_NAME, "Udi");
+        if (Objects.isNull(modemDbusPath) || !modemDbusPath.startsWith(MM_BUS_PATH)) {
+            logger.debug("Could not find ModemDbusPath for device {}", devicePath);
+            return Optional.empty();
+        }
+
+        logger.debug("Found ModemDbusPath {} for device {}", modemDbusPath, devicePath);
+        return Optional.of(modemDbusPath);
     }
 
     private Optional<Properties> getModemProperties(String modemPath) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -828,11 +828,11 @@ public class NMDbusConnector {
 
         String modemDbusPath = (String) deviceProperties.Get(NM_DEVICE_BUS_NAME, "Udi");
         if (Objects.isNull(modemDbusPath) || !modemDbusPath.startsWith(MM_BUS_PATH)) {
-            logger.debug("Could not find ModemDbusPath for device {}", devicePath);
+            logger.debug("Could not find DBus path for modem device {}", devicePath);
             return Optional.empty();
         }
 
-        logger.debug("Found ModemDbusPath {} for device {}", modemDbusPath, devicePath);
+        logger.debug("Found DBus path {} for modem device {}", modemDbusPath, devicePath);
         return Optional.of(modemDbusPath);
     }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1143,19 +1143,7 @@ public class NMDbusConnectorTest {
             boolean hasSims) throws DBusException {
         when(mockedProperties.Get("org.freedesktop.NetworkManager.Device.Modem", "DeviceId")).thenReturn("abcd1234");
         when(mockedProperties.Get("org.freedesktop.NetworkManager.Device", "IpInterface")).thenReturn("wwan0");
-
-        Map<String, Variant<?>> managedObjectProperties = new HashMap<>();
-        managedObjectProperties.put("DeviceIdentifier", new Variant<>("abcd1234"));
-        Map<String, Map<String, Variant<?>>> managedObject = new HashMap<>();
-        managedObject.put(MM_MODEM_BUS_NAME, managedObjectProperties);
-        Map<DBusPath, Map<String, Map<String, Variant<?>>>> managedObjects = new HashMap<>();
-        managedObjects.put(new DBusPath("/org/freedesktop/ModemManager1/Modem/3"), managedObject);
-
-        ObjectManager objectManager = mock(ObjectManager.class);
-        when(objectManager.getObjectPath()).thenReturn("org/freedesktop/ModemManager1");
-        when(objectManager.GetManagedObjects()).thenReturn(managedObjects);
-        doReturn(objectManager).when(this.dbusConnection).getRemoteObject("org.freedesktop.ModemManager1",
-                "/org/freedesktop/ModemManager1", ObjectManager.class);
+        when(mockedProperties.Get("org.freedesktop.NetworkManager.Device", "Udi")).thenReturn("/org/freedesktop/ModemManager1/Modem/3");
 
         Properties modemProperties = mock(Properties.class);
         doReturn(modemProperties).when(this.dbusConnection).getRemoteObject("org.freedesktop.ModemManager1",


### PR DESCRIPTION
Currently, in the Kura codebase, to retrieve the ModemManager dbus path for a NetworkManager device we:
- Gather all the objects managed by ModemManager using the `GetManagedObjects` method
- Iterate over the managed objects
- Look for a match between the ModemManager `DeviceIdentifier` and the NetworkManager `DeviceId`

This PR introduces a better way to achieve the same results leveraging the `Device.Udi` property of NetworkManager. Per [NetworkManager documentation](https://networkmanager.dev/docs/api/latest/gdbus-org.freedesktop.NetworkManager.Device.html#gdbus-property-org-freedesktop-NetworkManager-Device.Udi):

> Operating-system specific transient device hardware identifier. This is an opaque string representing the underlying hardware for the device, and shouldn't be used to keep track of individual devices. **For some device types (Bluetooth, Modems) it is an identifier used by the hardware service (ie bluez or ModemManager) to refer to that device, and client programs use it get additional information from those services which NM does not provide.** The Udi is not guaranteed to be consistent across reboots or hotplugs of the hardware. If you're looking for a way to uniquely track each device in your application, use the object path. If you're looking for a way to track a specific piece of hardware across reboot or hotplug, use a MAC address or USB serial number.

In the case of ModemManager it is the dbus path that we need to call the API methods on that object. Note that we don't need it to be consistent between reboots since it's only used to manipulate the object once we have uniquely identified using our internal representation.

---

Tests performed:
- [X] RPi4 w/ NM 1.30.6, MM  1.14.12
- [X] RPi4 w/ NM 1.14.6, MM  1.14.12
- [X] Dy1014 w/ NM 1.30.4, MM 1.16.2

```
2023-07-11T09:33:46,214 [Start Level: Equinox Container: 7b4847fc-4f84-469c-ab74-64bea6cd38cf] WARN  o.e.k.n.NMDbusConnector - Device "1-1.1" of type "NM_DEVICE_TYPE_MODEM" not configured. Disabling...
2023-07-11T09:33:46,260 [Start Level: Equinox Container: 7b4847fc-4f84-469c-ab74-64bea6cd38cf] INFO  o.e.k.n.NMDbusConnector - ModemDbusPath for device /org/freedesktop/NetworkManager/Devices/4 is /org/freedesktop/ModemManager1/Modem/0
```