### PR TITLE
fix(network.threat.manager): Added default flooding protection rules for filter table

### DIFF
--- a/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/AbstractFirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/AbstractFirewallConfigurationServiceImpl.java
@@ -14,7 +14,6 @@ package org.eclipse.kura.net.admin;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -355,11 +354,4 @@ public abstract class AbstractFirewallConfigurationServiceImpl<U extends IPAddre
         return this.firewall.getPortForwardRules();
     }
 
-    public void addFloodingProtectionRules(Set<String> floodingRules) {
-        try {
-            this.firewall.setAdditionalRules(new HashSet<>(), new HashSet<>(), floodingRules);
-        } catch (KuraException e) {
-            logger.error("Failed to set Firewall Flooding Protection Configuration", e);
-        }
-    }
 }

--- a/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -16,7 +16,10 @@ import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_P
 import static org.osgi.framework.Constants.SERVICE_PID;
 
 import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
@@ -46,6 +49,12 @@ public class FirewallConfigurationServiceImpl extends
         implements FirewallConfigurationService, SelfConfiguringComponent {
 
     private static final Logger logger = LoggerFactory.getLogger(FirewallConfigurationServiceImpl.class);
+    private static final String[] FP_FILTER_RULES = {
+            "-A input-kura -p tcp -m connlimit --connlimit-above 111 -j REJECT --reject-with tcp-reset",
+            "-A input-kura -p tcp --tcp-flags RST RST -m limit --limit 2/s --limit-burst 2 -j ACCEPT",
+            "-A input-kura -p tcp --tcp-flags RST RST -j DROP",
+            "-A input-kura -p tcp -m conntrack --ctstate NEW -m limit --limit 60/s --limit-burst 20 -j ACCEPT",
+            "-A input-kura -p tcp -m conntrack --ctstate NEW -j DROP" };
 
     @Override
     protected FirewallConfiguration buildFirewallConfigurationFromProperties(Map<String, Object> properties) {
@@ -141,7 +150,23 @@ public class FirewallConfigurationServiceImpl extends
         if (this.firewall == null) {
             this.firewall = LinuxFirewall.getInstance(this.executorService);
         }
-
         return this.firewall;
+    }
+
+    @Override
+    public void addFloodingProtectionRules(Set<String> floodingRules) {
+        // Since the flooding protection rules passed as a parameter
+        // is only for the mangle table, a default set of rules for the
+        // filter tables is added.
+        try {
+            if (floodingRules == null || floodingRules.isEmpty()) {
+                this.firewall.setAdditionalRules(new HashSet<>(), new HashSet<>(), new HashSet<>());
+            } else {
+                this.firewall.setAdditionalRules(new HashSet<>(Arrays.asList(FP_FILTER_RULES)), new HashSet<>(),
+                        floodingRules);
+            }
+        } catch (KuraException e) {
+            logger.error("Failed to set Firewall Flooding Protection Configuration", e);
+        }
     }
 }

--- a/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/ipv6/FirewallConfigurationServiceIPv6Impl.java
+++ b/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/ipv6/FirewallConfigurationServiceIPv6Impl.java
@@ -17,6 +17,7 @@ import static org.osgi.framework.Constants.SERVICE_PID;
 
 import java.net.UnknownHostException;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
@@ -138,5 +139,10 @@ public class FirewallConfigurationServiceIPv6Impl extends
         tocd.addAD(tad);
 
         return tocd;
+    }
+
+    @Override
+    public void addFloodingProtectionRules(Set<String> floodingRules) {
+        throw new UnsupportedOperationException("Unimplemented method 'addFloodingProtectionRules'");
     }
 }

--- a/kura/test/org.eclipse.kura.net.admin.firewall.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.firewall.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
@@ -568,11 +568,50 @@ public class FirewallConfigurationServiceImplTest {
                 "-A prerouting-kura -p tcp --tcp-flags ALL SYN,FIN,PSH,URG -j DROP",
                 "-A prerouting-kura -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP",
                 "-A prerouting-kura -p icmp -j DROP", "-A prerouting-kura -f -j DROP" };
+        Set<String> floodingRulesSet = new HashSet<>(Arrays.asList(floodingRules));
+        String[] floodingFilterRules = {
+                "-A input-kura -p tcp -m connlimit --connlimit-above 111 -j REJECT --reject-with tcp-reset",
+                "-A input-kura -p tcp --tcp-flags RST RST -m limit --limit 2/s --limit-burst 2 -j ACCEPT",
+                "-A input-kura -p tcp --tcp-flags RST RST -j DROP",
+                "-A input-kura -p tcp -m conntrack --ctstate NEW -m limit --limit 60/s --limit-burst 20 -j ACCEPT",
+                "-A input-kura -p tcp -m conntrack --ctstate NEW -j DROP" };
+        Set<String> floodingFilterRulesSet = new HashSet<>(Arrays.asList(floodingFilterRules));
 
-        svc.addFloodingProtectionRules(new HashSet<>(Arrays.asList(floodingRules)));
+        svc.addFloodingProtectionRules(floodingRulesSet);
 
         try {
-            verify(mockFirewall, times(1)).setAdditionalRules(any(), any(), any());
+            verify(mockFirewall, times(1)).setAdditionalRules(floodingFilterRulesSet, new HashSet<>(),
+                    floodingRulesSet);
+        } catch (KuraException e) {
+            assert (false);
+        }
+    }
+
+    @Test
+    public void addEmptyFloodingProtectionRulesTest() {
+        final LinuxFirewall mockFirewall = mock(LinuxFirewall.class);
+
+        FirewallConfigurationServiceImpl svc = new FirewallConfigurationServiceImpl() {
+
+            @Override
+            protected LinuxFirewall getLinuxFirewall() {
+                return mockFirewall;
+            }
+
+            @Override
+            public synchronized void updated(Map<String, Object> properties) {
+                // don't care about the properties in this test
+                // update is not called when adding flooding protection rules,
+                // it is called just during activate
+            }
+        };
+
+        ComponentContext mockContext = mock(ComponentContext.class);
+        svc.activate(mockContext, new HashMap<String, Object>());
+        svc.addFloodingProtectionRules(new HashSet<>());
+
+        try {
+            verify(mockFirewall, times(1)).setAdditionalRules(new HashSet<>(), new HashSet<>(), new HashSet<>());
         } catch (KuraException e) {
             assert (false);
         }

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
@@ -548,11 +548,50 @@ public class FirewallConfigurationServiceImplTest {
                 "-A prerouting-kura -p tcp --tcp-flags ALL SYN,FIN,PSH,URG -j DROP",
                 "-A prerouting-kura -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP",
                 "-A prerouting-kura -p icmp -j DROP", "-A prerouting-kura -f -j DROP" };
+        Set<String> floodingRulesSet = new HashSet<>(Arrays.asList(floodingRules));
+        String[] floodingFilterRules = {
+                "-A input-kura -p tcp -m connlimit --connlimit-above 111 -j REJECT --reject-with tcp-reset",
+                "-A input-kura -p tcp --tcp-flags RST RST -m limit --limit 2/s --limit-burst 2 -j ACCEPT",
+                "-A input-kura -p tcp --tcp-flags RST RST -j DROP",
+                "-A input-kura -p tcp -m conntrack --ctstate NEW -m limit --limit 60/s --limit-burst 20 -j ACCEPT",
+                "-A input-kura -p tcp -m conntrack --ctstate NEW -j DROP" };
+        Set<String> floodingFilterRulesSet = new HashSet<>(Arrays.asList(floodingFilterRules));
 
-        svc.addFloodingProtectionRules(new HashSet<>(Arrays.asList(floodingRules)));
+        svc.addFloodingProtectionRules(floodingRulesSet);
 
         try {
-            verify(mockFirewall, times(1)).setAdditionalRules(any(), any(), any());
+            verify(mockFirewall, times(1)).setAdditionalRules(floodingFilterRulesSet, new HashSet<>(),
+                    floodingRulesSet);
+        } catch (KuraException e) {
+            assert (false);
+        }
+    }
+
+    @Test
+    public void addEmptyFloodingProtectionRulesTest() {
+        final LinuxFirewall mockFirewall = mock(LinuxFirewall.class);
+
+        FirewallConfigurationServiceImpl svc = new FirewallConfigurationServiceImpl() {
+
+            @Override
+            protected LinuxFirewall getLinuxFirewall() {
+                return mockFirewall;
+            }
+
+            @Override
+            public synchronized void updated(Map<String, Object> properties) {
+                // don't care about the properties in this test
+                // update is not called when adding flooding protection rules,
+                // it is called just during activate
+            }
+        };
+
+        ComponentContext mockContext = mock(ComponentContext.class);
+        svc.activate(mockContext, new HashMap<String, Object>());
+        svc.addFloodingProtectionRules(new HashSet<>());
+
+        try {
+            verify(mockFirewall, times(1)).setAdditionalRules(new HashSet<>(), new HashSet<>(), new HashSet<>());
         } catch (KuraException e) {
             assert (false);
         }


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds a default set of rules for the firewall filter table if the flooding protection is enabled.

**Description of the solution adopted:** The `network.threat.manager` adds a set of firewall rules for flooding protection. These rules are mainly applied to the mangle table, but there are situations where more rules are needed to the filter tables. The current `FirewalConfigurationServiceImpl.addFloodingProtectionRules` method doesn't allow this, so this PR adds a basic set of default rules to the filter tables when the flooding protection is enabled.

The code is replicated both in the old `org.eclipse.kura.net.admin` and the new `org.eclipse.kura.net.admin.firewall`.
