### PR TITLE
docs: add documentation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Kura aims at offering a Java/OSGi-based container for M2M applications running i
 
 For more information, see the [Eclipse project proposal](http://www.eclipse.org/proposals/technology.kura/).
 
+Documentation
+-------------------
+
+- [**User Documentation**](https://eclipse.github.io/kura/latest/): here you'll find information on how to **use** Eclipse Kura i.e. installation instructions, informations on how to use the web UI and tutorials.
+- [**Developer Documentation**](https://github.com/eclipse/kura/wiki): the Eclipse Kura Github Wiki serves as a reference for **developers** who want to contribute to the Eclipse Kura project and/or develop new add-ons. Here you'll find Kura development/release model, guidelines on how to import internal packages, creating new bundles and development environment tips & tricks.
+- [**Developer Quickstart Guide**](https://github.com/eclipse/kura#getting-started): a quick guide on how to setup the development environment and build the project is also provided in this README.
+- [**Docker Container Documentation**](https://hub.docker.com/r/eclipse/kura/): the Eclipse Kura team also provides Docker containers for the project. Informations on how to build and run them are available at the project's Docker Hub page.
+
 
 System Requirements
 -------------------

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Documentation
 - [**Docker Containers Documentation**](https://hub.docker.com/r/eclipse/kura/): the Eclipse Kura team also provides Docker containers for the project. Informations on how to build and run them are available at the project's Docker Hub page.
 - [**Developer Quickstart Guide**](https://github.com/eclipse/kura#getting-started): a quick guide on how to setup the development environment and build the project is also provided in this README.
 
-Additionally we provide two channels if you encounter any issue with the project:
+Additionally we provide two channels for reporting any issue you find with the project
 - [**Github Issues**](https://github.com/eclipse/kura/issues): for bug reporting.
 - [**Github Discussions**](https://github.com/eclipse/kura/discussions): for receiving feedback, making new proposals and generally talking about the project.
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Documentation
 -------------------
 
 - [**User Documentation**](https://eclipse.github.io/kura/latest/): here you'll find information on how to **use** Eclipse Kura i.e. installation instructions, informations on how to use the web UI and tutorials.
-- [**Developer Documentation**](https://github.com/eclipse/kura/wiki): the Eclipse Kura Github Wiki serves as a reference for **developers** who want to contribute to the Eclipse Kura project and/or develop new add-ons. Here you'll find Kura development/release model, guidelines on how to import internal packages, creating new bundles and development environment tips & tricks.
+- [**Developer Documentation**](https://github.com/eclipse/kura/wiki): the Eclipse Kura Github Wiki serves as a reference for **developers** who want to contribute to the Eclipse Kura project and/or develop new add-ons. Here you'll find Eclipse Kura development/release model, guidelines on how to import internal packages, creating new bundles and development environment tips & tricks.
 - [**Docker Containers Documentation**](https://hub.docker.com/r/eclipse/kura/): the Eclipse Kura team also provides Docker containers for the project. Informations on how to build and run them are available at the project's Docker Hub page.
 - [**Developer Quickstart Guide**](https://github.com/eclipse/kura#getting-started): a quick guide on how to setup the development environment and build the project is also provided in this README.
 
-Additionally we provide two channels for reporting any issue you find with the project
+Additionally, we provide two channels for reporting any issue you find with the project
 - [**Github Issues**](https://github.com/eclipse/kura/issues): for bug reporting.
 - [**Github Discussions**](https://github.com/eclipse/kura/discussions): for receiving feedback, making new proposals and generally talking about the project.
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ Documentation
 
 - [**User Documentation**](https://eclipse.github.io/kura/latest/): here you'll find information on how to **use** Eclipse Kura i.e. installation instructions, informations on how to use the web UI and tutorials.
 - [**Developer Documentation**](https://github.com/eclipse/kura/wiki): the Eclipse Kura Github Wiki serves as a reference for **developers** who want to contribute to the Eclipse Kura project and/or develop new add-ons. Here you'll find Kura development/release model, guidelines on how to import internal packages, creating new bundles and development environment tips & tricks.
+- [**Docker Containers Documentation**](https://hub.docker.com/r/eclipse/kura/): the Eclipse Kura team also provides Docker containers for the project. Informations on how to build and run them are available at the project's Docker Hub page.
 - [**Developer Quickstart Guide**](https://github.com/eclipse/kura#getting-started): a quick guide on how to setup the development environment and build the project is also provided in this README.
-- [**Docker Container Documentation**](https://hub.docker.com/r/eclipse/kura/): the Eclipse Kura team also provides Docker containers for the project. Informations on how to build and run them are available at the project's Docker Hub page.
 
+Additionally we provide two channels if you encounter any issue with the project:
+- [**Github Issues**](https://github.com/eclipse/kura/issues): for bug reporting.
+- [**Github Discussions**](https://github.com/eclipse/kura/discussions): for receiving feedback, making new proposals and generally talking about the project.
 
 System Requirements
 -------------------

--- a/README.md
+++ b/README.md
@@ -22,15 +22,6 @@ Eclipse Kura™
 
 **Eclipse Kura**, from [the maori word for tank/container](https://maoridictionary.co.nz/search/?keywords=kura), is an OSGi-based Application Framework for M2M Service Gateways
 
-Background
-----------
-Until recently, machine-to-machine projects have been approached as embedded systems designed around custom hardware, custom software, and custom network connectivity. The challenge of developing such projects was given by the large customization and integration costs and the small re-usability across similar engagements. The results were often proprietary systems leveraging proprietary protocols.
-
-The emergence of the service gateway model, which operates on the edge of an M2M deployment as an aggregator and controller, has opened up new possibilities. Cost effective service gateways are now capable of running modern software stacks opening the world of M2M to enterprise technologies and programming languages. Advanced software frameworks, which isolate the developer from the complexity of the hardware and the networking sub-systems, can now be offered to complement the service gateway hardware into an integrated hardware and software solution.
-
-
-Description
------------
 Kura aims at offering a Java/OSGi-based container for M2M applications running in service gateways. Kura provides or, when available, aggregates open source implementations for the most common services needed by M2M applications. Kura components are designed as configurable OSGi Declarative Service exposing service API and raising events. While several Kura components are in pure Java, others are invoked through JNI and have a dependency on the Linux operating system.
 
 For more information, see the [Eclipse project proposal](http://www.eclipse.org/proposals/technology.kura/).


### PR DESCRIPTION
This PR adds the "Documentation" section in the main repository README to help newcomers to the project find the information they need.

Additonally I removed the "Background" section since it's a bad fit for the main repository README