### PR TITLE
ci: update release script so that added [TODO] sections don't get replaced

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -31,6 +31,7 @@ jobs:
           -Dexec.executable=echo
           -Dexec.args='${project.version}'
           --quiet exec:exec --non-recursive
+          -Pjava8
         )\" >> \"${GITHUB_OUTPUT}\""
       shell: bash
     
@@ -43,7 +44,7 @@ jobs:
 
     - name: Files exist
       id: get-old-text
-      if: steps.check_files.outputs.exists == true && github.event.inputs.overwrite == false
+      if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == 'false'
       run: |
         awk '/Description:/ {found=1; next} /^$/ {found=0} found {print}' ./kura/distrib/RELEASE_NOTES.txt > description.txt
         awk '/Target Environments:/ {found=1; next} /^$/ {found=0} found {print}' ./kura/distrib/RELEASE_NOTES.txt > target-env.txt
@@ -72,17 +73,17 @@ jobs:
     
     - name: Files exist write description
       id: get-description
-      if: steps.check_files.outputs.exists == true && github.event.inputs.overwrite == false
+      if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == 'false'
       # Only runs if all of the files exist
       run: |
-          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' description.txt done=0 RELEASE_NOTES.txt
-          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' target-env.txt done=0 RELEASE_NOTES.txt
-          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' known-issues.txt done=0 RELEASE_NOTES.txt
+          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' description.txt done=0 ./kura/distrib/RELEASE_NOTES.txt > tmpfile && mv tmpfile ./kura/distrib/RELEASE_NOTES.txt
+          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' target-env.txt done=0 ./kura/distrib/RELEASE_NOTES.txt > tmpfile && mv tmpfile ./kura/distrib/RELEASE_NOTES.txt
+          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' known-issues.txt done=0 ./kura/distrib/RELEASE_NOTES.txt > tmpfile && mv tmpfile ./kura/distrib/RELEASE_NOTES.txt
       shell: bash
         
     - name: Files exist clean up
       id: clean-up-files
-      if: steps.check_files.outputs.exists == true && github.event.inputs.overwrite == false
+      if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == 'false'
       # Only runs if all of the files exist
       run: |
         rm description.txt

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Files exist
       id: get-old-text
-      if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == false
+      if: steps.check_files.outputs.exists == true && github.event.inputs.overwrite == false
       run: |
         awk '/Description:/ {found=1; next} /^$/ {found=0} found {print}' ./kura/distrib/RELEASE_NOTES.txt > description.txt
         awk '/Target Environments:/ {found=1; next} /^$/ {found=0} found {print}' ./kura/distrib/RELEASE_NOTES.txt > target-env.txt
@@ -71,7 +71,7 @@ jobs:
     
     - name: Files exist write description
       id: get-description
-      if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == false
+      if: steps.check_files.outputs.exists == true && github.event.inputs.overwrite == false
       # Only runs if all of the files exist
       run: |
           awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' description.txt done=0 RELEASE_NOTES.txt
@@ -81,7 +81,7 @@ jobs:
         
     - name: Files exist clean up
       id: clean-up-files
-      if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == false
+      if: steps.check_files.outputs.exists == true && github.event.inputs.overwrite == false
       # Only runs if all of the files exist
       run: |
         rm description.txt

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -9,7 +9,7 @@ on:
           required: true
         overwrite:
           type: boolean
-          description: Overwrite the content of the release notes (typically needed for RC1 notes)
+          description: Overwrite the content of TODO fields in generated release notes (typically needed for RC1 notes)
           required: true
           default: false
 jobs:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,33 +3,51 @@ name: "Release Notes automation"
 on:
   workflow_dispatch:
     inputs:
-        target_branch:
-          type: string
-          default: 'master'
-          description: Target branch
-          required: true
         starting_commit:
           type: string
-          description: Commit from which to start generating the release notes (non-inclusive)
+          description: Commit from which to start generating the Release Notes (non-inclusive)
           required: true
-
+        overwrite:
+          type: boolean
+          description: Overwrite the content of the release notes (typically needed for RC1 notes)
+          required: true
+          default: false
 jobs:
   main:
     name: Generate Release Notes
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout target branch
+    - name: Checkout ${{ github.ref }} branch in ${{ github.repository }} repository.
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.target_branch }}
         fetch-depth: '0'
 
     - name: Get version
       id: get-version
-      uses: JActions/maven-version@v1.0.1
+      run: "echo \"resolved-version=\
+        $(mvn
+          --file ./pom.xml
+          -Dexec.executable=echo
+          -Dexec.args='${project.version}'
+          --quiet exec:exec --non-recursive
+        )\" >> \"${GITHUB_OUTPUT}\""
+      shell: bash
+    
+    - name: Check file existence
+      id: check_files
+      uses: thebinaryfelix/check-file-existence-action@1.0.0
       with:
-        pom: ./kura/pom.xml
+        files: 'RELEASE_NOTES.txt'
+
+    - name: Files exist
+      id: get-old-text
+      if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == false
+      run: |
+        awk '/Description:/ {found=1; next} /^$/ {found=0} found {print}' RELEASE_NOTES.txt > description.txt
+        awk '/Target Environments:/ {found=1; next} /^$/ {found=0} found {print}' RELEASE_NOTES.txt > target-env.txt
+        awk '/Known Issues:/ {found=1; next} /^$/ {found=0} found {print}' RELEASE_NOTES.txt > known-issues.txt
+      shell: bash
 
     - name: Download git-changelog-command-line tool
       id: download-changelog-cli
@@ -46,15 +64,34 @@ jobs:
       run: |
         java -jar ${{ steps.download-changelog-cli.outputs.file }} \
         -fc "${{ github.event.inputs.starting_commit }}" \
-        -ex "{\"version\":\"${{ steps.get-version.outputs.version }}\"}" \
+        -ex "{\"version\":\"${{ steps.get-version.outputs.resolved-version }}\"}" \
         -t .github/release_notes_template/template.hbs \
         -hhf .github/release_notes_template/helper.hbs \
-        -of kura/distrib/RELEASE_NOTES.txt
+        -of RELEASE_NOTES.txt
+    
+    - name: Files exist write description
+      id: get-description
+      if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == false
+      # Only runs if all of the files exist
+      run: |
+          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[WIP\]/ && !done { sub(/\[WIP\]/, desc); done=1 } 1' description.txt done=0 RELEASE_NOTES.txt
+          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[WIP\]/ && !done { sub(/\[WIP\]/, desc); done=1 } 1' target-env.txt done=0 RELEASE_NOTES.txt
+          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[WIP\]/ && !done { sub(/\[WIP\]/, desc); done=1 } 1' known-issues.txt done=0 RELEASE_NOTES.txt
+      shell: bash
+        
+    - name: Files exist clean up
+      id: clean-up-files
+      if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == false
+      # Only runs if all of the files exist
+      run: |
+        rm description.txt
+        rm target-env.txt
+        rm known-issues.txt
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:
-        title: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
-        commit-message: "chore: add Kura ${{ steps.get-version.outputs.version }} release notes"
-        body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.version }} version release notes since commit `${{ github.event.inputs.starting_commit }}` (non-inclusive)"
-        branch-suffix: short-commit-hash
+        title: "chore: add Project ${{ steps.get-version.outputs.resolved-version }} release notes"
+        commit-message: "chore: add Project ${{ steps.get-version.outputs.resolved-version }} release notes"
+        body: "Automated changes by _Release Notes automation_ action: add Project ${{ steps.get-version.outputs.resolved-version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
+        branch-suffix: timestamp

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -38,15 +38,15 @@ jobs:
       id: check_files
       uses: thebinaryfelix/check-file-existence-action@1.0.0
       with:
-        files: 'RELEASE_NOTES.txt'
+        files: './kura/distrib/RELEASE_NOTES.txt'
 
     - name: Files exist
       id: get-old-text
       if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == false
       run: |
-        awk '/Description:/ {found=1; next} /^$/ {found=0} found {print}' RELEASE_NOTES.txt > description.txt
-        awk '/Target Environments:/ {found=1; next} /^$/ {found=0} found {print}' RELEASE_NOTES.txt > target-env.txt
-        awk '/Known Issues:/ {found=1; next} /^$/ {found=0} found {print}' RELEASE_NOTES.txt > known-issues.txt
+        awk '/Description:/ {found=1; next} /^$/ {found=0} found {print}' ./kura/distrib/RELEASE_NOTES.txt > description.txt
+        awk '/Target Environments:/ {found=1; next} /^$/ {found=0} found {print}' ./kura/distrib/RELEASE_NOTES.txt > target-env.txt
+        awk '/Known Issues:/ {found=1; next} /^$/ {found=0} found {print}' ./kura/distrib/RELEASE_NOTES.txt > known-issues.txt
       shell: bash
 
     - name: Download git-changelog-command-line tool
@@ -67,7 +67,7 @@ jobs:
         -ex "{\"version\":\"${{ steps.get-version.outputs.resolved-version }}\"}" \
         -t .github/release_notes_template/template.hbs \
         -hhf .github/release_notes_template/helper.hbs \
-        -of RELEASE_NOTES.txt
+        -of ./kura/distrib/RELEASE_NOTES.txt
     
     - name: Files exist write description
       id: get-description

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -36,6 +36,7 @@ jobs:
     
     - name: Check file existence
       id: check_files
+      continue-on-error: true
       uses: thebinaryfelix/check-file-existence-action@1.0.0
       with:
         files: './kura/distrib/RELEASE_NOTES.txt'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -74,9 +74,9 @@ jobs:
       if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == false
       # Only runs if all of the files exist
       run: |
-          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[WIP\]/ && !done { sub(/\[WIP\]/, desc); done=1 } 1' description.txt done=0 RELEASE_NOTES.txt
-          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[WIP\]/ && !done { sub(/\[WIP\]/, desc); done=1 } 1' target-env.txt done=0 RELEASE_NOTES.txt
-          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[WIP\]/ && !done { sub(/\[WIP\]/, desc); done=1 } 1' known-issues.txt done=0 RELEASE_NOTES.txt
+          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' description.txt done=0 RELEASE_NOTES.txt
+          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' target-env.txt done=0 RELEASE_NOTES.txt
+          awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' known-issues.txt done=0 RELEASE_NOTES.txt
       shell: bash
         
     - name: Files exist clean up

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:
-        title: "chore: add Project ${{ steps.get-version.outputs.resolved-version }} release notes"
-        commit-message: "chore: add Project ${{ steps.get-version.outputs.resolved-version }} release notes"
-        body: "Automated changes by _Release Notes automation_ action: add Project ${{ steps.get-version.outputs.resolved-version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
-        branch-suffix: timestamp
+        title: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
+        commit-message: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
+        body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.resolved-version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
+        branch-suffix: short-commit-hash

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -27,7 +27,7 @@ jobs:
       id: get-version
       run: "echo \"resolved-version=\
         $(mvn
-          --file ./pom.xml
+          --file ./kura/pom.xml
           -Dexec.executable=echo
           -Dexec.args='${project.version}'
           --quiet exec:exec --non-recursive


### PR DESCRIPTION
this pr does the following:

1) checks if there is a existing release file
2) if yes, copy added [WIP] information to separate files
3) generate new release notes
4) find and replace [WIP] with content in the separated files.

NOTE: WIP fields, must not include any new lines. new lines are used to detect the end of the field.


also includes an override boolean to be used in RC releases, if you want to nuke existing [WIP] content. 

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
