### PR TITLE
fix(nm): WEP support for Generic Profiles

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -48,6 +48,9 @@ public class NMSettingsConverter {
 
     private static final int NM_WEP_KEY_TYPE_KEY = 1;
 
+    private static final String KURA_PROPS_KEY_WIFI_MODE = "net.interface.%s.config.wifi.mode";
+    private static final String KURA_PROPS_KEY_WIFI_SECURITY_TYPE = "net.interface.%s.config.wifi.%s.securityType";
+
     private NMSettingsConverter() {
         throw new IllegalStateException("Utility class");
     }
@@ -69,8 +72,8 @@ public class NMSettingsConverter {
                     deviceId);
             newConnectionSettings.put("802-11-wireless", wifiSettingsMap);
 
-            String propMode = properties.get(String.class, "net.interface.%s.config.wifi.mode", deviceId);
-            String securityType = properties.get(String.class, "net.interface.%s.config.wifi.%s.securityType", deviceId,
+            String propMode = properties.get(String.class, KURA_PROPS_KEY_WIFI_MODE, deviceId);
+            String securityType = properties.get(String.class, KURA_PROPS_KEY_WIFI_SECURITY_TYPE, deviceId,
                     propMode.toLowerCase());
             if (!"NONE".equals(securityType)) {
                 // Only populate "802-11-wireless-security" field if security is enabled
@@ -153,7 +156,7 @@ public class NMSettingsConverter {
     public static Map<String, Variant<?>> build80211WirelessSettings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
-        String propMode = props.get(String.class, "net.interface.%s.config.wifi.mode", deviceId);
+        String propMode = props.get(String.class, KURA_PROPS_KEY_WIFI_MODE, deviceId);
 
         String mode = wifiModeConvert(propMode);
         settings.put("mode", new Variant<>(mode));
@@ -178,8 +181,8 @@ public class NMSettingsConverter {
     }
 
     public static Map<String, Variant<?>> build80211WirelessSecuritySettings(NetworkProperties props, String deviceId) {
-        String propMode = props.get(String.class, "net.interface.%s.config.wifi.mode", deviceId);
-        String securityType = props.get(String.class, "net.interface.%s.config.wifi.%s.securityType", deviceId,
+        String propMode = props.get(String.class, KURA_PROPS_KEY_WIFI_MODE, deviceId);
+        String securityType = props.get(String.class, KURA_PROPS_KEY_WIFI_SECURITY_TYPE, deviceId,
                 propMode.toLowerCase());
 
         if ("SECURITY_WEP".equals(securityType)) {
@@ -218,7 +221,7 @@ public class NMSettingsConverter {
                 .toString();
         settings.put("psk", new Variant<>(psk));
 
-        String securityType = props.get(String.class, "net.interface.%s.config.wifi.%s.securityType", deviceId,
+        String securityType = props.get(String.class, KURA_PROPS_KEY_WIFI_SECURITY_TYPE, deviceId,
                 propMode.toLowerCase());
         List<String> proto = wifiProtoConvert(securityType);
         settings.put("proto", new Variant<>(proto, "as"));

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -73,6 +73,7 @@ public class NMSettingsConverter {
             String securityType = properties.get(String.class, "net.interface.%s.config.wifi.%s.securityType", deviceId,
                     propMode.toLowerCase());
             if (!"NONE".equals(securityType)) {
+                // Only populate "802-11-wireless-security" field if security is enabled
                 Map<String, Variant<?>> wifiSecuritySettingsMap = NMSettingsConverter
                         .build80211WirelessSecuritySettings(properties, deviceId);
                 newConnectionSettings.put("802-11-wireless-security", wifiSecuritySettingsMap);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -180,16 +180,17 @@ public class NMSettingsConverter {
                 propMode.toLowerCase());
 
         if ("SECURITY_WEP".equals(securityType)) {
-            return buildWEPSettings(props, deviceId, propMode);
+            return createWEPSettings(props, deviceId, propMode);
         } else if ("SECURITY_WPA".equals(securityType) || "SECURITY_WPA2".equals(securityType)
                 || "SECURITY_WPA_WPA2".equals(securityType)) {
-            return buildWPAWPA2Settings(props, deviceId, propMode);
+            return createWPAWPA2Settings(props, deviceId, propMode);
         } else {
             throw new IllegalArgumentException("Security type \"" + securityType + "\" is not supported.");
         }
     }
 
-    private static Map<String, Variant<?>> buildWEPSettings(NetworkProperties props, String deviceId, String propMode) {
+    private static Map<String, Variant<?>> createWEPSettings(NetworkProperties props, String deviceId,
+            String propMode) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
         settings.put("key-mgmt", new Variant<>("none"));
@@ -203,7 +204,7 @@ public class NMSettingsConverter {
         return settings;
     }
 
-    private static Map<String, Variant<?>> buildWPAWPA2Settings(NetworkProperties props, String deviceId,
+    private static Map<String, Variant<?>> createWPAWPA2Settings(NetworkProperties props, String deviceId,
             String propMode) {
         Map<String, Variant<?>> settings = new HashMap<>();
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -46,6 +46,8 @@ public class NMSettingsConverter {
     private static final String PPP_REFUSE_MSCHAP = "refuse-mschap";
     private static final String PPP_REFUSE_MSCHAPV2 = "refuse-mschapv2";
 
+    private static final int NM_WEP_KEY_TYPE_KEY = 1;
+
     private NMSettingsConverter() {
         throw new IllegalStateException("Utility class");
     }
@@ -194,7 +196,7 @@ public class NMSettingsConverter {
         Map<String, Variant<?>> settings = new HashMap<>();
 
         settings.put("key-mgmt", new Variant<>("none"));
-        settings.put("wep-key-type", new Variant<>(1));
+        settings.put("wep-key-type", new Variant<>(NM_WEP_KEY_TYPE_KEY));
 
         String wepKey = props
                 .get(Password.class, "net.interface.%s.config.wifi.%s.passphrase", deviceId, propMode.toLowerCase())

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -182,8 +182,7 @@ public class NMSettingsConverter {
                 propMode.toLowerCase());
 
         if ("SECURITY_WEP".equals(securityType)) {
-            String keyMgmt = wifiKeyMgmtConvert(securityType);
-            settings.put("key-mgmt", new Variant<>(keyMgmt));
+            settings.put("key-mgmt", new Variant<>("none"));
             settings.put("wep-key-type", new Variant<>(1));
 
             String wepKey = props
@@ -193,8 +192,7 @@ public class NMSettingsConverter {
         } else if ("SECURITY_WPA".equals(securityType) || "SECURITY_WPA2".equals(securityType)
                 || "SECURITY_WPA_WPA2".equals(securityType)) {
 
-            String keyMgmt = wifiKeyMgmtConvert(securityType);
-            settings.put("key-mgmt", new Variant<>(keyMgmt));
+            settings.put("key-mgmt", new Variant<>("wpa-psk"));
 
             String psk = props
                     .get(Password.class, "net.interface.%s.config.wifi.%s.passphrase", deviceId, propMode.toLowerCase())
@@ -393,21 +391,6 @@ public class NMSettingsConverter {
             return Arrays.asList("tkip", "ccmp");
         default:
             throw new IllegalArgumentException(String.format("Unsupported WiFi cipher \"%s\"", kuraCipher));
-        }
-    }
-
-    private static String wifiKeyMgmtConvert(String kuraSecurityType) {
-        switch (kuraSecurityType) {
-        case "NONE":
-        case "SECURITY_WEP":
-            return "none";
-        case "SECURITY_WPA":
-        case "SECURITY_WPA2":
-        case "SECURITY_WPA_WPA2":
-            return "wpa-psk";
-        default:
-            throw new IllegalArgumentException(
-                    String.format("Unsupported WiFi key management \"%s\"", kuraSecurityType));
         }
     }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -429,7 +429,7 @@ public class NMSettingsConverterTest {
     }
 
     @Test
-    public void build80211WirelessSecuritySettingsShouldWorkWhenGivenSecurityTypeNone() {
+    public void build80211WirelessSecuritySettingsShouldThrowWhenGivenSecurityTypeNone() {
 
         givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
         givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
@@ -440,12 +440,7 @@ public class NMSettingsConverterTest {
 
         whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
 
-        // TODO: This test is wrong! It should not work with security type NONE
-        // If security type is set to NONE the 802-11-wireless-security setting should not be set
-        // Throw an exception maybe?
-        thenNoExceptionsHaveBeenThrown();
-        thenResultingMapContains("key-mgmt", "none");
-        thenResultingMapNotContains("proto");
+        thenIllegalArgumentExceptionThrown();
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -440,6 +440,9 @@ public class NMSettingsConverterTest {
 
         whenBuild80211WirelessSecuritySettingsIsRunWith(this.networkProperties, "wlan0");
 
+        // TODO: This test is wrong! It should not work with security type NONE
+        // If security type is set to NONE the 802-11-wireless-security setting should not be set
+        // Throw an exception maybe?
         thenNoExceptionsHaveBeenThrown();
         thenResultingMapContains("key-mgmt", "none");
         thenResultingMapNotContains("proto");
@@ -459,7 +462,10 @@ public class NMSettingsConverterTest {
 
         thenNoExceptionsHaveBeenThrown();
         thenResultingMapContains("key-mgmt", "none");
+        thenResultingMapContains("wep-key-type", 1);
+        thenResultingMapContains("wep-key0", "test");
         thenResultingMapNotContains("proto");
+        thenResultingMapNotContains("wpa-psk");
     }
 
     @Test
@@ -477,6 +483,8 @@ public class NMSettingsConverterTest {
         thenNoExceptionsHaveBeenThrown();
         thenResultingMapContains("key-mgmt", "wpa-psk");
         thenResultingMapContains("proto", new Variant<>(Arrays.asList("wpa"), "as").getValue());
+        thenResultingMapNotContains("wep-key-type");
+        thenResultingMapNotContains("wep-key0");
     }
 
     @Test
@@ -494,6 +502,8 @@ public class NMSettingsConverterTest {
         thenNoExceptionsHaveBeenThrown();
         thenResultingMapContains("key-mgmt", "wpa-psk");
         thenResultingMapContains("proto", new Variant<>(Arrays.asList("rsn"), "as").getValue());
+        thenResultingMapNotContains("wep-key-type");
+        thenResultingMapNotContains("wep-key0");
     }
 
     @Test


### PR DESCRIPTION
As reported in https://github.com/eclipse/kura/pull/4759

> Warning: WEP support is currently broken. We're not correctly setting the password when setting up the connection and thus NetworkManager will not create the connection. We'll leave this as a known issue for now.

This PR addresses the issue by setting the correct parameters for the WEP connection.

Please note that, as we did on the non-generic profiles, we're only using `NM_WEP_KEY_TYPE_KEY`:

> in which case the key is either a 10- or 26-character hexadecimal string, or a 5- or 13-character ASCII password

`NM_WEP_KEY_TYPE_PASSPHRASE` is not currently supported.

Likewise we're only using index 0 WEP key. This is the WEP key used in most networks. See [NetworkManager documentation](https://networkmanager.dev/docs/api/latest/nm-settings-dbus.html) for additional informations.

**Test performed**: Tested working on RPi4:
- [X] DUT connecting to a device running Kura 5.2.3 acting as a WEP Access Point.
- [X] using my workstation to connect to DUT acting as WEP Access Point
- [x] using a device running Kura 5.2.3 to connect to DUT acting as WEP Access Point