### PR TITLE
feat(web.server.net2): add IPv6 configuration properties support

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -59,6 +59,7 @@ public class GwtNetInterfaceConfigBuilder {
         this.gwtConfig = createGwtNetInterfaceConfigSubtype();
         setCommonProperties();
         setIpv4Properties();
+        setIpv6Properties();
         setIpv4DhcpClientProperties();
         setIpv4DhcpServerProperties();
         setRouterMode();
@@ -116,6 +117,42 @@ public class GwtNetInterfaceConfigBuilder {
         this.gwtConfig.setSubnetMask(this.properties.getIp4Netmask(this.ifName));
         this.gwtConfig.setGateway(this.properties.getIp4Gateway(this.ifName));
         this.gwtConfig.setDnsServers(this.properties.getIp4DnsServers(this.ifName));
+    }
+
+    private void setIpv6Properties() {
+        Optional<String> status = this.properties.getIp6Status(this.ifName);
+        if (status.isPresent()) {
+            this.gwtConfig.setIpv6Status(status.get());
+        }
+
+        Optional<Integer> priority = this.properties.getIp6WanPriority(this.ifName);
+        if (priority.isPresent()) {
+            this.gwtConfig.setIpv6WanPriority(priority.get());
+        }
+
+        Optional<String> configure = this.properties.getIp6AddressMethod(this.ifName);
+        if (configure.isPresent()) {
+            this.gwtConfig.setIpv6ConfigMode(configure.get());
+        }
+
+        Optional<String> autoconfiguration = this.properties.getIp6AddressGenMode(this.ifName);
+        if (autoconfiguration.isPresent()) {
+            this.gwtConfig.setIpv6AutoconfigurationMode(autoconfiguration.get());
+        }
+
+        this.gwtConfig.setIpv6Address(this.properties.getIp6Address(this.ifName));
+
+        Optional<Integer> netmask = this.properties.getIp6Netmask(this.ifName);
+        if (netmask.isPresent()) {
+            this.gwtConfig.setIpv6SubnetMask(netmask.get());
+        }
+
+        this.gwtConfig.setIpv6Gateway(this.properties.getIp6Gateway(this.ifName));
+
+        Optional<String> privacy = this.properties.getIp6Privacy(this.ifName);
+        if (privacy.isPresent()) {
+            this.gwtConfig.setIpv6Privacy(privacy.get());
+        }
     }
 
     private void setIpv4DhcpClientProperties() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -146,6 +146,97 @@ public class NetworkConfigurationServiceProperties {
     }
 
     /*
+     * IPv6 properties
+     */
+
+    private static final String NET_INTERFACE_CONFIG_IP6_STATUS = "net.interface.%s.config.ip6.status";
+    private static final String NET_INTERFACE_CONFIG_IP6_WAN_PRIORITY = "net.interface.%s.config.ip6.wan.priority";
+    private static final String NET_INTERFACE_CONFIG_IP6_ADDRESS_METHOD = "net.interface.%s.config.ip6.address.method";
+    private static final String NET_INTERFACE_CONFIG_IP6_ADDR_GEN_MODE = "net.interface.%s.config.ip6.addr.gen.mode";
+    private static final String NET_INTERFACE_CONFIG_IP6_PRIVACY = "net.interface.%s.config.ip6.privacy";
+    private static final String NET_INTERFACE_CONFIG_IP6_ADDRESS = "net.interface.%s.config.ip6.address";
+    private static final String NET_INTERFACE_CONFIG_IP6_NETMASK = "net.interface.%s.config.ip6.prefix";
+    private static final String NET_INTERFACE_CONFIG_IP6_GATEWAY = "net.interface.%s.config.ip6.gateway";
+    private static final String NET_INTERFACE_CONFIG_IP6_DNS_SERVERS = "net.interface.%s.config.ip6.dnsServers";
+
+    public Optional<String> getIp6Status(String ifname) {
+        return getNonEmptyStringProperty(this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_STATUS, ifname)));
+    }
+
+    public void setIp6Status(String ifname, String status) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_STATUS, ifname), status);
+    }
+
+    public Optional<Integer> getIp6WanPriority(String ifname) {
+        return Optional.ofNullable(
+                (Integer) this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_WAN_PRIORITY, ifname)));
+    }
+
+    public void setIp6WanPriority(String ifname, int priority) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_WAN_PRIORITY, ifname), priority);
+    }
+
+    public Optional<String> getIp6AddressMethod(String ifname) {
+        return getNonEmptyStringProperty(
+                this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_ADDRESS_METHOD, ifname)));
+    }
+
+    public void setIp6AddressMethod(String ifname, String addressMethod) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_ADDRESS_METHOD, ifname), addressMethod);
+    }
+
+    public Optional<String> getIp6AddressGenMode(String ifname) {
+        return getNonEmptyStringProperty(
+                this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_ADDR_GEN_MODE, ifname)));
+    }
+
+    public void setIp6AddressGenMode(String ifname, String addrGenMode) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_ADDR_GEN_MODE, ifname), addrGenMode);
+    }
+
+    public Optional<String> getIp6Privacy(String ifname) {
+        return getNonEmptyStringProperty(
+                this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_PRIVACY, ifname)));
+    }
+
+    public void setIp6Privacy(String ifname, String privacy) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_PRIVACY, ifname), privacy);
+    }
+
+    public String getIp6Address(String ifname) {
+        return (String) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_IP6_ADDRESS, ifname), "");
+    }
+
+    public void setIp6Address(String ifname, String address) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_ADDRESS, ifname), address);
+    }
+
+    public Optional<Integer> getIp6Netmask(String ifname) {
+        return Optional
+                .ofNullable((Integer) this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_NETMASK, ifname)));
+    }
+
+    public void setIp6Netmask(String ifname, int netmask) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_NETMASK, ifname), netmask);
+    }
+
+    public String getIp6Gateway(String ifname) {
+        return (String) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_IP6_GATEWAY, ifname), "");
+    }
+
+    public void setIp6Gateway(String ifname, String gateway) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_GATEWAY, ifname), gateway);
+    }
+
+    public String getIp6DnsServers(String ifname) {
+        return (String) this.properties.getOrDefault(String.format(NET_INTERFACE_CONFIG_IP6_DNS_SERVERS, ifname), "");
+    }
+
+    public void setIp6DnsServers(String ifname, String dnsServers) {
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_DNS_SERVERS, ifname), dnsServers);
+    }
+
+    /*
      * IPv4 DHCP Server properties
      */
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -107,6 +107,12 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
     private void setIpv6Properties() {
         this.properties.setIp6Status(this.ifname, this.gwtConfig.getIpv6Status());
+
+        if (this.gwtConfig.getIpv6Status().equals("netIPv6StatusDisabled")
+                || this.gwtConfig.getIpv6Status().equals("netIPv6StatusUnmanaged")) {
+            return;
+        }
+
         this.properties.setIp6AddressMethod(this.ifname, this.gwtConfig.getIpv6ConfigMode());
 
         boolean isManual = this.gwtConfig.getIpv6ConfigMode().equals("netIPv6MethodManual");

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -49,6 +49,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
     public Map<String, Object> build() throws GwtKuraException {
         setCommonProperties();
         setIpv4Properties();
+        setIpv6Properties();
         setIpv4DhcpClientProperties();
         setIpv4DhcpServerProperties();
 
@@ -101,6 +102,37 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
         if (isManual && isWan) {
             this.properties.setIp4Gateway(this.ifname, this.gwtConfig.getGateway());
+        }
+    }
+
+    private void setIpv6Properties() {
+        this.properties.setIp6Status(this.ifname, this.gwtConfig.getIpv6Status());
+        this.properties.setIp6AddressMethod(this.ifname, this.gwtConfig.getIpv6ConfigMode());
+
+        boolean isManual = this.gwtConfig.getIpv6ConfigMode().equals("netIPv6MethodManual");
+        boolean isWan = this.gwtConfig.getIpv6Status().equals("netIPv6StatusEnabledWAN");
+        boolean isAuto = this.gwtConfig.getIpv6ConfigMode().equals("netIPv6MethodAuto");
+
+        if (isWan) {
+            if (!Objects.isNull(this.gwtConfig.getIpv6WanPriority())) {
+                this.properties.setIp6WanPriority(this.ifname, this.gwtConfig.getIpv6WanPriority());
+            }
+
+            this.properties.setIp6DnsServers(this.ifname, this.gwtConfig.getIpv6DnsServers());
+        }
+
+        if (isManual) {
+            this.properties.setIp6Address(this.ifname, this.gwtConfig.getIpv6Address());
+            this.properties.setIp6Netmask(this.ifname, this.gwtConfig.getIpv6SubnetMask());
+        }
+
+        if (isManual && isWan) {
+            this.properties.setIp6Gateway(this.ifname, this.gwtConfig.getIpv6Gateway());
+        }
+
+        if (isAuto) {
+            this.properties.setIp6AddressGenMode(this.ifname, this.gwtConfig.getIpv6AutoconfigurationMode());
+            this.properties.setIp6Privacy(this.ifname, this.gwtConfig.getIpv6Privacy());
         }
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -88,7 +88,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
         boolean isWan = this.gwtConfig.getStatus().equals(GwtNetIfStatus.netIPv4StatusEnabledWAN.name());
 
         if (isWan) {
-            if (!Objects.isNull(this.gwtConfig.getWanPriority())) {
+            if (Objects.nonNull(this.gwtConfig.getWanPriority())) {
                 this.properties.setIp4WanPriority(ifname, this.gwtConfig.getWanPriority());
             }
 
@@ -114,7 +114,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
         boolean isAuto = this.gwtConfig.getIpv6ConfigMode().equals("netIPv6MethodAuto");
 
         if (isWan) {
-            if (!Objects.isNull(this.gwtConfig.getIpv6WanPriority())) {
+            if (Objects.nonNull(this.gwtConfig.getIpv6WanPriority())) {
                 this.properties.setIp6WanPriority(this.ifname, this.gwtConfig.getIpv6WanPriority());
             }
 


### PR DESCRIPTION
This PR adds the support for the new IPv6 properties in the UI server part, it is a continuation of this PR: https://github.com/eclipse/kura/pull/4800.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
