### PR TITLE
feat(nm): add Access Point rescan leveraging wpa_supplicant

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -287,8 +287,11 @@ public class NMDbusConnector {
         long timestamp = System.currentTimeMillis();
         if (!this.lastScan.containsKey(interfaceId) || this.lastScan.get(interfaceId) == null
                 || this.lastScan.get(interfaceId) - timestamp > LAST_SCAN_TIMEOUT_5_MINUTES) {
+            logger.info("Triggering scan for interface {}", interfaceId); // Debug
             this.wpaSupplicant.triggerScan(interfaceId); // Trigger rescan of APs
             this.lastScan.put(interfaceId, timestamp);
+        } else {
+            logger.info("Skipping scan for interface {} as it was already performed recently", interfaceId); // Debug
         }
 
         List<Properties> accessPoints = this.networkManager.getAllAccessPoints(wirelessDevice);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -288,7 +288,7 @@ public class NMDbusConnector {
         if (!this.lastScan.containsKey(interfaceId) || this.lastScan.get(interfaceId) == null
                 || this.lastScan.get(interfaceId) - timestamp > LAST_SCAN_TIMEOUT_5_MINUTES) {
             logger.info("Triggering scan for interface {}", interfaceId); // Debug
-            this.wpaSupplicant.triggerScan(interfaceId); // Trigger rescan of APs
+            this.wpaSupplicant.syncScan(interfaceId); // Trigger rescan of APs
             this.lastScan.put(interfaceId, timestamp);
         } else {
             logger.info("Skipping scan for interface {} as it was already performed recently", interfaceId); // Debug

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -78,6 +78,7 @@ public class NMDbusConnector {
     private final DBusConnection dbusConnection;
     private final NetworkManagerDbusWrapper networkManager;
     private final ModemManagerDbusWrapper modemManager;
+    private final WpaSupplicantDbusWrapper wpaSupplicant;
 
     private Map<String, Object> cachedConfiguration = null;
 
@@ -90,6 +91,7 @@ public class NMDbusConnector {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.networkManager = new NetworkManagerDbusWrapper(this.dbusConnection);
         this.modemManager = new ModemManagerDbusWrapper(this.dbusConnection);
+        this.wpaSupplicant = new WpaSupplicantDbusWrapper(this.dbusConnection);
     }
 
     public static synchronized NMDbusConnector getInstance() throws DBusException {
@@ -276,6 +278,7 @@ public class NMDbusConnector {
         Properties wirelessDeviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
                 wirelessDevice.getObjectPath(), Properties.class);
 
+        this.wpaSupplicant.triggerScan(interfaceId); // Trigger rescan of APs
         List<Properties> accessPoints = this.networkManager.getAllAccessPoints(wirelessDevice);
 
         DBusPath activeAccessPointPath = wirelessDeviceProperties.Get(NM_DEVICE_WIRELESS_BUS_NAME, "ActiveAccessPoint");

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
@@ -41,10 +41,6 @@ public class WpaSupplicantDbusWrapper {
     public void triggerScan(String interfaceName) throws DBusException {
         DBusPath interfacePath = this.wpaSupplicant.GetInterface(interfaceName);
 
-        if (interfacePath.getPath().equals("/")) {
-            throw new IllegalArgumentException(String.format("Interface \"%s\" not found", interfaceName));
-        }
-
         Interface interfaceObject = this.dbusConnection.getRemoteObject(WPA_SUPPLICANT_BUS_NAME,
                 interfacePath.getPath(), Interface.class);
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
@@ -41,6 +41,10 @@ public class WpaSupplicantDbusWrapper {
     public void triggerScan(String interfaceName) throws DBusException {
         DBusPath interfacePath = this.wpaSupplicant.GetInterface(interfaceName);
 
+        if (interfacePath.getPath().equals("/")) {
+            throw new IllegalArgumentException(String.format("Interface \"%s\" not found", interfaceName));
+        }
+
         Interface interfaceObject = this.dbusConnection.getRemoteObject(WPA_SUPPLICANT_BUS_NAME,
                 interfacePath.getPath(), Interface.class);
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
@@ -29,6 +29,8 @@ public class WpaSupplicantDbusWrapper {
     private static final String WPA_SUPPLICANT_BUS_NAME = "fi.w1.wpa_supplicant1";
     private static final String WPA_SUPPLICANT_BUS_PATH = "/fi/w1/wpa_supplicant1";
 
+    private static final long DEFAULT_SCAN_TIMEOUT_SECONDS = 30;
+
     private final DBusConnection dbusConnection;
     private Wpa_supplicant1 wpaSupplicant;
 
@@ -39,13 +41,17 @@ public class WpaSupplicantDbusWrapper {
     }
 
     public void syncScan(String interfaceName) throws DBusException {
+        syncScan(interfaceName, DEFAULT_SCAN_TIMEOUT_SECONDS);
+    }
+
+    public void syncScan(String interfaceName, long scanTimeoutSeconds) throws DBusException {
         DBusPath interfacePath = this.wpaSupplicant.GetInterface(interfaceName);
 
         WPAScanLock scanLock = new WPAScanLock(this.dbusConnection, interfacePath.getPath());
 
         triggerScan(interfacePath);
 
-        scanLock.waitForSignal();
+        scanLock.waitForSignal(scanTimeoutSeconds);
     }
 
     public DBusPath asyncScan(String interfaceName) throws DBusException {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
@@ -1,0 +1,40 @@
+package org.eclipse.kura.nm;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.types.Variant;
+
+import fi.w1.Wpa_supplicant1;
+import fi.w1.wpa_supplicant1.Interface;
+
+public class WpaSupplicantDbusWrapper {
+
+    private static final String WPA_SUPPLICANT_BUS_NAME = "fi.w1.wpa_supplicant1";
+    private static final String WPA_SUPPLICANT_BUS_PATH = "/fi/w1/wpa_supplicant1";
+
+    private final DBusConnection dbusConnection;
+    private Wpa_supplicant1 wpaSupplicant;
+
+    public WpaSupplicantDbusWrapper(DBusConnection dbusConnection) throws DBusException {
+        this.dbusConnection = dbusConnection;
+        this.wpaSupplicant = this.dbusConnection.getRemoteObject(WPA_SUPPLICANT_BUS_NAME, WPA_SUPPLICANT_BUS_PATH,
+                Wpa_supplicant1.class);
+    }
+
+    public void triggerScan(String interfaceName) throws DBusException {
+        DBusPath interfacePath = this.wpaSupplicant.GetInterface(interfaceName);
+
+        Interface interfaceObject = this.dbusConnection.getRemoteObject(WPA_SUPPLICANT_BUS_NAME,
+                interfacePath.getPath(), Interface.class);
+
+        Map<String, Variant<?>> options = new HashMap<>();
+        options.put("Type", new Variant<>("active"));
+
+        interfaceObject.Scan(options);
+    }
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
@@ -3,6 +3,7 @@ package org.eclipse.kura.nm;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.kura.nm.signal.handlers.WPAScanLock;
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
@@ -35,7 +36,10 @@ public class WpaSupplicantDbusWrapper {
         options.put("Type", new Variant<>("active"));
         options.put("AllowRoam", new Variant<>(false));
 
+        WPAScanLock scanLock = new WPAScanLock(this.dbusConnection, interfacePath.getPath());
+
         interfaceObject.Scan(options);
+        scanLock.waitForSignal();
     }
 
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.eclipse.kura.nm;
 
 import java.util.HashMap;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapper.java
@@ -33,6 +33,7 @@ public class WpaSupplicantDbusWrapper {
 
         Map<String, Variant<?>> options = new HashMap<>();
         options.put("Type", new Variant<>("active"));
+        options.put("AllowRoam", new Variant<>(false));
 
         interfaceObject.Scan(options);
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/DeviceStateLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/DeviceStateLock.java
@@ -34,7 +34,7 @@ public class DeviceStateLock {
     public DeviceStateLock(DBusConnection dbusConnection, String dbusPath, NMDeviceState expectedNmDeviceState)
             throws DBusException {
         if (Objects.isNull(dbusPath) || dbusPath.isEmpty() || dbusPath.equals("/")) {
-            throw new IllegalArgumentException(String.format("Illegal DBus path for DeviceSateLock \"%s\"", dbusPath));
+            throw new IllegalArgumentException(String.format("Illegat DBus path for DeviceSateLock \"%s\"", dbusPath));
         }
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.stateHandler = new NMDeviceStateChangeHandler(this.latch, dbusPath, expectedNmDeviceState);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/DeviceStateLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/DeviceStateLock.java
@@ -34,7 +34,7 @@ public class DeviceStateLock {
     public DeviceStateLock(DBusConnection dbusConnection, String dbusPath, NMDeviceState expectedNmDeviceState)
             throws DBusException {
         if (Objects.isNull(dbusPath) || dbusPath.isEmpty() || dbusPath.equals("/")) {
-            throw new IllegalArgumentException(String.format("Illegat DBus path for DeviceSateLock \"%s\"", dbusPath));
+            throw new IllegalArgumentException(String.format("Illegal DBus path for DeviceSateLock \"%s\"", dbusPath));
         }
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.stateHandler = new NMDeviceStateChangeHandler(this.latch, dbusPath, expectedNmDeviceState);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanDoneHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanDoneHandler.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.nm.signal.handlers;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import fi.w1.wpa_supplicant1.Interface;
+
+public class WPAScanDoneHandler implements DBusSigHandler<Interface.ScanDone> {
+
+    private static final Logger logger = LoggerFactory.getLogger(WPAScanDoneHandler.class);
+
+    private final CountDownLatch latch;
+    private final String path;
+
+    public WPAScanDoneHandler(CountDownLatch latch, String path) {
+        this.latch = latch;
+        this.path = path;
+    }
+
+    @Override
+    public void handle(Interface.ScanDone s) {
+
+        logger.trace("AP scan done signal received for {}", s.getPath());
+        if (s.getPath().equals(this.path)) {
+            logger.debug("Notify waiting thread");
+            this.latch.countDown();
+        }
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanDoneHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanDoneHandler.java
@@ -35,9 +35,9 @@ public class WPAScanDoneHandler implements DBusSigHandler<Interface.ScanDone> {
     @Override
     public void handle(Interface.ScanDone s) {
 
-        logger.info("AP scan done signal received for {}", s.getPath());
+        logger.trace("AP scan done signal received for {}", s.getPath());
         if (s.getPath().equals(this.path)) {
-            logger.info("Notify waiting thread");
+            logger.debug("Notify waiting thread");
             this.latch.countDown();
         }
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanDoneHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanDoneHandler.java
@@ -35,9 +35,9 @@ public class WPAScanDoneHandler implements DBusSigHandler<Interface.ScanDone> {
     @Override
     public void handle(Interface.ScanDone s) {
 
-        logger.trace("AP scan done signal received for {}", s.getPath());
+        logger.info("AP scan done signal received for {}", s.getPath());
         if (s.getPath().equals(this.path)) {
-            logger.debug("Notify waiting thread");
+            logger.info("Notify waiting thread");
             this.latch.countDown();
         }
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
@@ -35,7 +35,7 @@ public class WPAScanLock {
 
     public WPAScanLock(DBusConnection dbusConnection, String dbusPath) throws DBusException {
         if (Objects.isNull(dbusPath) || dbusPath.isEmpty() || dbusPath.equals("/")) {
-            throw new IllegalArgumentException(String.format("Illegat DBus path for WPAScanLock \"%s\"", dbusPath));
+            throw new IllegalArgumentException(String.format("Illegal DBus path for WPAScanLock \"%s\"", dbusPath));
         }
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.scanHandler = new WPAScanDoneHandler(this.latch, dbusPath);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
@@ -27,8 +27,6 @@ public class WPAScanLock {
 
     private static final Logger logger = LoggerFactory.getLogger(WPAScanLock.class);
 
-    private static final long SCAN_TIMEOUT_S = 30;
-
     private final CountDownLatch latch = new CountDownLatch(1);
     private final WPAScanDoneHandler scanHandler;
     private final DBusConnection dbusConnection;
@@ -43,9 +41,9 @@ public class WPAScanLock {
         this.dbusConnection.addSigHandler(Interface.ScanDone.class, this.scanHandler);
     }
 
-    public void waitForSignal() throws DBusException {
+    public void waitForSignal(long scanTimeoutSeconds) throws DBusException {
         try {
-            boolean countdownCompleted = this.latch.await(SCAN_TIMEOUT_S, TimeUnit.SECONDS);
+            boolean countdownCompleted = this.latch.await(scanTimeoutSeconds, TimeUnit.SECONDS);
             if (!countdownCompleted) {
                 logger.warn("Timeout elapsed. Exiting anyway");
             }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
@@ -1,0 +1,48 @@
+package org.eclipse.kura.nm.signal.handlers;
+
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import fi.w1.wpa_supplicant1.Interface;
+
+public class WPAScanLock {
+
+    private static final Logger logger = LoggerFactory.getLogger(WPAScanLock.class);
+
+    private static final long SCAN_TIMEOUT_S = 30;
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private final WPAScanDoneHandler scanHandler;
+    private final DBusConnection dbusConnection;
+
+    public WPAScanLock(DBusConnection dbusConnection, String dbusPath) throws DBusException {
+        if (Objects.isNull(dbusPath) || dbusPath.isEmpty() || dbusPath.equals("/")) {
+            throw new IllegalArgumentException(String.format("Illegat DBus path for DeviceSateLock \"%s\"", dbusPath));
+        }
+        this.dbusConnection = Objects.requireNonNull(dbusConnection);
+        this.scanHandler = new WPAScanDoneHandler(this.latch, dbusPath);
+
+        this.dbusConnection.addSigHandler(Interface.ScanDone.class, this.scanHandler);
+    }
+
+    public void waitForSignal() throws DBusException {
+        try {
+            boolean countdownCompleted = this.latch.await(SCAN_TIMEOUT_S, TimeUnit.SECONDS);
+            if (!countdownCompleted) {
+                logger.warn("Timeout elapsed. Exiting anyway");
+            }
+        } catch (InterruptedException e) {
+            logger.warn("Wait interrupted because of:", e);
+            Thread.currentThread().interrupt();
+        } finally {
+            this.dbusConnection.removeSigHandler(Interface.ScanDone.class, this.scanHandler);
+        }
+    }
+
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.eclipse.kura.nm.signal.handlers;
 
 import java.util.Objects;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/WPAScanLock.java
@@ -23,7 +23,7 @@ public class WPAScanLock {
 
     public WPAScanLock(DBusConnection dbusConnection, String dbusPath) throws DBusException {
         if (Objects.isNull(dbusPath) || dbusPath.isEmpty() || dbusPath.equals("/")) {
-            throw new IllegalArgumentException(String.format("Illegat DBus path for DeviceSateLock \"%s\"", dbusPath));
+            throw new IllegalArgumentException(String.format("Illegat DBus path for WPAScanLock \"%s\"", dbusPath));
         }
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.scanHandler = new WPAScanDoneHandler(this.latch, dbusPath);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -75,7 +75,6 @@ import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
-import org.freedesktop.dbus.interfaces.ObjectManager;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.UInt32;
 import org.freedesktop.dbus.types.UInt64;

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
@@ -26,7 +26,7 @@ public class WpaSupplicantDbusWrapperTest {
     @Test
     public void syncScanShouldThrowWithNonExistentInterface() throws DBusException {
         givenMockWpaSupplicant();
-        givenWpaSupplicantWillThrowWhenGetInterfaceIsCalledWith("wlan0");
+        givenMockWpaSupplicantWillThrowWhenGetInterfaceIsCalledWith("wlan0");
 
         givenWpaSupplicantDbusWrapper();
 
@@ -38,7 +38,7 @@ public class WpaSupplicantDbusWrapperTest {
     @Test
     public void asyncScanShouldThrowWithNonExistentInterface() throws DBusException {
         givenMockWpaSupplicant();
-        givenWpaSupplicantWillThrowWhenGetInterfaceIsCalledWith("wlan0");
+        givenMockWpaSupplicantWillThrowWhenGetInterfaceIsCalledWith("wlan0");
 
         givenWpaSupplicantDbusWrapper();
 
@@ -56,7 +56,7 @@ public class WpaSupplicantDbusWrapperTest {
                 .thenReturn(this.mockedWpaSupplicant);
     }
 
-    private void givenWpaSupplicantWillThrowWhenGetInterfaceIsCalledWith(String interfaceName) {
+    private void givenMockWpaSupplicantWillThrowWhenGetInterfaceIsCalledWith(String interfaceName) {
         when(this.mockedWpaSupplicant.GetInterface(interfaceName))
                 .thenThrow(new DBusExecutionException("Interface not found"));
     }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
@@ -44,6 +44,7 @@ public class WpaSupplicantDbusWrapperTest {
 
     private WpaSupplicantDbusWrapper wpaSupplicantDbusWrapper;
     private Exception occurredException;
+    private DBusPath returnedDbusPath;
 
     @Test
     public void syncScanShouldThrowWithNonExistentInterface() throws DBusException {
@@ -79,6 +80,7 @@ public class WpaSupplicantDbusWrapperTest {
 
         thenExceptionDidNotOccur();
         thenInterfaceScanWasTriggered();
+        thenReturnedDbusPathIs("/fi/w1/wpa_supplicant1/Interfaces/0");
     }
 
     /*
@@ -120,7 +122,7 @@ public class WpaSupplicantDbusWrapperTest {
 
     private void whenAsyncScanIsCalledWith(String interfaceName) {
         try {
-            this.wpaSupplicantDbusWrapper.asyncScan(interfaceName);
+            this.returnedDbusPath = this.wpaSupplicantDbusWrapper.asyncScan(interfaceName);
         } catch (Exception e) {
             this.occurredException = e;
         }
@@ -145,5 +147,9 @@ public class WpaSupplicantDbusWrapperTest {
         expectedOptions.put("Type", new Variant<>("active"));
 
         verify(this.mockedInterface, times(1)).Scan(expectedOptions);
+    }
+
+    private void thenReturnedDbusPathIs(String expectedDbusPath) {
+        assertEquals(expectedDbusPath, this.returnedDbusPath.getPath());
     }
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
@@ -1,0 +1,96 @@
+package org.eclipse.kura.nm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.exceptions.DBusExecutionException;
+import org.junit.Test;
+
+import fi.w1.Wpa_supplicant1;
+
+public class WpaSupplicantDbusWrapperTest {
+
+    private static final String WPA_SUPPLICANT_BUS_NAME = "fi.w1.wpa_supplicant1";
+    private static final String WPA_SUPPLICANT_BUS_PATH = "/fi/w1/wpa_supplicant1";
+
+    private final DBusConnection mockedDbusConnection = mock(DBusConnection.class);
+    private final Wpa_supplicant1 mockedWpaSupplicant = mock(Wpa_supplicant1.class);
+
+    private WpaSupplicantDbusWrapper wpaSupplicantDbusWrapper;
+    private Object occurredException;
+
+    @Test
+    public void syncScanShouldThrowWithNonExistentInterface() throws DBusException {
+        givenMockWpaSupplicant();
+        givenWpaSupplicantWillThrowWhenGetInterfaceIsCalledWith("wlan0");
+
+        givenWpaSupplicantDbusWrapper();
+
+        whenSyncScanIsCalledWith("wlan0");
+
+        thenExceptionOccurred(DBusExecutionException.class);
+    }
+
+    @Test
+    public void asyncScanShouldThrowWithNonExistentInterface() throws DBusException {
+        givenMockWpaSupplicant();
+        givenWpaSupplicantWillThrowWhenGetInterfaceIsCalledWith("wlan0");
+
+        givenWpaSupplicantDbusWrapper();
+
+        whenAsyncScanIsCalledWith("wlan0");
+
+        thenExceptionOccurred(DBusExecutionException.class);
+    }
+
+    /*
+     * Given
+     */
+
+    private void givenMockWpaSupplicant() throws DBusException {
+        when(this.mockedDbusConnection.getRemoteObject(WPA_SUPPLICANT_BUS_NAME, WPA_SUPPLICANT_BUS_PATH, Wpa_supplicant1.class))
+                .thenReturn(this.mockedWpaSupplicant);
+    }
+
+    private void givenWpaSupplicantWillThrowWhenGetInterfaceIsCalledWith(String interfaceName) {
+        when(this.mockedWpaSupplicant.GetInterface(interfaceName))
+                .thenThrow(new DBusExecutionException("Interface not found"));
+    }
+
+    private void givenWpaSupplicantDbusWrapper() throws DBusException {
+        this.wpaSupplicantDbusWrapper = new WpaSupplicantDbusWrapper(this.mockedDbusConnection);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenSyncScanIsCalledWith(String interfaceName) {
+        try {
+            this.wpaSupplicantDbusWrapper.syncScan(interfaceName);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenAsyncScanIsCalledWith(String interfaceName) {
+        try {
+            this.wpaSupplicantDbusWrapper.asyncScan(interfaceName);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    /*
+     * Then
+     */
+    private void thenExceptionOccurred(Class<DBusExecutionException> expectedExceptionClass) {
+        assertNotNull(this.occurredException);
+        assertEquals(expectedExceptionClass, this.occurredException.getClass());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
@@ -57,10 +57,7 @@ public class WpaSupplicantDbusWrapperTest {
     @Test
     public void asyncScanShouldWorkWithExistentInterface() throws DBusException {
         givenMockWpaSupplicant();
-        givenMockWpaSupplicantWillReturnDbusPathWhenGetInterfaceIsCalledWith("wlan0",
-                "/fi/w1/wpa_supplicant1/Interfaces/0");
-        givenMockDbusConnectionWillReturnInterfaceWhenGetRemoteObjectIsCalledWith(
-                "/fi/w1/wpa_supplicant1/Interfaces/0");
+        givenMockInterface("wlan0", "/fi/w1/wpa_supplicant1/Interfaces/0");
         givenWpaSupplicantDbusWrapper();
 
         whenAsyncScanIsCalledWith("wlan0");
@@ -73,11 +70,6 @@ public class WpaSupplicantDbusWrapperTest {
      * Given
      */
 
-    private void givenMockDbusConnectionWillReturnInterfaceWhenGetRemoteObjectIsCalledWith(String dbusPath) throws DBusException {
-        when(this.mockedDbusConnection.getRemoteObject(WPA_SUPPLICANT_BUS_NAME, dbusPath, Interface.class))
-                .thenReturn(this.mockedInterface);
-    }
-
     private void givenMockWpaSupplicant() throws DBusException {
         when(this.mockedDbusConnection.getRemoteObject(WPA_SUPPLICANT_BUS_NAME, WPA_SUPPLICANT_BUS_PATH, Wpa_supplicant1.class))
                 .thenReturn(this.mockedWpaSupplicant);
@@ -88,9 +80,11 @@ public class WpaSupplicantDbusWrapperTest {
                 .thenThrow(new DBusExecutionException("Interface not found"));
     }
 
-    private void givenMockWpaSupplicantWillReturnDbusPathWhenGetInterfaceIsCalledWith(String interfaceName, String dbusPath) {
+    private void givenMockInterface(String interfaceName, String dbusPath) throws DBusException {
         when(this.mockedWpaSupplicant.GetInterface(interfaceName))
                 .thenReturn(new DBusPath(dbusPath));
+        when(this.mockedDbusConnection.getRemoteObject(WPA_SUPPLICANT_BUS_NAME, dbusPath, Interface.class))
+                .thenReturn(this.mockedInterface);
     }
 
     private void givenWpaSupplicantDbusWrapper() throws DBusException {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
@@ -120,6 +120,7 @@ public class WpaSupplicantDbusWrapperTest {
     /*
      * Then
      */
+
     private void thenExceptionDidNotOccur() {
         assertNull(this.occurredException);
     }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
@@ -9,10 +9,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
 import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
+import org.freedesktop.dbus.types.Variant;
 import org.junit.Test;
 
 import fi.w1.Wpa_supplicant1;
@@ -125,6 +129,10 @@ public class WpaSupplicantDbusWrapperTest {
     }
 
     private void thenInterfaceScanWasTriggered() {
-        verify(this.mockedInterface, times(1)).Scan(any());
+        Map<String, Variant<?>> expectedOptions = new HashMap<>();
+        expectedOptions.put("AllowRoam", new Variant<>(false));
+        expectedOptions.put("Type", new Variant<>("active"));
+
+        verify(this.mockedInterface, times(1)).Scan(expectedOptions);
     }
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
@@ -53,7 +53,7 @@ public class WpaSupplicantDbusWrapperTest {
 
         givenWpaSupplicantDbusWrapper();
 
-        whenSyncScanIsCalledWith("wlan0");
+        whenSyncScanIsCalledWith("wlan0", 1);
 
         thenExceptionOccurred(DBusExecutionException.class);
     }
@@ -89,7 +89,7 @@ public class WpaSupplicantDbusWrapperTest {
         givenMockInterface("wlan1", "/fi/w1/wpa_supplicant1/Interfaces/1");
         givenWpaSupplicantDbusWrapper();
 
-        whenSyncScanIsCalledWith("wlan1");
+        whenSyncScanIsCalledWith("wlan1", 1);
 
         thenExceptionDidNotOccur();
         thenInterfaceScanWasTriggered();
@@ -124,9 +124,9 @@ public class WpaSupplicantDbusWrapperTest {
      * When
      */
 
-    private void whenSyncScanIsCalledWith(String interfaceName) {
+    private void whenSyncScanIsCalledWith(String interfaceName, long scanTimeoutSeconds) {
         try {
-            this.wpaSupplicantDbusWrapper.syncScan(interfaceName);
+            this.wpaSupplicantDbusWrapper.syncScan(interfaceName, scanTimeoutSeconds);
         } catch (Exception e) {
             this.occurredException = e;
         }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
@@ -83,6 +83,18 @@ public class WpaSupplicantDbusWrapperTest {
         thenReturnedDbusPathIs("/fi/w1/wpa_supplicant1/Interfaces/0");
     }
 
+    @Test
+    public void syncScanShouldWorkWithExistentInterface() throws DBusException {
+        givenMockWpaSupplicant();
+        givenMockInterface("wlan1", "/fi/w1/wpa_supplicant1/Interfaces/1");
+        givenWpaSupplicantDbusWrapper();
+
+        whenSyncScanIsCalledWith("wlan1");
+
+        thenExceptionDidNotOccur();
+        thenInterfaceScanWasTriggered();
+    }
+
     /*
      * Given
      */

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/WpaSupplicantDbusWrapperTest.java
@@ -1,9 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.eclipse.kura.nm;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/signal/handlers/WpaScanDoneHandlerTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/signal/handlers/WpaScanDoneHandlerTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.eclipse.kura.nm.signal.handlers;
 
 import static org.mockito.Mockito.mock;

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/signal/handlers/WpaScanDoneHandlerTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/signal/handlers/WpaScanDoneHandlerTest.java
@@ -4,41 +4,63 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CountDownLatch;
 
+import org.freedesktop.dbus.exceptions.DBusException;
 import org.junit.Test;
 
 import fi.w1.wpa_supplicant1.Interface;
 
 public class WpaScanDoneHandlerTest {
 
+    private CountDownLatch mockLatch = mock(CountDownLatch.class);
+    private WPAScanDoneHandler handler;
+
     @Test
-    public void WpaScanDoneHandlerShouldTriggerWithExpectedDBusPath() {
-        CountDownLatch mockLatch = mock(CountDownLatch.class);
+    public void WpaScanDoneHandlerShouldTriggerWithExpectedDBusPath() throws DBusException {
 
-        WPAScanDoneHandler handler = new WPAScanDoneHandler(mockLatch, "/fi/w1/wpa_supplicant1/Interfaces/0");
+        givenWpaScanDoneHandlerWithDBusPath("/fi/w1/wpa_supplicant1/Interfaces/0");
 
-        Interface.ScanDone scanDone = mock(Interface.ScanDone.class);
-        when(scanDone.getPath()).thenReturn("/fi/w1/wpa_supplicant1/Interfaces/0");
+        whenHandlerReceivesScanDoneSignalWith("/fi/w1/wpa_supplicant1/Interfaces/0");
 
-        handler.handle(scanDone);
-
-        verify(mockLatch, times(1)).countDown();
+        thenLatchShouldBeCountedDown();
     }
 
     @Test
-    public void WpaScanDoneHandlerShouldNotTriggerWithDifferentDBusPath() {
-        CountDownLatch mockLatch = mock(CountDownLatch.class);
+    public void WpaScanDoneHandlerShouldNotTriggerWithDifferentDBusPath() throws DBusException {
+        givenWpaScanDoneHandlerWithDBusPath("/fi/w1/wpa_supplicant1/Interfaces/0");
 
-        WPAScanDoneHandler handler = new WPAScanDoneHandler(mockLatch, "/fi/w1/wpa_supplicant1/Interfaces/0");
+        whenHandlerReceivesScanDoneSignalWith("/fi/w1/wpa_supplicant1/Interfaces/6");
 
-        Interface.ScanDone scanDone = mock(Interface.ScanDone.class);
-        when(scanDone.getPath()).thenReturn("/fi/w1/wpa_supplicant1/Interfaces/6");
+        thenLatchShouldNotBeUpdated();
+    }
 
-        handler.handle(scanDone);
+    /*
+     * Given
+     */
 
-        verify(mockLatch, never()).countDown();
+    private void givenWpaScanDoneHandlerWithDBusPath(String dbusPath) {
+        this.handler = new WPAScanDoneHandler(this.mockLatch, dbusPath);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenHandlerReceivesScanDoneSignalWith(String dbusPath) throws DBusException {
+        Interface.ScanDone scanDoneSignal = new Interface.ScanDone(dbusPath, true);
+        handler.handle(scanDoneSignal);
+    }
+
+    /*
+     * Then
+     */
+    private void thenLatchShouldBeCountedDown() {
+        verify(this.mockLatch, times(1)).countDown();
+    }
+
+    private void thenLatchShouldNotBeUpdated() {
+        verify(this.mockLatch, never()).countDown();
     }
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/signal/handlers/WpaScanDoneHandlerTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/signal/handlers/WpaScanDoneHandlerTest.java
@@ -1,0 +1,44 @@
+package org.eclipse.kura.nm.signal.handlers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Test;
+
+import fi.w1.wpa_supplicant1.Interface;
+
+public class WpaScanDoneHandlerTest {
+
+    @Test
+    public void WpaScanDoneHandlerShouldTriggerWithExpectedDBusPath() {
+        CountDownLatch mockLatch = mock(CountDownLatch.class);
+
+        WPAScanDoneHandler handler = new WPAScanDoneHandler(mockLatch, "/fi/w1/wpa_supplicant1/Interfaces/0");
+
+        Interface.ScanDone scanDone = mock(Interface.ScanDone.class);
+        when(scanDone.getPath()).thenReturn("/fi/w1/wpa_supplicant1/Interfaces/0");
+
+        handler.handle(scanDone);
+
+        verify(mockLatch, times(1)).countDown();
+    }
+
+    @Test
+    public void WpaScanDoneHandlerShouldNotTriggerWithDifferentDBusPath() {
+        CountDownLatch mockLatch = mock(CountDownLatch.class);
+
+        WPAScanDoneHandler handler = new WPAScanDoneHandler(mockLatch, "/fi/w1/wpa_supplicant1/Interfaces/0");
+
+        Interface.ScanDone scanDone = mock(Interface.ScanDone.class);
+        when(scanDone.getPath()).thenReturn("/fi/w1/wpa_supplicant1/Interfaces/6");
+
+        handler.handle(scanDone);
+
+        verify(mockLatch, never()).countDown();
+    }
+}


### PR DESCRIPTION
Currently, when displaying nearby Access Point when the wifi interface is set as AP itself, Kura only shows its AP as the only available nearby Access Point. This is due to the fact that, when set in AP mode, NetworkManager doesn't perform background scans and thus only displays itself.

This PR adds the necessary facilities to trigger a rescan for an interface by reproducing what was described [here](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1241), leveraging `wpa_supplicant`.

Changelog:
- Added `WpaSupplicantDbusWrapper` responsible for retrieving the `wpa_supplicant` object path and calling the [`Scan` method](https://w1.fi/wpa_supplicant/devel/dbus.html#dbus_interface) for the Wifi Interface. Please note that I provided two methods for running the AP scan: 
  - `syncScan`: synchronous method. It will wait for the `Interface.ScanDone` signal before returning.
  - `asyncScan`: asynchronous method. It will not wait the signal but returns the DBusPath of the interface.
- Added the required facilites to wait for the correct signal (`WPAScanLock` and `WPAScanDoneHandler`)
- Added corresponding unit tests.

**What's missing from this PR?**: The actual call to the methods. We're still deciding what's the best way to trigger the rescan of the APs.

### Testing

Tested working on RPi4 running `wpa_supplicant` v2.9.

For testing I modified the `NMDbusConnector` as follows:

<details>
   <summary> Show diff </summary>


```diff
diff --git a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
index 554832952..47c5823ca 100644
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -15,6 +15,7 @@ package org.eclipse.kura.nm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -74,10 +75,13 @@ public class NMDbusConnector {
             NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceType.NM_DEVICE_TYPE_WIFI,
             NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);

+    private static final long LAST_SCAN_TIMEOUT_5_MINUTES = 5 * 60 * 1000;
+
     private static NMDbusConnector instance;
     private final DBusConnection dbusConnection;
     private final NetworkManagerDbusWrapper networkManager;
     private final ModemManagerDbusWrapper modemManager;
+    private final WpaSupplicantDbusWrapper wpaSupplicant;

     private Map<String, Object> cachedConfiguration = null;

@@ -86,10 +90,13 @@ public class NMDbusConnector {

     private boolean configurationEnforcementHandlerIsArmed = false;

+    private Map<String, Long> lastScan = new HashMap<>();
+
     private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
         this.networkManager = new NetworkManagerDbusWrapper(this.dbusConnection);
         this.modemManager = new ModemManagerDbusWrapper(this.dbusConnection);
+        this.wpaSupplicant = new WpaSupplicantDbusWrapper(this.dbusConnection);
     }

     public static synchronized NMDbusConnector getInstance() throws DBusException {
@@ -276,6 +283,17 @@ public class NMDbusConnector {
         Properties wirelessDeviceProperties = this.dbusConnection.getRemoteObject(NM_BUS_NAME,
                 wirelessDevice.getObjectPath(), Properties.class);

+        // Decide whether to trigger a scan or not
+        long timestamp = System.currentTimeMillis();
+        if (!this.lastScan.containsKey(interfaceId) || this.lastScan.get(interfaceId) == null
+                || this.lastScan.get(interfaceId) - timestamp > LAST_SCAN_TIMEOUT_5_MINUTES) {
+            logger.info("Triggering scan for interface {}", interfaceId); // Debug
+            this.wpaSupplicant.syncScan(interfaceId); // Trigger rescan of APs
+            this.lastScan.put(interfaceId, timestamp);
+        } else {
+            logger.info("Skipping scan for interface {} as it was already performed recently", interfaceId); // Debug
+        }
+
         List<Properties> accessPoints = this.networkManager.getAllAccessPoints(wirelessDevice);

         DBusPath activeAccessPointPath = wirelessDeviceProperties.Get(NM_DEVICE_WIRELESS_BUS_NAME, "ActiveAccessPoint");
```

</details>