### PR TITLE
feat: add BIRTH message caching on already connected connections for CloudConnectionManager implementations

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifecycleMessage.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifecycleMessage.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.internal.cloudconnection.eclipseiot.mqtt.cloud;
+
+import org.eclipse.kura.internal.cloudconnection.eclipseiot.mqtt.message.MessageType;
+import org.eclipse.kura.message.KuraPayload;
+
+public class LifecycleMessage {
+    
+    private StringBuilder topicBuilder;
+    private CloudConnectionManagerOptions options;
+    private LifeCyclePayloadBuilder payloadBuilder;
+    private KuraPayload payload;
+
+    public LifecycleMessage(CloudConnectionManagerOptions options, CloudConnectionManagerImpl cloudServiceImpl) {
+        this.options = options;
+
+        this.topicBuilder = new StringBuilder(MessageType.EVENT.getTopicPrefix());
+        this.topicBuilder.append(this.options.getTopicSeparator()).append(this.options.getTopicSeparator())
+                .append(this.options.getTopicSeparator());
+        
+        this.payloadBuilder = new LifeCyclePayloadBuilder(cloudServiceImpl);
+    }
+
+    public LifecycleMessage asBirthCertificateMessage() {
+        this.topicBuilder.append(this.options.getTopicBirthSuffix());
+        this.payload = this.payloadBuilder.buildBirthPayload();
+        return this;
+    }
+
+    public LifecycleMessage asDisconnectCertificateMessage() {
+        this.topicBuilder.append(this.options.getTopicDisconnectSuffix());
+        this.payload = this.payloadBuilder.buildDisconnectPayload();
+        return this;
+    }
+
+    public String getTopic() {
+        return this.topicBuilder.toString();
+    }
+
+    public KuraPayload getPayload() {
+        return this.payload;
+    }
+
+}

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -37,12 +37,16 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -161,6 +165,9 @@ public class CloudServiceImpl
     private Set<TamperDetectionService> tamperDetectionServices = new HashSet<>();
 
     private String ownPid;
+
+    private ScheduledFuture<?> scheduledBirthPublisherFuture;
+    private ScheduledExecutorService scheduledBirthPublisher = Executors.newScheduledThreadPool(1);
 
     public CloudServiceImpl() {
         this.cloudClients = new CopyOnWriteArrayList<>();
@@ -374,13 +381,13 @@ public class CloudServiceImpl
             handleModemReadyEvent(event);
         } else if (TamperEvent.TAMPER_EVENT_TOPIC.equals(event.getTopic()) && this.dataService.isConnected()
                 && this.options.getRepubBirthCertOnTamperEvent()) {
-            tryPublishBirthCertificate();
+            tryPublishBirthCertificate(false);
         }
     }
 
-    private void tryPublishBirthCertificate() {
+    private void tryPublishBirthCertificate(boolean isNewConnection) {
         try {
-            publishBirthCertificate();
+            publishBirthCertificate(isNewConnection);
         } catch (KuraException e) {
             logger.warn("Cannot publish birth certificate", e);
         }
@@ -403,7 +410,7 @@ public class CloudServiceImpl
 
         if (this.dataService.isConnected() && this.options.getRepubBirthCertOnModemDetection() && isModemInfoValid()) {
             logger.debug("handleEvent() :: publishing BIRTH certificate ...");
-            tryPublishBirthCertificate();
+            tryPublishBirthCertificate(false);
         }
     }
 
@@ -420,7 +427,7 @@ public class CloudServiceImpl
         // republish the birth certificate only if we are configured to
         logger.info("Handling PositionLockedEvent");
         if (this.dataService.isConnected() && this.options.getRepubBirthCertOnGpsLock()) {
-            tryPublishBirthCertificate();
+            tryPublishBirthCertificate(false);
         }
     }
 
@@ -777,9 +784,9 @@ public class CloudServiceImpl
     //
     // ----------------------------------------------------------------
 
-    private void setupCloudConnection(boolean onConnect) throws KuraException {
+    private void setupCloudConnection(boolean isNewConnection) throws KuraException {
         // assume we are not yet subscribed
-        if (onConnect) {
+        if (isNewConnection) {
             this.subscribed = false;
         }
 
@@ -793,7 +800,7 @@ public class CloudServiceImpl
 
         // publish birth certificate
         if (publishBirth) {
-            publishBirthCertificate();
+            publishBirthCertificate(isNewConnection);
             this.birthPublished = true;
         }
 
@@ -812,20 +819,32 @@ public class CloudServiceImpl
         }
     }
 
-    private void publishBirthCertificate() throws KuraException {
+    private void publishBirthCertificate(boolean isNewConnection) throws KuraException {
         if (this.options.isLifecycleCertsDisabled()) {
             return;
         }
 
-        StringBuilder sbTopic = new StringBuilder();
-        sbTopic.append(this.options.getTopicControlPrefix()).append(CloudServiceOptions.getTopicSeparator())
-                .append(CloudServiceOptions.getTopicAccountToken()).append(CloudServiceOptions.getTopicSeparator())
-                .append(CloudServiceOptions.getTopicClientIdToken()).append(CloudServiceOptions.getTopicSeparator())
-                .append(CloudServiceOptions.getTopicBirthSuffix());
+        LifecycleMessage birthToPublish = new LifecycleMessage(this.options, this).asBirthCertificateMessage();
 
-        String topic = sbTopic.toString();
-        KuraPayload payload = createBirthPayload();
-        publishLifeCycleMessage(topic, payload);
+        if (isNewConnection) {
+            publishLifeCycleMessage(birthToPublish);
+        } else {
+            publishWithDelay(birthToPublish);
+        }
+    }
+
+    private void publishWithDelay(LifecycleMessage birthMessage) {
+        if (Objects.nonNull(this.scheduledBirthPublisherFuture)) {
+            this.scheduledBirthPublisherFuture.cancel(false);
+        }
+
+        this.scheduledBirthPublisherFuture = this.scheduledBirthPublisher.schedule(() -> {
+            try {
+                publishLifeCycleMessage(birthMessage);
+            } catch (KuraException e) {
+                logger.error("Error sending birth certificate.", e);
+            }
+        }, 30L, TimeUnit.SECONDS);
     }
 
     private void publishDisconnectCertificate() throws KuraException {
@@ -833,15 +852,7 @@ public class CloudServiceImpl
             return;
         }
 
-        StringBuilder sbTopic = new StringBuilder();
-        sbTopic.append(this.options.getTopicControlPrefix()).append(CloudServiceOptions.getTopicSeparator())
-                .append(CloudServiceOptions.getTopicAccountToken()).append(CloudServiceOptions.getTopicSeparator())
-                .append(CloudServiceOptions.getTopicClientIdToken()).append(CloudServiceOptions.getTopicSeparator())
-                .append(CloudServiceOptions.getTopicDisconnectSuffix());
-
-        String topic = sbTopic.toString();
-        KuraPayload payload = createDisconnectPayload();
-        publishLifeCycleMessage(topic, payload);
+        publishLifeCycleMessage(new LifecycleMessage(this.options, this).asDisconnectCertificateMessage());
     }
 
     private void publishAppCertificate() throws KuraException {
@@ -849,36 +860,19 @@ public class CloudServiceImpl
             return;
         }
 
-        StringBuilder sbTopic = new StringBuilder();
-        sbTopic.append(this.options.getTopicControlPrefix()).append(CloudServiceOptions.getTopicSeparator())
-                .append(CloudServiceOptions.getTopicAccountToken()).append(CloudServiceOptions.getTopicSeparator())
-                .append(CloudServiceOptions.getTopicClientIdToken()).append(CloudServiceOptions.getTopicSeparator())
-                .append(CloudServiceOptions.getTopicAppsSuffix());
-
-        String topic = sbTopic.toString();
-        KuraPayload payload = createBirthPayload();
-        publishLifeCycleMessage(topic, payload);
+        publishLifeCycleMessage(new LifecycleMessage(this.options, this).asAppCertificateMessage());
     }
 
-    private KuraPayload createBirthPayload() {
-        LifeCyclePayloadBuilder payloadBuilder = new LifeCyclePayloadBuilder(this);
-        return payloadBuilder.buildBirthPayload();
-    }
-
-    private KuraPayload createDisconnectPayload() {
-        LifeCyclePayloadBuilder payloadBuilder = new LifeCyclePayloadBuilder(this);
-        return payloadBuilder.buildDisconnectPayload();
-    }
-
-    private void publishLifeCycleMessage(String topic, KuraPayload payload) throws KuraException {
+    private void publishLifeCycleMessage(LifecycleMessage message) throws KuraException {
         // track the message ID and block until the message
         // has been published (i.e. written to the socket).
         synchronized (this.messageId) {
             this.messageId.set(-1);
             // add a timestamp to the message
+            KuraPayload payload = message.getPayload();
             payload.setTimestamp(new Date());
             byte[] encodedPayload = encodePayload(payload);
-            int messageId = this.dataService.publish(topic, encodedPayload,
+            int messageId = this.dataService.publish(message.getTopic(), encodedPayload,
                     CloudServiceOptions.getLifeCycleMessageQos(), CloudServiceOptions.getLifeCycleMessageRetain(),
                     CloudServiceOptions.getLifeCycleMessagePriority());
             this.messageId.set(messageId);

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -891,10 +891,10 @@ public class CloudServiceImpl
             KuraPayload payload = message.getPayload();
             payload.setTimestamp(new Date());
             byte[] encodedPayload = encodePayload(payload);
-            int messageId = this.dataService.publish(message.getTopic(), encodedPayload,
+            int id = this.dataService.publish(message.getTopic(), encodedPayload,
                     CloudServiceOptions.getLifeCycleMessageQos(), CloudServiceOptions.getLifeCycleMessageRetain(),
                     CloudServiceOptions.getLifeCycleMessagePriority());
-            this.messageId.set(messageId);
+            this.messageId.set(id);
             try {
                 this.messageId.wait(1000);
             } catch (InterruptedException e) {

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -854,7 +854,10 @@ public class CloudServiceImpl
     private void publishWithDelay(LifecycleMessage message) {
         if (Objects.nonNull(this.scheduledBirthPublisherFuture)) {
             this.scheduledBirthPublisherFuture.cancel(false);
+            logger.debug("CloudServiceImpl: BIRTH message cache timer restarted.");
         }
+
+        logger.debug("CloudServiceImpl: BIRTH message cached for 30s.");
 
         if (message.isBirthCertificateMessage()) {
             this.lastBirthMessage = message;
@@ -868,10 +871,12 @@ public class CloudServiceImpl
             try {
 
                 if (Objects.nonNull(this.lastBirthMessage)) {
+                    logger.debug("CloudServiceImpl: publishing cached BIRTH message.");
                     publishLifeCycleMessage(lastBirthMessage);
                 }
 
                 if (Objects.nonNull(this.lastAppMessage)) {
+                    logger.debug("CloudServiceImpl: publishing cached APP message.");
                     publishLifeCycleMessage(lastAppMessage);
                 }
 

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -488,11 +488,7 @@ public class CloudServiceImpl
 
         // publish updated birth certificate with updated list of active apps
         if (isConnected()) {
-            try {
-                publishAppCertificate();
-            } catch (KuraException e) {
-                logger.warn("Cannot publish app certificate");
-            }
+            publishAppCertificate();
         }
     }
 
@@ -843,7 +839,7 @@ public class CloudServiceImpl
         publishLifeCycleMessage(new LifecycleMessage(this.options, this).asDisconnectCertificateMessage());
     }
 
-    private void publishAppCertificate() throws KuraException {
+    private void publishAppCertificate() {
         if (this.options.isLifecycleCertsDisabled()) {
             return;
         }
@@ -970,11 +966,7 @@ public class CloudServiceImpl
         }
 
         if (isConnected()) {
-            try {
-                publishAppCertificate();
-            } catch (KuraException e) {
-                logger.warn("Unable to publish updated App Certificate");
-            }
+            publishAppCertificate();
         }
     }
 
@@ -988,11 +980,7 @@ public class CloudServiceImpl
         }
 
         if (isConnected()) {
-            try {
-                publishAppCertificate();
-            } catch (KuraException e) {
-                logger.warn("Unable to publish updated App Certificate");
-            }
+            publishAppCertificate();
         }
     }
 

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/LifecycleMessage.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/LifecycleMessage.java
@@ -19,6 +19,8 @@ public class LifecycleMessage {
     private StringBuilder topicBuilder;
     private LifeCyclePayloadBuilder payloadBuilder;
     private KuraPayload payload;
+    private boolean isAppCertificateMessage = false;
+    private boolean isBirthCertificateMessage = false;
 
     public LifecycleMessage(CloudServiceOptions options, CloudServiceImpl cloudServiceImpl) {
         this.topicBuilder = new StringBuilder(options.getTopicControlPrefix());
@@ -34,12 +36,14 @@ public class LifecycleMessage {
     public LifecycleMessage asBirthCertificateMessage() {
         this.topicBuilder.append(CloudServiceOptions.getTopicBirthSuffix());
         this.payload = this.payloadBuilder.buildBirthPayload();
+        this.isBirthCertificateMessage = true;
         return this;
     }
 
     public LifecycleMessage asAppCertificateMessage() {
         this.topicBuilder.append(CloudServiceOptions.getTopicAppsSuffix());
         this.payload = this.payloadBuilder.buildBirthPayload();
+        this.isAppCertificateMessage = true;
         return this;
     }
 
@@ -55,6 +59,14 @@ public class LifecycleMessage {
 
     public KuraPayload getPayload() {
         return this.payload;
+    }
+
+    public boolean isAppCertificateMessage() {
+        return this.isAppCertificateMessage;
+    }
+
+    public boolean isBirthCertificateMessage() {
+        return this.isBirthCertificateMessage;
     }
 
 }

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/LifecycleMessage.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/LifecycleMessage.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.core.cloud;
+
+import org.eclipse.kura.message.KuraPayload;
+
+public class LifecycleMessage {
+    
+    private StringBuilder topicBuilder;
+    private LifeCyclePayloadBuilder payloadBuilder;
+    private KuraPayload payload;
+
+    public LifecycleMessage(CloudServiceOptions options, CloudServiceImpl cloudServiceImpl) {
+        this.topicBuilder = new StringBuilder(options.getTopicControlPrefix());
+        this.topicBuilder.append(CloudServiceOptions.getTopicSeparator())
+                .append(CloudServiceOptions.getTopicAccountToken())
+                .append(CloudServiceOptions.getTopicSeparator())
+                .append(CloudServiceOptions.getTopicClientIdToken())
+                .append(CloudServiceOptions.getTopicSeparator());
+
+        this.payloadBuilder = new LifeCyclePayloadBuilder(cloudServiceImpl);
+    }
+
+    public LifecycleMessage asBirthCertificateMessage() {
+        this.topicBuilder.append(CloudServiceOptions.getTopicBirthSuffix());
+        this.payload = this.payloadBuilder.buildBirthPayload();
+        return this;
+    }
+
+    public LifecycleMessage asAppCertificateMessage() {
+        this.topicBuilder.append(CloudServiceOptions.getTopicAppsSuffix());
+        this.payload = this.payloadBuilder.buildBirthPayload();
+        return this;
+    }
+
+    public LifecycleMessage asDisconnectCertificateMessage() {
+        this.topicBuilder.append(CloudServiceOptions.getTopicDisconnectSuffix());
+        this.payload = this.payloadBuilder.buildDisconnectPayload();
+        return this;
+    }
+
+    public String getTopic() {
+        return this.topicBuilder.toString();
+    }
+
+    public KuraPayload getPayload() {
+        return this.payload;
+    }
+
+}

--- a/kura/test/org.eclipse.kura.core.cloud.test/src/main/java/org/eclipse/kura/core/cloud/CloudServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.cloud.test/src/main/java/org/eclipse/kura/core/cloud/CloudServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.core.cloud.test/src/main/java/org/eclipse/kura/core/cloud/CloudServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.cloud.test/src/main/java/org/eclipse/kura/core/cloud/CloudServiceTest.java
@@ -359,7 +359,7 @@ public class CloudServiceTest {
             final CompletableFuture<byte[]> message = observerInspector.nextMessage("$EDC/mqtt/underTest/MQTT/BIRTH");
             eventAdmin.postEvent(new TamperEvent("foo", tamperStatus));
 
-            metrics = getMetrics(message.get(30, TimeUnit.SECONDS));
+            metrics = getMetrics(message.get(35, TimeUnit.SECONDS));
 
             assertEquals(KuraBirthPayload.TamperStatus.NOT_TAMPERED.name(), metrics.get("tamper_status").asString());
         } finally {

--- a/kura/test/org.eclipse.kura.core.cloud.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
+++ b/kura/test/org.eclipse.kura.core.cloud.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
@@ -172,6 +172,7 @@ public class BirthMessagesTest {
         thenBirthIsPublishedImmediately(BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicBirthSuffix());
     }
 
+    @Test
     public void shouldPublishImmediatelyOnDisconnecting() throws KuraException {
         givenConfiguredCloudService();
         givenConnected();
@@ -182,6 +183,7 @@ public class BirthMessagesTest {
         thenBirthIsPublishedImmediately(BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicDisconnectSuffix());
     }
 
+    @Test
     public void shouldPublishWithDelayWhenRegisterRequestHandler() throws KuraException {
         givenConfiguredCloudService();
         givenConnected();
@@ -192,6 +194,7 @@ public class BirthMessagesTest {
         thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicAppsSuffix());
     }
 
+    @Test
     public void shouldPublishWithDelayWhenUnregisterRequestHandler() throws KuraException {
         givenConfiguredCloudService();
         givenConnected();
@@ -240,6 +243,7 @@ public class BirthMessagesTest {
     private void givenTamperEvent() {
         this.event = new Event(TamperEvent.TAMPER_EVENT_TOPIC, new HashMap<String, Object>());
     }
+
 
     /*
      * When

--- a/kura/test/org.eclipse.kura.core.cloud.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
+++ b/kura/test/org.eclipse.kura.core.cloud.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
@@ -1,0 +1,441 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.core.cloud;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.KuraStoreException;
+import org.eclipse.kura.cloudconnection.request.RequestHandler;
+import org.eclipse.kura.configuration.ConfigurationService;
+import org.eclipse.kura.data.DataService;
+import org.eclipse.kura.marshalling.Marshaller;
+import org.eclipse.kura.message.KuraPayload;
+import org.eclipse.kura.net.modem.ModemReadyEvent;
+import org.eclipse.kura.position.PositionLockedEvent;
+import org.eclipse.kura.security.tamper.detection.TamperEvent;
+import org.eclipse.kura.system.SystemAdminService;
+import org.eclipse.kura.system.SystemService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventAdmin;
+
+public class BirthMessagesTest {
+
+    private static final String BIRTH_TOPIC_PREFIX = "$EDC" + CloudServiceOptions.getTopicSeparator()
+            + CloudServiceOptions.getTopicAccountToken() + CloudServiceOptions.getTopicSeparator()
+            + CloudServiceOptions.getTopicClientIdToken() + CloudServiceOptions.getTopicSeparator();
+
+    private static final long SEND_DELAY = 25000L;
+    private static final long SLACK_DELAY = 10000L;
+
+    private CloudServiceImpl cloudService = new CloudServiceImpl();
+    private DataService dataService = mock(DataService.class);
+    private Exception occurredException;
+    private Event event;
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void shouldNotPublishOnActivationWhenDisconnected() throws KuraException {
+        givenDisconnected();
+
+        whenActivate();
+
+        thenNoExceptionOccurred();
+        thenNoBirthIsPublished();
+    }
+
+    @Test
+    public void shouldPublishImmediatelyOnActivationWhenConnected() throws KuraException {
+        givenConnected();
+
+        whenActivate();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedImmediately(BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicBirthSuffix());
+    }
+
+    @Test
+    public void shouldNotPublishOnUpdatedWhenDisconnected() throws KuraException {
+        givenDisconnected();
+
+        whenUpdated();
+
+        thenNoExceptionOccurred();
+        thenNoBirthIsPublished();
+    }
+
+    @Test
+    public void shouldPublishWithDelayOnUpdateWhenConnected() throws KuraException {
+        givenConnected();
+
+        whenUpdated();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicBirthSuffix());
+    }
+
+    @Test
+    public void shouldPublishImmediatelyWhenDeactivate() throws KuraException {
+        givenConfiguredCloudService();
+        givenConnected();
+
+        whenDeactivate();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedImmediately(BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicDisconnectSuffix());
+    }
+
+    @Test
+    public void shouldPublishWithDelayOnPositionLockedEvent() throws KuraException {
+        givenPositionLockedEvent();
+        givenConfiguredCloudService();
+        givenConnected();
+
+        whenHandleEvent();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicBirthSuffix());
+    }
+
+    @Test
+    public void shouldPublishWithDelayOnModemReadyEvent() throws KuraException {
+        givenModemReadyEvent();
+        givenConfiguredCloudService();
+        givenConnected();
+
+        whenHandleEvent();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicBirthSuffix());
+    }
+
+    @Test
+    public void shouldPublishWithDelayOnTamperEvent() throws KuraException {
+        givenTamperEvent();
+        givenConfiguredCloudService();
+        givenConnected();
+
+        whenHandleEvent();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicBirthSuffix());
+    }
+
+    @Test
+    public void shouldPublishImmediatelyOnConnectionEstabilished() throws KuraException {
+        givenConfiguredCloudService();
+
+        whenOnConnectionEstabilished();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedImmediately(BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicBirthSuffix());
+    }
+
+    public void shouldPublishImmediatelyOnDisconnecting() throws KuraException {
+        givenConfiguredCloudService();
+        givenConnected();
+
+        whenOnDisconnecting();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedImmediately(BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicDisconnectSuffix());
+    }
+
+    public void shouldPublishWithDelayWhenRegisterRequestHandler() throws KuraException {
+        givenConfiguredCloudService();
+        givenConnected();
+
+        whenRegisterRequestHandler();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicAppsSuffix());
+    }
+
+    public void shouldPublishWithDelayWhenUnregisterRequestHandler() throws KuraException {
+        givenConfiguredCloudService();
+        givenConnected();
+
+        whenUnregisterRequestHandler();
+
+        thenNoExceptionOccurred();
+        thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicAppsSuffix());
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenConfiguredCloudService() {
+        this.cloudService.activate(getMockComponentContext(), getDefaultProperties());
+    }
+
+    private void givenConnected() {
+        when(this.dataService.isConnected()).thenReturn(true);
+    }
+
+    private void givenDisconnected() {
+        when(this.dataService.isConnected()).thenReturn(false);
+    }
+
+    private void givenPositionLockedEvent() {
+        this.event = new Event(PositionLockedEvent.POSITION_LOCKED_EVENT_TOPIC, new HashMap<String, Object>());
+    }
+
+    private void givenModemReadyEvent() {
+        Map<String, Object> properties = new HashMap<String, Object>();
+        properties.put(ModemReadyEvent.FW_VERSION, "1.1.1");
+        properties.put(ModemReadyEvent.ICCID, "1234");
+        properties.put(ModemReadyEvent.IMEI, "4321");
+        properties.put(ModemReadyEvent.IMSI, "6789");
+        properties.put(ModemReadyEvent.MODEM_DEVICE, "ppp0");
+        properties.put(ModemReadyEvent.RSSI, "9876");
+        this.event = new ModemReadyEvent(properties);
+    }
+
+    private void givenTamperEvent() {
+        this.event = new Event(TamperEvent.TAMPER_EVENT_TOPIC, new HashMap<String, Object>());
+    }
+
+    /*
+     * When
+     */
+
+    private void whenActivate() {
+        try {
+            givenConfiguredCloudService();
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenUpdated() {
+        try {
+            this.cloudService.updated(getDefaultProperties());
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenDeactivate() {
+        try {
+            this.cloudService.deactivate(getMockComponentContext());
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenHandleEvent() {
+        try {
+            this.cloudService.handleEvent(this.event);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenOnConnectionEstabilished() {
+        try {
+            this.cloudService.onConnectionEstablished();
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenOnDisconnecting() {
+        try {
+            this.cloudService.onDisconnecting();
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenRegisterRequestHandler() {
+        try {
+            RequestHandler handler = mock(RequestHandler.class);
+            this.cloudService.registerRequestHandler("example.id", handler);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenUnregisterRequestHandler() {
+        try {
+            this.cloudService.unregister("example.id");
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenNoExceptionOccurred() {
+        String errorMessage = "Empty message";
+        if (Objects.nonNull(this.occurredException)) {
+            StringWriter sw = new StringWriter();
+            this.occurredException.printStackTrace(new PrintWriter(sw));
+
+            errorMessage = String.format("No exception expected, \"%s\" found. Caused by: %s",
+                    this.occurredException.getClass().getName(), sw.toString());
+        }
+
+        assertNull(errorMessage, this.occurredException);
+    }
+
+    private <E extends Exception> void thenExceptionOccurred(Class<E> expectedException) {
+        assertNotNull(this.occurredException);
+        assertEquals(expectedException.getName(), this.occurredException.getClass().getName());
+    }
+
+    private void thenNoBirthIsPublished() throws KuraStoreException {
+        verify(this.dataService, times(0)).publish(anyString(), any(), anyInt(), anyBoolean(), anyInt());
+    }
+
+    private void thenBirthIsPublishedAfter(long delayMillis, String expectedTopic) throws KuraException {
+        verify(this.dataService, after(delayMillis).never()).publish(eq(expectedTopic), any(), eq(0), eq(false),
+                eq(0));
+        verify(this.dataService, after(delayMillis + SLACK_DELAY).times(1)).publish(eq(expectedTopic), any(), eq(0),
+                eq(false), eq(0));
+    }
+
+    private void thenBirthIsPublishedImmediately(String expectedTopic) throws KuraException {
+        verify(this.dataService, timeout(SLACK_DELAY).times(1)).publish(eq(expectedTopic), any(), eq(0), eq(false),
+                eq(0));
+    }
+
+    /*
+     * Utilities
+     */
+
+    @Before
+    public void setup() {
+        SystemService systemService = mock(SystemService.class);
+        when(systemService.getDeviceName()).thenReturn("test-device");
+        when(systemService.getHostname()).thenReturn("localhost");
+        when(systemService.getModelName()).thenReturn("test-model");
+        when(systemService.getModelId()).thenReturn("test-model-id");
+        when(systemService.getPartNumber()).thenReturn("test-part-number");
+        when(systemService.getSerialNumber()).thenReturn("test-sn");
+        when(systemService.getFirmwareVersion()).thenReturn("test-fm-vers");
+        when(systemService.getCpuVersion()).thenReturn("test-cpu-vers");
+        when(systemService.getBiosVersion()).thenReturn("test-bios-vers");
+        when(systemService.getOsName()).thenReturn("test-os");
+        when(systemService.getOsVersion()).thenReturn("test-os-vers");
+        when(systemService.getJavaVmName()).thenReturn("test-jvm");
+        when(systemService.getJavaVmVersion()).thenReturn("test-jvm-vers");
+        when(systemService.getJavaVmInfo()).thenReturn("test-jvm-info");
+        when(systemService.getJavaVendor()).thenReturn("test-java-vendor");
+        when(systemService.getJavaVersion()).thenReturn("17");
+        when(systemService.getKuraVersion()).thenReturn("develop");
+        when(systemService.getNumberOfProcessors()).thenReturn(4);
+        when(systemService.getTotalMemory()).thenReturn(8000L);
+        when(systemService.getOsArch()).thenReturn("x86");
+        when(systemService.getOsgiFwName()).thenReturn("test-osgi-fm");
+        when(systemService.getOsgiFwVersion()).thenReturn("test-osgi-vers");
+        
+        SystemAdminService systemAdminService = mock(SystemAdminService.class);
+        when(systemAdminService.getUptime()).thenReturn("1 day");
+
+        Marshaller marshaller = new Marshaller() {
+
+            @Override
+            public String marshal(Object object) throws KuraException {
+                if (object instanceof KuraPayload) {
+                    return "this is a birth message";
+                }
+                return null;
+            }
+            
+        };
+
+        EventAdmin eventAdmin = mock(EventAdmin.class);
+        doNothing().when(eventAdmin).postEvent(any());
+
+        this.cloudService.setDataService(this.dataService);
+        this.cloudService.setSystemService(systemService);
+        this.cloudService.setSystemAdminService(systemAdminService);
+        this.cloudService.setJsonMarshaller(marshaller);
+        this.cloudService.setEventAdmin(eventAdmin);
+    }
+
+    private Map<String, Object> getDefaultProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ConfigurationService.KURA_SERVICE_PID, "test.pid");
+        properties.put("payload.encoding", "simple-json");
+        properties.put("topic.control-prefix", "$EDC");
+        properties.put("birth.cert.policy", "birth-connect-reconnect");
+        properties.put("republish.mqtt.birth.cert.on.gps.lock", true);
+        properties.put("republish.mqtt.birth.cert.on.modem.detect", true);
+        properties.put("republish.mqtt.birth.cert.on.tamper.event", true);
+
+        return properties;
+    }
+
+    private ComponentContext getMockComponentContext() {
+        Dictionary<String, Object> componentContextProperties = new Hashtable<>();
+        componentContextProperties.put(ConfigurationService.KURA_SERVICE_PID, "test.pid");
+
+        ServiceRegistration registration = mock(ServiceRegistration.class);
+        BundleContext bundleContext = mock(BundleContext.class);
+        when(bundleContext.registerService(ArgumentMatchers.anyString(), ArgumentMatchers.any(),
+                ArgumentMatchers.any(Dictionary.class))).thenReturn(registration);
+
+        ComponentContext componentContext = mock(ComponentContext.class);
+        when(componentContext.getProperties()).thenReturn(componentContextProperties);
+        when(componentContext.getBundleContext()).thenReturn(bundleContext);
+        
+
+        return componentContext;
+    }
+
+    private Object anyObject() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}


### PR DESCRIPTION
This PR caches the BIRTH and APP messages for 30 seconds before sending, resetting the timer when new BIRTH messages arrive. On new connections or on disconnect, the BIRTH messages are always sent immediately.

APP messages are guaranteed to be always sent only if the CC is connected; this means after the first connection BIRTH.

It is sufficient to send only the last APP/BIRTH message; the payload is not incremental and contains all the metrics available at that moment (hence the last message contains the most updated system picture).

The changes are made for `core.cloud` and reflected into the `cloudconnection.eclipseiot.mqtt.cloud` package.