### PR TITLE
fix: support for no Wireless Security

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -65,10 +65,16 @@ public class NMSettingsConverter {
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_WIFI) {
             Map<String, Variant<?>> wifiSettingsMap = NMSettingsConverter.build80211WirelessSettings(properties,
                     deviceId);
-            Map<String, Variant<?>> wifiSecuritySettingsMap = NMSettingsConverter
-                    .build80211WirelessSecuritySettings(properties, deviceId);
             newConnectionSettings.put("802-11-wireless", wifiSettingsMap);
-            newConnectionSettings.put("802-11-wireless-security", wifiSecuritySettingsMap);
+
+            String propMode = properties.get(String.class, "net.interface.%s.config.wifi.mode", deviceId);
+            String securityType = properties.get(String.class, "net.interface.%s.config.wifi.%s.securityType", deviceId,
+                    propMode.toLowerCase());
+            if (!"NONE".equals(securityType)) {
+                Map<String, Variant<?>> wifiSecuritySettingsMap = NMSettingsConverter
+                        .build80211WirelessSecuritySettings(properties, deviceId);
+                newConnectionSettings.put("802-11-wireless-security", wifiSecuritySettingsMap);
+            }
         } else if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {
             Map<String, Variant<?>> gsmSettingsMap = NMSettingsConverter.buildGsmSettings(properties, deviceId);
             Map<String, Variant<?>> pppSettingsMap = NMSettingsConverter.buildPPPSettings(properties, deviceId);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -178,18 +178,18 @@ public class NMSettingsConverter {
         Map<String, Variant<?>> settings = new HashMap<>();
 
         String propMode = props.get(String.class, "net.interface.%s.config.wifi.mode", deviceId);
+        String securityType = props.get(String.class, "net.interface.%s.config.wifi.%s.securityType", deviceId,
+                propMode.toLowerCase());
 
         String psk = props
                 .get(Password.class, "net.interface.%s.config.wifi.%s.passphrase", deviceId, propMode.toLowerCase())
                 .toString();
-        String keyMgmt = wifiKeyMgmtConvert(props.get(String.class, "net.interface.%s.config.wifi.%s.securityType",
-                deviceId, propMode.toLowerCase()));
         settings.put("psk", new Variant<>(psk));
+        String keyMgmt = wifiKeyMgmtConvert(securityType);
         settings.put("key-mgmt", new Variant<>(keyMgmt));
 
         if ("wpa-psk".equals(keyMgmt)) {
-            List<String> proto = wifiProtoConvert(props.get(String.class,
-                    "net.interface.%s.config.wifi.%s.securityType", deviceId, propMode.toLowerCase()));
+            List<String> proto = wifiProtoConvert(securityType);
             settings.put("proto", new Variant<>(proto, "as"));
         }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/utils/EnumsParser.java
@@ -147,6 +147,10 @@ public class EnumsParser {
      */
     public static String getGwtWifiSecurity(Optional<String> wifiSecurity) {
         if (wifiSecurity.isPresent()) {
+            if (wifiSecurity.get().equals(WifiSecurity.NONE.name())) {
+                return GwtWifiSecurity.netWifiSecurityNONE.name();
+            }
+
             if (wifiSecurity.get().equals(WifiSecurity.SECURITY_WEP.name())) {
                 return GwtWifiSecurity.netWifiSecurityWEP.name();
             }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -873,6 +873,10 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
         givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
         givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "NONE");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.ignoreSSID", true);
+        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
+        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
+        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",


### PR DESCRIPTION
During testing we found a couple of bugs affecting the Generic profiles when set for connecting to a Wireless Access Point with no security.

The first bug was affecting the backend, more precisely the NetworkManager-interfacing code. It was found that, when connecting or providing an AP without security, the `802-11-wireless-security` settings **should not be set**. Fixed in 1e31329

The second bug was affecting the UI. When parsing the configuration returned by the backend, the parser would not take into account the `NONE` option. Resulting in a UI reporting "WPA2" as the configured security type but actually using "NONE" under the hood. Fixed in 3445fba

> **Warning**: WEP encryption is currently broken. We're not correctly setting the password when setting up the connection and thus NetworkManager will not create the connection. We'll leave this as a known issue for now.