### PR TITLE
feat(net.admin): added method for applying additional firewall rules to all tables

### DIFF
--- a/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/AbstractFirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/AbstractFirewallConfigurationServiceImpl.java
@@ -14,7 +14,6 @@ package org.eclipse.kura.net.admin;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -355,11 +354,4 @@ public abstract class AbstractFirewallConfigurationServiceImpl<U extends IPAddre
         return this.firewall.getPortForwardRules();
     }
 
-    public void addFloodingProtectionRules(Set<String> floodingRules) {
-        try {
-            this.firewall.setAdditionalRules(new HashSet<>(), new HashSet<>(), floodingRules);
-        } catch (KuraException e) {
-            logger.error("Failed to set Firewall Flooding Protection Configuration", e);
-        }
-    }
 }

--- a/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationService.java
+++ b/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationService.java
@@ -67,9 +67,32 @@ public interface FirewallConfigurationService {
      * Adds flooding protection rules to the firewall configuration.
      * 
      * @param floodingRules
-     *            the set of rules specified as Strings to protect against
+     *            Set of rules specified as Strings to protect against
      *            flooding attacks
+     * 
+     * @deprecated since 2.6. Use {@link addFloodingProtectionRules(Set<String> filterFloodingRules, Set<String>
+     *             natFloodingRules, Set<String> mangleFloodingRules)} instead.
      */
+    @Deprecated
     public void addFloodingProtectionRules(Set<String> floodingRules);
+
+    /**
+     * Adds flooding protection rules to the firewall configuration
+     * in the FILTER, NAT and MANGLE tables.
+     * 
+     * @param filterFloodingRules
+     *            Set of FILTER rules specified as Strings to protect against
+     *            flooding attacks
+     * @param natFloodingRules
+     *            Set of NAT rules specified as Strings to protect against
+     *            flooding attacks
+     * @param mangleFloodingRules
+     *            Set of MANGLE rules specified as Strings to protect against
+     *            flooding attacks
+     * 
+     * @since 2.6
+     */
+    public void addFloodingProtectionRules(Set<String> filterFloodingRules, Set<String> natFloodingRules,
+            Set<String> mangleFloodingRules);
 
 }

--- a/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -16,7 +16,9 @@ import static org.eclipse.kura.configuration.ConfigurationService.KURA_SERVICE_P
 import static org.osgi.framework.Constants.SERVICE_PID;
 
 import java.net.UnknownHostException;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
@@ -141,7 +143,22 @@ public class FirewallConfigurationServiceImpl extends
         if (this.firewall == null) {
             this.firewall = LinuxFirewall.getInstance(this.executorService);
         }
-
         return this.firewall;
+    }
+
+    @Override
+    public void addFloodingProtectionRules(Set<String> floodingRules) {
+        // The flooding protection rules are applied only to the mangle table.
+        addFloodingProtectionRules(new HashSet<>(), new HashSet<>(), floodingRules);
+    }
+
+    @Override
+    public void addFloodingProtectionRules(Set<String> filterFloodingRules, Set<String> natFloodingRules,
+            Set<String> mangleFloodingRules) {
+        try {
+            this.firewall.setAdditionalRules(filterFloodingRules, natFloodingRules, mangleFloodingRules);
+        } catch (KuraException e) {
+            logger.error("Failed to set Firewall Flooding Protection Configuration", e);
+        }
     }
 }

--- a/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/ipv6/FirewallConfigurationServiceIPv6Impl.java
+++ b/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/ipv6/FirewallConfigurationServiceIPv6Impl.java
@@ -17,6 +17,7 @@ import static org.osgi.framework.Constants.SERVICE_PID;
 
 import java.net.UnknownHostException;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
@@ -138,5 +139,16 @@ public class FirewallConfigurationServiceIPv6Impl extends
         tocd.addAD(tad);
 
         return tocd;
+    }
+
+    @Override
+    public void addFloodingProtectionRules(Set<String> floodingRules) {
+        throw new UnsupportedOperationException("Unimplemented method 'addFloodingProtectionRules'");
+    }
+
+    @Override
+    public void addFloodingProtectionRules(Set<String> filterFloodingRules, Set<String> natFloodingRules,
+            Set<String> mangleFloodingRules) {
+        throw new UnsupportedOperationException("Unimplemented method 'addFloodingProtectionRules'");
     }
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationService.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -67,8 +67,32 @@ public interface FirewallConfigurationService {
      * Adds flooding protection rules to the firewall configuration.
      * 
      * @param floodingRules
-     *            Set of rules specified as Strings to protect against flooding attacks
+     *            Set of rules specified as Strings to protect against
+     *            flooding attacks
+     * 
+     * @deprecated since 2.6. Use {@link addFloodingProtectionRules(Set<String> filterFloodingRules, Set<String>
+     *             natFloodingRules, Set<String> mangleFloodingRules)} instead.
      */
+    @Deprecated
     public void addFloodingProtectionRules(Set<String> floodingRules);
+
+    /**
+     * Adds flooding protection rules to the firewall configuration
+     * in the FILTER, NAT and MANGLE tables.
+     * 
+     * @param filterFloodingRules
+     *            Set of FILTER rules specified as Strings to protect against
+     *            flooding attacks
+     * @param natFloodingRules
+     *            Set of NAT rules specified as Strings to protect against
+     *            flooding attacks
+     * @param mangleFloodingRules
+     *            Set of MANGLE rules specified as Strings to protect against
+     *            flooding attacks
+     * 
+     * @since 2.6
+     */
+    public void addFloodingProtectionRules(Set<String> filterFloodingRules, Set<String> natFloodingRules,
+            Set<String> mangleFloodingRules);
 
 }

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -406,8 +406,15 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
 
     @Override
     public void addFloodingProtectionRules(Set<String> floodingRules) {
+        // The flooding protection rules are applied only to the mangle table.
+        addFloodingProtectionRules(new HashSet<>(), new HashSet<>(), floodingRules);
+    }
+
+    @Override
+    public void addFloodingProtectionRules(Set<String> filterFloodingRules, Set<String> natFloodingRules,
+            Set<String> mangleFloodingRules) {
         try {
-            this.firewall.setAdditionalRules(new HashSet<>(), new HashSet<>(), floodingRules);
+            this.firewall.setAdditionalRules(filterFloodingRules, natFloodingRules, mangleFloodingRules);
         } catch (KuraException e) {
             logger.error("Failed to set Firewall Flooding Protection Configuration", e);
         }

--- a/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionConfigurator.java
+++ b/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2023 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import org.eclipse.kura.configuration.SelfConfiguringComponent;
 import org.eclipse.kura.core.configuration.ComponentConfigurationImpl;
 import org.eclipse.kura.security.FloodingProtectionConfigurationService;
 import org.eclipse.kura.security.ThreatManagerService;
-import org.osgi.service.component.ComponentContext;
 import org.eclipse.kura.net.admin.FirewallConfigurationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +43,7 @@ public class FloodingProtectionConfigurator
         }
     }
 
-    public void activate(ComponentContext componentContext, Map<String, Object> properties) {
+    public void activate(Map<String, Object> properties) {
         logger.info("Activating FloodingConfigurator...");
         doUpdate(properties);
         logger.info("Activating FloodingConfigurator... Done.");
@@ -56,7 +55,7 @@ public class FloodingProtectionConfigurator
         logger.info("Updating FloodingConfigurator... Done.");
     }
 
-    public void deactivate(ComponentContext componentContext) {
+    public void deactivate() {
         logger.info("Deactivating FloodingConfigurator...");
         logger.info("Deactivating FloodingConfigurator... Done.");
     }
@@ -64,8 +63,10 @@ public class FloodingProtectionConfigurator
     private void doUpdate(Map<String, Object> properties) {
         logger.info("Updating firewall configuration...");
         this.floodingProtectionOptions = new FloodingProtectionOptions(properties);
-        this.firewallService
-                .addFloodingProtectionRules(this.floodingProtectionOptions.getFloodingProtectionMangleRules());
+        Set<String> filterRules = this.floodingProtectionOptions.getFloodingProtectionFilterRules();
+        Set<String> natRules = this.floodingProtectionOptions.getFloodingProtectionNatRules();
+        Set<String> mangleRules = this.floodingProtectionOptions.getFloodingProtectionMangleRules();
+        this.firewallService.addFloodingProtectionRules(filterRules, natRules, mangleRules);
         logger.info("Updating firewall configuration... Done.");
     }
 

--- a/kura/test/org.eclipse.kura.net.admin.firewall.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.firewall.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -528,54 +527,6 @@ public class FirewallConfigurationServiceImplTest {
 
         svc.setFirewallOpenPortConfiguration(firewallConfiguration);
 
-    }
-
-    @Test
-    public void addFloodingProtectionRulesTest() {
-        final LinuxFirewall mockFirewall = mock(LinuxFirewall.class);
-
-        FirewallConfigurationServiceImpl svc = new FirewallConfigurationServiceImpl() {
-
-            @Override
-            protected LinuxFirewall getLinuxFirewall() {
-                return mockFirewall;
-            }
-
-            @Override
-            public synchronized void updated(Map<String, Object> properties) {
-                // don't care about the properties in this test
-                // update is not called when adding flooding protection rules,
-                // it is called just during activate
-            }
-        };
-
-        ComponentContext mockContext = mock(ComponentContext.class);
-        svc.activate(mockContext, new HashMap<String, Object>());
-
-        String[] floodingRules = { "-A prerouting-kura -m conntrack --ctstate INVALID -j DROP",
-                "-A prerouting-kura -p tcp ! --syn -m conntrack --ctstate NEW -j DROP",
-                "-A prerouting-kura -p tcp -m conntrack --ctstate NEW -m tcpmss ! --mss 536:65535 -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags FIN,SYN FIN,SYN -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags SYN,RST SYN,RST -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags FIN,RST FIN,RST -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags FIN,ACK FIN -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ACK,URG URG -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ACK,FIN FIN -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ACK,PSH PSH -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL ALL -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL NONE -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL FIN,PSH,URG -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL SYN,FIN,PSH,URG -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP",
-                "-A prerouting-kura -p icmp -j DROP", "-A prerouting-kura -f -j DROP" };
-
-        svc.addFloodingProtectionRules(new HashSet<>(Arrays.asList(floodingRules)));
-
-        try {
-            verify(mockFirewall, times(1)).setAdditionalRules(any(), any(), any());
-        } catch (KuraException e) {
-            assert (false);
-        }
     }
 
 }

--- a/kura/test/org.eclipse.kura.net.admin.firewall.test/src/test/java/org/eclipse/kura/net/admin/FirewallFloodingProtectionTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.firewall.test/src/test/java/org/eclipse/kura/net/admin/FirewallFloodingProtectionTest.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.net.admin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.linux.net.iptables.AbstractLinuxFirewall;
+import org.eclipse.kura.linux.net.iptables.LinuxFirewall;
+import org.eclipse.kura.linux.net.iptables.LinuxFirewallIPv6;
+import org.eclipse.kura.net.admin.ipv6.FirewallConfigurationServiceIPv6Impl;
+import org.junit.Test;
+import org.osgi.service.component.ComponentContext;
+
+public class FirewallFloodingProtectionTest {
+
+    private final String[] floodingFilterRules = { "first filter rule", "second filter rule" };
+    private final String[] floodingNatRules = { "first nat rule", "second nat rule" };
+    private final String[] floodingMangleRules = { "first mangle rule", "second mangle rule" };
+    private final Set<String> filterRules = new HashSet<>(Arrays.asList(floodingFilterRules));
+    private final Set<String> natRules = new HashSet<>(Arrays.asList(floodingNatRules));
+    private final Set<String> mangleRules = new HashSet<>(Arrays.asList(floodingMangleRules));
+
+    private AbstractLinuxFirewall mockFirewall;
+    private FirewallConfigurationServiceImpl firewallService;
+    private FirewallConfigurationServiceIPv6Impl firewallServiceIPv6;
+    private Exception occurredException;
+
+    @Test
+    public void shouldAddFloodingProtectionRulesOnlyToMangleTableTest() {
+        givenFirewallConfigurationServiceImpl();
+
+        whenFirewallConfigurationServiceImplIsActivated();
+        whenFloodingProtectionRulesAreAddedToMangleTable();
+
+        thenSetAdditionalRulesToMangleOnlyIsCalled();
+    }
+
+    @Test
+    public void shouldAddFloodingProtectionRulesToAllTablesTest() {
+        givenFirewallConfigurationServiceImpl();
+
+        whenFirewallConfigurationServiceImplIsActivated();
+        whenFloodingProtectionRulesAreAdded();
+
+        thenSetAdditionalRulesIsCalled();
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAddRulesToMangleIPv6() {
+        givenFirewallConfigurationServiceIPv6Impl();
+
+        whenFirewallConfigurationServiceIPv6ImplIsActivated();
+        whenFloodingProtectionRulesAreAddedToMangleTableIpv6();
+
+        thenExceptionIsThrown(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAddRulesIPv6() {
+        givenFirewallConfigurationServiceIPv6Impl();
+
+        whenFirewallConfigurationServiceIPv6ImplIsActivated();
+        whenFloodingProtectionRulesAreAddedIPv6();
+
+        thenExceptionIsThrown(UnsupportedOperationException.class);
+    }
+
+    private void givenFirewallConfigurationServiceImpl() {
+        this.mockFirewall = mock(LinuxFirewall.class);
+        this.firewallService = new FirewallConfigurationServiceImpl() {
+
+            @Override
+            protected AbstractLinuxFirewall getLinuxFirewall() {
+                return mockFirewall;
+            }
+
+            @Override
+            public synchronized void updated(Map<String, Object> properties) {
+            }
+        };
+    }
+
+    private void givenFirewallConfigurationServiceIPv6Impl() {
+        this.mockFirewall = mock(LinuxFirewallIPv6.class);
+        this.firewallServiceIPv6 = new FirewallConfigurationServiceIPv6Impl() {
+
+            @Override
+            protected AbstractLinuxFirewall getLinuxFirewall() {
+                return mockFirewall;
+            }
+
+            @Override
+            public synchronized void updated(Map<String, Object> properties) {
+            }
+        };
+    }
+
+    private void whenFirewallConfigurationServiceImplIsActivated() {
+        ComponentContext mockContext = mock(ComponentContext.class);
+        firewallService.activate(mockContext, new HashMap<String, Object>());
+    }
+
+    private void whenFirewallConfigurationServiceIPv6ImplIsActivated() {
+        ComponentContext mockContext = mock(ComponentContext.class);
+        firewallServiceIPv6.activate(mockContext, new HashMap<String, Object>());
+    }
+
+    private void whenFloodingProtectionRulesAreAddedToMangleTable() {
+        firewallService.addFloodingProtectionRules(this.mangleRules);
+    }
+
+    private void whenFloodingProtectionRulesAreAddedToMangleTableIpv6() {
+        try {
+            firewallServiceIPv6.addFloodingProtectionRules(this.mangleRules);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenFloodingProtectionRulesAreAdded() {
+        firewallService.addFloodingProtectionRules(this.filterRules, this.natRules, this.mangleRules);
+    }
+
+    private void whenFloodingProtectionRulesAreAddedIPv6() {
+        try {
+            firewallServiceIPv6.addFloodingProtectionRules(this.filterRules, this.natRules, this.mangleRules);
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void thenSetAdditionalRulesToMangleOnlyIsCalled() {
+        try {
+            verify(mockFirewall, times(1)).setAdditionalRules(new HashSet<String>(), new HashSet<String>(),
+                    this.mangleRules);
+        } catch (KuraException e) {
+            assert (false);
+        }
+    }
+
+    private void thenSetAdditionalRulesIsCalled() {
+        try {
+            verify(mockFirewall, times(1)).setAdditionalRules(this.filterRules, this.natRules, this.mangleRules);
+        } catch (KuraException e) {
+            assert (false);
+        }
+    }
+
+    private <E extends Exception> void thenExceptionIsThrown(Class<E> expectedException) {
+        assertNotNull(this.occurredException);
+        assertEquals(expectedException.getName(), this.occurredException.getClass().getName());
+    }
+}

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImplTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -508,54 +507,6 @@ public class FirewallConfigurationServiceImplTest {
         firewallConfiguration.add(builder.build());
         svc.setFirewallOpenPortConfiguration(firewallConfiguration);
 
-    }
-
-    @Test
-    public void addFloodingProtectionRulesTest() {
-        final LinuxFirewall mockFirewall = mock(LinuxFirewall.class);
-
-        FirewallConfigurationServiceImpl svc = new FirewallConfigurationServiceImpl() {
-
-            @Override
-            protected LinuxFirewall getLinuxFirewall() {
-                return mockFirewall;
-            }
-
-            @Override
-            public synchronized void updated(Map<String, Object> properties) {
-                // don't care about the properties in this test
-                // update is not called when adding flooding protection rules,
-                // it is called just during activate
-            }
-        };
-
-        ComponentContext mockContext = mock(ComponentContext.class);
-        svc.activate(mockContext, new HashMap<String, Object>());
-
-        String[] floodingRules = { "-A prerouting-kura -m conntrack --ctstate INVALID -j DROP",
-                "-A prerouting-kura -p tcp ! --syn -m conntrack --ctstate NEW -j DROP",
-                "-A prerouting-kura -p tcp -m conntrack --ctstate NEW -m tcpmss ! --mss 536:65535 -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags FIN,SYN FIN,SYN -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags SYN,RST SYN,RST -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags FIN,RST FIN,RST -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags FIN,ACK FIN -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ACK,URG URG -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ACK,FIN FIN -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ACK,PSH PSH -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL ALL -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL NONE -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL FIN,PSH,URG -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL SYN,FIN,PSH,URG -j DROP",
-                "-A prerouting-kura -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP",
-                "-A prerouting-kura -p icmp -j DROP", "-A prerouting-kura -f -j DROP" };
-
-        svc.addFloodingProtectionRules(new HashSet<>(Arrays.asList(floodingRules)));
-
-        try {
-            verify(mockFirewall, times(1)).setAdditionalRules(any(), any(), any());
-        } catch (KuraException e) {
-            assert (false);
-        }
     }
 
 }

--- a/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallFloodingProtectionTest.java
+++ b/kura/test/org.eclipse.kura.net.admin.test/src/test/java/org/eclipse/kura/net/admin/FirewallFloodingProtectionTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.net.admin;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.linux.net.iptables.LinuxFirewall;
+import org.junit.Test;
+import org.osgi.service.component.ComponentContext;
+
+public class FirewallFloodingProtectionTest {
+
+    private final String[] floodingFilterRules = { "first filter rule", "second filter rule" };
+    private final String[] floodingNatRules = { "first nat rule", "second nat rule" };
+    private final String[] floodingMangleRules = { "first mangle rule", "second mangle rule" };
+    private final Set<String> filterRules = new HashSet<>(Arrays.asList(floodingFilterRules));
+    private final Set<String> natRules = new HashSet<>(Arrays.asList(floodingNatRules));
+    private final Set<String> mangleRules = new HashSet<>(Arrays.asList(floodingMangleRules));
+
+    private LinuxFirewall mockFirewall;
+    private FirewallConfigurationServiceImpl firewallService;
+
+    @Test
+    public void shouldAddFloodingProtectionRulesOnlyToMangleTableTest() {
+        givenFirewallConfigurationServiceImpl();
+
+        whenFirewallConfigurationServiceImplIsActivated();
+        whenFloodingProtectionRulesAreAddedToMangleTable();
+
+        thenSetAdditionalRulesToMangleOnlyIsCalled();
+    }
+
+    @Test
+    public void shouldAddFloodingProtectionRulesToAllTablesTest() {
+        givenFirewallConfigurationServiceImpl();
+
+        whenFirewallConfigurationServiceImplIsActivated();
+        whenFloodingProtectionRulesAreAddedTable();
+
+        thenSetAdditionalRulesIsCalled();
+    }
+
+    private void givenFirewallConfigurationServiceImpl() {
+        this.mockFirewall = mock(LinuxFirewall.class);
+        this.firewallService = new FirewallConfigurationServiceImpl() {
+
+            @Override
+            protected LinuxFirewall getLinuxFirewall() {
+                return mockFirewall;
+            }
+
+            @Override
+            public synchronized void updated(Map<String, Object> properties) {
+            }
+        };
+    }
+
+    private void whenFirewallConfigurationServiceImplIsActivated() {
+        ComponentContext mockContext = mock(ComponentContext.class);
+        firewallService.activate(mockContext, new HashMap<String, Object>());
+    }
+
+    private void whenFloodingProtectionRulesAreAddedToMangleTable() {
+        firewallService.addFloodingProtectionRules(this.mangleRules);
+    }
+
+    private void whenFloodingProtectionRulesAreAddedTable() {
+        firewallService.addFloodingProtectionRules(this.filterRules, this.natRules, this.mangleRules);
+    }
+
+    private void thenSetAdditionalRulesToMangleOnlyIsCalled() {
+        try {
+            verify(mockFirewall, times(1)).setAdditionalRules(new HashSet<String>(), new HashSet<String>(),
+                    this.mangleRules);
+        } catch (KuraException e) {
+            assert (false);
+        }
+    }
+
+    private void thenSetAdditionalRulesIsCalled() {
+        try {
+            verify(mockFirewall, times(1)).setAdditionalRules(this.filterRules, this.natRules, this.mangleRules);
+        } catch (KuraException e) {
+            assert (false);
+        }
+    }
+}


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR add a method for applying additional firewall rules to FILTER, NAT and MANGLE tables. The old method has been deprecated. Moreover, the `org.eclipse.kura.network.threat.manager` has been updated accordingly.
