### PR TITLE
fix(nm): "unmanaged", "unknown" and "disabled" interface status handling inside NMSettingsConverter

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -156,19 +156,10 @@ public class NMSettingsConverter {
     }
 
     public static Map<String, Variant<?>> buildIpv6Settings(NetworkProperties props, String deviceId) {
-        KuraIpStatus ip6Status = KuraIpStatus
-                .fromString(props.get(String.class, "net.interface.%s.config.ip6.status", deviceId));
-
-        if (ip6Status == KuraIpStatus.UNMANAGED || ip6Status == KuraIpStatus.UNKNOWN) {
-            throw new IllegalArgumentException("IPv6 status is not supported: " + ip6Status
-                    + ". Build settings should be called only for managed interfaces.");
-        }
-
         Map<String, Variant<?>> settings = new HashMap<>();
-        if (ip6Status == KuraIpStatus.DISABLED) {
-            settings.put(NM_SETTINGS_IPV4_METHOD, new Variant<>("disabled"));
-            return settings;
-        }
+
+        // Disabled for now
+        settings.put(NM_SETTINGS_IPV6_METHOD, new Variant<>("disabled"));
 
         return settings;
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -156,10 +156,19 @@ public class NMSettingsConverter {
     }
 
     public static Map<String, Variant<?>> buildIpv6Settings(NetworkProperties props, String deviceId) {
-        Map<String, Variant<?>> settings = new HashMap<>();
+        KuraIpStatus ip6Status = KuraIpStatus
+                .fromString(props.get(String.class, "net.interface.%s.config.ip6.status", deviceId));
 
-        // Disabled for now
-        settings.put(NM_SETTINGS_IPV6_METHOD, new Variant<>("disabled"));
+        if (ip6Status == KuraIpStatus.UNMANAGED) {
+            throw new IllegalArgumentException("IPv6 status is not supported: " + ip6Status
+                    + ". Build settings should be called only for managed interfaces.");
+        }
+
+        Map<String, Variant<?>> settings = new HashMap<>();
+        if (ip6Status == KuraIpStatus.DISABLED) {
+            settings.put(NM_SETTINGS_IPV4_METHOD, new Variant<>("disabled"));
+            return settings;
+        }
 
         return settings;
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -94,12 +94,21 @@ public class NMSettingsConverter {
     }
 
     public static Map<String, Variant<?>> buildIpv4Settings(NetworkProperties props, String deviceId) {
-        Map<String, Variant<?>> settings = new HashMap<>();
-
-        Boolean dhcpClient4Enabled = props.get(Boolean.class, "net.interface.%s.config.dhcpClient4.enabled", deviceId);
-
         KuraIpStatus ip4Status = KuraIpStatus
                 .fromString(props.get(String.class, "net.interface.%s.config.ip4.status", deviceId));
+
+        if (ip4Status == KuraIpStatus.UNMANAGED) {
+            throw new IllegalArgumentException("IPv4 status is not supported: " + ip4Status
+                    + ". Build settings should be called only for managed interfaces.");
+        }
+
+        Map<String, Variant<?>> settings = new HashMap<>();
+        if (ip4Status == KuraIpStatus.DISABLED) {
+            settings.put(NM_SETTINGS_IPV4_METHOD, new Variant<>("disabled"));
+            return settings;
+        }
+
+        Boolean dhcpClient4Enabled = props.get(Boolean.class, "net.interface.%s.config.dhcpClient4.enabled", deviceId);
 
         if (Boolean.FALSE.equals(dhcpClient4Enabled)) {
             settings.put(NM_SETTINGS_IPV4_METHOD, new Variant<>("manual"));

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -159,7 +159,7 @@ public class NMSettingsConverter {
         KuraIpStatus ip6Status = KuraIpStatus
                 .fromString(props.get(String.class, "net.interface.%s.config.ip6.status", deviceId));
 
-        if (ip6Status == KuraIpStatus.UNMANAGED) {
+        if (ip6Status == KuraIpStatus.UNMANAGED || ip6Status == KuraIpStatus.UNKNOWN) {
             throw new IllegalArgumentException("IPv6 status is not supported: " + ip6Status
                     + ". Build settings should be called only for managed interfaces.");
         }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -97,7 +97,7 @@ public class NMSettingsConverter {
         KuraIpStatus ip4Status = KuraIpStatus
                 .fromString(props.get(String.class, "net.interface.%s.config.ip4.status", deviceId));
 
-        if (ip4Status == KuraIpStatus.UNMANAGED) {
+        if (ip4Status == KuraIpStatus.UNMANAGED || ip4Status == KuraIpStatus.UNKNOWN) {
             throw new IllegalArgumentException("IPv4 status is not supported: " + ip4Status
                     + ". Build settings should be called only for managed interfaces.");
         }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -405,7 +405,6 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
-        givenNetworkConfigMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -428,7 +427,6 @@ public class NMDbusConnectorTest {
         givenMockToPrepNetworkManagerToAllowDeviceToCreateNewConnection();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
-        givenNetworkConfigMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -535,7 +533,6 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
-        givenNetworkConfigMapWith("net.interface.1-5.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.1-5.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
         givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
@@ -558,7 +555,6 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
-        givenNetworkConfigMapWith("net.interface.1-5.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.1-5.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
         givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
@@ -581,7 +577,6 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
-        givenNetworkConfigMapWith("net.interface.1-5.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.1-5.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
         givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
@@ -736,7 +731,6 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
-        givenNetworkConfigMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -763,7 +757,6 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
-        givenNetworkConfigMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -405,6 +405,7 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -427,6 +428,7 @@ public class NMDbusConnectorTest {
         givenMockToPrepNetworkManagerToAllowDeviceToCreateNewConnection();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -533,6 +535,7 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
+        givenNetworkConfigMapWith("net.interface.1-5.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.1-5.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
         givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
@@ -555,6 +558,7 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
+        givenNetworkConfigMapWith("net.interface.1-5.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.1-5.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
         givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
@@ -577,6 +581,7 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "1-5,");
+        givenNetworkConfigMapWith("net.interface.1-5.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.1-5.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
         givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
@@ -731,6 +736,7 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -757,6 +763,7 @@ public class NMDbusConnectorTest {
         givenMockedDeviceList();
 
         givenNetworkConfigMapWith("net.interfaces", "eth0");
+        givenNetworkConfigMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenNetworkConfigMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenNetworkConfigMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -706,7 +706,7 @@ public class NMSettingsConverterTest {
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLan() {
         givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
@@ -749,7 +749,7 @@ public class NMSettingsConverterTest {
     public void buildSettingsShouldWorkWithExpectedConfiguredForInputsWiFiWan() {
         givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
@@ -791,7 +791,7 @@ public class NMSettingsConverterTest {
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLanAndHiddenSsid() {
         givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
@@ -835,7 +835,7 @@ public class NMSettingsConverterTest {
     public void buildSettingsShouldNotSet80211WirelessSecuritySettingsIfSecurityTypeIsSetToNone() {
         givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
@@ -872,7 +872,7 @@ public class NMSettingsConverterTest {
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
         givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
@@ -927,7 +927,7 @@ public class NMSettingsConverterTest {
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
         givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedLan");
+        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
@@ -950,7 +950,7 @@ public class NMSettingsConverterTest {
     public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
         givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
@@ -992,8 +992,9 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldThrowDhcpDisabledAndNullIp() {
+        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.eth0.config.ip4.address", null);
         givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
@@ -1008,8 +1009,9 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldThrowDhcpDisabledAndNullPrefix() {
+        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.eth0.config.ip4.prefix", null);
         givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
@@ -1024,6 +1026,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldThrowDhcpDisabledAndNullStatus() {
+        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.eth0.config.ip4.status", null);
         givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -1040,8 +1043,9 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldThrowDhcpDisabledAndNullWifiSsid() {
+        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
@@ -1066,8 +1070,9 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldThrowDhcpDisabledAndNullWifiPassword() {
+        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
@@ -1092,8 +1097,9 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldThrowDhcpDisabledAndNullWifiSecurityType() {
+        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
         givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -101,6 +101,24 @@ public class NMSettingsConverterTest {
     }
 
     @Test
+    public void buildIpv4SettingsShouldWorkWhenDisabled() {
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusDisabled");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("method", "disabled");
+        thenResultingMapNotContains("ignore-auto-dns");
+        thenResultingMapNotContains("ignore-auto-routes");
+        thenResultingMapNotContains("route-metric");
+        thenResultingMapNotContains("address-data");
+        thenResultingMapNotContains("dns");
+        thenResultingMapNotContains("ignore-auto-dns");
+        thenResultingMapNotContains("gateway");
+    }
+
+    @Test
     public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForWan() {
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -81,6 +81,26 @@ public class NMSettingsConverterTest {
     }
 
     @Test
+    public void buildIpv4SettingsShouldThrowWithUnmanagedStatus() {
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
+
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenIllegalArgumentExceptionThrown();
+    }
+
+    @Test
+    public void buildIpv4SettingsShouldThrowWithUnknownStatus() {
+        givenMapWith("net.interface.wlan0.config.ip4.status", "myNewAnDifferentUnknownStatus");
+
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenIllegalArgumentExceptionThrown();
+    }
+
+    @Test
     public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsTrueAndEnabledForWan() {
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
@@ -730,8 +750,19 @@ public class NMSettingsConverterTest {
     }
 
     @Test
-    public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiUnmanged() {
+    public void buildSettingsShouldThrowWithStatusUnmanaged() {
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
+                NMDeviceType.NM_DEVICE_TYPE_WIFI);
+
+        thenIllegalArgumentExceptionThrown();
+    }
+
+    @Test
+    public void buildSettingsShouldThrowWithStatusUnknown() {
+        givenMapWith("net.interface.wlan0.config.ip4.status", "myAwesomeUnknownString");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -761,7 +761,6 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLan() {
-        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -806,7 +805,6 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedConfiguredForInputsWiFiWan() {
-        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -852,7 +850,6 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLanAndHiddenSsid() {
-        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -898,7 +895,6 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldNotSet80211WirelessSecuritySettingsIfSecurityTypeIsSetToNone() {
-        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -937,7 +933,6 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
-        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -997,7 +992,6 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
-        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -1022,7 +1016,6 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
-        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -1050,7 +1043,6 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithModemSettings() {
-        givenMapWith("net.interface.1-1.1.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.1-1.1.config.dhcpClient4.enabled", true);
         givenMapWith("net.interface.1-1.1.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.1-1.1.config.apn", "mobile.test.com");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -148,19 +148,12 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndUnmanaged() {
-        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
-        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 
-        thenNoExceptionsHaveBeenThrown();
-        thenResultingMapContains("method", "manual");
-        thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenIllegalArgumentExceptionThrown();
     }
 
     @Test
@@ -700,43 +693,13 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiUnmanged() {
-        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
-        givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
-        givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
-        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-        givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
-        givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
-        givenMapWith("net.interface.wlan0.config.wifi.infra.channel", "10");
-        givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
-        givenMapWith("net.interface.wlan0.config.wifi.infra.passphrase", new Password("test"));
-        givenMapWith("net.interface.wlan0.config.wifi.infra.securityType", "SECURITY_WPA_WPA2");
-        givenMapWith("net.interface.wlan0.config.wifi.infra.groupCiphers", "CCMP");
-        givenMapWith("net.interface.wlan0.config.wifi.infra.pairwiseCiphers", "CCMP");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "wlan0", "wlan0",
                 NMDeviceType.NM_DEVICE_TYPE_WIFI);
 
-        thenNoExceptionsHaveBeenThrown();
-        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-        thenResultingBuildAllMapContains("ipv4", "method", "manual");
-        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-        thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
-        thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
-        thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
-        thenResultingBuildAllMapContains("802-11-wireless", "mode", "infrastructure");
-        thenResultingBuildAllMapContainsBytes("802-11-wireless", "ssid", "ssidtest");
-        thenResultingBuildAllMapContains("802-11-wireless", "band", "a");
-        thenResultingBuildAllMapContains("802-11-wireless", "channel", new UInt32(Short.parseShort("10")));
-        thenResultingBuildAllMapContains("802-11-wireless-security", "psk", new Password("test").toString());
-        thenResultingBuildAllMapContains("802-11-wireless-security", "key-mgmt", "wpa-psk");
-        thenResultingBuildAllMapContains("802-11-wireless-security", "group",
-                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
-        thenResultingBuildAllMapContains("802-11-wireless-security", "pairwise",
-                new Variant<>(Arrays.asList("ccmp"), "as").getValue());
+        thenIllegalArgumentExceptionThrown();
     }
 
     @Test
@@ -946,24 +909,13 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndUnmanaged() {
-        givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusUnmanaged");
-        givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
-        givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
-        givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
-        givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0", "eth0",
                 NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
-        thenNoExceptionsHaveBeenThrown();
-        thenResultingBuildAllMapContains("ipv6", "method", "disabled");
-        thenResultingBuildAllMapContains("ipv4", "method", "manual");
-        thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
-        thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
-        thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
-        thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
+        thenIllegalArgumentExceptionThrown();
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -110,6 +110,9 @@ public class NMSettingsConverterTest {
         thenNoExceptionsHaveBeenThrown();
 
         thenResultingMapContains("method", "auto");
+        thenResultingMapNotContains("ignore-auto-dns");
+        thenResultingMapNotContains("ignore-auto-routes");
+        thenResultingMapNotContains("route-metric");
     }
 
     @Test
@@ -130,7 +133,7 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("dns", new Variant<>(Arrays.asList(new UInt32(16843009)), "au").getValue());
         thenResultingMapContains("ignore-auto-dns", true);
         thenResultingMapContains("gateway", "192.168.0.1");
-
+        thenResultingMapNotContains("route-metric");
     }
 
     @Test
@@ -145,6 +148,7 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("method", "auto");
         thenResultingMapContains("ignore-auto-dns", true);
         thenResultingMapContains("ignore-auto-routes", true);
+        thenResultingMapNotContains("route-metric");
     }
 
     @Test
@@ -164,27 +168,7 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
         thenResultingMapContains("ignore-auto-dns", true);
         thenResultingMapContains("ignore-auto-routes", true);
-    }
-
-    @Test
-    public void buildIpv4SettingsShouldWorkWhenGivenExpectedMapAndDhcpIsFalseAndUnmanaged() {
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusUnmanaged");
-        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-
-        thenIllegalArgumentExceptionThrown();
-    }
-
-    @Test
-    public void buildIpv4SettingsShouldSupportEmptyWanPriorityProperty() {
-        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
-        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-
-        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapNotContains("dns");
         thenResultingMapNotContains("route-metric");
     }
 
@@ -198,6 +182,7 @@ public class NMSettingsConverterTest {
         whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 
         thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("method", "auto");
         thenResultingMapContains("route-metric", new Variant<>(new Long(30)).getValue());
     }
 
@@ -211,6 +196,9 @@ public class NMSettingsConverterTest {
         whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
 
         thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("method", "auto");
+        thenResultingMapContains("ignore-auto-dns", true);
+        thenResultingMapContains("ignore-auto-routes", true);
         thenResultingMapNotContains("route-metric");
     }
 
@@ -1341,6 +1329,11 @@ public class NMSettingsConverterTest {
 
     public void thenResultingBuildAllMapNotContains(String key) {
         assertFalse(this.resultAllSettingsMap.containsKey(key));
+    }
+
+    public void thenResultingBuildAllMapNotContains(String key, String subKey) {
+        Map<String, Variant<?>> innerMap = this.resultAllSettingsMap.get(key);
+        assertFalse(innerMap.containsKey(key));
     }
 
     public void thenResultingBuildAllMapContainsBytes(String key, String subKey, Object value) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -766,8 +766,6 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
         givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
         givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
         givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
@@ -787,6 +785,10 @@ public class NMSettingsConverterTest {
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
         thenResultingBuildAllMapContains("ipv4", "method", "manual");
         thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapNotContains("ipv4", "gateway");
+        thenResultingBuildAllMapNotContains("ipv4", "dns");
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-dns", true);
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-routes", true);
         thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
         thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
         thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
@@ -829,6 +831,10 @@ public class NMSettingsConverterTest {
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
         thenResultingBuildAllMapContains("ipv4", "method", "manual");
         thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-dns", true);
+        thenResultingBuildAllMapContains("ipv4", "dns",
+                new Variant<>(Arrays.asList(new UInt32(16843009)), "au").getValue());
+        thenResultingBuildAllMapContains("ipv4", "gateway", "192.168.0.1");
         thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
         thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
         thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
@@ -851,8 +857,6 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
         givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
         givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
         givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
@@ -872,6 +876,10 @@ public class NMSettingsConverterTest {
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
         thenResultingBuildAllMapContains("ipv4", "method", "manual");
         thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapNotContains("ipv4", "gateway");
+        thenResultingBuildAllMapNotContains("ipv4", "dns");
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-dns", true);
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-routes", true);
         thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
         thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
         thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
@@ -895,8 +903,6 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.wlan0.config.ip4.prefix", (short) 25);
-        givenMapWith("net.interface.wlan0.config.ip4.dnsServers", "1.1.1.1");
-        givenMapWith("net.interface.wlan0.config.ip4.gateway", "192.168.0.1");
         givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
         givenMapWith("net.interface.wlan0.config.wifi.infra.ssid", "ssidtest");
         givenMapWith("net.interface.wlan0.config.wifi.infra.radioMode", "RADIO_MODE_80211a");
@@ -915,6 +921,10 @@ public class NMSettingsConverterTest {
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
         thenResultingBuildAllMapContains("ipv4", "method", "manual");
         thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapNotContains("ipv4", "gateway");
+        thenResultingBuildAllMapNotContains("ipv4", "dns");
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-dns", true);
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-routes", true);
         thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
         thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
         thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
@@ -953,6 +963,11 @@ public class NMSettingsConverterTest {
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
         thenResultingBuildAllMapContains("ipv4", "method", "manual");
         thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("ipv4", "gateway", "192.168.0.1");
+        thenResultingBuildAllMapContains("ipv4", "dns",
+                new Variant<>(Arrays.asList(new UInt32(16843009)), "au").getValue());
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-dns", true);
+        thenResultingBuildAllMapNotContains("ipv4", "ignore-auto-routes");
         thenResultingBuildAllMapContains("connection", "id", "kura-wlan0-connection");
         thenResultingBuildAllMapContains("connection", "interface-name", "wlan0");
         thenResultingBuildAllMapContains("connection", "type", "802-11-wireless");
@@ -987,8 +1002,6 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusEnabledLAN");
         givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
         givenMapWith("net.interface.eth0.config.ip4.prefix", (short) 25);
-        givenMapWith("net.interface.eth0.config.ip4.dnsServers", "1.1.1.1");
-        givenMapWith("net.interface.eth0.config.ip4.gateway", "192.168.0.1");
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildSettingsIsRunWith(this.networkProperties, Optional.empty(), "eth0", "eth0",
@@ -998,6 +1011,10 @@ public class NMSettingsConverterTest {
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
         thenResultingBuildAllMapContains("ipv4", "method", "manual");
         thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-dns", true);
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-routes", true);
+        thenResultingBuildAllMapNotContains("ipv4", "gateway");
+        thenResultingBuildAllMapNotContains("ipv4", "dns");
         thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
         thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
         thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
@@ -1021,6 +1038,11 @@ public class NMSettingsConverterTest {
         thenResultingBuildAllMapContains("ipv6", "method", "disabled");
         thenResultingBuildAllMapContains("ipv4", "method", "manual");
         thenResultingBuildAllMapContains("ipv4", "address-data", buildAddressDataWith("192.168.0.12", new UInt32(25)));
+        thenResultingBuildAllMapContains("ipv4", "gateway", "192.168.0.1");
+        thenResultingBuildAllMapContains("ipv4", "dns",
+                new Variant<>(Arrays.asList(new UInt32(16843009)), "au").getValue());
+        thenResultingBuildAllMapContains("ipv4", "ignore-auto-dns", true);
+        thenResultingBuildAllMapNotContains("ipv4", "ignore-auto-routes");
         thenResultingBuildAllMapContains("connection", "id", "kura-eth0-connection");
         thenResultingBuildAllMapContains("connection", "interface-name", "eth0");
         thenResultingBuildAllMapContains("connection", "type", "802-3-ethernet");
@@ -1333,7 +1355,7 @@ public class NMSettingsConverterTest {
 
     public void thenResultingBuildAllMapNotContains(String key, String subKey) {
         Map<String, Variant<?>> innerMap = this.resultAllSettingsMap.get(key);
-        assertFalse(innerMap.containsKey(key));
+        assertFalse(innerMap.containsKey(subKey));
     }
 
     public void thenResultingBuildAllMapContainsBytes(String key, String subKey, Object value) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -704,6 +704,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLan() {
+        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -746,6 +747,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedConfiguredForInputsWiFiWan() {
+        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -787,6 +789,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiLanAndHiddenSsid() {
+        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -830,6 +833,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldNotSet80211WirelessSecuritySettingsIfSecurityTypeIsSetToNone() {
+        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedLan");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -866,6 +870,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForWiFiWanAndHiddenSsid() {
+        givenMapWith("net.interface.wlan0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusManagedWan");
         givenMapWith("net.interface.wlan0.config.ip4.address", "192.168.0.12");
@@ -920,6 +925,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsConfiguredForEthernetAndLan() {
+        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedLan");
         givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -942,6 +948,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithExpectedInputsEthernetAndWan() {
+        givenMapWith("net.interface.eth0.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.eth0.config.dhcpClient4.enabled", false);
         givenMapWith("net.interface.eth0.config.ip4.status", "netIPv4StatusManagedWan");
         givenMapWith("net.interface.eth0.config.ip4.address", "192.168.0.12");
@@ -964,6 +971,7 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildSettingsShouldWorkWithModemSettings() {
+        givenMapWith("net.interface.1-1.1.config.ip6.status", "netIPv6StatusDisabled");
         givenMapWith("net.interface.1-1.1.config.dhcpClient4.enabled", true);
         givenMapWith("net.interface.1-1.1.config.ip4.status", "netIPv4StatusEnabledWAN");
         givenMapWith("net.interface.1-1.1.config.apn", "mobile.test.com");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -157,6 +157,44 @@ public class NMSettingsConverterTest {
     }
 
     @Test
+    public void buildIpv4SettingsShouldSupportEmptyWanPriorityProperty() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapNotContains("route-metric");
+    }
+
+    @Test
+    public void buildIpv4SettingsShouldPopulateWanPriorityProperty() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenMapWith("net.interface.wlan0.config.ip4.wan.priority", new Integer(30));
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapContains("route-metric", new Variant<>(new Long(30)).getValue());
+    }
+
+    @Test
+    public void buildIpv4SettingsShouldNotPopulateWanPriorityPropertyIfNotWAN() {
+        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
+        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
+        givenMapWith("net.interface.wlan0.config.ip4.wan.priority", new Integer(30));
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionsHaveBeenThrown();
+        thenResultingMapNotContains("route-metric");
+    }
+
+    @Test
     public void build80211WirelessSettingsShouldWorkWhenGivenExpectedMapAndSetToInfraAndWithChannelField() {
 
         givenMapWith("net.interface.wlan0.config.wifi.mode", "INFRA");
@@ -1121,45 +1159,6 @@ public class NMSettingsConverterTest {
 
         thenNoSuchElementExceptionThrown();
     }
-
-    @Test
-    public void shouldSupportEmptyWanPriorityProperty() {
-        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
-        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-
-        thenNoExceptionsHaveBeenThrown();
-        thenResultingMapNotContains("route-metric");
-    }
-
-    @Test
-    public void shouldPopulateWanPriorityProperty() {
-        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledWAN");
-        givenMapWith("net.interface.wlan0.config.ip4.wan.priority", new Integer(30));
-        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-
-        thenNoExceptionsHaveBeenThrown();
-        thenResultingMapContains("route-metric", new Variant<>(new Long(30)).getValue());
-    }
-
-    @Test
-    public void shouldNotPopulateWanPriorityPropertyIfNotWAN() {
-        givenMapWith("net.interface.wlan0.config.dhcpClient4.enabled", true);
-        givenMapWith("net.interface.wlan0.config.ip4.status", "netIPv4StatusEnabledLAN");
-        givenMapWith("net.interface.wlan0.config.ip4.wan.priority", new Integer(30));
-        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
-
-        whenBuildIpv4SettingsIsRunWith(this.networkProperties, "wlan0");
-
-        thenNoExceptionsHaveBeenThrown();
-        thenResultingMapNotContains("route-metric");
-    }
-
     /*
      * Given
      */


### PR DESCRIPTION
> **Warning**
> Wait #4786 before merging to avoid merge conflicts on that PR

This PR fixes two issues related to the `net.interface.%s.config.ip4.status` and `net.interface.%s.config.ip6.status`.

#### `Unmanaged` handling

The first one concerns a wrong behaviour that was encoded in the unit tests: in the `buildSettings` tests, when the interface is set as `Unmanaged` we still check for the settings to be sent to NetworkManager. This is *wrong* at the design level. When the device is set as `Unmanaged` none of the `buildSettings` method should be called because *we shouldn't set anything*. If we do we would overwrite what the user set and thus lose the meaning of the `Unmanaged` property.

To prevent similar issues, in addition to updating the tests,  I added an exception for when the `buildSettings` methods are called with an `Unmanaged` interface.

#### `Disabled` handling

Due to the fact that, until now, `ip6.status` was always set to `Disabled` or `Unmanaged` we did not take into account the case in which one ip version is enabled and one disabled. Therefore we collapsed the concept of **interface disabled** with **ipv4 disabled**. In reality, when only one ip version is disabled, the **interface** is enabled we just need to set the corresponding `ipvX.method` as disabled.

This PR adds a simple check inside the `buildIp4Settings` and `buildIp6Settings` methods so that when the corresponding ip is disabled they will set the correct NetworkManager property.

#### `Unknown` handling

Similarly to what happened to the `Unmanaged` status we're not correctly handling the `Unknown` status in the `buildSettings`. Again, this is due to the fact that `buildSettings` assumes the statuses it sees were already checked by the `NMDbusConnector`. Unfortunately in the tests these assumptions are violeted and there are some curious behaviour.

See: https://github.com/eclipse/kura/blob/1acc7838278e6dbe430bc9d6d70cfb00bcbf2059/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java#L745


`netIPv4StatusManagedLan` is not correct, but the tests works anyway.

To prevent similar issues, in addition to updating the tests,  I added an exception for when the `buildSettings` methods are called with an `Unknown` status.