### PR TITLE
fix(web2.server): fixed IPv6-related UI settings

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui.network;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.kura.web.client.messages.Messages;
@@ -588,7 +589,7 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         updatedNetIf.setIpv6ConfigMode(this.configure.getSelectedValue());
         updatedNetIf.setIpv6AutoconfigurationMode(this.autoconfiguration.getSelectedValue());
 
-        if (notNullOrEmpty(this.ip.getValue())) {
+        if (!nullOrEmpty(this.ip.getValue())) {
             updatedNetIf.setIpv6Address(this.ip.getValue().trim());
         } else {
             updatedNetIf.setIpv6Address("");
@@ -598,12 +599,12 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         } else {
             updatedNetIf.setIpv6SubnetMask(0);
         }
-        if (notNullOrEmpty(this.gateway.getValue())) {
+        if (!nullOrEmpty(this.gateway.getValue())) {
             updatedNetIf.setIpv6Gateway(this.gateway.getValue().trim());
         } else {
             updatedNetIf.setIpv6Gateway("");
         }
-        if (notNullOrEmpty(this.dns.getValue())) {
+        if (!nullOrEmpty(this.dns.getValue())) {
             updatedNetIf.setIpv6DnsServers(this.dns.getValue().trim());
         } else {
             updatedNetIf.setIpv6DnsServers("");
@@ -612,8 +613,8 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         updatedNetIf.setIpv6Privacy(this.privacy.getSelectedValue());
     }
 
-    private boolean notNullOrEmpty(String value) {
-        return value != null && value.trim().length() > 0;
+    private boolean nullOrEmpty(String value) {
+        return Objects.isNull(value) || value.trim().isEmpty();
     }
 
     @Override
@@ -622,8 +623,8 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         boolean isManual = this.configure.getSelectedValue().equals(CONFIGURE_MANUAL);
 
         if (isWan && isManual) {
-            if (!notNullOrEmpty(this.ip.getValue()) || this.subnet.getValue() == null
-                    || !notNullOrEmpty(this.gateway.getValue())) {
+            if (nullOrEmpty(this.ip.getValue()) || this.subnet.getValue() == null
+                    || nullOrEmpty(this.gateway.getValue())) {
                 this.groupIp.setValidationState(ValidationState.ERROR);
                 this.groupSubnet.setValidationState(ValidationState.ERROR);
                 this.groupGateway.setValidationState(ValidationState.ERROR);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -317,16 +317,38 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             }
         });
         this.priority.addMouseOutHandler(event -> resetHelpText());
+
         this.priority.addValueChangeHandler(valChangeEvent -> {
             setDirty(true);
-            if (this.priority.getValue() == null || this.priority.getValue() < 1) {
-                this.groupPriority.setValidationState(ValidationState.ERROR);
-                this.wrongInputPriority.setText(MSGS.netIPv6InvalidPriority());
-            } else {
+
+            String inputText = this.priority.getText();
+            boolean isValidValue = false;
+
+            if (inputText != null) {
+                if (inputText.trim().isEmpty()) {
+                    isValidValue = true;
+                } else {
+                    isValidValue = isValidIntegerInRange(inputText, -1, Integer.MAX_VALUE);
+                }
+            }
+
+            if (isValidValue) {
                 this.groupPriority.setValidationState(ValidationState.NONE);
                 this.wrongInputPriority.setText("");
+            } else {
+                this.groupPriority.setValidationState(ValidationState.ERROR);
+                this.wrongInputPriority.setText(MSGS.netIPv6InvalidPriority());
             }
         });
+    }
+
+    private boolean isValidIntegerInRange(String integerText, int min, int max) {
+        try {
+            int value = Integer.parseInt(integerText.trim());
+            return value >= min && value <= max;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     private void initIpField() {
@@ -679,7 +701,10 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             }
         }
 
-        this.priority.setValue(this.selectedNetIfConfig.get().getIpv6WanPriority());
+        Integer wanPriority = this.selectedNetIfConfig.get().getIpv6WanPriority();
+        if (wanPriority != null) {
+            this.priority.setText(wanPriority.toString());
+        }
 
         for (int i = 0; i < this.configure.getItemCount(); i++) {
             if (this.configure.getValue(i).equals(this.selectedNetIfConfig.get().getIpv6ConfigMode())) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -622,7 +622,7 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         boolean isManual = this.configure.getSelectedValue().equals(CONFIGURE_MANUAL);
 
         if (isWan && isManual) {
-            if (!notNullOrEmpty(this.ip.getValue()) || this.subnet.getValue() != null
+            if (!notNullOrEmpty(this.ip.getValue()) || this.subnet.getValue() == null
                     || !notNullOrEmpty(this.gateway.getValue())) {
                 this.groupIp.setValidationState(ValidationState.ERROR);
                 this.groupSubnet.setValidationState(ValidationState.ERROR);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.ui.xml
@@ -60,9 +60,7 @@
                                 <b:FormLabel for="priority" ui:field="labelPriority"></b:FormLabel>
                                 <util:HelpButton ui:field="helpButtonPriority" />
                                 <b:HelpBlock color="red" ui:field="wrongInputPriority" />
-                                <g:FlowPanel>
-                                    <b:IntegerBox b:id="priority" ui:field="priority" />
-                                </g:FlowPanel>
+                                <b:IntegerBox b:id="priority" ui:field="priority" />
                             </b:FormGroup>
 
                             <b:FormGroup ui:field="groupConfigure">

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -212,12 +212,16 @@ public class NetworkConfigurationServiceProperties {
     }
 
     public Optional<Integer> getIp6Netmask(String ifname) {
-        return Optional
-                .ofNullable((Integer) this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_NETMASK, ifname)));
+        if (this.properties.containsKey(String.format(NET_INTERFACE_CONFIG_IP6_NETMASK, ifname))) {
+            Short netmask = (Short) this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_NETMASK, ifname));
+            return Optional.ofNullable((Integer) netmask.intValue());
+        }
+
+        return Optional.empty();
     }
 
     public void setIp6Netmask(String ifname, int netmask) {
-        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_NETMASK, ifname), netmask);
+        this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_NETMASK, ifname), ((Integer) netmask).shortValue());
     }
 
     public String getIp6Gateway(String ifname) {


### PR DESCRIPTION
This PR contains UI fixes to the newly introduced IPv6 properties. Changelog:
- Added necessary conversion for ipv6 netmask from `Integer` to `Short` because this is what the Configuration service expected (see 3687b295b9065b98a27bdf53aca3f92c2075df8a)
- Fixed wrong conditional in WAN/Manual ipv6 settings validation (see 923bdfa1ba52ee9cd8ce7d3d87dbe4a07d2b71a7)
- Refactored method name to avoid using double negatives (see 7c6debbad64c445b150839dd0cceaed336e123c1)
- Fixed accepted values for *WAN Priority* field: allowed empty and integers from -1 to 2147483647 (see 97d6f7015e50065d87547f2f074e186d5a631167)

> **Warning**
While working on this fixes we found _yet another_ bug affecting the Wan Priority field for both ipv4 and ipv6. Once set to a specific value, it cannot be reset by leaving the value empty. We'll address this issue in a future PR.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: IPv6 addresses (positive) test cases:

```
2001:0000:3238:DFE1:0063:0000:0000:FEFB
2001:0000:3238:DFE1:63:0000:0000:FEFB
2001:0000:3238:DFE1:63::FEFB
2001:0:3238:DFE1:63::FEFB
::
::1
FE80::
```

**Any side note on the changes made:** N/A.
