### PR TITLE
refactor(web.ui): support unmanaged IPv6 status

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -286,7 +286,6 @@ public class NetworkTabsUi extends Composite {
     private void arrangeOptionalTabs() {
         boolean isIpv4EnabledLAN = this.ip4Tab.getStatus().equals(IPV4_STATUS_ENABLED_LAN_MESSAGE);
         boolean isIpv4Disabled = this.ip4Tab.getStatus().equals(IPV4_STATUS_DISABLED_MESSAGE);
-        boolean isIpv4Unmanaged = this.ip4Tab.getStatus().equals(IPV4_STATUS_UNMANAGED_MESSAGE);
         boolean isWirelessAP = this.wirelessTab.getWirelessMode() != null
                 && this.wirelessTab.getWirelessMode().name().equals(WIFI_ACCESS_POINT);
         boolean isDhcp = this.ip4Tab.isDhcp();
@@ -302,7 +301,7 @@ public class NetworkTabsUi extends Composite {
             }
         } else if (wrapper.isModem()) {
             includeDhcpNat = false;
-            this.modemGpsTabAnchorItem.setEnabled(wrapper.isGpsSupported() && !isIpv4Unmanaged);
+            this.modemGpsTabAnchorItem.setEnabled(wrapper.isGpsSupported() && !isUnmanagedSelected());
             showModemTabs();
         } else {
             showEthernetTabs();
@@ -314,9 +313,10 @@ public class NetworkTabsUi extends Composite {
         }
 
         this.dhcp4NatTabAnchorItem.setEnabled(includeDhcpNat);
+        this.ip6TabAnchorItem.setEnabled(!isUnmanagedSelected());
 
-        if (isIpv4Disabled || isIpv4Unmanaged) {
-            disableOptionalTabs();
+        if (isIpv4Disabled || isUnmanagedSelected()) {
+            removeOptionalTabs();
         }
     }
 
@@ -361,16 +361,12 @@ public class NetworkTabsUi extends Composite {
         return false;
     }
 
-    private void disableOptionalTabs() {
+    private void removeOptionalTabs() {
         this.visibleTabs.remove(this.wirelessTabAnchorItem);
-        this.visibleTabs.remove(this.modemTabAnchorItem);
         this.visibleTabs.remove(this.dhcp4NatTabAnchorItem);
-
-        this.wirelessTabAnchorItem.setEnabled(false);
-        this.modemTabAnchorItem.setEnabled(false);
-        this.modemGpsTabAnchorItem.setEnabled(false);
-        this.modemAntennaTabAnchorItem.setEnabled(false);
-        this.dhcp4NatTabAnchorItem.setEnabled(false);
+        this.visibleTabs.remove(this.modemTabAnchorItem);
+        this.visibleTabs.remove(this.modemGpsTabAnchorItem);
+        this.visibleTabs.remove(this.modemAntennaTabAnchorItem);
     }
 
     private void refreshAllVisibleTabs() {
@@ -514,7 +510,8 @@ public class NetworkTabsUi extends Composite {
             return false;
         }
 
-        if (this.visibleTabs.contains(this.ip6TabAnchorItem) && !this.ip6Tab.isValid()) {
+        if (this.visibleTabs.contains(this.ip6TabAnchorItem) && this.ip6TabAnchorItem.isEnabled()
+                && !this.ip6Tab.isValid()) {
             return false;
         }
 
@@ -522,7 +519,8 @@ public class NetworkTabsUi extends Composite {
             return false;
         }
 
-        if (this.visibleTabs.contains(this.dhcp4NatTabAnchorItem) && !this.dhcp4NatTab.isValid()) {
+        if (this.visibleTabs.contains(this.dhcp4NatTabAnchorItem) && this.dhcp4NatTabAnchorItem.isEnabled()
+                && !this.dhcp4NatTab.isValid()) {
             return false;
         }
 
@@ -534,15 +532,21 @@ public class NetworkTabsUi extends Composite {
             return false;
         }
 
-        if (this.visibleTabs.contains(this.modemGpsTabAnchorItem) && !this.modemGpsTab.isValid()) {
+        if (this.visibleTabs.contains(this.modemGpsTabAnchorItem) && this.modemGpsTabAnchorItem.isEnabled()
+                && !this.modemGpsTab.isValid()) {
             return false;
         }
 
-        if (this.visibleTabs.contains(this.modemAntennaTabAnchorItem) && !this.modemAntennaTab.isValid()) {
+        if (this.visibleTabs.contains(this.modemAntennaTabAnchorItem) && this.modemAntennaTabAnchorItem.isEnabled()
+                && !this.modemAntennaTab.isValid()) {
             return false;
         }
 
         return true;
+    }
+
+    public boolean isUnmanagedSelected() {
+        return this.ip4Tab.getStatus().equals(IPV4_STATUS_UNMANAGED_MESSAGE);
     }
 
     /*

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -42,6 +42,7 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class TabIp6Ui extends Composite implements NetworkTab {
 
+    private static final String STATUS_UNMANAGED = "netIPv6StatusUnmanaged";
     private static final String STATUS_DISABLED = "netIPv6StatusDisabled";
     private static final String STATUS_LAN = "netIPv6StatusEnabledLAN";
     private static final String STATUS_WAN = "netIPv6StatusEnabledWAN";
@@ -569,30 +570,38 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     @Override
     public void getUpdatedNetInterface(GwtNetInterfaceConfig updatedNetIf) {
         if (this.form != null) {
-            updatedNetIf.setIpv6Status(this.status.getSelectedValue());
-
-            if (this.priority.getValue() != null) {
-                updatedNetIf.setIpv6WanPriority(this.priority.getValue());
+            if (this.tabs.isUnmanagedSelected()) {
+                updatedNetIf.setIpv6Status(STATUS_UNMANAGED);
+            } else {
+                updateConfigWithSelectedValues(updatedNetIf);
             }
-
-            updatedNetIf.setIpv6ConfigMode(this.configure.getSelectedValue());
-            updatedNetIf.setIpv6AutoconfigurationMode(this.autoconfiguration.getSelectedValue());
-            
-            if (notNullOrEmpty(this.ip.getValue())) {
-                updatedNetIf.setIpv6Address(this.ip.getValue().trim());
-            }
-            if (this.subnet.getValue() != null) {
-                updatedNetIf.setIpv6SubnetMask(this.subnet.getValue());
-            }
-            if (notNullOrEmpty(this.gateway.getValue())) {
-                updatedNetIf.setIpv6Gateway(this.gateway.getValue().trim());
-            }
-            if (notNullOrEmpty(this.dns.getValue())) {
-                updatedNetIf.setIpv6DnsServers(this.dns.getValue().trim());
-            }
-
-            updatedNetIf.setIpv6Privacy(this.privacy.getSelectedValue());
         }
+    }
+
+    private void updateConfigWithSelectedValues(GwtNetInterfaceConfig updatedNetIf) {
+        updatedNetIf.setIpv6Status(this.status.getSelectedValue());
+
+        if (this.priority.getValue() != null) {
+            updatedNetIf.setIpv6WanPriority(this.priority.getValue());
+        }
+
+        updatedNetIf.setIpv6ConfigMode(this.configure.getSelectedValue());
+        updatedNetIf.setIpv6AutoconfigurationMode(this.autoconfiguration.getSelectedValue());
+
+        if (notNullOrEmpty(this.ip.getValue())) {
+            updatedNetIf.setIpv6Address(this.ip.getValue().trim());
+        }
+        if (this.subnet.getValue() != null) {
+            updatedNetIf.setIpv6SubnetMask(this.subnet.getValue());
+        }
+        if (notNullOrEmpty(this.gateway.getValue())) {
+            updatedNetIf.setIpv6Gateway(this.gateway.getValue().trim());
+        }
+        if (notNullOrEmpty(this.dns.getValue())) {
+            updatedNetIf.setIpv6DnsServers(this.dns.getValue().trim());
+        }
+
+        updatedNetIf.setIpv6Privacy(this.privacy.getSelectedValue());
     }
 
     private boolean notNullOrEmpty(String value) {


### PR DESCRIPTION
This refactor takes into account the selected IPv4 status in order to create a consistent `GwtNetInterfaceConfig` where the IPv6 status is set to unmanaged when the IPv4 status is. Other minor improvements are made for `NetworkTabsUi`. Triggered by https://github.com/eclipse/kura/pull/4804#discussion_r1293162025.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
