### PR TITLE
fix(web2): correctly report gateway and WAN priority when not set

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -31,6 +31,7 @@ import org.eclipse.kura.web.shared.model.GwtWifiWirelessMode;
 public class GwtNetInterfaceConfigBuilder {
 
     private static final String NA = "N/A";
+    private static final Integer DEFAULT_WAN_PRIORITY = -1;
 
     private final NetworkConfigurationServiceProperties properties;
     private GwtNetInterfaceConfig gwtConfig;
@@ -111,6 +112,8 @@ public class GwtNetInterfaceConfigBuilder {
         Optional<Integer> wanPriority = this.properties.getIp4WanPriority(ifName);
         if (wanPriority.isPresent()) {
             this.gwtConfig.setWanPriority(wanPriority.get());
+        } else {
+            this.gwtConfig.setWanPriority(DEFAULT_WAN_PRIORITY);
         }
 
         this.gwtConfig.setIpAddress(this.properties.getIp4Address(this.ifName));
@@ -128,6 +131,8 @@ public class GwtNetInterfaceConfigBuilder {
         Optional<Integer> priority = this.properties.getIp6WanPriority(this.ifName);
         if (priority.isPresent()) {
             this.gwtConfig.setIpv6WanPriority(priority.get());
+        } else {
+            this.gwtConfig.setIpv6WanPriority(DEFAULT_WAN_PRIORITY);
         }
 
         Optional<String> configure = this.properties.getIp6AddressMethod(this.ifName);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -31,6 +31,8 @@ import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
 
 public class NetworkConfigurationServicePropertiesBuilder {
 
+    private static final Integer DEFAULT_WAN_PRIORITY = -1;
+
     private final GwtNetInterfaceConfig gwtConfig;
     private final NetworkConfigurationServiceProperties properties;
     private final String ifname;
@@ -90,6 +92,8 @@ public class NetworkConfigurationServicePropertiesBuilder {
         if (isWan) {
             if (Objects.nonNull(this.gwtConfig.getWanPriority())) {
                 this.properties.setIp4WanPriority(ifname, this.gwtConfig.getWanPriority());
+            } else {
+                this.properties.setIp4WanPriority(ifname, DEFAULT_WAN_PRIORITY);
             }
 
             this.properties.setIp4DnsServers(this.ifname, this.gwtConfig.getDnsServers());
@@ -122,6 +126,8 @@ public class NetworkConfigurationServicePropertiesBuilder {
         if (isWan) {
             if (Objects.nonNull(this.gwtConfig.getIpv6WanPriority())) {
                 this.properties.setIp6WanPriority(this.ifname, this.gwtConfig.getIpv6WanPriority());
+            } else {
+                this.properties.setIp6WanPriority(ifname, DEFAULT_WAN_PRIORITY);
             }
 
             this.properties.setIp6DnsServers(this.ifname, this.gwtConfig.getIpv6DnsServers());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -59,6 +59,8 @@ import org.slf4j.LoggerFactory;
  */
 public class NetworkStatusServiceAdapter {
 
+    private final static String EMPTY_STRING = "";
+
     private final Logger logger = LoggerFactory.getLogger(NetworkStatusServiceAdapter.class);
     private final NetworkStatusService networkStatusService;
 
@@ -210,9 +212,11 @@ public class NetworkStatusServiceAdapter {
                     gwtConfig.setIpAddress(firstAddress.getAddress().getHostAddress());
                     gwtConfig.setSubnetMask(NetworkUtil.getNetmaskStringForm(firstAddress.getPrefix()));
                 }
-                if (address.getGateway().isPresent()) {
-                    gwtConfig.setGateway(address.getGateway().get().getHostAddress());
-                }
+
+                String gatewayAddress = address.getGateway().isPresent() ? address.getGateway().get().getHostAddress()
+                        : EMPTY_STRING;
+                gwtConfig.setGateway(gatewayAddress);
+
                 gwtConfig.setReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses()));
             });
         }
@@ -236,9 +240,11 @@ public class NetworkStatusServiceAdapter {
                     gwtConfig.setIpv6Address(firstAddress.getAddress().getHostAddress());
                     gwtConfig.setIpv6SubnetMask((int) firstAddress.getPrefix());
                 }
-                if (address.getGateway().isPresent()) {
-                    gwtConfig.setIpv6Gateway(address.getGateway().get().getHostAddress());
-                }
+
+                String gatewayAddress = address.getGateway().isPresent() ? address.getGateway().get().getHostAddress()
+                        : EMPTY_STRING;
+                gwtConfig.setIpv6Gateway(gatewayAddress);
+
                 gwtConfig.setIpv6ReadOnlyDnsServers(prettyPrintDnsServers(address.getDnsServerAddresses()));
             });
         }


### PR DESCRIPTION
This PR fixes an issue that emerged while testing IpV6 w/ SLAAC and DHCPv6.

## Issue description

Steps to reproduce:
- On an interface set the IpV6 Configuration as “Manually” and fill all the required fields.
- Press “Apply”
- Check that the configuration was correctly applied through `nmcli`
- On that same interface set IpV6 Configuration as “DHCPv6” and press “Apply”. Be sure that, on your LAN, nothing provides the gateway address
- The gateway address shown by the UI **will still be the one provided at the step before (i.e. the manually set one).**
- `nmcli` will report **no gateway set**

<details>
<summary>Screenshots</summary>

`nmcli con show kura-eth0-connection` reports:

![image-20230822-072338](https://github.com/eclipse/kura/assets/22748355/f8aaecdb-df43-4f52-add8-a7d956de418e)

Meanwhile the UI reports the following:

![image-20230822-072453](https://github.com/eclipse/kura/assets/22748355/1d89666a-eb8d-4fd2-adc6-9147d0c2dd5d)

</details>

---

Similar behaviour for the "WAN priority" field


https://github.com/eclipse/kura/assets/22748355/4f09b1b3-f5b8-46ff-b5d4-ce0d62a9610a



## Fix description

I updated `NetworkStatusServiceAdapter` so that when the IP address of the gateway is missing from the status **it actually sets it as empty** instead of not setting it at all. This prevents the UI to fill the field with the cached configuration.

This behaviour is similar to what we do with the DNS servers: if the DNS server list is empty **we actually set it to empty** instead of not setting it at all. See:

https://github.com/eclipse/kura/blob/93ad9a86ba00b41b8b86a5ba0a29330141c47e8f/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java#L216

> **Note**
> Notice that the issue affected the IpV4 Gateway too and therefore I updated that accordingly.

---

The fix is similar for the "WAN priority" case.