### PR TITLE
feat(distrib): Updated firewall.init script for ipv6 in generic profiles

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/firewall.init
+++ b/kura/distrib/src/main/resources/generic-aarch64/firewall.init
@@ -17,108 +17,118 @@
 #
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
+ip6tables_config_file=/etc/sysconfig/ip6tables
+ip6forward_file=/proc/sys/net/ipv6/conf/all/forwarding
 enable_ipforwarding=false;
 
 create_filter_chains() {
+    iptables_command="$1"
 	# create custom chains if needed
 	custom_filter_chains=(input-kura output-kura forward-kura)
-	for custom_chain in ${custom_filter_chains[@]}; do
-	    chain=(${custom_chain//-/ })
-	    iptables -C ${chain[0]^^} -j $custom_chain -t filter > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t filter > /dev/null 2>&1
-	        iptables -I ${chain[0]^^} -t filter -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_filter_chains[@]}"; do
+	    chain=("${custom_chain//-/ }")
+	    if ! "$iptables_command" -C "${chain[0]^^}" -j "$custom_chain" -t filter > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t filter > /dev/null 2>&1
+	        "$iptables_command" -I "${chain[0]^^}" -t filter -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 	custom_filter_chains=(forward-kura-pf forward-kura-ipf)
-	for custom_chain in ${custom_filter_chains[@]}; do
-	    iptables -C forward-kura -j $custom_chain -t filter > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t filter > /dev/null 2>&1
-	        iptables -I forward-kura -t filter -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_filter_chains[@]}"; do
+	    if ! "$iptables_command" -C forward-kura -j "$custom_chain" -t filter > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t filter > /dev/null 2>&1
+	        "$iptables_command" -I forward-kura -t filter -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 }
 
 create_nat_chains() {
+    iptables_command="$1"
 	custom_nat_chains=(prerouting-kura postrouting-kura input-kura output-kura)
-	for custom_chain in ${custom_nat_chains[@]}; do
-	    chain=(${custom_chain//-/ }[0])
-	    iptables -C ${chain[0]^^} -j $custom_chain -t nat > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t nat > /dev/null 2>&1
-	        iptables -I ${chain[0]^^} -t nat -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_nat_chains[@]}"; do
+	    chain=("${custom_chain//-/ }"[0])
+	    if ! "$iptables_command" -C "${chain[0]^^}" -j "$custom_chain" -t nat > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t nat > /dev/null 2>&1
+	        "$iptables_command" -I "${chain[0]^^}" -t nat -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
-	iptables -C prerouting-kura -j prerouting-kura-pf -t nat > /dev/null 2>&1
-	if [[ $? -ne 0 ]]; then
-	    iptables -N prerouting-kura-pf -t nat > /dev/null 2>&1
-	    iptables -I prerouting-kura -t nat -j prerouting-kura-pf > /dev/null 2>&1
+	if ! "$iptables_command" -C prerouting-kura -j prerouting-kura-pf -t nat > /dev/null 2>&1; then
+	    "$iptables_command" -N prerouting-kura-pf -t nat > /dev/null 2>&1
+	    "$iptables_command" -I prerouting-kura -t nat -j prerouting-kura-pf > /dev/null 2>&1
 	fi
 	custom_nat_chains=(postrouting-kura-pf postrouting-kura-ipf)
-	for custom_chain in ${custom_nat_chains[@]}; do
-	    iptables -C postrouting-kura -j $custom_chain -t nat > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t nat > /dev/null 2>&1
-	        iptables -I postrouting-kura -t nat -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_nat_chains[@]}"; do
+	    if "$iptables_command" -C postrouting-kura -j "$custom_chain" -t nat > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t nat > /dev/null 2>&1
+	        "$iptables_command" -I postrouting-kura -t nat -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 }
 
 create_mangle_chains() {
+    iptables_command="$1"
 	custom_mangle_chains=(prerouting-kura postrouting-kura input-kura output-kura forward-kura)
-	for custom_chain in ${custom_mangle_chains[@]}; do
-	    chain=(${custom_chain//-/ }[0])
-	    iptables -C ${chain[0]^^} -j $custom_chain -t mangle > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t mangle > /dev/null 2>&1
-	        iptables -I ${chain[0]^^} -t mangle -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_mangle_chains[@]}"; do
+	    chain=("${custom_chain//-/ }"[0])
+	    if ! "$iptables_command" -C "${chain[0]^^}" -j "$custom_chain" -t mangle > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t mangle > /dev/null 2>&1
+	        "$iptables_command" -I "${chain[0]^^}" -t mangle -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 }
 
 configure_policies() {
+    iptables_command="$1"
 	# configure policies for standard chains
-	policy=$(iptables -nL -t filter | grep policy | grep INPUT)
+	policy=$("$iptables_command" -nL -t filter | grep policy | grep INPUT)
 	if [[ "$policy" == *ACCEPT* ]]; then
-		iptables -P INPUT DROP
+		"$iptables_command" -P INPUT DROP
 	fi
-	policy=$(iptables -nL -t filter | grep policy | grep OUTPUT)
+	policy=$("$iptables_command" -nL -t filter | grep policy | grep OUTPUT)
 	if [[ "$policy" == *DROP* ]]; then
-		iptables -P OUTPUT ACCEPT
+		"$iptables_command" -P OUTPUT ACCEPT
 	fi
-	policy=$(iptables -nL -t filter | grep policy | grep FORWARD)
+	policy=$("$iptables_command" -nL -t filter | grep policy | grep FORWARD)
 	if [[ "$policy" == *ACCEPT* ]]; then
-		iptables -P FORWARD DROP
+		"$iptables_command" -P FORWARD DROP
 	fi
 }
 
 configure_ip_forwarding() {
+    config_file="$1"
+    ipforward_config_file="$2"
 	# enable ip forwarding if needed
-	if [ -f $iptables_config_file ]; then
+	if [ -f "$config_file" ]; then
 		while IFS='' read -r line || [[ -n "$line" ]]; do
 		    if [[ $line =~ "-A forward-kura" ]]; then
 		        enable_ipforwarding=true
 		        break
 		    fi
-		done < $iptables_config_file
+		done < "$config_file"
 	fi
-	if [ $enable_ipforwarding = true ]; then
-	    echo "1" > $ipforward_file
+	if [ "$enable_ipforwarding" = true ]; then
+	    echo "1" > "$ipforward_config_file"
 	else
-	    echo "0" > $ipforward_file
+	    echo "0" > "$ipforward_config_file"
 	fi
 }
 
 if [ -f $iptables_config_file ]; then
 	iptables-restore < $iptables_config_file
 fi
+if [ -f $ip6tables_config_file ]; then
+	ip6tables-restore < $ip6tables_config_file
+fi
 
-create_filter_chains
-create_nat_chains
-create_mangle_chains
-configure_policies
-configure_ip_forwarding
+configure_iptables() {
+    create_filter_chains "$1"
+    create_nat_chains "$1"
+    create_mangle_chains "$1"
+    configure_policies "$1"
+    configure_ip_forwarding "$2" "$3"
+}
+
+configure_iptables iptables "$iptables_config_file" "$ipforward_file"
+configure_iptables ip6tables "$ip6tables_config_file" "$ip6forward_file"
 
 # source a custom firewall script
 if [ -f /etc/init.d/firewall_cust ]; then

--- a/kura/distrib/src/main/resources/generic-arm32/firewall.init
+++ b/kura/distrib/src/main/resources/generic-arm32/firewall.init
@@ -17,108 +17,118 @@
 #
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
+ip6tables_config_file=/etc/sysconfig/ip6tables
+ip6forward_file=/proc/sys/net/ipv6/conf/all/forwarding
 enable_ipforwarding=false;
 
 create_filter_chains() {
+    iptables_command="$1"
 	# create custom chains if needed
 	custom_filter_chains=(input-kura output-kura forward-kura)
-	for custom_chain in ${custom_filter_chains[@]}; do
-	    chain=(${custom_chain//-/ })
-	    iptables -C ${chain[0]^^} -j $custom_chain -t filter > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t filter > /dev/null 2>&1
-	        iptables -I ${chain[0]^^} -t filter -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_filter_chains[@]}"; do
+	    chain=("${custom_chain//-/ }")
+	    if ! "$iptables_command" -C "${chain[0]^^}" -j "$custom_chain" -t filter > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t filter > /dev/null 2>&1
+	        "$iptables_command" -I "${chain[0]^^}" -t filter -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 	custom_filter_chains=(forward-kura-pf forward-kura-ipf)
-	for custom_chain in ${custom_filter_chains[@]}; do
-	    iptables -C forward-kura -j $custom_chain -t filter > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t filter > /dev/null 2>&1
-	        iptables -I forward-kura -t filter -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_filter_chains[@]}"; do
+	    if ! "$iptables_command" -C forward-kura -j "$custom_chain" -t filter > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t filter > /dev/null 2>&1
+	        "$iptables_command" -I forward-kura -t filter -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 }
 
 create_nat_chains() {
+    iptables_command="$1"
 	custom_nat_chains=(prerouting-kura postrouting-kura input-kura output-kura)
-	for custom_chain in ${custom_nat_chains[@]}; do
-	    chain=(${custom_chain//-/ }[0])
-	    iptables -C ${chain[0]^^} -j $custom_chain -t nat > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t nat > /dev/null 2>&1
-	        iptables -I ${chain[0]^^} -t nat -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_nat_chains[@]}"; do
+	    chain=("${custom_chain//-/ }"[0])
+	    if ! "$iptables_command" -C "${chain[0]^^}" -j "$custom_chain" -t nat > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t nat > /dev/null 2>&1
+	        "$iptables_command" -I "${chain[0]^^}" -t nat -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
-	iptables -C prerouting-kura -j prerouting-kura-pf -t nat > /dev/null 2>&1
-	if [[ $? -ne 0 ]]; then
-	    iptables -N prerouting-kura-pf -t nat > /dev/null 2>&1
-	    iptables -I prerouting-kura -t nat -j prerouting-kura-pf > /dev/null 2>&1
+	if ! "$iptables_command" -C prerouting-kura -j prerouting-kura-pf -t nat > /dev/null 2>&1; then
+	    "$iptables_command" -N prerouting-kura-pf -t nat > /dev/null 2>&1
+	    "$iptables_command" -I prerouting-kura -t nat -j prerouting-kura-pf > /dev/null 2>&1
 	fi
 	custom_nat_chains=(postrouting-kura-pf postrouting-kura-ipf)
-	for custom_chain in ${custom_nat_chains[@]}; do
-	    iptables -C postrouting-kura -j $custom_chain -t nat > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t nat > /dev/null 2>&1
-	        iptables -I postrouting-kura -t nat -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_nat_chains[@]}"; do
+	    if "$iptables_command" -C postrouting-kura -j "$custom_chain" -t nat > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t nat > /dev/null 2>&1
+	        "$iptables_command" -I postrouting-kura -t nat -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 }
 
 create_mangle_chains() {
+    iptables_command="$1"
 	custom_mangle_chains=(prerouting-kura postrouting-kura input-kura output-kura forward-kura)
-	for custom_chain in ${custom_mangle_chains[@]}; do
-	    chain=(${custom_chain//-/ }[0])
-	    iptables -C ${chain[0]^^} -j $custom_chain -t mangle > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t mangle > /dev/null 2>&1
-	        iptables -I ${chain[0]^^} -t mangle -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_mangle_chains[@]}"; do
+	    chain=("${custom_chain//-/ }"[0])
+	    if ! "$iptables_command" -C "${chain[0]^^}" -j "$custom_chain" -t mangle > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t mangle > /dev/null 2>&1
+	        "$iptables_command" -I "${chain[0]^^}" -t mangle -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 }
 
 configure_policies() {
+    iptables_command="$1"
 	# configure policies for standard chains
-	policy=$(iptables -nL -t filter | grep policy | grep INPUT)
+	policy=$("$iptables_command" -nL -t filter | grep policy | grep INPUT)
 	if [[ "$policy" == *ACCEPT* ]]; then
-		iptables -P INPUT DROP
+		"$iptables_command" -P INPUT DROP
 	fi
-	policy=$(iptables -nL -t filter | grep policy | grep OUTPUT)
+	policy=$("$iptables_command" -nL -t filter | grep policy | grep OUTPUT)
 	if [[ "$policy" == *DROP* ]]; then
-		iptables -P OUTPUT ACCEPT
+		"$iptables_command" -P OUTPUT ACCEPT
 	fi
-	policy=$(iptables -nL -t filter | grep policy | grep FORWARD)
+	policy=$("$iptables_command" -nL -t filter | grep policy | grep FORWARD)
 	if [[ "$policy" == *ACCEPT* ]]; then
-		iptables -P FORWARD DROP
+		"$iptables_command" -P FORWARD DROP
 	fi
 }
 
 configure_ip_forwarding() {
+    config_file="$1"
+    ipforward_config_file="$2"
 	# enable ip forwarding if needed
-	if [ -f $iptables_config_file ]; then
+	if [ -f "$config_file" ]; then
 		while IFS='' read -r line || [[ -n "$line" ]]; do
 		    if [[ $line =~ "-A forward-kura" ]]; then
 		        enable_ipforwarding=true
 		        break
 		    fi
-		done < $iptables_config_file
+		done < "$config_file"
 	fi
-	if [ $enable_ipforwarding = true ]; then
-	    echo "1" > $ipforward_file
+	if [ "$enable_ipforwarding" = true ]; then
+	    echo "1" > "$ipforward_config_file"
 	else
-	    echo "0" > $ipforward_file
+	    echo "0" > "$ipforward_config_file"
 	fi
 }
 
 if [ -f $iptables_config_file ]; then
 	iptables-restore < $iptables_config_file
 fi
+if [ -f $ip6tables_config_file ]; then
+	ip6tables-restore < $ip6tables_config_file
+fi
 
-create_filter_chains
-create_nat_chains
-create_mangle_chains
-configure_policies
-configure_ip_forwarding
+configure_iptables() {
+    create_filter_chains "$1"
+    create_nat_chains "$1"
+    create_mangle_chains "$1"
+    configure_policies "$1"
+    configure_ip_forwarding "$2" "$3"
+}
+
+configure_iptables iptables "$iptables_config_file" "$ipforward_file"
+configure_iptables ip6tables "$ip6tables_config_file" "$ip6forward_file"
 
 # source a custom firewall script
 if [ -f /etc/init.d/firewall_cust ]; then

--- a/kura/distrib/src/main/resources/generic-x86_64/firewall.init
+++ b/kura/distrib/src/main/resources/generic-x86_64/firewall.init
@@ -17,108 +17,118 @@
 #
 iptables_config_file=/etc/sysconfig/iptables
 ipforward_file=/proc/sys/net/ipv4/ip_forward
+ip6tables_config_file=/etc/sysconfig/ip6tables
+ip6forward_file=/proc/sys/net/ipv6/conf/all/forwarding
 enable_ipforwarding=false;
 
 create_filter_chains() {
+    iptables_command="$1"
 	# create custom chains if needed
 	custom_filter_chains=(input-kura output-kura forward-kura)
-	for custom_chain in ${custom_filter_chains[@]}; do
-	    chain=(${custom_chain//-/ })
-	    iptables -C ${chain[0]^^} -j $custom_chain -t filter > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t filter > /dev/null 2>&1
-	        iptables -I ${chain[0]^^} -t filter -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_filter_chains[@]}"; do
+	    chain=("${custom_chain//-/ }")
+	    if ! "$iptables_command" -C "${chain[0]^^}" -j "$custom_chain" -t filter > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t filter > /dev/null 2>&1
+	        "$iptables_command" -I "${chain[0]^^}" -t filter -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 	custom_filter_chains=(forward-kura-pf forward-kura-ipf)
-	for custom_chain in ${custom_filter_chains[@]}; do
-	    iptables -C forward-kura -j $custom_chain -t filter > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t filter > /dev/null 2>&1
-	        iptables -I forward-kura -t filter -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_filter_chains[@]}"; do
+	    if ! "$iptables_command" -C forward-kura -j "$custom_chain" -t filter > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t filter > /dev/null 2>&1
+	        "$iptables_command" -I forward-kura -t filter -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 }
 
 create_nat_chains() {
+    iptables_command="$1"
 	custom_nat_chains=(prerouting-kura postrouting-kura input-kura output-kura)
-	for custom_chain in ${custom_nat_chains[@]}; do
-	    chain=(${custom_chain//-/ }[0])
-	    iptables -C ${chain[0]^^} -j $custom_chain -t nat > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t nat > /dev/null 2>&1
-	        iptables -I ${chain[0]^^} -t nat -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_nat_chains[@]}"; do
+	    chain=("${custom_chain//-/ }"[0])
+	    if ! "$iptables_command" -C "${chain[0]^^}" -j "$custom_chain" -t nat > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t nat > /dev/null 2>&1
+	        "$iptables_command" -I "${chain[0]^^}" -t nat -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
-	iptables -C prerouting-kura -j prerouting-kura-pf -t nat > /dev/null 2>&1
-	if [[ $? -ne 0 ]]; then
-	    iptables -N prerouting-kura-pf -t nat > /dev/null 2>&1
-	    iptables -I prerouting-kura -t nat -j prerouting-kura-pf > /dev/null 2>&1
+	if ! "$iptables_command" -C prerouting-kura -j prerouting-kura-pf -t nat > /dev/null 2>&1; then
+	    "$iptables_command" -N prerouting-kura-pf -t nat > /dev/null 2>&1
+	    "$iptables_command" -I prerouting-kura -t nat -j prerouting-kura-pf > /dev/null 2>&1
 	fi
 	custom_nat_chains=(postrouting-kura-pf postrouting-kura-ipf)
-	for custom_chain in ${custom_nat_chains[@]}; do
-	    iptables -C postrouting-kura -j $custom_chain -t nat > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t nat > /dev/null 2>&1
-	        iptables -I postrouting-kura -t nat -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_nat_chains[@]}"; do
+	    if "$iptables_command" -C postrouting-kura -j "$custom_chain" -t nat > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t nat > /dev/null 2>&1
+	        "$iptables_command" -I postrouting-kura -t nat -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 }
 
 create_mangle_chains() {
+    iptables_command="$1"
 	custom_mangle_chains=(prerouting-kura postrouting-kura input-kura output-kura forward-kura)
-	for custom_chain in ${custom_mangle_chains[@]}; do
-	    chain=(${custom_chain//-/ }[0])
-	    iptables -C ${chain[0]^^} -j $custom_chain -t mangle > /dev/null 2>&1
-	    if [[ $? -ne 0 ]]; then
-	        iptables -N $custom_chain -t mangle > /dev/null 2>&1
-	        iptables -I ${chain[0]^^} -t mangle -j $custom_chain > /dev/null 2>&1
+	for custom_chain in "${custom_mangle_chains[@]}"; do
+	    chain=("${custom_chain//-/ }"[0])
+	    if ! "$iptables_command" -C "${chain[0]^^}" -j "$custom_chain" -t mangle > /dev/null 2>&1; then
+	        "$iptables_command" -N "$custom_chain" -t mangle > /dev/null 2>&1
+	        "$iptables_command" -I "${chain[0]^^}" -t mangle -j "$custom_chain" > /dev/null 2>&1
 	    fi
 	done
 }
 
 configure_policies() {
+    iptables_command="$1"
 	# configure policies for standard chains
-	policy=$(iptables -nL -t filter | grep policy | grep INPUT)
+	policy=$("$iptables_command" -nL -t filter | grep policy | grep INPUT)
 	if [[ "$policy" == *ACCEPT* ]]; then
-		iptables -P INPUT DROP
+		"$iptables_command" -P INPUT DROP
 	fi
-	policy=$(iptables -nL -t filter | grep policy | grep OUTPUT)
+	policy=$("$iptables_command" -nL -t filter | grep policy | grep OUTPUT)
 	if [[ "$policy" == *DROP* ]]; then
-		iptables -P OUTPUT ACCEPT
+		"$iptables_command" -P OUTPUT ACCEPT
 	fi
-	policy=$(iptables -nL -t filter | grep policy | grep FORWARD)
+	policy=$("$iptables_command" -nL -t filter | grep policy | grep FORWARD)
 	if [[ "$policy" == *ACCEPT* ]]; then
-		iptables -P FORWARD DROP
+		"$iptables_command" -P FORWARD DROP
 	fi
 }
 
 configure_ip_forwarding() {
+    config_file="$1"
+    ipforward_config_file="$2"
 	# enable ip forwarding if needed
-	if [ -f $iptables_config_file ]; then
+	if [ -f "$config_file" ]; then
 		while IFS='' read -r line || [[ -n "$line" ]]; do
 		    if [[ $line =~ "-A forward-kura" ]]; then
 		        enable_ipforwarding=true
 		        break
 		    fi
-		done < $iptables_config_file
+		done < "$config_file"
 	fi
-	if [ $enable_ipforwarding = true ]; then
-	    echo "1" > $ipforward_file
+	if [ "$enable_ipforwarding" = true ]; then
+	    echo "1" > "$ipforward_config_file"
 	else
-	    echo "0" > $ipforward_file
+	    echo "0" > "$ipforward_config_file"
 	fi
 }
 
 if [ -f $iptables_config_file ]; then
 	iptables-restore < $iptables_config_file
 fi
+if [ -f $ip6tables_config_file ]; then
+	ip6tables-restore < $ip6tables_config_file
+fi
 
-create_filter_chains
-create_nat_chains
-create_mangle_chains
-configure_policies
-configure_ip_forwarding
+configure_iptables() {
+    create_filter_chains "$1"
+    create_nat_chains "$1"
+    create_mangle_chains "$1"
+    configure_policies "$1"
+    configure_ip_forwarding "$2" "$3"
+}
+
+configure_iptables iptables "$iptables_config_file" "$ipforward_file"
+configure_iptables ip6tables "$ip6tables_config_file" "$ip6forward_file"
 
 # source a custom firewall script
 if [ -f /etc/init.d/firewall_cust ]; then


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR updates the `firewall.init` script to take into account the IPv6 firewall support (see #4793 and #4802). The script (run by a systemd unit at startup) applies the firewall rules (if present in the filesystem) and check if some minimal configuration for ipv4 and ipv6 firewall are present.
