### PR TITLE
refactor(nm): add NetworkManagerDbusWrapper and ModemManagerDbusWrapper objects

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -1,10 +1,13 @@
 package org.eclipse.kura.nm;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
+import org.eclipse.kura.nm.enums.MMModemLocationSource;
 import org.eclipse.kura.nm.enums.MMModemState;
 import org.eclipse.kura.nm.status.SimProperties;
 import org.freedesktop.dbus.DBusPath;
@@ -14,6 +17,7 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.modemmanager1.Modem;
+import org.freedesktop.modemmanager1.modem.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +36,58 @@ public class ModemManagerDbusWrapper {
 
     protected ModemManagerDbusWrapper(DBusConnection dbusConnection) {
         this.dbusConnection = dbusConnection;
+    }
+
+    protected void handleModemManagerGPSSetup(Optional<String> modemDevicePath, Optional<Boolean> enableGPS)
+            throws DBusException {
+
+        if (!modemDevicePath.isPresent()) {
+            logger.warn("Cannot retrieve MM.Modem from NM.Modem. Skipping GPS configuration.");
+            return;
+        }
+
+        enableModem(modemDevicePath.get());
+
+        boolean isGPSSourceEnabled = enableGPS.isPresent() && enableGPS.get();
+
+        Location modemLocation = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath.get(),
+                Location.class);
+        Properties modemLocationProperties = this.dbusConnection.getRemoteObject(MM_BUS_NAME,
+                modemLocation.getObjectPath(), Properties.class);
+
+        Set<MMModemLocationSource> availableLocationSources = EnumSet
+                .of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE);
+        Set<MMModemLocationSource> currentLocationSources = EnumSet
+                .of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE);
+        Set<MMModemLocationSource> desiredLocationSources = EnumSet
+                .of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE);
+
+        try {
+            availableLocationSources = MMModemLocationSource.toMMModemLocationSourceFromBitMask(
+                    modemLocationProperties.Get(MM_LOCATION_BUS_NAME, "Capabilities"));
+            currentLocationSources = MMModemLocationSource
+                    .toMMModemLocationSourceFromBitMask(modemLocationProperties.Get(MM_LOCATION_BUS_NAME, "Enabled"));
+        } catch (DBusExecutionException e) {
+            logger.warn("Cannot retrive Modem.Location capabilities for {}. Caused by: ",
+                    modemLocationProperties.getObjectPath(), e);
+            return;
+        }
+
+        if (isGPSSourceEnabled) {
+            if (!availableLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED)) {
+                logger.warn("Cannot setup Modem.Location, MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED not supported for {}",
+                        modemLocationProperties.getObjectPath());
+                return;
+            }
+            desiredLocationSources = EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED);
+        }
+
+        logger.debug("Modem location setup {} for modem {}", currentLocationSources, modemDevicePath.get());
+
+        if (!currentLocationSources.equals(desiredLocationSources)) {
+            modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(desiredLocationSources),
+                    false);
+        }
     }
 
     protected void enableModem(String modemDevicePath) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -38,9 +38,7 @@ public class ModemManagerDbusWrapper {
         this.dbusConnection = dbusConnection;
     }
 
-    protected void handleModemManagerGPSSetup(Optional<String> modemDevicePath, Optional<Boolean> enableGPS)
-            throws DBusException {
-
+    protected void setGPS(Optional<String> modemDevicePath, Optional<Boolean> enableGPS) throws DBusException {
         if (!modemDevicePath.isPresent()) {
             logger.warn("Cannot retrieve MM.Modem from NM.Modem. Skipping GPS configuration.");
             return;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -1,6 +1,11 @@
 package org.eclipse.kura.nm;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +24,15 @@ public class ModemManagerDbusWrapper {
 
     protected ModemManagerDbusWrapper(DBusConnection dbusConnection) {
         this.dbusConnection = dbusConnection;
+    }
+
+    protected Optional<Properties> getModemProperties(String modemPath) throws DBusException {
+        Optional<Properties> modemProperties = Optional.empty();
+        Properties properties = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemPath, Properties.class);
+        if (Objects.nonNull(properties)) {
+            modemProperties = Optional.of(properties);
+        }
+        return modemProperties;
     }
 
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -1,0 +1,24 @@
+package org.eclipse.kura.nm;
+
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ModemManagerDbusWrapper {
+
+    private static final Logger logger = LoggerFactory.getLogger(ModemManagerDbusWrapper.class);
+
+    private static final String MM_BUS_NAME = "org.freedesktop.ModemManager1";
+    private static final String MM_BUS_PATH = "/org/freedesktop/ModemManager1";
+    private static final String MM_MODEM_NAME = "org.freedesktop.ModemManager1.Modem";
+    private static final String MM_SIM_NAME = "org.freedesktop.ModemManager1.Sim";
+    private static final String MM_MODEM_PROPERTY_STATE = "State";
+    private static final String MM_LOCATION_BUS_NAME = "org.freedesktop.ModemManager1.Modem.Location";
+
+    private DBusConnection dbusConnection;
+
+    protected ModemManagerDbusWrapper(DBusConnection dbusConnection) {
+        this.dbusConnection = dbusConnection;
+    }
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -1,11 +1,18 @@
 package org.eclipse.kura.nm;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.kura.nm.status.SimProperties;
+import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.modemmanager1.Modem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +40,81 @@ public class ModemManagerDbusWrapper {
             modemProperties = Optional.of(properties);
         }
         return modemProperties;
+    }
+
+    protected List<SimProperties> getModemSimProperties(Properties modemProperties) throws DBusException {
+        List<SimProperties> simProperties = new ArrayList<>();
+        try {
+            UInt32 primarySimSlot = modemProperties.Get(MM_MODEM_NAME, "PrimarySimSlot");
+
+            if (primarySimSlot.intValue() == 0) {
+                // Multiple SIM slots aren't supported
+                DBusPath simPath = modemProperties.Get(MM_MODEM_NAME, "Sim");
+                if (!simPath.getPath().equals("/")) {
+                    Properties simProp = this.dbusConnection.getRemoteObject(MM_BUS_NAME, simPath.getPath(),
+                            Properties.class);
+                    simProperties.add(new SimProperties(simProp, true, true));
+                }
+            } else {
+                List<DBusPath> simPaths = modemProperties.Get(MM_MODEM_NAME, "SimSlots");
+                for (int index = 0; index < simPaths.size(); index++) {
+                    String dbusPath = simPaths.get(index).getPath();
+
+                    if (dbusPath.equals("/")) {
+                        // SIM slot doesn't contain a SIM
+                        continue;
+                    }
+
+                    Properties simProp = this.dbusConnection.getRemoteObject(MM_BUS_NAME, dbusPath, Properties.class);
+                    boolean isActive = simProp.Get(MM_SIM_NAME, "Active");
+                    boolean isPrimary = index == (primarySimSlot.intValue() - 1);
+
+                    simProperties.add(new SimProperties(simProp, isActive, isPrimary));
+                }
+            }
+        } catch (DBusExecutionException e) {
+            // Fallback for ModemManager version prior to 1.16
+            DBusPath simPath = modemProperties.Get(MM_MODEM_NAME, "Sim");
+            if (!simPath.getPath().equals("/")) {
+                Properties simProp = this.dbusConnection.getRemoteObject(MM_BUS_NAME, simPath.getPath(),
+                        Properties.class);
+                simProperties.add(new SimProperties(simProp, true, true));
+            }
+
+        }
+        return simProperties;
+    }
+
+    protected List<Properties> getModemBearersProperties(String modemPath, Properties modemProperties)
+            throws DBusException {
+        List<Properties> bearerProperties = new ArrayList<>();
+        try {
+            Modem modem = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemPath, Modem.class);
+            if (Objects.nonNull(modem)) {
+                List<DBusPath> bearerPaths = modem.ListBearers();
+                bearerProperties = getBearersPropertiesFromPaths(bearerPaths);
+            }
+        } catch (DBusExecutionException e) {
+            try {
+                List<DBusPath> bearerPaths = modemProperties.Get(MM_BUS_NAME, "Bearers");
+                bearerProperties = getBearersPropertiesFromPaths(bearerPaths);
+            } catch (DBusExecutionException e1) {
+                logger.warn("Cannot get bearers for modem {}", modemPath, e1);
+            }
+        }
+        return bearerProperties;
+    }
+
+    private List<Properties> getBearersPropertiesFromPaths(List<DBusPath> bearerPaths) throws DBusException {
+        List<Properties> bearerProperties = new ArrayList<>();
+        for (DBusPath bearerPath : bearerPaths) {
+            if (!bearerPath.getPath().equals("/")) {
+                bearerProperties
+                        .add(this.dbusConnection.getRemoteObject(MM_BUS_NAME, bearerPath.getPath(), Properties.class));
+            }
+        }
+        return bearerProperties;
+
     }
 
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -225,7 +225,7 @@ public class ModemManagerDbusWrapper {
         }
     }
 
-    protected String getHardwarePath(Optional<String> dbusPath) throws DBusException {
+    protected String getHardwareSysfsPath(Optional<String> dbusPath) throws DBusException {
         if (!dbusPath.isPresent()) {
             throw new IllegalStateException(String.format("Cannot retrieve modem path for: %s.", dbusPath));
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -26,7 +26,6 @@ public class ModemManagerDbusWrapper {
     private static final Logger logger = LoggerFactory.getLogger(ModemManagerDbusWrapper.class);
 
     private static final String MM_BUS_NAME = "org.freedesktop.ModemManager1";
-    private static final String MM_BUS_PATH = "/org/freedesktop/ModemManager1";
     private static final String MM_MODEM_NAME = "org.freedesktop.ModemManager1.Modem";
     private static final String MM_SIM_NAME = "org.freedesktop.ModemManager1.Sim";
     private static final String MM_MODEM_PROPERTY_STATE = "State";

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.kura.nm.enums.MMModemState;
 import org.eclipse.kura.nm.status.SimProperties;
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
@@ -31,6 +32,20 @@ public class ModemManagerDbusWrapper {
 
     protected ModemManagerDbusWrapper(DBusConnection dbusConnection) {
         this.dbusConnection = dbusConnection;
+    }
+
+    protected void enableModem(String modemDevicePath) throws DBusException {
+        Modem modem = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath, Modem.class);
+        Properties modemProperties = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath,
+                Properties.class);
+
+        MMModemState currentModemState = MMModemState
+                .toMMModemState(modemProperties.Get(MM_MODEM_NAME, MM_MODEM_PROPERTY_STATE));
+
+        if (currentModemState.getValue() < MMModemState.MM_MODEM_STATE_ENABLED.getValue()) {
+            logger.info("Modem {} not enabled. Enabling modem...", modemDevicePath);
+            modem.Enable(true);
+        }
     }
 
     protected Optional<Properties> getModemProperties(String modemPath) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -158,6 +158,18 @@ public class ModemManagerDbusWrapper {
         return simProperties;
     }
 
+    protected String getHardwareSysfsPath(Optional<String> dbusPath) throws DBusException {
+        if (!dbusPath.isPresent()) {
+            throw new IllegalStateException(String.format("Cannot retrieve modem path for: %s.", dbusPath));
+        }
+        Optional<Properties> modemDeviceProperties = getModemProperties(dbusPath.get());
+        if (!modemDeviceProperties.isPresent()) {
+            throw new IllegalStateException(String.format("Cannot retrieve modem properties for: %s.", dbusPath));
+        }
+        String modemDeviceProperty = (String) modemDeviceProperties.get().Get(MM_MODEM_NAME, "Device");
+        return modemDeviceProperty.substring(modemDeviceProperty.lastIndexOf("/") + 1);
+    }
+
     protected List<Properties> getModemBearersProperties(String modemPath, Properties modemProperties)
             throws DBusException {
         List<Properties> bearerProperties = new ArrayList<>();
@@ -223,17 +235,5 @@ public class ModemManagerDbusWrapper {
                 logger.warn("Couldn't remove signal handler for: {}. Caused by:", handler.getNMDevicePath(), e);
             }
         }
-    }
-
-    protected String getHardwareSysfsPath(Optional<String> dbusPath) throws DBusException {
-        if (!dbusPath.isPresent()) {
-            throw new IllegalStateException(String.format("Cannot retrieve modem path for: %s.", dbusPath));
-        }
-        Optional<Properties> modemDeviceProperties = getModemProperties(dbusPath.get());
-        if (!modemDeviceProperties.isPresent()) {
-            throw new IllegalStateException(String.format("Cannot retrieve modem properties for: %s.", dbusPath));
-        }
-        String modemDeviceProperty = (String) modemDeviceProperties.get().Get(MM_MODEM_NAME, "Device");
-        return modemDeviceProperty.substring(modemDeviceProperty.lastIndexOf("/") + 1);
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -225,4 +225,15 @@ public class ModemManagerDbusWrapper {
         }
     }
 
+    protected String getHardwarePath(Optional<String> dbusPath) throws DBusException {
+        if (!dbusPath.isPresent()) {
+            throw new IllegalStateException(String.format("Cannot retrieve modem path for: %s.", dbusPath));
+        }
+        Optional<Properties> modemDeviceProperties = getModemProperties(dbusPath.get());
+        if (!modemDeviceProperties.isPresent()) {
+            throw new IllegalStateException(String.format("Cannot retrieve modem properties for: %s.", dbusPath));
+        }
+        String modemDeviceProperty = (String) modemDeviceProperties.get().Get(MM_MODEM_NAME, "Device");
+        return modemDeviceProperty.substring(modemDeviceProperty.lastIndexOf("/") + 1);
+    }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -409,7 +409,7 @@ public class NMDbusConnector {
     private void enableInterface(String deviceId, NetworkProperties properties, Device device, NMDeviceType deviceType)
             throws DBusException {
         if (Boolean.FALSE.equals(this.networkManager.isDeviceManaged(device))) {
-            setDeviceManaged(device, true);
+            this.networkManager.setDeviceManaged(device, true);
         }
         String interfaceName = this.networkManager.getDeviceInterface(device);
 
@@ -465,7 +465,7 @@ public class NMDbusConnector {
         }
 
         if (Boolean.FALSE.equals(this.networkManager.isDeviceManaged(device))) {
-            setDeviceManaged(device, true);
+            this.networkManager.setDeviceManaged(device, true);
         }
 
         logger.warn("Device \"{}\" of type \"{}\" not configured. Disabling...", deviceId, deviceType);
@@ -609,13 +609,6 @@ public class NMDbusConnector {
         }
 
         return accessPointProperties;
-    }
-
-    private void setDeviceManaged(Device device, Boolean manage) throws DBusException {
-        Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.getObjectPath(),
-                Properties.class);
-
-        deviceProperties.Set(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_MANAGED, manage);
     }
 
     private NMDeviceType getDeviceType(String deviceDbusPath) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -15,7 +15,6 @@ package org.eclipse.kura.nm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -34,7 +33,6 @@ import org.eclipse.kura.nm.enums.NMDeviceType;
 import org.eclipse.kura.nm.signal.handlers.DeviceStateLock;
 import org.eclipse.kura.nm.signal.handlers.NMConfigurationEnforcementHandler;
 import org.eclipse.kura.nm.signal.handlers.NMDeviceAddedHandler;
-import org.eclipse.kura.nm.signal.handlers.NMModemResetHandler;
 import org.eclipse.kura.nm.status.AccessPointsProperties;
 import org.eclipse.kura.nm.status.DevicePropertiesWrapper;
 import org.eclipse.kura.nm.status.NMStatusConverter;
@@ -88,8 +86,6 @@ public class NMDbusConnector {
     private NMDeviceAddedHandler deviceAddedHandler = null;
 
     private boolean configurationEnforcementHandlerIsArmed = false;
-
-    private final Map<String, NMModemResetHandler> modemHandlers = new HashMap<>();
 
     private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -102,6 +102,7 @@ public class NMDbusConnector {
 
     private static NMDbusConnector instance;
     private final DBusConnection dbusConnection;
+    private final NetworkManagerDbusWrapper networkManager;
     private final NetworkManager nm;
 
     private Map<String, Object> cachedConfiguration = null;
@@ -115,6 +116,7 @@ public class NMDbusConnector {
 
     private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
+        this.networkManager = new NetworkManagerDbusWrapper(this.dbusConnection);
         this.nm = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_BUS_PATH, NetworkManager.class);
     }
 
@@ -140,7 +142,7 @@ public class NMDbusConnector {
     }
 
     public void checkPermissions() {
-        Map<String, String> getPermissions = this.nm.GetPermissions();
+        Map<String, String> getPermissions = this.networkManager.getPermissions();
         if (logger.isDebugEnabled()) {
             for (Entry<String, String> entry : getPermissions.entrySet()) {
                 logger.debug("Permission for {}: {}", entry.getKey(), entry.getValue());
@@ -149,10 +151,7 @@ public class NMDbusConnector {
     }
 
     public void checkVersion() throws DBusException {
-        Properties nmProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_BUS_PATH, Properties.class);
-
-        String nmVersion = nmProperties.Get(NM_BUS_NAME, NM_PROPERTY_VERSION);
-
+        String nmVersion = this.networkManager.getVersion();
         logger.debug("NM Version: {}", nmVersion);
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -50,7 +50,6 @@ import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
-import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.modemmanager1.Modem;
 import org.freedesktop.modemmanager1.modem.Location;
@@ -72,7 +71,6 @@ public class NMDbusConnector {
     private static final String NM_SETTINGS_BUS_PATH = "/org/freedesktop/NetworkManager/Settings";
     private static final String MM_BUS_NAME = "org.freedesktop.ModemManager1";
     private static final String MM_MODEM_NAME = "org.freedesktop.ModemManager1.Modem";
-    private static final String MM_SIM_NAME = "org.freedesktop.ModemManager1.Sim";
     private static final String MM_LOCATION_BUS_NAME = "org.freedesktop.ModemManager1.Modem.Location";
 
     private static final String NM_DEVICE_PROPERTY_INTERFACE = "Interface";
@@ -252,8 +250,9 @@ public class NMDbusConnector {
         if (modemPath.isPresent()) {
             modemDeviceProperties = this.modemManager.getModemProperties(modemPath.get());
             if (modemDeviceProperties.isPresent()) {
-                simProperties = getModemSimProperties(modemDeviceProperties.get());
-                bearerProperties = getModemBearersProperties(modemPath.get(), modemDeviceProperties.get());
+                simProperties = this.modemManager.getModemSimProperties(modemDeviceProperties.get());
+                bearerProperties = this.modemManager.getModemBearersProperties(modemPath.get(),
+                        modemDeviceProperties.get());
             }
         }
         DevicePropertiesWrapper modemPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
@@ -655,77 +654,4 @@ public class NMDbusConnector {
         }
     }
 
-    private List<SimProperties> getModemSimProperties(Properties modemProperties) throws DBusException {
-        List<SimProperties> simProperties = new ArrayList<>();
-        try {
-            UInt32 primarySimSlot = modemProperties.Get(MM_MODEM_NAME, "PrimarySimSlot");
-
-            if (primarySimSlot.intValue() == 0) {
-                // Multiple SIM slots aren't supported
-                DBusPath simPath = modemProperties.Get(MM_MODEM_NAME, "Sim");
-                if (!simPath.getPath().equals("/")) {
-                    Properties simProp = this.dbusConnection.getRemoteObject(MM_BUS_NAME, simPath.getPath(),
-                            Properties.class);
-                    simProperties.add(new SimProperties(simProp, true, true));
-                }
-            } else {
-                List<DBusPath> simPaths = modemProperties.Get(MM_MODEM_NAME, "SimSlots");
-                for (int index = 0; index < simPaths.size(); index++) {
-                    String dbusPath = simPaths.get(index).getPath();
-
-                    if (dbusPath.equals("/")) {
-                        // SIM slot doesn't contain a SIM
-                        continue;
-                    }
-
-                    Properties simProp = this.dbusConnection.getRemoteObject(MM_BUS_NAME, dbusPath, Properties.class);
-                    boolean isActive = simProp.Get(MM_SIM_NAME, "Active");
-                    boolean isPrimary = index == (primarySimSlot.intValue() - 1);
-
-                    simProperties.add(new SimProperties(simProp, isActive, isPrimary));
-                }
-            }
-        } catch (DBusExecutionException e) {
-            // Fallback for ModemManager version prior to 1.16
-            DBusPath simPath = modemProperties.Get(MM_MODEM_NAME, "Sim");
-            if (!simPath.getPath().equals("/")) {
-                Properties simProp = this.dbusConnection.getRemoteObject(MM_BUS_NAME, simPath.getPath(),
-                        Properties.class);
-                simProperties.add(new SimProperties(simProp, true, true));
-            }
-
-        }
-        return simProperties;
-    }
-
-    private List<Properties> getModemBearersProperties(String modemPath, Properties modemProperties)
-            throws DBusException {
-        List<Properties> bearerProperties = new ArrayList<>();
-        try {
-            Modem modem = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemPath, Modem.class);
-            if (Objects.nonNull(modem)) {
-                List<DBusPath> bearerPaths = modem.ListBearers();
-                bearerProperties = getBearersPropertiesFromPaths(bearerPaths);
-            }
-        } catch (DBusExecutionException e) {
-            try {
-                List<DBusPath> bearerPaths = modemProperties.Get(MM_BUS_NAME, "Bearers");
-                bearerProperties = getBearersPropertiesFromPaths(bearerPaths);
-            } catch (DBusExecutionException e1) {
-                logger.warn("Cannot get bearers for modem {}", modemPath, e1);
-            }
-        }
-        return bearerProperties;
-    }
-
-    private List<Properties> getBearersPropertiesFromPaths(List<DBusPath> bearerPaths) throws DBusException {
-        List<Properties> bearerProperties = new ArrayList<>();
-        for (DBusPath bearerPath : bearerPaths) {
-            if (!bearerPath.getPath().equals("/")) {
-                bearerProperties
-                        .add(this.dbusConnection.getRemoteObject(MM_BUS_NAME, bearerPath.getPath(), Properties.class));
-            }
-        }
-        return bearerProperties;
-    }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -63,7 +63,6 @@ public class NMDbusConnector {
     private static final String NM_SETTINGS_BUS_PATH = "/org/freedesktop/NetworkManager/Settings";
 
     private static final String NM_DEVICE_PROPERTY_INTERFACE = "Interface";
-    private static final String NM_DEVICE_PROPERTY_DEVICETYPE = "DeviceType";
     private static final String NM_DEVICE_PROPERTY_IP4CONFIG = "Ip4Config";
 
     private static final List<NMDeviceType> CONFIGURATION_SUPPORTED_DEVICE_TYPES = Arrays.asList(

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -460,15 +460,7 @@ public class NMDbusConnector {
         NMDeviceType deviceType = this.networkManager.getDeviceType(dbusPath);
         if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
             Optional<String> modemPath = this.networkManager.getModemManagerDbusPath(dbusPath);
-            if (!modemPath.isPresent()) {
-                throw new IllegalStateException(String.format("Cannot retrieve modem path for: %s.", dbusPath));
-            }
-            Optional<Properties> modemDeviceProperties = this.modemManager.getModemProperties(modemPath.get());
-            if (!modemDeviceProperties.isPresent()) {
-                throw new IllegalStateException(String.format("Cannot retrieve modem properties for: %s.", dbusPath));
-
-            }
-            return NMStatusConverter.getModemDeviceHwPath(modemDeviceProperties.get());
+            return this.modemManager.getHardwarePath(modemPath);
         } else {
             Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, dbusPath, Properties.class);
             return deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_INTERFACE);
@@ -505,12 +497,8 @@ public class NMDbusConnector {
                     .fromUInt32(deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_DEVICETYPE));
             if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
                 Optional<String> modemPath = this.networkManager.getModemManagerDbusPath(d.getObjectPath());
-                if (modemPath.isPresent()) {
-                    Optional<Properties> modemDeviceProperties = this.modemManager.getModemProperties(modemPath.get());
-                    if (modemDeviceProperties.isPresent() && NMStatusConverter
-                            .getModemDeviceHwPath(modemDeviceProperties.get()).equals(interfaceId)) {
-                        return Optional.of(d);
-                    }
+                if (this.modemManager.getHardwarePath(modemPath).equals(interfaceId)) {
+                    return Optional.of(d);
                 }
             } else {
                 if (deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_INTERFACE).equals(interfaceId)) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -274,7 +274,7 @@ public class NMDbusConnector {
         Properties wirelessDeviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
                 wirelessDevice.getObjectPath(), Properties.class);
 
-        List<Properties> accessPoints = getAllAccessPoints(wirelessDevice);
+        List<Properties> accessPoints = this.networkManager.getAllAccessPoints(wirelessDevice);
 
         DBusPath activeAccessPointPath = wirelessDeviceProperties.Get(NM_DEVICE_WIRELESS_BUS_NAME, "ActiveAccessPoint");
         Optional<Properties> activeAccessPoint = Optional.empty();
@@ -577,21 +577,6 @@ public class NMDbusConnector {
         for (Connection connection : availableConnections) {
             connection.Delete();
         }
-    }
-
-    private List<Properties> getAllAccessPoints(Wireless wirelessDevice) throws DBusException {
-        List<DBusPath> accessPointPaths = wirelessDevice.GetAllAccessPoints();
-
-        List<Properties> accessPointProperties = new ArrayList<>();
-
-        for (DBusPath path : accessPointPaths) {
-            Properties apProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, path.getPath(),
-                    Properties.class);
-            accessPointProperties.add(apProperties);
-
-        }
-
-        return accessPointProperties;
     }
 
     private Optional<Device> getDeviceByInterfaceId(String interfaceId) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -215,37 +215,35 @@ public class NMDbusConnector {
             }
 
             switch (deviceType) {
-                case NM_DEVICE_TYPE_ETHERNET:
-                    Wired wiredDevice = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.get().getObjectPath(),
-                            Wired.class);
-                    Properties wiredDeviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
-                            wiredDevice.getObjectPath(), Properties.class);
+            case NM_DEVICE_TYPE_ETHERNET:
+                Wired wiredDevice = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.get().getObjectPath(),
+                        Wired.class);
+                Properties wiredDeviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
+                        wiredDevice.getObjectPath(), Properties.class);
 
-                    DevicePropertiesWrapper ethernetPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
-                            Optional.of(wiredDeviceProperties), NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+                DevicePropertiesWrapper ethernetPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
+                        Optional.of(wiredDeviceProperties), NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
-                    networkInterfaceStatus = NMStatusConverter.buildEthernetStatus(interfaceId,
-                            ethernetPropertiesWrapper,
-                            ip4configProperties);
-                    break;
-                case NM_DEVICE_TYPE_LOOPBACK:
-                    DevicePropertiesWrapper loopbackPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
-                            Optional.empty(), NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
+                networkInterfaceStatus = NMStatusConverter.buildEthernetStatus(interfaceId, ethernetPropertiesWrapper,
+                        ip4configProperties);
+                break;
+            case NM_DEVICE_TYPE_LOOPBACK:
+                DevicePropertiesWrapper loopbackPropertiesWrapper = new DevicePropertiesWrapper(deviceProperties,
+                        Optional.empty(), NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
 
-                    networkInterfaceStatus = NMStatusConverter.buildLoopbackStatus(interfaceId,
-                            loopbackPropertiesWrapper,
-                            ip4configProperties);
-                    break;
-                case NM_DEVICE_TYPE_WIFI:
-                    networkInterfaceStatus = createWirelessStatus(interfaceId, commandExecutorService, device.get(),
-                            deviceProperties, ip4configProperties);
-                    break;
-                case NM_DEVICE_TYPE_MODEM:
-                    networkInterfaceStatus = createModemStatus(interfaceId, device.get(), deviceProperties,
-                            ip4configProperties);
-                    break;
-                default:
-                    break;
+                networkInterfaceStatus = NMStatusConverter.buildLoopbackStatus(interfaceId, loopbackPropertiesWrapper,
+                        ip4configProperties);
+                break;
+            case NM_DEVICE_TYPE_WIFI:
+                networkInterfaceStatus = createWirelessStatus(interfaceId, commandExecutorService, device.get(),
+                        deviceProperties, ip4configProperties);
+                break;
+            case NM_DEVICE_TYPE_MODEM:
+                networkInterfaceStatus = createModemStatus(interfaceId, device.get(), deviceProperties,
+                        ip4configProperties);
+                break;
+            default:
+                break;
             }
         }
         return networkInterfaceStatus;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -426,8 +426,7 @@ public class NMDbusConnector {
         }
 
         try {
-            this.nm.ActivateConnection(new DBusPath(connection.get().getObjectPath()),
-                    new DBusPath(device.getObjectPath()), new DBusPath("/"));
+            this.networkManager.activateConnection(connection.get(), device);
             dsLock.waitForSignal();
         } catch (DBusExecutionException e) {
             logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -408,7 +408,7 @@ public class NMDbusConnector {
 
     private void enableInterface(String deviceId, NetworkProperties properties, Device device, NMDeviceType deviceType)
             throws DBusException {
-        if (Boolean.FALSE.equals(isDeviceManaged(device))) {
+        if (Boolean.FALSE.equals(this.networkManager.isDeviceManaged(device))) {
             setDeviceManaged(device, true);
         }
         String interfaceName = this.networkManager.getDeviceInterface(device);
@@ -464,7 +464,7 @@ public class NMDbusConnector {
             return;
         }
 
-        if (Boolean.FALSE.equals(isDeviceManaged(device))) {
+        if (Boolean.FALSE.equals(this.networkManager.isDeviceManaged(device))) {
             setDeviceManaged(device, true);
         }
 
@@ -616,13 +616,6 @@ public class NMDbusConnector {
                 Properties.class);
 
         deviceProperties.Set(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_MANAGED, manage);
-    }
-
-    private Boolean isDeviceManaged(Device device) throws DBusException {
-        Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.getObjectPath(),
-                Properties.class);
-
-        return deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_MANAGED);
     }
 
     private NMDeviceType getDeviceType(String deviceDbusPath) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -477,7 +477,7 @@ public class NMDbusConnector {
             return;
         }
 
-        enableModem(modemDevicePath.get());
+        this.modemManager.enableModem(modemDevicePath.get());
 
         boolean isGPSSourceEnabled = enableGPS.isPresent() && enableGPS.get();
 
@@ -518,20 +518,6 @@ public class NMDbusConnector {
         if (!currentLocationSources.equals(desiredLocationSources)) {
             modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(desiredLocationSources),
                     false);
-        }
-    }
-
-    private void enableModem(String modemDevicePath) throws DBusException {
-        Modem modem = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath, Modem.class);
-        Properties modemProperties = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath,
-                Properties.class);
-
-        MMModemState currentModemState = MMModemState
-                .toMMModemState(modemProperties.Get(MM_MODEM_NAME, MM_MODEM_PROPERTY_STATE));
-
-        if (currentModemState.getValue() < MMModemState.MM_MODEM_STATE_ENABLED.getValue()) {
-            logger.info("Modem {} not enabled. Enabling modem...", modemDevicePath);
-            modem.Enable(true);
         }
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -456,6 +456,16 @@ public class NMDbusConnector {
         }
     }
 
+    private Optional<Device> getDeviceByInterfaceId(String interfaceId) throws DBusException {
+        for (Device nmDevice : this.networkManager.getAllDevices()) {
+            String deviceInterfaceId = getDeviceIdByDBusPath(nmDevice.getObjectPath());
+            if (deviceInterfaceId.equals(interfaceId)) {
+                return Optional.of(nmDevice);
+            }
+        }
+        return Optional.empty();
+    }
+
     public String getDeviceIdByDBusPath(String dbusPath) throws DBusException {
         NMDeviceType deviceType = this.networkManager.getDeviceType(dbusPath);
         if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
@@ -487,26 +497,6 @@ public class NMDbusConnector {
         for (Connection connection : availableConnections) {
             connection.Delete();
         }
-    }
-
-    private Optional<Device> getDeviceByInterfaceId(String interfaceId) throws DBusException {
-        for (Device d : this.networkManager.getAllDevices()) {
-            Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, d.getObjectPath(),
-                    Properties.class);
-            NMDeviceType deviceType = NMDeviceType
-                    .fromUInt32(deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_DEVICETYPE));
-            if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
-                Optional<String> modemPath = this.networkManager.getModemManagerDbusPath(d.getObjectPath());
-                if (this.modemManager.getHardwareSysfsPath(modemPath).equals(interfaceId)) {
-                    return Optional.of(d);
-                }
-            } else {
-                if (deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_INTERFACE).equals(interfaceId)) {
-                    return Optional.of(d);
-                }
-            }
-        }
-        return Optional.empty();
     }
 
     private void configurationEnforcementEnable() throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -385,7 +385,7 @@ public class NMDbusConnector {
             Optional<Boolean> enableGPS = properties.getOpt(Boolean.class, "net.interface.%s.config.gpsEnabled",
                     deviceId);
             Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-            this.modemManager.handleModemManagerGPSSetup(mmDbusPath, enableGPS);
+            this.modemManager.setGPS(mmDbusPath, enableGPS);
         }
 
     }
@@ -457,7 +457,7 @@ public class NMDbusConnector {
 
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {
             Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-            this.modemManager.handleModemManagerGPSSetup(mmDbusPath, Optional.of(false));
+            this.modemManager.setGPS(mmDbusPath, Optional.of(false));
         }
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -460,7 +460,7 @@ public class NMDbusConnector {
         NMDeviceType deviceType = this.networkManager.getDeviceType(dbusPath);
         if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
             Optional<String> modemPath = this.networkManager.getModemManagerDbusPath(dbusPath);
-            return this.modemManager.getHardwarePath(modemPath);
+            return this.modemManager.getHardwareSysfsPath(modemPath);
         } else {
             Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, dbusPath, Properties.class);
             return deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_INTERFACE);
@@ -497,7 +497,7 @@ public class NMDbusConnector {
                     .fromUInt32(deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_DEVICETYPE));
             if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
                 Optional<String> modemPath = this.networkManager.getModemManagerDbusPath(d.getObjectPath());
-                if (this.modemManager.getHardwarePath(modemPath).equals(interfaceId)) {
+                if (this.modemManager.getHardwareSysfsPath(modemPath).equals(interfaceId)) {
                     return Optional.of(d);
                 }
             } else {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -250,7 +250,7 @@ public class NMDbusConnector {
         List<SimProperties> simProperties = Collections.emptyList();
         List<Properties> bearerProperties = Collections.emptyList();
         if (modemPath.isPresent()) {
-            modemDeviceProperties = getModemProperties(modemPath.get());
+            modemDeviceProperties = this.modemManager.getModemProperties(modemPath.get());
             if (modemDeviceProperties.isPresent()) {
                 simProperties = getModemSimProperties(modemDeviceProperties.get());
                 bearerProperties = getModemBearersProperties(modemPath.get(), modemDeviceProperties.get());
@@ -543,7 +543,7 @@ public class NMDbusConnector {
             if (!modemPath.isPresent()) {
                 throw new IllegalStateException(String.format("Cannot retrieve modem path for: %s.", dbusPath));
             }
-            Optional<Properties> modemDeviceProperties = getModemProperties(modemPath.get());
+            Optional<Properties> modemDeviceProperties = this.modemManager.getModemProperties(modemPath.get());
             if (!modemDeviceProperties.isPresent()) {
                 throw new IllegalStateException(String.format("Cannot retrieve modem properties for: %s.", dbusPath));
 
@@ -586,7 +586,7 @@ public class NMDbusConnector {
             if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
                 Optional<String> modemPath = this.networkManager.getModemManagerDbusPath(d.getObjectPath());
                 if (modemPath.isPresent()) {
-                    Optional<Properties> modemDeviceProperties = getModemProperties(modemPath.get());
+                    Optional<Properties> modemDeviceProperties = this.modemManager.getModemProperties(modemPath.get());
                     if (modemDeviceProperties.isPresent() && NMStatusConverter
                             .getModemDeviceHwPath(modemDeviceProperties.get()).equals(interfaceId)) {
                         return Optional.of(d);
@@ -653,15 +653,6 @@ public class NMDbusConnector {
                 logger.warn("Couldn't remove signal handler for: {}. Caused by:", handler.getNMDevicePath(), e);
             }
         }
-    }
-
-    private Optional<Properties> getModemProperties(String modemPath) throws DBusException {
-        Optional<Properties> modemProperties = Optional.empty();
-        Properties properties = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemPath, Properties.class);
-        if (Objects.nonNull(properties)) {
-            modemProperties = Optional.of(properties);
-        }
-        return modemProperties;
     }
 
     private List<SimProperties> getModemSimProperties(Properties modemProperties) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -67,12 +67,10 @@ public class NMDbusConnector {
     private static final Logger logger = LoggerFactory.getLogger(NMDbusConnector.class);
 
     private static final String NM_BUS_NAME = "org.freedesktop.NetworkManager";
-    private static final String NM_BUS_PATH = "/org/freedesktop/NetworkManager";
     private static final String NM_DEVICE_BUS_NAME = "org.freedesktop.NetworkManager.Device";
     private static final String NM_DEVICE_WIRELESS_BUS_NAME = "org.freedesktop.NetworkManager.Device.Wireless";
     private static final String NM_SETTINGS_BUS_PATH = "/org/freedesktop/NetworkManager/Settings";
     private static final String MM_BUS_NAME = "org.freedesktop.ModemManager1";
-    private static final String MM_BUS_PATH = "/org/freedesktop/ModemManager1";
     private static final String MM_MODEM_NAME = "org.freedesktop.ModemManager1.Modem";
     private static final String MM_SIM_NAME = "org.freedesktop.ModemManager1.Sim";
     private static final String MM_LOCATION_BUS_NAME = "org.freedesktop.ModemManager1.Modem.Location";
@@ -95,7 +93,6 @@ public class NMDbusConnector {
     private static NMDbusConnector instance;
     private final DBusConnection dbusConnection;
     private final NetworkManagerDbusWrapper networkManager;
-    private final NetworkManager nm;
 
     private Map<String, Object> cachedConfiguration = null;
 
@@ -109,7 +106,6 @@ public class NMDbusConnector {
     private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.networkManager = new NetworkManagerDbusWrapper(this.dbusConnection);
-        this.nm = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_BUS_PATH, NetworkManager.class);
     }
 
     public static synchronized NMDbusConnector getInstance() throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -15,7 +15,6 @@ package org.eclipse.kura.nm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +22,6 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.executor.CommandExecutorService;
@@ -31,8 +29,6 @@ import org.eclipse.kura.linux.net.util.IwCapabilityTool;
 import org.eclipse.kura.net.status.NetworkInterfaceStatus;
 import org.eclipse.kura.net.wifi.WifiChannel;
 import org.eclipse.kura.nm.configuration.NMSettingsConverter;
-import org.eclipse.kura.nm.enums.MMModemLocationSource;
-import org.eclipse.kura.nm.enums.MMModemState;
 import org.eclipse.kura.nm.enums.NMDeviceState;
 import org.eclipse.kura.nm.enums.NMDeviceType;
 import org.eclipse.kura.nm.signal.handlers.DeviceStateLock;
@@ -52,7 +48,6 @@ import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.modemmanager1.Modem;
-import org.freedesktop.modemmanager1.modem.Location;
 import org.freedesktop.networkmanager.Device;
 import org.freedesktop.networkmanager.Settings;
 import org.freedesktop.networkmanager.device.Wired;
@@ -70,14 +65,10 @@ public class NMDbusConnector {
     private static final String NM_DEVICE_WIRELESS_BUS_NAME = "org.freedesktop.NetworkManager.Device.Wireless";
     private static final String NM_SETTINGS_BUS_PATH = "/org/freedesktop/NetworkManager/Settings";
     private static final String MM_BUS_NAME = "org.freedesktop.ModemManager1";
-    private static final String MM_MODEM_NAME = "org.freedesktop.ModemManager1.Modem";
-    private static final String MM_LOCATION_BUS_NAME = "org.freedesktop.ModemManager1.Modem.Location";
 
     private static final String NM_DEVICE_PROPERTY_INTERFACE = "Interface";
     private static final String NM_DEVICE_PROPERTY_DEVICETYPE = "DeviceType";
     private static final String NM_DEVICE_PROPERTY_IP4CONFIG = "Ip4Config";
-
-    private static final String MM_MODEM_PROPERTY_STATE = "State";
 
     private static final List<NMDeviceType> CONFIGURATION_SUPPORTED_DEVICE_TYPES = Arrays.asList(
             NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceType.NM_DEVICE_TYPE_WIFI, NMDeviceType.NM_DEVICE_TYPE_MODEM);
@@ -393,7 +384,8 @@ public class NMDbusConnector {
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {
             Optional<Boolean> enableGPS = properties.getOpt(Boolean.class, "net.interface.%s.config.gpsEnabled",
                     deviceId);
-            handleModemManagerGPSSetup(device, enableGPS);
+            Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
+            this.modemManager.handleModemManagerGPSSetup(mmDbusPath, enableGPS);
         }
 
     }
@@ -464,60 +456,8 @@ public class NMDbusConnector {
         disable(device);
 
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {
-            handleModemManagerGPSSetup(device, Optional.of(false));
-        }
-    }
-
-    private void handleModemManagerGPSSetup(Device device, Optional<Boolean> enableGPS) throws DBusException {
-        Optional<String> modemDevicePath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-
-        if (!modemDevicePath.isPresent()) {
-            logger.warn("Cannot retrieve MM.Modem from NM.Modem at path: {}. Skipping GPS configuration.",
-                    device.getObjectPath());
-            return;
-        }
-
-        this.modemManager.enableModem(modemDevicePath.get());
-
-        boolean isGPSSourceEnabled = enableGPS.isPresent() && enableGPS.get();
-
-        Location modemLocation = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath.get(),
-                Location.class);
-        Properties modemLocationProperties = this.dbusConnection.getRemoteObject(MM_BUS_NAME,
-                modemLocation.getObjectPath(), Properties.class);
-
-        Set<MMModemLocationSource> availableLocationSources = EnumSet
-                .of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE);
-        Set<MMModemLocationSource> currentLocationSources = EnumSet
-                .of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE);
-        Set<MMModemLocationSource> desiredLocationSources = EnumSet
-                .of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE);
-
-        try {
-            availableLocationSources = MMModemLocationSource.toMMModemLocationSourceFromBitMask(
-                    modemLocationProperties.Get(MM_LOCATION_BUS_NAME, "Capabilities"));
-            currentLocationSources = MMModemLocationSource
-                    .toMMModemLocationSourceFromBitMask(modemLocationProperties.Get(MM_LOCATION_BUS_NAME, "Enabled"));
-        } catch (DBusExecutionException e) {
-            logger.warn("Cannot retrive Modem.Location capabilities for {}. Caused by: ",
-                    modemLocationProperties.getObjectPath(), e);
-            return;
-        }
-
-        if (isGPSSourceEnabled) {
-            if (!availableLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED)) {
-                logger.warn("Cannot setup Modem.Location, MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED not supported for {}",
-                        modemLocationProperties.getObjectPath());
-                return;
-            }
-            desiredLocationSources = EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED);
-        }
-
-        logger.debug("Modem location setup {} for modem {}", currentLocationSources, modemDevicePath.get());
-
-        if (!currentLocationSources.equals(desiredLocationSources)) {
-            modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(desiredLocationSources),
-                    false);
+            Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
+            this.modemManager.handleModemManagerGPSSetup(mmDbusPath, Optional.of(false));
         }
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -149,7 +149,7 @@ public class NMDbusConnector {
     }
 
     public synchronized List<String> getDeviceIds() throws DBusException {
-        List<Device> availableDevices = getAllDevices();
+        List<Device> availableDevices = this.networkManager.getAllDevices();
 
         List<String> supportedDeviceNames = new ArrayList<>();
         for (Device device : availableDevices) {
@@ -339,7 +339,7 @@ public class NMDbusConnector {
 
     private synchronized void doApply(Map<String, Object> networkConfiguration) throws DBusException {
         logger.info("Applying configuration using NetworkManager Dbus connector");
-        List<Device> availableDevices = getAllDevices();
+        List<Device> availableDevices = this.networkManager.getAllDevices();
         availableDevices.forEach(device -> {
             try {
                 String deviceId = getDeviceIdByDBusPath(device.getObjectPath());
@@ -581,17 +581,6 @@ public class NMDbusConnector {
         }
     }
 
-    private List<Device> getAllDevices() throws DBusException {
-        List<DBusPath> devicePaths = this.nm.GetAllDevices();
-
-        List<Device> devices = new ArrayList<>();
-        for (DBusPath path : devicePaths) {
-            devices.add(this.dbusConnection.getRemoteObject(NM_BUS_NAME, path.getPath(), Device.class));
-        }
-
-        return devices;
-    }
-
     private List<Properties> getAllAccessPoints(Wireless wirelessDevice) throws DBusException {
         List<DBusPath> accessPointPaths = wirelessDevice.GetAllAccessPoints();
 
@@ -608,7 +597,7 @@ public class NMDbusConnector {
     }
 
     private Optional<Device> getDeviceByInterfaceId(String interfaceId) throws DBusException {
-        for (Device d : getAllDevices()) {
+        for (Device d : this.networkManager.getAllDevices()) {
             Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, d.getObjectPath(),
                     Properties.class);
             NMDeviceType deviceType = NMDeviceType

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -47,7 +47,6 @@ import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.Variant;
-import org.freedesktop.modemmanager1.Modem;
 import org.freedesktop.networkmanager.Device;
 import org.freedesktop.networkmanager.Settings;
 import org.freedesktop.networkmanager.device.Wired;
@@ -64,7 +63,6 @@ public class NMDbusConnector {
     private static final String NM_DEVICE_BUS_NAME = "org.freedesktop.NetworkManager.Device";
     private static final String NM_DEVICE_WIRELESS_BUS_NAME = "org.freedesktop.NetworkManager.Device.Wireless";
     private static final String NM_SETTINGS_BUS_PATH = "/org/freedesktop/NetworkManager/Settings";
-    private static final String MM_BUS_NAME = "org.freedesktop.ModemManager1";
 
     private static final String NM_DEVICE_PROPERTY_INTERFACE = "Interface";
     private static final String NM_DEVICE_PROPERTY_DEVICETYPE = "DeviceType";

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -93,6 +93,7 @@ public class NMDbusConnector {
     private static NMDbusConnector instance;
     private final DBusConnection dbusConnection;
     private final NetworkManagerDbusWrapper networkManager;
+    private final ModemManagerDbusWrapper modemManager;
 
     private Map<String, Object> cachedConfiguration = null;
 
@@ -106,6 +107,7 @@ public class NMDbusConnector {
     private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.networkManager = new NetworkManagerDbusWrapper(this.dbusConnection);
+        this.modemManager = new ModemManagerDbusWrapper(this.dbusConnection);
     }
 
     public static synchronized NMDbusConnector getInstance() throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -18,6 +18,7 @@ import org.freedesktop.dbus.types.Variant;
 import org.freedesktop.networkmanager.Device;
 import org.freedesktop.networkmanager.Settings;
 import org.freedesktop.networkmanager.device.Generic;
+import org.freedesktop.networkmanager.device.Wireless;
 import org.freedesktop.networkmanager.settings.Connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,6 +190,21 @@ public class NetworkManagerDbusWrapper {
     protected void activateConnection(Connection connection, Device device) throws DBusException {
         this.networkManager.ActivateConnection(new DBusPath(connection.getObjectPath()),
                 new DBusPath(device.getObjectPath()), new DBusPath("/"));
+    }
+
+    protected List<Properties> getAllAccessPoints(Wireless wirelessDevice) throws DBusException {
+        List<DBusPath> accessPointPaths = wirelessDevice.GetAllAccessPoints();
+
+        List<Properties> accessPointProperties = new ArrayList<>();
+
+        for (DBusPath path : accessPointPaths) {
+            Properties apProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, path.getPath(),
+                    Properties.class);
+            accessPointProperties.add(apProperties);
+
+        }
+
+        return accessPointProperties;
     }
 
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -63,4 +63,11 @@ public class NetworkManagerDbusWrapper {
                 Properties.class);
         return deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_MANAGED);
     }
+
+    protected void setDeviceManaged(Device device, Boolean manage) throws DBusException {
+        Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.getObjectPath(),
+                Properties.class);
+
+        deviceProperties.Set(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_MANAGED, manage);
+    }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -1,10 +1,13 @@
 package org.eclipse.kura.nm;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.kura.nm.enums.NMDeviceState;
 import org.eclipse.kura.nm.enums.NMDeviceType;
 import org.freedesktop.NetworkManager;
+import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.interfaces.Properties;
@@ -71,6 +74,17 @@ public class NetworkManagerDbusWrapper {
                 Properties.class);
 
         deviceProperties.Set(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_MANAGED, manage);
+    }
+
+    protected List<Device> getAllDevices() throws DBusException {
+        List<DBusPath> devicePaths = this.networkManager.GetAllDevices();
+
+        List<Device> devices = new ArrayList<>();
+        for (DBusPath path : devicePaths) {
+            devices.add(this.dbusConnection.getRemoteObject(NM_BUS_NAME, path.getPath(), Device.class));
+        }
+
+        return devices;
     }
 
     protected NMDeviceType getDeviceType(String deviceDbusPath) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -2,10 +2,12 @@ package org.eclipse.kura.nm;
 
 import java.util.Map;
 
+import org.eclipse.kura.nm.enums.NMDeviceState;
 import org.freedesktop.NetworkManager;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.interfaces.Properties;
+import org.freedesktop.networkmanager.Device;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,8 +17,17 @@ public class NetworkManagerDbusWrapper {
 
     private static final String NM_BUS_NAME = "org.freedesktop.NetworkManager";
     private static final String NM_BUS_PATH = "/org/freedesktop/NetworkManager";
+    private static final String NM_DEVICE_BUS_NAME = "org.freedesktop.NetworkManager.Device";
+    private static final String NM_GENERIC_DEVICE_BUS_NAME = "org.freedesktop.NetworkManager.Device.Generic";
+    private static final String NM_SETTINGS_BUS_PATH = "/org/freedesktop/NetworkManager/Settings";
 
     private static final String NM_PROPERTY_VERSION = "Version";
+    private static final String NM_DEVICE_PROPERTY_INTERFACE = "Interface";
+    private static final String NM_DEVICE_PROPERTY_MANAGED = "Managed";
+    private static final String NM_DEVICE_PROPERTY_DEVICETYPE = "DeviceType";
+    private static final String NM_DEVICE_PROPERTY_STATE = "State";
+    private static final String NM_SETTING_CONNECTION_KEY = "connection";
+    private static final String NM_DEVICE_GENERIC_PROPERTY_TYPEDESCRIPTION = "TypeDescription";
 
     private DBusConnection dbusConnection;
     private NetworkManager networkManager;
@@ -33,5 +44,17 @@ public class NetworkManagerDbusWrapper {
 
     protected Map<String, String> getPermissions() {
         return this.networkManager.GetPermissions();
+    }
+
+    protected String getDeviceInterface(Device device) throws DBusException {
+        Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.getObjectPath(),
+                Properties.class);
+        return deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_INTERFACE);
+    }
+
+    protected NMDeviceState getDeviceState(Device device) throws DBusException {
+        Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.getObjectPath(),
+                Properties.class);
+        return NMDeviceState.fromUInt32(deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_STATE));
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -57,4 +57,10 @@ public class NetworkManagerDbusWrapper {
                 Properties.class);
         return NMDeviceState.fromUInt32(deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_STATE));
     }
+
+    protected Boolean isDeviceManaged(Device device) throws DBusException {
+        Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.getObjectPath(),
+                Properties.class);
+        return deviceProperties.Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_MANAGED);
+    }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -1,8 +1,11 @@
 package org.eclipse.kura.nm;
 
+import java.util.Map;
+
 import org.freedesktop.NetworkManager;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,11 +16,22 @@ public class NetworkManagerDbusWrapper {
     private static final String NM_BUS_NAME = "org.freedesktop.NetworkManager";
     private static final String NM_BUS_PATH = "/org/freedesktop/NetworkManager";
 
+    private static final String NM_PROPERTY_VERSION = "Version";
+
     private DBusConnection dbusConnection;
     private NetworkManager networkManager;
 
     protected NetworkManagerDbusWrapper(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = dbusConnection;
         this.networkManager = dbusConnection.getRemoteObject(NM_BUS_NAME, NM_BUS_PATH, NetworkManager.class);
+    }
+
+    protected String getVersion() throws DBusException {
+        Properties nmProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, NM_BUS_PATH, Properties.class);
+        return nmProperties.Get(NM_BUS_NAME, NM_PROPERTY_VERSION);
+    }
+
+    protected Map<String, String> getPermissions() {
+        return this.networkManager.GetPermissions();
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -1,0 +1,23 @@
+package org.eclipse.kura.nm;
+
+import org.freedesktop.NetworkManager;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class NetworkManagerDbusWrapper {
+
+    private static final Logger logger = LoggerFactory.getLogger(NetworkManagerDbusWrapper.class);
+
+    private static final String NM_BUS_NAME = "org.freedesktop.NetworkManager";
+    private static final String NM_BUS_PATH = "/org/freedesktop/NetworkManager";
+
+    private DBusConnection dbusConnection;
+    private NetworkManager networkManager;
+
+    protected NetworkManagerDbusWrapper(DBusConnection dbusConnection) throws DBusException {
+        this.dbusConnection = dbusConnection;
+        this.networkManager = dbusConnection.getRemoteObject(NM_BUS_NAME, NM_BUS_PATH, NetworkManager.class);
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -186,4 +186,9 @@ public class NetworkManagerDbusWrapper {
         return connections;
     }
 
+    protected void activateConnection(Connection connection, Device device) throws DBusException {
+        this.networkManager.ActivateConnection(new DBusPath(connection.getObjectPath()),
+                new DBusPath(device.getObjectPath()), new DBusPath("/"));
+    }
+
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -212,11 +212,6 @@ public class NMStatusConverter {
         }
     }
 
-    public static String getModemDeviceHwPath(Properties modemProperties) {
-        String modemDeviceProperty = (String) modemProperties.Get(MM_MODEM_BUS_NAME, "Device");
-        return modemDeviceProperty.substring(modemDeviceProperty.lastIndexOf("/") + 1);
-    }
-
     private static String getHwAddressFrom(DevicePropertiesWrapper devicePropertiesWrapper) {
         try {
             return devicePropertiesWrapper.getDeviceProperties().Get(NM_DEVICE_BUS_NAME, NM_DEVICE_PROPERTY_HW_ADDRESS);


### PR DESCRIPTION
This PR adds two new objects to the `org.eclipse.kura.nm` bundle that abstract the two main services to which the `NMDbusConnector` interfaces: **NetworkManager** and **ModemManager**.

This refactoring was necessary since the `NMDbusConnector`, initially dedicated to interfacing only with NetworkManager, grew too much and started touching other services (ModemManager, soon WPA Supplicant) as features were added.

The introduction of these two new objects should increase the readability of the code since it is now clear to which dbus service the `NMDbusConnector` is talking to.

Additional notes:
- I moved `getModemDeviceHwPath` method from `NMStatusConverter` to the ModemManager wrapper.

Things I don't particularly like:
- The `NetworkManagerDbusWrapper` and the `ModemManagerDbusWrapper` have a `dbusConnection` as private member, but the sole owner of the `dbusConnection` *is `NMDbusConnector`* (which is why we modeled it as a singleton). Another way to avoid confusion would be to always pass the `dbusConnection` as parameter of the method. Any suggestion is welcome.
- The modem reset handlers were moved inside `ModemManagerDbusWrapper` since ModemManager is responsible for managing the Modem **but** to decide whether we need to reset the modem or not we monitor a _NetworkManager_ signal. The reset handlers are a "bridge" between the two services but I decided to move them in the ModemManager anyway.
- Lack of unit tests for the wrappers object. Coverage is pretty high because we have the `NMDbusConnector` tests but a set of dedicated tests for the wrappers would be a great idea.

Test performed on Raspberry Pi 4:
- [X] Installation and check that all connection work as expected
- [X] Wifi connection
- [X] Cellular connection
- [X] Modem reset
- [X] Configuration enforcement
- [X] Manual IP configuration for ethernet device

Any additional test is welcome