### PR TITLE
feat(web2): ipv6 status information display

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -470,9 +470,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             refreshFieldsBasedOnInterface(this.selectedNetIfConfig.get());
             refreshFieldsBasedOnSelectedValues();
         }
-
-        // Show read-only dns field when there are no custom DNS entries
-        this.dnsRead.setVisible(this.dns.getValue() == null || this.dns.getValue().isEmpty());
     }
 
     private void refreshFieldsBasedOnInterface(GwtNetInterfaceConfig config) {
@@ -546,6 +543,9 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             this.autoconfiguration.setEnabled(false);
             this.privacy.setEnabled(false);
         }
+
+        // Show read-only dns field when there are no custom DNS entries
+        this.dnsRead.setVisible(this.dns.getValue() == null || this.dns.getValue().isEmpty());
     }
 
     @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -470,6 +470,16 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             refreshFieldsBasedOnInterface(this.selectedNetIfConfig.get());
             refreshFieldsBasedOnSelectedValues();
         }
+
+        // Show read-only dns field when DHCP is selected and there are no
+        // custom DNS entries
+        String configureValue = this.configure.getSelectedItemText();
+        if (configureValue.equals("netIPv6MethodDhcp")
+                && (this.dns.getValue() == null || this.dns.getValue().isEmpty())) {
+            this.dnsRead.setVisible(true);
+        } else {
+            this.dnsRead.setVisible(false);
+        }
     }
 
     private void refreshFieldsBasedOnInterface(GwtNetInterfaceConfig config) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -408,13 +408,13 @@ public class TabIp6Ui extends Composite implements NetworkTab {
 
         this.dns.addValueChangeHandler(event -> {
             setDirty(true);
-            
+
             if (this.dns.getText().trim().length() == 0) {
                 this.groupDns.setValidationState(ValidationState.NONE);
                 this.wrongInputDns.setText("");
                 return;
             }
-            
+
             String[] addresses = this.dns.getText().trim().split(DNS_REGEX);
             boolean isValid = addresses.length > 0;
 
@@ -474,30 +474,30 @@ public class TabIp6Ui extends Composite implements NetworkTab {
 
     private void refreshFieldsBasedOnInterface(GwtNetInterfaceConfig config) {
         switch (config.getHwTypeEnum()) {
-            case ETHERNET:
-                break;
-            case LOOPBACK:
-                this.status.setEnabled(false);
-                this.priority.setEnabled(false);
-                this.configure.setEnabled(false);
-                this.autoconfiguration.setEnabled(false);
-                this.ip.setEnabled(false);
-                this.subnet.setEnabled(false);
-                this.gateway.setEnabled(false);
-                this.dns.setEnabled(false);
-                this.privacy.setEnabled(false);
-                break;
-            case MODEM:
-                this.configure.setEnabled(false);
-                this.configure.setSelectedIndex(0);
-                this.ip.setEnabled(false);
-                this.subnet.setEnabled(false);
-                this.gateway.setEnabled(false);
-                break;
-            case WIFI:
-                break;
-            default:
-                break;
+        case ETHERNET:
+            break;
+        case LOOPBACK:
+            this.status.setEnabled(false);
+            this.priority.setEnabled(false);
+            this.configure.setEnabled(false);
+            this.autoconfiguration.setEnabled(false);
+            this.ip.setEnabled(false);
+            this.subnet.setEnabled(false);
+            this.gateway.setEnabled(false);
+            this.dns.setEnabled(false);
+            this.privacy.setEnabled(false);
+            break;
+        case MODEM:
+            this.configure.setEnabled(false);
+            this.configure.setSelectedIndex(0);
+            this.ip.setEnabled(false);
+            this.subnet.setEnabled(false);
+            this.gateway.setEnabled(false);
+            break;
+        case WIFI:
+            break;
+        default:
+            break;
 
         }
     }
@@ -639,10 +639,10 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             setDirty(false);
             resetValidations();
 
-            if (this.selectedNetIfConfig.isEmpty()) {
-                reset();
-            } else {
+            if (this.selectedNetIfConfig.isPresent()) {
                 fillFormWithCachedConfig();
+            } else {
+                reset();
             }
         }
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -471,15 +471,8 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             refreshFieldsBasedOnSelectedValues();
         }
 
-        // Show read-only dns field when DHCP is selected and there are no
-        // custom DNS entries
-        String configureValue = this.configure.getSelectedItemText();
-        if (configureValue.equals("netIPv6MethodDhcp")
-                && (this.dns.getValue() == null || this.dns.getValue().isEmpty())) {
-            this.dnsRead.setVisible(true);
-        } else {
-            this.dnsRead.setVisible(false);
-        }
+        // Show read-only dns field when there are no custom DNS entries
+        this.dnsRead.setVisible(this.dns.getValue() == null || this.dns.getValue().isEmpty());
     }
 
     private void refreshFieldsBasedOnInterface(GwtNetInterfaceConfig config) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -599,6 +599,8 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         }
         if (notNullOrEmpty(this.dns.getValue())) {
             updatedNetIf.setIpv6DnsServers(this.dns.getValue().trim());
+        } else {
+            updatedNetIf.setIpv6DnsServers("");
         }
 
         updatedNetIf.setIpv6Privacy(this.privacy.getSelectedValue());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -534,11 +534,8 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         if (this.configure.getSelectedValue().equals(CONFIGURE_AUTO)
                 || this.configure.getSelectedValue().equals(CONFIGURE_DHCP)) {
             this.ip.setEnabled(false);
-            this.ip.setText("");
             this.subnet.setEnabled(false);
-            this.subnet.setText("");
             this.gateway.setEnabled(false);
-            this.gateway.setText("");
         }
 
         if (this.configure.getSelectedValue().equals(CONFIGURE_MANUAL)

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -590,12 +590,18 @@ public class TabIp6Ui extends Composite implements NetworkTab {
 
         if (notNullOrEmpty(this.ip.getValue())) {
             updatedNetIf.setIpv6Address(this.ip.getValue().trim());
+        } else {
+            updatedNetIf.setIpv6Address("");
         }
         if (this.subnet.getValue() != null) {
             updatedNetIf.setIpv6SubnetMask(this.subnet.getValue());
+        } else {
+            updatedNetIf.setIpv6SubnetMask(0);
         }
         if (notNullOrEmpty(this.gateway.getValue())) {
             updatedNetIf.setIpv6Gateway(this.gateway.getValue().trim());
+        } else {
+            updatedNetIf.setIpv6Gateway("");
         }
         if (notNullOrEmpty(this.dns.getValue())) {
             updatedNetIf.setIpv6DnsServers(this.dns.getValue().trim());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -148,6 +148,7 @@ public class GwtNetInterfaceConfigBuilder {
         }
 
         this.gwtConfig.setIpv6Gateway(this.properties.getIp6Gateway(this.ifName));
+        this.gwtConfig.setIpv6DnsServers(this.properties.getIp6DnsServers(this.ifName));
 
         Optional<String> privacy = this.properties.getIp6Privacy(this.ifName);
         if (privacy.isPresent()) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -213,7 +213,7 @@ public class NetworkStatusServiceAdapter {
                 if (address.getGateway().isPresent()) {
                     gwtConfig.setGateway(address.getGateway().get().getHostAddress());
                 }
-                gwtConfig.setReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses(), "\n"));
+                gwtConfig.setReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses()));
             });
         }
     }
@@ -240,7 +240,7 @@ public class NetworkStatusServiceAdapter {
                     gwtConfig.setIpv6Gateway(address.getGateway().get().getHostAddress());
                 }
                 if (ipConfigMode.equals("netIPv6MethodDhcp")) {
-                    gwtConfig.setIpv6ReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses(), "\n"));
+                    gwtConfig.setIpv6ReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses()));
                 }
             });
         }
@@ -251,11 +251,11 @@ public class NetworkStatusServiceAdapter {
                 && (ipConfigMode.equals("netIPv6MethodAuto") || ipConfigMode.equals("netIPv6MethodDhcp"));
     }
 
-    private <T extends IPAddress> String prettyPrintDnsServers(List<T> dnsAddresses, String separator) {
+    private <T extends IPAddress> String prettyPrintDnsServers(List<T> dnsAddresses) {
         StringBuilder result = new StringBuilder();
         for (T dnsAddress : dnsAddresses) {
             result.append(dnsAddress.getHostAddress());
-            result.append(separator);
+            result.append("\n");
         }
 
         return result.toString();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -213,7 +213,7 @@ public class NetworkStatusServiceAdapter {
                 if (address.getGateway().isPresent()) {
                     gwtConfig.setGateway(address.getGateway().get().getHostAddress());
                 }
-                gwtConfig.setReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses()));
+                gwtConfig.setReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses(), "\n"));
             });
         }
     }
@@ -239,7 +239,11 @@ public class NetworkStatusServiceAdapter {
                 if (address.getGateway().isPresent()) {
                     gwtConfig.setIpv6Gateway(address.getGateway().get().getHostAddress());
                 }
-                gwtConfig.setIpv6ReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses()));
+                if (ipConfigMode.equals("netIPv6MethodDhcp")) {
+                    gwtConfig.setIpv6ReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses(), "\n"));
+                } else {
+                    gwtConfig.setIpv6DnsServers(prettyPrintDnsServers(address.getDnsServerAddresses(), ","));
+                }
             });
         }
     }
@@ -249,11 +253,11 @@ public class NetworkStatusServiceAdapter {
                 && (ipConfigMode.equals("netIPv6MethodAuto") || ipConfigMode.equals("netIPv6MethodDhcp"));
     }
 
-    private <T extends IPAddress> String prettyPrintDnsServers(List<T> dnsAddresses) {
+    private <T extends IPAddress> String prettyPrintDnsServers(List<T> dnsAddresses, String separator) {
         StringBuilder result = new StringBuilder();
         for (T dnsAddress : dnsAddresses) {
             result.append(dnsAddress.getHostAddress());
-            result.append("\n");
+            result.append(separator);
         }
 
         return result.toString();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -224,7 +224,7 @@ public class NetworkStatusServiceAdapter {
 
     private void setIpv6StatusProperties(GwtNetInterfaceConfig gwtConfig, NetworkInterfaceStatus networkInterfaceInfo) {
 
-        String ipConfigMode = gwtConfig.getIpv6AutoconfigurationMode();
+        String ipConfigMode = gwtConfig.getIpv6ConfigMode();
         if (isIpv6AutoConfig(ipConfigMode)) {
             /*
              * An interface can have multiple active addresses, we select just the first
@@ -245,9 +245,8 @@ public class NetworkStatusServiceAdapter {
     }
 
     private boolean isIpv6AutoConfig(String ipConfigMode) {
-        // WIP
-        // return ipConfigMode != null && ipConfigMode.equals("..?");
-        return true;
+        return ipConfigMode != null
+                && (ipConfigMode.equals("netIPv6MethodAuto") || ipConfigMode.equals("netIPv6MethodDhcp"));
     }
 
     private <T extends IPAddress> String prettyPrintDnsServers(List<T> dnsAddresses) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -76,7 +76,7 @@ public class NetworkStatusServiceAdapter {
         if (networkInterfaceInfo.isPresent()) {
             setCommonStateProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
             setIpv4DhcpClientProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
-            setIpv6DhcpClientProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
+            setIpv6StatusProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
             setWifiStateProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
             setModemStateProperties(gwtConfigToUpdate, networkInterfaceInfo.get());
         }
@@ -222,8 +222,7 @@ public class NetworkStatusServiceAdapter {
         return ipConfigMode != null && ipConfigMode.equals(GwtNetIfConfigMode.netIPv4ConfigModeDHCP.name());
     }
 
-    private void setIpv6DhcpClientProperties(GwtNetInterfaceConfig gwtConfig,
-            NetworkInterfaceStatus networkInterfaceInfo) {
+    private void setIpv6StatusProperties(GwtNetInterfaceConfig gwtConfig, NetworkInterfaceStatus networkInterfaceInfo) {
 
         String ipConfigMode = gwtConfig.getIpv6AutoconfigurationMode();
         if (isIpv6AutoConfig(ipConfigMode)) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -239,9 +239,7 @@ public class NetworkStatusServiceAdapter {
                 if (address.getGateway().isPresent()) {
                     gwtConfig.setIpv6Gateway(address.getGateway().get().getHostAddress());
                 }
-                if (ipConfigMode.equals("netIPv6MethodDhcp")) {
-                    gwtConfig.setIpv6ReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses()));
-                }
+                gwtConfig.setIpv6ReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses()));
             });
         }
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -234,7 +234,7 @@ public class NetworkStatusServiceAdapter {
                 if (!address.getAddresses().isEmpty()) {
                     NetworkInterfaceIpAddress<IP6Address> firstAddress = address.getAddresses().get(0);
                     gwtConfig.setIpv6Address(firstAddress.getAddress().getHostAddress());
-                    // gwtConfig.setIpv6SubnetMask(new Integer(firstAddress.getPrefix())); WIP
+                    gwtConfig.setIpv6SubnetMask((int) firstAddress.getPrefix());
                 }
                 if (address.getGateway().isPresent()) {
                     gwtConfig.setIpv6Gateway(address.getGateway().get().getHostAddress());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -241,8 +241,6 @@ public class NetworkStatusServiceAdapter {
                 }
                 if (ipConfigMode.equals("netIPv6MethodDhcp")) {
                     gwtConfig.setIpv6ReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses(), "\n"));
-                } else {
-                    gwtConfig.setIpv6DnsServers(prettyPrintDnsServers(address.getDnsServerAddresses(), ","));
                 }
             });
         }


### PR DESCRIPTION
This PR adds the required code to display the ipv6 status information. It is a follow-up of #4806

> **Note**
While performing these changes I encountered a bug that let me discover a wrong assumption that was made in #4800. In [TabIp6Ui.getUpdatedNetInterface](https://github.com/marcellorinaldo/kura/blob/1cc4ad77dfa148a93f27952e14450c18bc39930b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java#L570) we assumed that `updatedNetIf` was freshly created and empty. **This is not correct** as we can see from [`NetworkTabsUi`](https://github.com/marcellorinaldo/kura/blob/1cc4ad77dfa148a93f27952e14450c18bc39930b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java#L478). This led to the changes in af8a8a02d03128903f1bf44d7a25b2417e4f5d7b

> **Warning**
The PR in its current form is not 100% functional. While working on this we found that there were a couple of bugs affecting the frontend and UI validation. These will be addressed in a separate PR.

<details>
<summary>

## Tests

</summary>

To verify everything is working correctly I ran this PR code on a RPi 4 w/ Raspberry Pi OS

![image](https://github.com/eclipse/kura/assets/22748355/d23cbf93-cef8-49d8-997d-68065fda69fa)

The output of Kura is consistent with what `nmcli` and `ip` provide:

![image](https://github.com/eclipse/kura/assets/22748355/a04b4b2d-4949-4635-8089-ffec82bef929)

![image](https://github.com/eclipse/kura/assets/22748355/a09d8c1d-fb0b-4d92-a1c1-f863aeea6a22)

---

With DHCP server on the LAN advertising:

![image](https://github.com/eclipse/kura/assets/22748355/84759808-9e83-4aca-9bfc-eb3e66e5989e)

![image](https://github.com/eclipse/kura/assets/22748355/bab93ab2-0e95-4d22-b766-b7cf747ce629)

</details>