### PR TITLE
feat(nm): ipv6 status information retrieval

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -278,13 +278,9 @@ public class NMStatusConverter {
                 ip6AddressStatusBuilder.withGateway(Optional.of(gwAddress));
 
                 // DNS Servers
-                List<Map<String, Variant<?>>> nameserverData = properties.Get(NM_IP4CONFIG_BUS_NAME, "NameserverData");
-                final List<IP6Address> dnsAddresses = new ArrayList<>();
-                for (Map<String, Variant<?>> dns : nameserverData) {
-                    dnsAddresses.add(
-                            (IP6Address) IPAddress.parseHostAddress(String.class.cast(dns.get("address").getValue())));
-                }
-                ip6AddressStatusBuilder.withDnsServerAddresses(dnsAddresses);
+                List<List<Byte>> nameservers = properties.Get(NM_IP6CONFIG_BUS_NAME, "Nameservers");
+                // TODO
+                // ip6AddressStatusBuilder.withDnsServerAddresses(dnsAddresses);
 
                 // Addresses
                 List<Map<String, Variant<?>>> addressData = properties.Get(NM_IP4CONFIG_BUS_NAME, "AddressData");

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -280,6 +280,7 @@ public class NMStatusConverter {
                 }
 
                 // DNS Servers
+                List<IP6Address> dnsAddresses = new ArrayList<>();
                 List<List<Byte>> nameservers = properties.Get(NM_IP6CONFIG_BUS_NAME, "Nameservers");
                 for (List<Byte> nameserver : nameservers) {
                     // Convert to byte array
@@ -289,9 +290,9 @@ public class NMStatusConverter {
                         dnsByteArray[i] = nameserver.get(i);
                     }
 
-                    final IP6Address dnsAddress = (IP6Address) IPAddress.getByAddress(dnsByteArray);
-                    ip6AddressStatusBuilder.withDnsServerAddresses(Collections.singletonList(dnsAddress));
+                    dnsAddresses.add((IP6Address) IPAddress.getByAddress(dnsByteArray));
                 }
+                ip6AddressStatusBuilder.withDnsServerAddresses(dnsAddresses);
 
                 // Addresses
                 List<Map<String, Variant<?>>> addressData = properties.Get(NM_IP6CONFIG_BUS_NAME, "AddressData");

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -281,8 +281,17 @@ public class NMStatusConverter {
 
                 // DNS Servers
                 List<List<Byte>> nameservers = properties.Get(NM_IP6CONFIG_BUS_NAME, "Nameservers");
-                // TODO
-                // ip6AddressStatusBuilder.withDnsServerAddresses(dnsAddresses);
+                for (List<Byte> nameserver : nameservers) {
+                    // Convert to byte array
+                    // jeez Java sucks sometimes
+                    byte[] dnsByteArray = new byte[nameserver.size()];
+                    for (int i = 0; i < nameserver.size(); i++) {
+                        dnsByteArray[i] = nameserver.get(i);
+                    }
+
+                    final IP6Address dnsAddress = (IP6Address) IPAddress.getByAddress(dnsByteArray);
+                    ip6AddressStatusBuilder.withDnsServerAddresses(Collections.singletonList(dnsAddress));
+                }
 
                 // Addresses
                 List<Map<String, Variant<?>>> addressData = properties.Get(NM_IP6CONFIG_BUS_NAME, "AddressData");

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -255,9 +255,9 @@ public class NMStatusConverter {
             try {
                 NetworkInterfaceIpAddressStatus.Builder<IP4Address> ip4AddressStatusBuilder = NetworkInterfaceIpAddressStatus
                         .builder();
-                setIP4Gateway(properties, ip4AddressStatusBuilder);
+                setIPGateway(properties, ip4AddressStatusBuilder, IP4Address.class);
                 setIP4DnsServers(properties, ip4AddressStatusBuilder);
-                setIP4Addresses(properties, ip4AddressStatusBuilder);
+                setIPAddresses(properties, ip4AddressStatusBuilder, IP4Address.class);
                 builder.withInterfaceIp4Addresses(Optional.of(ip4AddressStatusBuilder.build()));
             } catch (UnknownHostException e) {
                 logger.error("Failed to set IP4 address.", e);
@@ -271,42 +271,9 @@ public class NMStatusConverter {
             try {
                 NetworkInterfaceIpAddressStatus.Builder<IP6Address> ip6AddressStatusBuilder = NetworkInterfaceIpAddressStatus
                         .builder();
-
-                // Gateway
-                String gateway = properties.Get(NM_IP6CONFIG_BUS_NAME, "Gateway");
-                if (Objects.nonNull(gateway) && !gateway.isEmpty()) {
-                    final IP6Address gwAddress = (IP6Address) IPAddress.parseHostAddress(gateway);
-                    ip6AddressStatusBuilder.withGateway(Optional.of(gwAddress));
-                }
-
-                // DNS Servers
-                List<IP6Address> dnsAddresses = new ArrayList<>();
-                List<List<Byte>> nameservers = properties.Get(NM_IP6CONFIG_BUS_NAME, "Nameservers");
-                for (List<Byte> nameserver : nameservers) {
-                    // Convert to byte array
-                    // jeez Java sucks sometimes
-                    byte[] dnsByteArray = new byte[nameserver.size()];
-                    for (int i = 0; i < nameserver.size(); i++) {
-                        dnsByteArray[i] = nameserver.get(i);
-                    }
-
-                    dnsAddresses.add((IP6Address) IPAddress.getByAddress(dnsByteArray));
-                }
-                ip6AddressStatusBuilder.withDnsServerAddresses(dnsAddresses);
-
-                // Addresses
-                List<Map<String, Variant<?>>> addressData = properties.Get(NM_IP6CONFIG_BUS_NAME, "AddressData");
-
-                final List<NetworkInterfaceIpAddress<IP6Address>> addresses = new ArrayList<>();
-                for (Map<String, Variant<?>> data : addressData) {
-                    String addressStr = String.class.cast(data.get("address").getValue());
-                    UInt32 prefix = UInt32.class.cast(data.get("prefix").getValue());
-                    NetworkInterfaceIpAddress<IP6Address> address = new NetworkInterfaceIpAddress<>(
-                            (IP6Address) IPAddress.parseHostAddress(addressStr), prefix.shortValue());
-                    addresses.add(address);
-                }
-                ip6AddressStatusBuilder.withAddresses(addresses);
-
+                setIPGateway(properties, ip6AddressStatusBuilder, IP6Address.class);
+                setIP6DnsServers(properties, ip6AddressStatusBuilder);
+                setIPAddresses(properties, ip6AddressStatusBuilder, IP6Address.class);
                 builder.withInterfaceIp6Addresses(Optional.of(ip6AddressStatusBuilder.build()));
             } catch (UnknownHostException e) {
                 logger.error("Failed to set IP6 address.", e);
@@ -532,18 +499,37 @@ public class NMStatusConverter {
         }
     }
 
-    private static void setIP4Addresses(Properties ip4configProperties,
-            NetworkInterfaceIpAddressStatus.Builder<IP4Address> builder) throws UnknownHostException {
-        List<Map<String, Variant<?>>> addressData = ip4configProperties.Get(NM_IP4CONFIG_BUS_NAME, "AddressData");
-        final List<NetworkInterfaceIpAddress<IP4Address>> addresses = new ArrayList<>();
+    private static <T extends IPAddress> void setIPGateway(Properties ipConfigProperties,
+            NetworkInterfaceIpAddressStatus.Builder<T> ipAddressStatus, Class<T> ipVersionType)
+            throws UnknownHostException {
+        String gateway = ipVersionType == IP4Address.class ? ipConfigProperties.Get(NM_IP4CONFIG_BUS_NAME, "Gateway")
+                : ipConfigProperties.Get(NM_IP6CONFIG_BUS_NAME, "Gateway");
+
+        if (Objects.isNull(gateway) || gateway.isEmpty()) {
+            return;
+        }
+
+        final T address = ipVersionType.cast(IPAddress.parseHostAddress(gateway));
+        ipAddressStatus.withGateway(Optional.of(address));
+    }
+
+    private static <T extends IPAddress> void setIPAddresses(Properties ipConfigProperties,
+            NetworkInterfaceIpAddressStatus.Builder<T> ipAddressStatus, Class<T> ipVersionType)
+            throws UnknownHostException {
+
+        List<Map<String, Variant<?>>> addressData = ipVersionType == IP4Address.class
+                ? ipConfigProperties.Get(NM_IP4CONFIG_BUS_NAME, "AddressData")
+                : ipConfigProperties.Get(NM_IP6CONFIG_BUS_NAME, "AddressData");
+
+        final List<NetworkInterfaceIpAddress<T>> addresses = new ArrayList<>();
         for (Map<String, Variant<?>> data : addressData) {
             String addressStr = String.class.cast(data.get("address").getValue());
             UInt32 prefix = UInt32.class.cast(data.get("prefix").getValue());
-            NetworkInterfaceIpAddress<IP4Address> address = new NetworkInterfaceIpAddress<>(
-                    (IP4Address) IPAddress.parseHostAddress(addressStr), prefix.shortValue());
+            NetworkInterfaceIpAddress<T> address = new NetworkInterfaceIpAddress<>(
+                    ipVersionType.cast(IPAddress.parseHostAddress(addressStr)), prefix.shortValue());
             addresses.add(address);
         }
-        builder.withAddresses(addresses);
+        ipAddressStatus.withAddresses(addresses);
     }
 
     private static void setIP4DnsServers(Properties ip4configProperties,
@@ -556,13 +542,21 @@ public class NMStatusConverter {
         builder.withDnsServerAddresses(dnsAddresses);
     }
 
-    private static void setIP4Gateway(Properties ip4configProperties,
-            NetworkInterfaceIpAddressStatus.Builder<IP4Address> ip4AddressStatus) throws UnknownHostException {
-        String gateway = ip4configProperties.Get(NM_IP4CONFIG_BUS_NAME, "Gateway");
-        if (Objects.nonNull(gateway) && !gateway.isEmpty()) {
-            final IP4Address address = (IP4Address) IPAddress.parseHostAddress(gateway);
-            ip4AddressStatus.withGateway(Optional.of(address));
+    private static void setIP6DnsServers(Properties ip6configProperties,
+            NetworkInterfaceIpAddressStatus.Builder<IP6Address> builder) throws UnknownHostException {
+        List<IP6Address> dnsAddresses = new ArrayList<>();
+        List<List<Byte>> nameservers = ip6configProperties.Get(NM_IP6CONFIG_BUS_NAME, "Nameservers");
+        for (List<Byte> nameserver : nameservers) {
+            // Convert to byte array
+            // jeez Java sucks sometimes
+            byte[] dnsByteArray = new byte[nameserver.size()];
+            for (int i = 0; i < nameserver.size(); i++) {
+                dnsByteArray[i] = nameserver.get(i);
+            }
+
+            dnsAddresses.add((IP6Address) IPAddress.getByAddress(dnsByteArray));
         }
+        builder.withDnsServerAddresses(dnsAddresses);
     }
 
     private static void setModemStatus(ModemInterfaceStatusBuilder builder, Optional<Properties> modemProperties,

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -544,11 +544,11 @@ public class NMStatusConverter {
 
     private static void setIP6DnsServers(Properties ip6configProperties,
             NetworkInterfaceIpAddressStatus.Builder<IP6Address> builder) throws UnknownHostException {
-        List<IP6Address> dnsAddresses = new ArrayList<>();
         List<List<Byte>> nameservers = ip6configProperties.Get(NM_IP6CONFIG_BUS_NAME, "Nameservers");
+
+        List<IP6Address> dnsAddresses = new ArrayList<>();
         for (List<Byte> nameserver : nameservers) {
-            // Convert to byte array
-            // jeez Java sucks sometimes
+            // Convert List<Byte> to byte[]
             byte[] dnsByteArray = new byte[nameserver.size()];
             for (int i = 0; i < nameserver.size(); i++) {
                 dnsByteArray[i] = nameserver.get(i);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -285,7 +285,7 @@ public class NMStatusConverter {
                 // ip6AddressStatusBuilder.withDnsServerAddresses(dnsAddresses);
 
                 // Addresses
-                List<Map<String, Variant<?>>> addressData = properties.Get(NM_IP4CONFIG_BUS_NAME, "AddressData");
+                List<Map<String, Variant<?>>> addressData = properties.Get(NM_IP6CONFIG_BUS_NAME, "AddressData");
 
                 final List<NetworkInterfaceIpAddress<IP6Address>> addresses = new ArrayList<>();
                 for (Map<String, Variant<?>> data : addressData) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -274,8 +274,10 @@ public class NMStatusConverter {
 
                 // Gateway
                 String gateway = properties.Get(NM_IP6CONFIG_BUS_NAME, "Gateway");
-                final IP6Address gwAddress = (IP6Address) IPAddress.parseHostAddress(gateway);
-                ip6AddressStatusBuilder.withGateway(Optional.of(gwAddress));
+                if (Objects.nonNull(gateway) && !gateway.isEmpty()) {
+                    final IP6Address gwAddress = (IP6Address) IPAddress.parseHostAddress(gateway);
+                    ip6AddressStatusBuilder.withGateway(Optional.of(gwAddress));
+                }
 
                 // DNS Servers
                 List<List<Byte>> nameservers = properties.Get(NM_IP6CONFIG_BUS_NAME, "Nameservers");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1167,10 +1167,8 @@ public class NMDbusConnectorTest {
         when(mockedProperties.Get("org.freedesktop.NetworkManager.Device", "HwAddress"))
                 .thenReturn("F5:5B:32:7C:40:EA");
 
-        DBusPath path = mock(DBusPath.class);
-        when(path.getPath()).thenReturn("/");
-
-        when(mockedProperties.Get("org.freedesktop.NetworkManager.Device", "Ip4Config")).thenReturn(path);
+        when(mockedProperties.Get("org.freedesktop.NetworkManager.Device", "Ip4Config")).thenReturn(new DBusPath("/"));
+        when(mockedProperties.Get("org.freedesktop.NetworkManager.Device", "Ip6Config")).thenReturn(new DBusPath("/"));
     }
 
     private void givenModemMocksFor(String deviceId, String interfaceName, Properties mockedProperties, boolean hasBearers,

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -203,43 +203,44 @@ public class NMStatusConverterTest {
         thenResultingIp4InterfaceAddressIsMissing();
     }
 
-    // @Test
-    // public void buildEthernetStatusWorksWithIPV4Info() throws UnknownHostException {
-    // givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
-    // givenDevicePropertiesWith("Autoconnect", false);
-    // givenDevicePropertiesWith("FirmwareVersion", "isThisRealLife");
-    // givenDevicePropertiesWith("Driver", "isThisJustFantasy");
+    @Test
+    public void buildEthernetStatusWorksWithIPV4Info() throws UnknownHostException {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
+        givenDevicePropertiesWith("Autoconnect", false);
+        givenDevicePropertiesWith("FirmwareVersion", "isThisRealLife");
+        givenDevicePropertiesWith("Driver", "isThisJustFantasy");
+        givenDevicePropertiesWith("DriverVersion", "caughtInALandslide");
+        givenDevicePropertiesWith("Mtu", new UInt32(69));
+        givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
 
-    // nDevicePropertiesWith("HwA
+        givenIpv4ConfigPropertiesWith("Gateway", "192.168.1.1");
+        givenIpv4ConfigPropertiesWithDNS(Arrays.asList("192.168.1.10"));
+        givenIpv4ConfigPropertiesWithAddress("192.168.1.82", new UInt32(24));
 
-    // givenIpv4ConfigPropertiesWith("Gateway", "192.168.1.1");
-    // givenIpv4ConfigPropertiesWithDNS(Arrays.asList("192.168.1.10"));
+        givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
 
-    // givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
-    // NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+        whenBuildEthernetStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper,
+                Optional.of(this.mockIp4ConfigProperties), Optional.empty());
 
-    // whenBuildLoopbackStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper,
-    // Optional.of(this.mockIp4ConfigProperties), Optional.empty(
- 
+        thenNoExceptionIsThrown();
 
-    // thenNoExceptionIsThrown();
+        thenResultingNetworkInterfaceIsVirtual(false);
+        thenResultingNetworkInterfaceAutoConnectIs(false);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
+        thenResultingNetworkInterfaceDriverIs("isThisJustFantasy");
+        thenResultingNetworkInterfaceDriverVersionIs("caughtInALandslide");
+        thenResultingNetworkInterfaceMtuIs(69);
+        thenResultingNetworkInterfaceHardwareAddressIs(
+                new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
 
-    // thenResultingNetworkInterfaceIsVirtual(false);
-    // thenResultingNetworkInterfaceAutoConnectIs(false);
-    // ResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
-    // thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
-    // thenResultingNetworkInterfaceDriverIs("isThisJustFantasy");
-    // thenResultingNetworkInterfaceDriverVersionIs("caughtInALandslide");
-    // thenResultingNetworkInterfaceMtuIs(69);
-    // ltingNetworkInterfaceHardwareAddressIs(
-    //             new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
- 
-    //     thenResultingEthernetInterfaceLinkUpIs(true);
- 
-    // thenResultingIp4InterfaceGatewayIs(IPAddress.parseHostAddress("192.168.1.1"));
-    // thenResultingIp4InterfaceDNSIs(Arrays.asList(IPAddress.parseHostAddress("192.168.1.10")));
-    //     thenResultingIp4InterfaceAddressIs(IPAddress.parseHostAddress("192.168.1.82"), (short) 24);
-    // }
+        thenResultingEthernetInterfaceLinkUpIs(true);
+
+        thenResultingIp4InterfaceGatewayIs(IPAddress.parseHostAddress("192.168.1.1"));
+        thenResultingIp4InterfaceDNSIs(Arrays.asList(IPAddress.parseHostAddress("192.168.1.10")));
+        thenResultingIp4InterfaceAddressIs(IPAddress.parseHostAddress("192.168.1.82"), (short) 24);
+    }
 
     /*
      * Given

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -461,6 +461,65 @@ public class NMStatusConverterTest {
                         (IP6Address) IP6Address.parseHostAddress("fe80::dea6:32ff:fee0:54f6"), (short) 64)));
     }
 
+    @Test
+    public void buildEthernetStatusWorksWithBothIPV4AndIPV6Info() throws UnknownHostException {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
+        givenDevicePropertiesWith("Autoconnect", false);
+        givenDevicePropertiesWith("FirmwareVersion", "anAwesomeFirmwareVersion");
+        givenDevicePropertiesWith("Driver", "anAwesomeDriver");
+        givenDevicePropertiesWith("DriverVersion", "anAwesomeDriverVersion");
+        givenDevicePropertiesWith("Mtu", new UInt32(42));
+        givenDevicePropertiesWith("HwAddress", "DE:AD:BE:EF:66:69");
+
+        givenIpv4ConfigPropertiesWith("Gateway", "192.168.1.1");
+        givenIpv4ConfigPropertiesWithDNS(Arrays.asList("8.8.8.8", "8.8.4.4"));
+        givenIpv4ConfigPropertiesWithAddress(Arrays.asList("192.168.1.82/24", "192.168.3.69/24"));
+
+        givenIpv6ConfigPropertiesWith("Gateway", "fe80:0:0:0:dea6:32ff:fee0:0001");
+        givenIpv6ConfigPropertiesWithDNS(Arrays.asList("20.01.48.60.48.60.00.00.00.00.00.00.00.00.88.88",
+                "20.01.48.60.48.60.00.00.00.00.00.00.00.00.88.44"));
+        givenIpv6ConfigPropertiesWithAddress(
+                Arrays.asList("fe80::dea6:32ff:fee0:54f0/64", "fe80::dea6:32ff:fee0:54f6/64"));
+
+        givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        whenBuildEthernetStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper,
+                Optional.of(this.mockIp4ConfigProperties), Optional.of(this.mockIp6ConfigProperties));
+
+        thenNoExceptionOccurred();
+
+        thenResultingNetworkInterfaceIsVirtual(false);
+        thenResultingNetworkInterfaceAutoConnectIs(false);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("anAwesomeFirmwareVersion");
+        thenResultingNetworkInterfaceDriverIs("anAwesomeDriver");
+        thenResultingNetworkInterfaceDriverVersionIs("anAwesomeDriverVersion");
+        thenResultingNetworkInterfaceMtuIs(42);
+        thenResultingNetworkInterfaceHardwareAddressIs(
+                new byte[] { (byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF, (byte) 0x66, (byte) 0x69 });
+
+        thenResultingEthernetInterfaceLinkUpIs(true);
+
+        thenResultingIp4InterfaceGatewayIs(IPAddress.parseHostAddress("192.168.1.1"));
+        thenResultingIp4InterfaceDNSIs(
+                Arrays.asList(IPAddress.parseHostAddress("8.8.4.4"), IPAddress.parseHostAddress("8.8.8.8")));
+        thenResultingIp4InterfaceAddressIs(Arrays.asList(
+                new NetworkInterfaceIpAddress<IP4Address>((IP4Address) IP4Address.parseHostAddress("192.168.1.82"),
+                        (short) 24),
+                new NetworkInterfaceIpAddress<IP4Address>((IP4Address) IP4Address.parseHostAddress("192.168.3.69"),
+                        (short) 24)));
+
+        thenResultingIp6InterfaceGatewayIs(IPAddress.parseHostAddress("fe80::dea6:32ff:fee0:0001"));
+        thenResultingIp6InterfaceDNSIs(Arrays.asList(IPAddress.parseHostAddress("2001:4860:4860:0:0:0:0:8844"),
+                IPAddress.parseHostAddress("2001:4860:4860:0:0:0:0:8888")));
+        thenResultingIp6InterfaceAddressIs(Arrays.asList(
+                new NetworkInterfaceIpAddress<IP6Address>(
+                        (IP6Address) IP6Address.parseHostAddress("fe80::dea6:32ff:fee0:54f0"), (short) 64),
+                new NetworkInterfaceIpAddress<IP6Address>(
+                        (IP6Address) IP6Address.parseHostAddress("fe80::dea6:32ff:fee0:54f6"), (short) 64)));
+    }
+
     /*
      * Given
      */

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -247,12 +246,12 @@ public class NMStatusConverterTest {
      */
 
     private void givenDevicePropertiesWith(String propertyName, Object propertyValue) {
-        when(this.mockDeviceProperties.Get(eq(NM_DEVICE_BUS_NAME), eq(propertyName)))
+        when(this.mockDeviceProperties.Get(NM_DEVICE_BUS_NAME, propertyName))
                 .thenReturn(propertyValue);
     }
 
     private void givenIpv4ConfigPropertiesWith(String propertyName, Object propertyValue) {
-        when(this.mockIp4ConfigProperties.Get(eq(NM_IP4CONFIG_BUS_NAME), eq(propertyName)))
+        when(this.mockIp4ConfigProperties.Get(NM_IP4CONFIG_BUS_NAME, propertyName))
                 .thenReturn(propertyValue);
     }
 
@@ -266,7 +265,7 @@ public class NMStatusConverterTest {
             addressList.add(structure);
         }
 
-        when(this.mockIp4ConfigProperties.Get(eq(NM_IP4CONFIG_BUS_NAME), eq("NameserverData"))).thenReturn(addressList);
+        when(this.mockIp4ConfigProperties.Get(NM_IP4CONFIG_BUS_NAME, "NameserverData")).thenReturn(addressList);
     }
 
     private void givenIpv4ConfigPropertiesWithAddress(String address, UInt32 prefix) {
@@ -274,7 +273,7 @@ public class NMStatusConverterTest {
         structure.put("address", new Variant<>(address));
         structure.put("prefix", new Variant<>(prefix));
 
-        when(this.mockIp4ConfigProperties.Get(eq(NM_IP4CONFIG_BUS_NAME), eq("AddressData")))
+        when(this.mockIp4ConfigProperties.Get(NM_IP4CONFIG_BUS_NAME, "AddressData"))
                 .thenReturn(Arrays.asList(structure));
     }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -161,6 +161,42 @@ public class NMStatusConverterTest {
     }
 
     @Test
+    public void buildLoopbackStatusWorksWithWrongIPV4Info() throws UnknownHostException {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
+        givenDevicePropertiesWith("Autoconnect", false);
+        givenDevicePropertiesWith("FirmwareVersion", "isThisRealLife");
+        givenDevicePropertiesWith("Driver", "isThisJustFantasy");
+        givenDevicePropertiesWith("DriverVersion", "caughtInALandslide");
+        givenDevicePropertiesWith("Mtu", new UInt32(69));
+        givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
+
+        givenIpv4ConfigPropertiesWith("Gateway", "");
+        givenIpv4ConfigPropertiesWithDNS(Arrays.asList());
+        givenIpv4ConfigPropertiesWithAddress("not-an-ip-address", new UInt32(8));
+
+        givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
+                NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
+
+        whenBuildLoopbackStatusIsCalledWith("lo", this.mockDevicePropertiesWrapper,
+                Optional.of(this.mockIp4ConfigProperties), Optional.empty());
+
+        thenNoExceptionOccurred();
+
+        thenResultingNetworkInterfaceIsVirtual(true);
+        thenResultingNetworkInterfaceAutoConnectIs(false);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
+        thenResultingNetworkInterfaceDriverIs("isThisJustFantasy");
+        thenResultingNetworkInterfaceDriverVersionIs("caughtInALandslide");
+        thenResultingNetworkInterfaceMtuIs(69);
+        thenResultingNetworkInterfaceHardwareAddressIs(
+                new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
+
+        thenResultingIp4InterfaceAddressIsMissing();
+        thenResultingIp6InterfaceAddressIsMissing();
+    }
+
+    @Test
     public void buildLoopbackStatusWorksWithIPV6Info() throws UnknownHostException {
         givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
         givenDevicePropertiesWith("Autoconnect", false);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -1,0 +1,392 @@
+package org.eclipse.kura.nm.status;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.kura.net.IP4Address;
+import org.eclipse.kura.net.IPAddress;
+import org.eclipse.kura.net.status.NetworkInterfaceIpAddress;
+import org.eclipse.kura.net.status.NetworkInterfaceIpAddressStatus;
+import org.eclipse.kura.net.status.NetworkInterfaceState;
+import org.eclipse.kura.net.status.NetworkInterfaceStatus;
+import org.eclipse.kura.net.status.ethernet.EthernetInterfaceStatus;
+import org.eclipse.kura.nm.enums.NMDeviceState;
+import org.eclipse.kura.nm.enums.NMDeviceType;
+import org.freedesktop.dbus.interfaces.Properties;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+import org.junit.Test;
+
+public class NMStatusConverterTest {
+
+    private static final String NM_DEVICE_BUS_NAME = "org.freedesktop.NetworkManager.Device";
+    private static final String NM_IP4CONFIG_BUS_NAME = "org.freedesktop.NetworkManager.IP4Config";
+
+    private Properties mockDeviceProperties = mock(Properties.class);
+    private Properties mockIp4ConfigProperties = mock(Properties.class);
+
+    private DevicePropertiesWrapper mockDevicePropertiesWrapper;
+
+    private NetworkInterfaceStatus resultingStatus;
+    private EthernetInterfaceStatus resultingEthernetStatus;
+
+    private boolean nullPointerExceptionWasThrown = false;
+
+    @Test
+    public void buildLoopbackStatusThrowsWithEmptyProperties() {
+        whenBuildLoopbackStatusIsCalledWith("lo", this.mockDevicePropertiesWrapper, Optional.empty(), Optional.empty());
+
+        thenNullPointerExceptionIsThrown();
+    }
+
+    @Test
+    public void buildLoopbackStatusThrowsWithPartialProperties() {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_UNMANAGED));
+        givenDevicePropertiesWith("Autoconnect", true);
+        givenDevicePropertiesWith("FirmwareVersion", "awesomeFirmwareVersion");
+
+        givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
+                NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
+
+        whenBuildLoopbackStatusIsCalledWith("lo", this.mockDevicePropertiesWrapper, Optional.empty(), Optional.empty());
+
+        thenNullPointerExceptionIsThrown();
+    }
+
+    private void givenDevicePropertiesWrapperBuiltWith(Properties deviceProperties,
+            Optional<Properties> deviceSpecificProperties, NMDeviceType nmDeviceType) {
+        this.mockDevicePropertiesWrapper = new DevicePropertiesWrapper(deviceProperties, deviceSpecificProperties,
+                nmDeviceType);
+    }
+
+    @Test
+    public void buildLoopbackStatusWorksWithoutIPV4Info() {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_UNMANAGED));
+        givenDevicePropertiesWith("Autoconnect", true);
+        givenDevicePropertiesWith("FirmwareVersion", "awesomeFirmwareVersion");
+        givenDevicePropertiesWith("Driver", "awesomeDriver");
+        givenDevicePropertiesWith("DriverVersion", "awesomeDriverVersion");
+        givenDevicePropertiesWith("Mtu", new UInt32(42));
+        givenDevicePropertiesWith("HwAddress", "00:00:00:00:00:00");
+
+        givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
+                NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
+
+        whenBuildLoopbackStatusIsCalledWith("lo", this.mockDevicePropertiesWrapper, Optional.empty(), Optional.empty());
+
+        thenNoExceptionIsThrown();
+
+        thenResultingNetworkInterfaceIsVirtual(true);
+        thenResultingNetworkInterfaceAutoConnectIs(true);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.UNMANAGED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("awesomeFirmwareVersion");
+        thenResultingNetworkInterfaceDriverIs("awesomeDriver");
+        thenResultingNetworkInterfaceDriverVersionIs("awesomeDriverVersion");
+        thenResultingNetworkInterfaceMtuIs(42);
+        thenResultingNetworkInterfaceHardwareAddressIs(new byte[] { 0, 0, 0, 0, 0, 0 });
+
+        thenResultingIp4InterfaceAddressIsMissing();
+    }
+
+    @Test
+    public void buildLoopbackStatusWorksWithIPV4Info() throws UnknownHostException {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
+        givenDevicePropertiesWith("Autoconnect", false);
+        givenDevicePropertiesWith("FirmwareVersion", "isThisRealLife");
+        givenDevicePropertiesWith("Driver", "isThisJustFantasy");
+        givenDevicePropertiesWith("DriverVersion", "caughtInALandslide");
+        givenDevicePropertiesWith("Mtu", new UInt32(69));
+        givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
+
+        givenIpv4ConfigPropertiesWith("Gateway", "");
+        givenIpv4ConfigPropertiesWithDNS(Arrays.asList());
+        givenIpv4ConfigPropertiesWithAddress("127.0.0.1", new UInt32(8));
+
+        givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
+                NMDeviceType.NM_DEVICE_TYPE_LOOPBACK);
+
+        whenBuildLoopbackStatusIsCalledWith("lo", this.mockDevicePropertiesWrapper,
+                Optional.of(this.mockIp4ConfigProperties), Optional.empty());
+
+        thenNoExceptionIsThrown();
+
+        thenResultingNetworkInterfaceIsVirtual(true);
+        thenResultingNetworkInterfaceAutoConnectIs(false);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
+        thenResultingNetworkInterfaceDriverIs("isThisJustFantasy");
+        thenResultingNetworkInterfaceDriverVersionIs("caughtInALandslide");
+        thenResultingNetworkInterfaceMtuIs(69);
+        thenResultingNetworkInterfaceHardwareAddressIs(
+                new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
+
+        thenResultingIp4InterfaceGatewayIsMissing();
+        thenResultingIp4InterfaceDNSIsMissing();
+        thenResultingIp4InterfaceAddressIs(IPAddress.parseHostAddress("127.0.0.1"), (short) 8);
+    }
+
+    @Test
+    public void buildEthernetStatusThrowsWithEmptyProperties() {
+        whenBuildEthernetStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper, Optional.empty(),
+                Optional.empty());
+
+        thenNullPointerExceptionIsThrown();
+    }
+
+    @Test
+    public void buildEthernetStatusThrowsWithPartialProperties() {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_UNMANAGED));
+        givenDevicePropertiesWith("Autoconnect", true);
+        givenDevicePropertiesWith("FirmwareVersion", "awesomeFirmwareVersion");
+
+        givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        whenBuildEthernetStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper, Optional.empty(),
+                Optional.empty());
+
+        thenNullPointerExceptionIsThrown();
+    }
+
+    @Test
+    public void buildEthernetStatusWorksWithoutIPV4Info() {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_UNMANAGED));
+        givenDevicePropertiesWith("Autoconnect", true);
+        givenDevicePropertiesWith("FirmwareVersion", "awesomeFirmwareVersion");
+        givenDevicePropertiesWith("Driver", "awesomeDriver");
+        givenDevicePropertiesWith("DriverVersion", "awesomeDriverVersion");
+        givenDevicePropertiesWith("Mtu", new UInt32(42));
+        givenDevicePropertiesWith("HwAddress", "00:00:00:00:00:00");
+
+        givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
+                NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+        whenBuildEthernetStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper, Optional.empty(),
+                Optional.empty());
+
+        thenNoExceptionIsThrown();
+
+        thenResultingNetworkInterfaceIsVirtual(false);
+        thenResultingNetworkInterfaceAutoConnectIs(true);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.UNMANAGED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("awesomeFirmwareVersion");
+        thenResultingNetworkInterfaceDriverIs("awesomeDriver");
+        thenResultingNetworkInterfaceDriverVersionIs("awesomeDriverVersion");
+        thenResultingNetworkInterfaceMtuIs(42);
+        thenResultingNetworkInterfaceHardwareAddressIs(new byte[] { 0, 0, 0, 0, 0, 0 });
+
+        thenResultingIp4InterfaceAddressIsMissing();
+    }
+
+    // @Test
+    // public void buildEthernetStatusWorksWithIPV4Info() throws UnknownHostException {
+    // givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
+    // givenDevicePropertiesWith("Autoconnect", false);
+    // givenDevicePropertiesWith("FirmwareVersion", "isThisRealLife");
+    // givenDevicePropertiesWith("Driver", "isThisJustFantasy");
+    // givenDevicePropertiesWith("DriverVersion", "caughtInALandslide");
+    // givenDevicePropertiesWith("Mtu", new UInt32(69));
+    // givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
+
+    // givenIpv4ConfigPropertiesWith("Gateway", "192.168.1.1");
+    // givenIpv4ConfigPropertiesWithDNS(Arrays.asList("192.168.1.10"));
+
+    // givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.empty(),
+    // NMDeviceType.NM_DEVICE_TYPE_ETHERNET);
+
+    // whenBuildLoopbackStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper,
+    // Optional.of(this.mockIp4ConfigProperties), Optional.empty(
+
+    
+    //     thenNoExceptionIsThrown();
+ 
+    // thenResultingNetworkInterfaceIsVirtual(false);
+    // thenResultingNetworkInterfaceAutoConnectIs(false);
+    // thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
+    // thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
+    // thenResultingNetworkInterfaceDriverIs("isThisJustFantasy");
+    // thenResultingNetworkInterfaceDriverVersionIs("caughtInALandslide");
+    // thenResultingNetworkInterfaceMtuIs(69);
+    // ltingNetworkInterfaceHardwareAddressIs(
+    //             new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
+ 
+    //     thenResultingEthernetInterfaceLinkUpIs(true);
+ 
+    // thenResultingIp4InterfaceGatewayIs(IPAddress.parseHostAddress("192.168.1.1"));
+    // thenResultingIp4InterfaceDNSIs(Arrays.asList(IPAddress.parseHostAddress("192.168.1.10")));
+    //     thenResultingIp4InterfaceAddressIs(IPAddress.parseHostAddress("192.168.1.82"), (short) 24);
+    // }
+
+    /*
+     * Given
+     */
+
+    private void givenDevicePropertiesWith(String propertyName, Object propertyValue) {
+        when(this.mockDeviceProperties.Get(eq(NM_DEVICE_BUS_NAME), eq(propertyName)))
+                .thenReturn(propertyValue);
+    }
+
+    private void givenIpv4ConfigPropertiesWith(String propertyName, Object propertyValue) {
+        when(this.mockIp4ConfigProperties.Get(eq(NM_IP4CONFIG_BUS_NAME), eq(propertyName)))
+                .thenReturn(propertyValue);
+    }
+
+    private void givenIpv4ConfigPropertiesWithDNS(List<String> addresses) {
+        List<Map<String, Variant<?>>> addressList = new ArrayList<>();
+
+        for (String address : addresses) {
+            Map<String, Variant<?>> structure = new HashMap<>();
+            structure.put("address", new Variant<>(address));
+
+            addressList.add(structure);
+        }
+
+        when(this.mockIp4ConfigProperties.Get(eq(NM_IP4CONFIG_BUS_NAME), eq("NameserverData"))).thenReturn(addressList);
+    }
+
+    private void givenIpv4ConfigPropertiesWithAddress(String address, UInt32 prefix) {
+        Map<String, Variant<?>> structure = new HashMap<>();
+        structure.put("address", new Variant<>(address));
+        structure.put("prefix", new Variant<>(prefix));
+
+        when(this.mockIp4ConfigProperties.Get(eq(NM_IP4CONFIG_BUS_NAME), eq("AddressData")))
+                .thenReturn(Arrays.asList(structure));
+    }
+
+    /*
+     * When
+     */
+
+    private void whenBuildLoopbackStatusIsCalledWith(String ifaceName, DevicePropertiesWrapper deviceProps,
+            Optional<Properties> ip4Properties, Optional<Properties> ip6Properties) {
+        try {
+            this.resultingStatus = NMStatusConverter.buildLoopbackStatus(ifaceName, deviceProps, ip4Properties,
+                    ip6Properties);
+        } catch (NullPointerException e) {
+            this.nullPointerExceptionWasThrown = true;
+        }
+    }
+
+    private void whenBuildEthernetStatusIsCalledWith(String ifaceName, DevicePropertiesWrapper deviceProps,
+            Optional<Properties> ip4Properties, Optional<Properties> ip6Properties) {
+        try {
+            this.resultingStatus = NMStatusConverter.buildEthernetStatus(ifaceName, deviceProps, ip4Properties,
+                    ip6Properties);
+            this.resultingEthernetStatus = (EthernetInterfaceStatus) this.resultingStatus;
+        } catch (NullPointerException e) {
+            this.nullPointerExceptionWasThrown = true;
+        }
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenNoExceptionIsThrown() {
+        assertFalse(this.nullPointerExceptionWasThrown);
+    }
+
+    private void thenNullPointerExceptionIsThrown() {
+        assertTrue(this.nullPointerExceptionWasThrown);
+    }
+
+    private void thenResultingNetworkInterfaceIsVirtual(boolean expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.isVirtual());
+    }
+
+    private void thenResultingNetworkInterfaceAutoConnectIs(boolean expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.isAutoConnect());
+    }
+
+    private void thenResultingNetworkInterfaceStateIs(NetworkInterfaceState expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getState());
+    }
+
+    private void thenResultingNetworkInterfaceFirmwareVersionIs(String expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getFirmwareVersion());
+    }
+
+    private void thenResultingNetworkInterfaceDriverIs(String expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getDriver());
+    }
+
+    private void thenResultingNetworkInterfaceDriverVersionIs(String expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getDriverVersion());
+    }
+
+    private void thenResultingNetworkInterfaceMtuIs(int expectedResult) {
+        assertEquals(expectedResult, this.resultingStatus.getMtu());
+    }
+
+    private void thenResultingNetworkInterfaceHardwareAddressIs(byte[] expectedResult) {
+        assertArrayEquals(expectedResult, this.resultingStatus.getHardwareAddress());
+    }
+
+    private void thenResultingIp4InterfaceAddressIsMissing() {
+        assertFalse(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+    }
+
+    private void thenResultingIp4InterfaceGatewayIsMissing() {
+        assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+        NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
+
+        assertFalse(address.getGateway().isPresent());
+    }
+
+    private void thenResultingIp4InterfaceGatewayIs(IPAddress expectedResult) {
+        assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+        NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
+
+        assertTrue(address.getGateway().isPresent());
+        assertEquals(expectedResult, address.getGateway().get());
+    }
+
+    private void thenResultingIp4InterfaceDNSIsMissing() {
+        assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+        NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
+
+        List<IP4Address> dns = address.getDnsServerAddresses();
+        assertTrue(dns.isEmpty());
+    }
+
+    private void thenResultingIp4InterfaceDNSIs(List<IPAddress> expectedDNSAddresses) {
+        assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+        NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
+
+        List<IP4Address> dns = address.getDnsServerAddresses();
+        assertEquals(expectedDNSAddresses.size(), dns.size());
+
+        for (IPAddress expectedDNSAddress : expectedDNSAddresses) {
+            assertTrue(dns.contains(expectedDNSAddress));
+        }
+    }
+
+    private void thenResultingIp4InterfaceAddressIs(IPAddress expectedAddress, short expectedPrefix) {
+        assertTrue(this.resultingStatus.getInterfaceIp4Addresses().isPresent());
+        NetworkInterfaceIpAddressStatus<IP4Address> address = this.resultingStatus.getInterfaceIp4Addresses().get();
+
+        List<NetworkInterfaceIpAddress<IP4Address>> addresses = address.getAddresses();
+        assertEquals(1, addresses.size());
+
+        assertEquals(expectedAddress, addresses.get(0).getAddress());
+        assertEquals(expectedPrefix, addresses.get(0).getPrefix());
+    }
+
+    private void thenResultingEthernetInterfaceLinkUpIs(boolean expectedResult) {
+        assertEquals(expectedResult, this.resultingEthernetStatus.isLinkUp());
+    }
+
+}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.eclipse.kura.nm.status;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -197,9 +209,8 @@ public class NMStatusConverterTest {
     // givenDevicePropertiesWith("Autoconnect", false);
     // givenDevicePropertiesWith("FirmwareVersion", "isThisRealLife");
     // givenDevicePropertiesWith("Driver", "isThisJustFantasy");
-    // givenDevicePropertiesWith("DriverVersion", "caughtInALandslide");
-    // givenDevicePropertiesWith("Mtu", new UInt32(69));
-    // givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
+
+    // nDevicePropertiesWith("HwA
 
     // givenIpv4ConfigPropertiesWith("Gateway", "192.168.1.1");
     // givenIpv4ConfigPropertiesWithDNS(Arrays.asList("192.168.1.10"));
@@ -209,13 +220,13 @@ public class NMStatusConverterTest {
 
     // whenBuildLoopbackStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper,
     // Optional.of(this.mockIp4ConfigProperties), Optional.empty(
-
-    
-    //     thenNoExceptionIsThrown();
  
+
+    // thenNoExceptionIsThrown();
+
     // thenResultingNetworkInterfaceIsVirtual(false);
     // thenResultingNetworkInterfaceAutoConnectIs(false);
-    // thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
+    // ResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
     // thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
     // thenResultingNetworkInterfaceDriverIs("isThisJustFantasy");
     // thenResultingNetworkInterfaceDriverVersionIs("caughtInALandslide");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -106,7 +106,7 @@ public class NMStatusConverterTest {
 
         whenBuildLoopbackStatusIsCalledWith("lo", this.mockDevicePropertiesWrapper, Optional.empty(), Optional.empty());
 
-        thenNoExceptionIsThrown();
+        thenNoExceptionOccurred();
 
         thenResultingNetworkInterfaceIsVirtual(true);
         thenResultingNetworkInterfaceAutoConnectIs(true);
@@ -141,7 +141,7 @@ public class NMStatusConverterTest {
         whenBuildLoopbackStatusIsCalledWith("lo", this.mockDevicePropertiesWrapper,
                 Optional.of(this.mockIp4ConfigProperties), Optional.empty());
 
-        thenNoExceptionIsThrown();
+        thenNoExceptionOccurred();
 
         thenResultingNetworkInterfaceIsVirtual(true);
         thenResultingNetworkInterfaceAutoConnectIs(false);
@@ -180,7 +180,7 @@ public class NMStatusConverterTest {
         whenBuildLoopbackStatusIsCalledWith("lo", this.mockDevicePropertiesWrapper, Optional.empty(),
                 Optional.of(this.mockIp6ConfigProperties));
 
-        thenNoExceptionIsThrown();
+        thenNoExceptionOccurred();
 
         thenResultingNetworkInterfaceIsVirtual(true);
         thenResultingNetworkInterfaceAutoConnectIs(false);
@@ -236,7 +236,7 @@ public class NMStatusConverterTest {
         whenBuildEthernetStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper, Optional.empty(),
                 Optional.empty());
 
-        thenNoExceptionIsThrown();
+        thenNoExceptionOccurred();
 
         thenResultingNetworkInterfaceIsVirtual(false);
         thenResultingNetworkInterfaceAutoConnectIs(true);
@@ -271,7 +271,7 @@ public class NMStatusConverterTest {
         whenBuildEthernetStatusIsCalledWith("eth0", this.mockDevicePropertiesWrapper,
                 Optional.of(this.mockIp4ConfigProperties), Optional.empty());
 
-        thenNoExceptionIsThrown();
+        thenNoExceptionOccurred();
 
         thenResultingNetworkInterfaceIsVirtual(false);
         thenResultingNetworkInterfaceAutoConnectIs(false);
@@ -379,7 +379,7 @@ public class NMStatusConverterTest {
      * Then
      */
 
-    private void thenNoExceptionIsThrown() {
+    private void thenNoExceptionOccurred() {
         String errorMessage = "Empty message";
         if (Objects.nonNull(this.occurredException)) {
             StringWriter sw = new StringWriter();


### PR DESCRIPTION
This PR adds the required glue code for retrieving the **ipv6 status** for a network interface from NetworkManager.

Changes: I mostly replicated the existing logic for the IPv4 status. To avoid repetitions I modified `setIP4Addresses` and `setIP4Gateway` so that they can work with both ipv4 and ipv6. The ramaining big bulk of the changes is the newly introduced `NMStatusConverterTest` class, responsible for testing how the status is populated by Kura.

## Tests

To verify everything is working correctly I ran this PR code on a RPi 4 w/ Raspberry Pi OS and performed the following requests through the RestAPI:

```bash
curl -X POST -H 'Content-Type: application/json' -d '{ "interfaceIds": [ "wlan0" ] }' -k -u admin:eurotech https://$ADDRESS/services/networkStatus/v1/status/byInterfaceId
...
"interfaceIp6Addresses":{
            "addresses":[
               {
                  "address":"fe80:0:0:0:5f33:6903:bb44:64ef",
                  "prefix":64
               }
            ],
            "dnsServerAddresses":[
               "2001:4860:4860:0:0:0:0:8888"
            ]
         }
...
```

given the configuration reported in the screenshot below:

![image](https://github.com/eclipse/kura/assets/22748355/634a51ef-9901-46c3-bbd4-297c3768dda6)
