### PR TITLE
refactor(nm): rename methods to use `interfaceId` consistently

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -143,7 +143,7 @@ public class NMDbusConnector {
     }
 
     public synchronized String getInterfaceName(String interfaceId) throws DBusException {
-        Optional<Device> device = getDeviceByInterfaceId(interfaceId);
+        Optional<Device> device = getNetworkManagerDeviceByInterfaceId(interfaceId);
         if (device.isPresent()) {
             NMDeviceType deviceType = this.networkManager.getDeviceType(device.get().getObjectPath());
             if (!NMDeviceType.NM_DEVICE_TYPE_MODEM.equals(deviceType)) {
@@ -167,7 +167,7 @@ public class NMDbusConnector {
         return "";
     }
 
-    private Optional<Device> getDeviceByInterfaceId(String interfaceId) throws DBusException {
+    private Optional<Device> getNetworkManagerDeviceByInterfaceId(String interfaceId) throws DBusException {
         for (Device nmDevice : this.networkManager.getAllDevices()) {
             String deviceInterfaceId = getInterfaceIdByDBusPath(nmDevice.getObjectPath());
             if (deviceInterfaceId.equals(interfaceId)) {
@@ -191,7 +191,7 @@ public class NMDbusConnector {
     public synchronized NetworkInterfaceStatus getInterfaceStatus(String interfaceId,
             CommandExecutorService commandExecutorService) throws DBusException, KuraException {
         NetworkInterfaceStatus networkInterfaceStatus = null;
-        Optional<Device> device = getDeviceByInterfaceId(interfaceId);
+        Optional<Device> device = getNetworkManagerDeviceByInterfaceId(interfaceId);
         if (device.isPresent()) {
             NMDeviceType deviceType = this.networkManager.getDeviceType(device.get().getObjectPath());
             Properties deviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME, device.get().getObjectPath(),
@@ -356,7 +356,7 @@ public class NMDbusConnector {
         NetworkProperties properties = new NetworkProperties(networkConfiguration);
         List<String> configuredInterfaceIds = properties.getStringList("net.interfaces");
 
-        Optional<Device> device = getDeviceByInterfaceId(deviceIdToBeConfigured);
+        Optional<Device> device = getNetworkManagerDeviceByInterfaceId(deviceIdToBeConfigured);
         if (device.isPresent()) {
             if (configuredInterfaceIds.contains(deviceIdToBeConfigured)) {
                 manageConfiguredInterface(device.get(), deviceIdToBeConfigured, properties);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -127,14 +127,14 @@ public class NMDbusConnector {
         logger.debug("NM Version: {}", nmVersion);
     }
 
-    public synchronized List<String> getDeviceIds() throws DBusException {
+    public synchronized List<String> getInterfaceIds() throws DBusException {
         List<Device> availableDevices = this.networkManager.getAllDevices();
 
         List<String> supportedDeviceNames = new ArrayList<>();
         for (Device device : availableDevices) {
             NMDeviceType deviceType = this.networkManager.getDeviceType(device.getObjectPath());
             if (STATUS_SUPPORTED_DEVICE_TYPES.contains(deviceType)) {
-                supportedDeviceNames.add(getDeviceIdByDBusPath(device.getObjectPath()));
+                supportedDeviceNames.add(getInterfaceIdByDBusPath(device.getObjectPath()));
             }
 
         }
@@ -169,7 +169,7 @@ public class NMDbusConnector {
 
     private Optional<Device> getDeviceByInterfaceId(String interfaceId) throws DBusException {
         for (Device nmDevice : this.networkManager.getAllDevices()) {
-            String deviceInterfaceId = getDeviceIdByDBusPath(nmDevice.getObjectPath());
+            String deviceInterfaceId = getInterfaceIdByDBusPath(nmDevice.getObjectPath());
             if (deviceInterfaceId.equals(interfaceId)) {
                 return Optional.of(nmDevice);
             }
@@ -177,7 +177,7 @@ public class NMDbusConnector {
         return Optional.empty();
     }
 
-    public String getDeviceIdByDBusPath(String dbusPath) throws DBusException {
+    public String getInterfaceIdByDBusPath(String dbusPath) throws DBusException {
         NMDeviceType deviceType = this.networkManager.getDeviceType(dbusPath);
         if (deviceType.equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
             Optional<String> modemPath = this.networkManager.getModemManagerDbusPath(dbusPath);
@@ -343,7 +343,7 @@ public class NMDbusConnector {
         List<Device> availableDevices = this.networkManager.getAllDevices();
         availableDevices.forEach(device -> {
             try {
-                String deviceId = getDeviceIdByDBusPath(device.getObjectPath());
+                String deviceId = getInterfaceIdByDBusPath(device.getObjectPath());
                 doApply(deviceId, networkConfiguration);
             } catch (DBusException | DBusExecutionException | IllegalArgumentException | NoSuchElementException e) {
                 logger.error("Unable to apply configuration to the device path {}", device.getObjectPath(), e);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMConfigurationEnforcementHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMConfigurationEnforcementHandler.java
@@ -50,7 +50,7 @@ public class NMConfigurationEnforcementHandler implements DBusSigHandler<Device.
         if (deviceIsConnectingToANewNetwork || deviceDisconnectedBecauseOfConfigurationEvent) {
             try {
                 logger.info("Network change detected on interface {}. Roll-back to cached configuration", s.getPath());
-                String deviceId = this.nm.getDeviceIdByDBusPath(s.getPath());
+                String deviceId = this.nm.getInterfaceIdByDBusPath(s.getPath());
                 this.nm.apply(deviceId);
             } catch (DBusException e) {
                 logger.error("Failed to handle network configuration change event for device: {}. Caused by:",

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMDeviceAddedHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMDeviceAddedHandler.java
@@ -34,7 +34,7 @@ public class NMDeviceAddedHandler implements DBusSigHandler<NetworkManager.Devic
     public void handle(NetworkManager.DeviceAdded s) {
         try {
             logger.info("New network device connected at {}", s.getDevicePath());
-            String deviceId = this.nm.getDeviceIdByDBusPath(s.getDevicePath().getPath());
+            String deviceId = this.nm.getInterfaceIdByDBusPath(s.getDevicePath().getPath());
             this.nm.apply(deviceId);
         } catch (DBusException e) {
             logger.error("Failed to handle DeviceAdded event for device: {}. Caused by:", s.getDevicePath(), e);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusServiceImpl.java
@@ -90,7 +90,7 @@ public class NMStatusServiceImpl implements NetworkStatusService {
     public List<String> getInterfaceIds() throws KuraException {
         List<String> interfaces = new ArrayList<>();
         try {
-            interfaces = this.nmDbusConnector.getDeviceIds();
+            interfaces = this.nmDbusConnector.getInterfaceIds();
         } catch (DBusException e) {
             throw new KuraIOException(e, "Could not retrieve interfaces from NM.");
         }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -284,7 +284,7 @@ public class NMDbusConnectorTest {
                 NMDeviceState.NM_DEVICE_STATE_DISCONNECTED, true, false, false);
         givenMockedDeviceList();
 
-        whenGetInterfacesIsCalled();
+        whenGetInterfaceIdsIsCalled();
 
         thenNoExceptionIsThrown();
         thenGetInterfacesReturn(Arrays.asList("wlan0", "eth0"));
@@ -1296,9 +1296,9 @@ public class NMDbusConnectorTest {
         }
     }
 
-    private void whenGetInterfacesIsCalled() {
+    private void whenGetInterfaceIdsIsCalled() {
         try {
-            this.internalStringList = this.instanceNMDbusConnector.getDeviceIds();
+            this.internalStringList = this.instanceNMDbusConnector.getInterfaceIds();
         } catch (DBusException e) {
             this.hasDBusExceptionBeenThrown = true;
         }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusServiceImplTest.java
@@ -233,12 +233,12 @@ public class NMStatusServiceImplTest {
 
     private void givenNMStatusServiceImplWithoutInterfaces() throws DBusException, UnknownHostException {
         createTestObjects();
-        when(this.nmDbusConnector.getDeviceIds()).thenReturn(Collections.emptyList());
+        when(this.nmDbusConnector.getInterfaceIds()).thenReturn(Collections.emptyList());
     }
 
     private void givenNMStatusServiceImplWithInterfaces() throws DBusException, UnknownHostException, KuraException {
         createTestObjects();
-        when(this.nmDbusConnector.getDeviceIds()).thenReturn(Arrays.asList("abcd0", "wlan0"));
+        when(this.nmDbusConnector.getInterfaceIds()).thenReturn(Arrays.asList("abcd0", "wlan0"));
         when(this.nmDbusConnector.getInterfaceStatus("abcd0", this.commandExecutorService))
                 .thenReturn(buildEthernetInterfaceStatus("abcd0"));
         when(this.nmDbusConnector.getInterfaceStatus("wlan0", this.commandExecutorService))
@@ -264,7 +264,7 @@ public class NMStatusServiceImplTest {
     private void givenNMStatusServiceImplThrowingDBusExceptionOnGetInterfaces()
             throws UnknownHostException, DBusException, KuraException {
         createTestObjects();
-        when(this.nmDbusConnector.getDeviceIds()).thenThrow(new DBusException("Cannot retrieve interface list."));
+        when(this.nmDbusConnector.getInterfaceIds()).thenThrow(new DBusException("Cannot retrieve interface list."));
     }
 
     private void whenInterfaceStatusIsRetrieved(String interfaceName) {


### PR DESCRIPTION
This PR addresses an inconsistency in the method names inside the `NMDbusConnetor`. We used `deviceId` and `interfaceId` interchangeably to identify the Kura interface identifier (i.e. the identifier we find in the snapshot). It is better to stick to a single name to avoid confusion.