### PR TITLE
fix(rest.command.service): separated async and non async api's to aline with output

### DIFF
--- a/kura/org.eclipse.kura.rest.command.provider/src/main/java/org/eclipse/kura/rest/command/api/RestCommandRequest.java
+++ b/kura/org.eclipse.kura.rest.command.provider/src/main/java/org/eclipse/kura/rest/command/api/RestCommandRequest.java
@@ -23,7 +23,6 @@ public class RestCommandRequest {
     private String[] arguments;
     private Map<String, String> environmentPairs;
     private String workingDirectory;
-    private boolean isRunAsync;
 
     public void setCommand(String command) {
         this.command = command;
@@ -43,10 +42,6 @@ public class RestCommandRequest {
 
     public void setPassword(String password) {
         this.password = password;
-    }
-
-    public void setIsRunAsync(boolean isRunAsync) {
-        this.isRunAsync = isRunAsync;
     }
 
     public void setZipBytes(String zipBytes) {
@@ -79,10 +74,6 @@ public class RestCommandRequest {
 
     public String getPassword() {
         return this.password;
-    }
-
-    public boolean getIsRunAsync() {
-        return this.isRunAsync;
     }
 
     public String getZipBytes() {


### PR DESCRIPTION

This PR separates the async, and sync endpoints for the command service.  The synchronous endpoint will continue to return the expected RestCommandResponse object. The async endpoint will now only return a status code because when running a long async command, these vars are not returned.



> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
