### PR TITLE
feat: Added ipv6 status in generic snapshots

### DIFF
--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
@@ -56,6 +56,9 @@
             <esf:property name="net.interface.eth0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledWAN</esf:value>
             </esf:property>
+            <esf:property name="net.interface.eth0.config.ip6.status" array="false" encrypted="false" type="String">
+                <esf:value>netIPv6StatusDisabled</esf:value>
+            </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.infra.broadcast" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
@@ -131,6 +134,9 @@
             <esf:property name="net.interface.lo.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusUnmanaged</esf:value>
             </esf:property>
+            <esf:property name="net.interface.lo.config.ip6.status" array="false" encrypted="false" type="String">
+                <esf:value>netIPv6StatusUnmanaged</esf:value>
+            </esf:property>
             <esf:property name="net.interface.wlan0.config.dhcpServer4.maxLeaseTime" array="false" encrypted="false" type="Integer">
                 <esf:value>7200</esf:value>
             </esf:property>
@@ -163,6 +169,9 @@
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledLAN</esf:value>
+            </esf:property>
+            <esf:property name="net.interface.wlan0.config.ip6.status" array="false" encrypted="false" type="String">
+                <esf:value>netIPv6StatusDisabled</esf:value>
             </esf:property>
         </esf:properties>
     </esf:configuration>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-intelup2
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-intelup2
@@ -36,7 +36,10 @@
                 <esf:value>enp3s0,lo,enp2s0</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.lo.config.ip4.status" type="String">
-                <esf:value>netIPv4StatusEnabledLAN</esf:value>
+                <esf:value>netIPv4StatusUnmanaged</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="net.interface.lo.config.ip6.status" type="String">
+                <esf:value>netIPv6StatusUnmanaged</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.ip4.address" type="String">
                 <esf:value>172.16.0.1</esf:value>
@@ -49,6 +52,9 @@
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.ip4.status" type="String">
                 <esf:value>netIPv4StatusEnabledLAN</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="net.interface.enp2s0.config.ip6.status" type="String">
+                <esf:value>netIPv6StatusDisabled</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp2s0.ip4.address" type="String">
                 <esf:value>172.16.0.1</esf:value>
@@ -118,6 +124,9 @@
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.enp3s0.config.ip4.status" type="String">
                 <esf:value>netIPv4StatusEnabledWAN</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="net.interface.enp3s0.config.ip6.status" type="String">
+                <esf:value>netIPv6StatusDisabled</esf:value>
             </esf:property>
         </esf:properties>
     </esf:configuration>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-jetson-nano
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-jetson-nano
@@ -47,6 +47,9 @@
             <esf:property name="net.interface.eth0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledWAN</esf:value>
             </esf:property>
+            <esf:property name="net.interface.eth0.config.ip6.status" array="false" encrypted="false" type="String">
+                <esf:value>netIPv6StatusDisabled</esf:value>
+            </esf:property>
             <esf:property name="net.interface.eth0.config.dhcpServer4.prefix" array="false" encrypted="false" type="Short">
                 <esf:value>24</esf:value>
             </esf:property>
@@ -81,7 +84,10 @@
                 <esf:value></esf:value>
             </esf:property>
             <esf:property name="net.interface.lo.config.ip4.status" array="false" encrypted="false" type="String">
-                <esf:value>netIPv4StatusEnabledLAN</esf:value>
+                <esf:value>netIPv4StatusUnmanaged</esf:value>
+            </esf:property>
+            <esf:property name="net.interface.lo.config.ip6.status" array="false" encrypted="false" type="String">
+                <esf:value>netIPv6StatusUnmanaged</esf:value>
             </esf:property>
             <esf:property name="net.interface.lo.config.ip4.dnsServers" array="false" encrypted="false" type="String">
                 <esf:value></esf:value>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
@@ -56,6 +56,9 @@
             <esf:property name="net.interface.eth0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledWAN</esf:value>
             </esf:property>
+            <esf:property name="net.interface.eth0.config.ip6.status" array="false" encrypted="false" type="String">
+                <esf:value>netIPv6StatusDisabled</esf:value>
+            </esf:property>
             <esf:property name="net.interface.wlan0.config.wifi.infra.broadcast" array="false" encrypted="false" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
@@ -131,6 +134,9 @@
             <esf:property name="net.interface.lo.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusUnmanaged</esf:value>
             </esf:property>
+            <esf:property name="net.interface.lo.config.ip6.status" array="false" encrypted="false" type="String">
+                <esf:value>netIPv6StatusUnmanaged</esf:value>
+            </esf:property>
             <esf:property name="net.interface.wlan0.config.dhcpServer4.maxLeaseTime" array="false" encrypted="false" type="Integer">
                 <esf:value>7200</esf:value>
             </esf:property>
@@ -163,6 +169,9 @@
             </esf:property>
             <esf:property name="net.interface.wlan0.config.ip4.status" array="false" encrypted="false" type="String">
                 <esf:value>netIPv4StatusEnabledLAN</esf:value>
+            </esf:property>
+            <esf:property name="net.interface.wlan0.config.ip6.status" array="false" encrypted="false" type="String">
+                <esf:value>netIPv6StatusDisabled</esf:value>
             </esf:property>
         </esf:properties>
     </esf:configuration>


### PR DESCRIPTION
This PR introduces the `config.ip6.status` field in the snapshots of generic profiles. This way we have a known value for the IPv6 protocol of network interfaces in a new installation.

It also changed the value of `lo.config.ip4.status` from `netIPv4StatusEnabledLAN` to `netIPv4StatusUnmanaged` for the JetsonNano and IntelUP2 snapshots.



**Related Issue:** 

**Description of the solution adopted:** 

**Screenshots:** 

**Manual Tests:** Tested on Raspberry Pi - Kura Version: generic-aarch64

**Any side note on the changes made:**
