### PR TITLE
docs: update command rest v1 to support async endpoint

### DIFF
--- a/docs/references/rest-apis/rest-command-api.md
+++ b/docs/references/rest-apis/rest-command-api.md
@@ -48,7 +48,7 @@
 
  --- 
 
- #### Execute Asynchronous Command
+#### Execute Asynchronous Command
 - Method: POST
 - API PATH: `/services/command/v1/command/async`
 ##### Request Body

--- a/docs/references/rest-apis/rest-command-api.md
+++ b/docs/references/rest-apis/rest-command-api.md
@@ -27,8 +27,6 @@
     //Working directory of command to be executed
     "workingDirectory":"/tmp",
     
-    //Run command synchronously/asynchronously
-    "isRunAsync":false
 }
 ```
 
@@ -48,7 +46,43 @@
 - 404 Resource Not Found
 - 500 Internal Server Error
 
+ --- 
 
+ #### Execute Asynchronous Command
+- Method: POST
+- API PATH: `/services/command/v1/command/async`
+##### Request Body
+``` JSON
+{
+	//Command to be excuted on gateway
+    "command":"printenv TextEnvVarName1",
+
+    //Service Password for command Service
+    "password":"s3curePassw0rd",
+
+    //String base64 encoding of a zip file to transfer to gateway
+    "zipBytes": "UEsDBAoACAAAAIyD1lYAA AAAAAAAAAAAAAAJACAAdGVzdGZpbGUxVVQNAAfprpRk6a6UZOmulGR1eAsAAQT1AQAABBQAAABQSwcIAAAAAAAAAAAAAAAAUEsBAgoDCgAIAAAAjIPWVgAAAAAAAAAAAAAAAAkAIAAAAAAAAAAAAKSBAAAAAHRlc3RmaWxlMVVUDQAH6a6UZOmulGTprpRkdXgLAAEE9QEAAAQUAAAAUEsFBgAAAAABAAEAVwAAAFcAAAAAAA==",
+
+    //Command argument String array
+    "arguments":["arg 1"],
+
+    //Shell environment Pairs Map
+    "environmentPairs": 
+    {
+        "TextEnvVarName1":"TextEnvVarValue1",
+        "TextEnvVarName2":"TextEnvVarValue2"
+    },
+    //Working directory of command to be executed
+    "workingDirectory":"/tmp",
+    
+}
+```
+
+##### Responses
+- 202 Accepted
+- 400 Bad Request (Malformed Client JSON)
+- 404 Resource Not Found
+- 500 Internal Server Error
 
 !!! note
 


### PR DESCRIPTION
This change adds a secondary async endpoint introduced by this [PR](https://github.com/eclipse/kura/pull/4764) to the docs.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
