### PR TITLE
feat(core.cloud): publish BIRTH on EventAdmin install/uninstall events

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -332,7 +332,6 @@ public class CloudConnectionManagerImpl
                 || EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL.equals(topic)) && this.dataService.isConnected()) {
             logger.debug("CloudConnectionManagerImpl: received install/uninstall event, publishing BIRTH.");
             tryPublishBirthCertificate(false);
-            return;
         }
     }
     

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -320,16 +320,19 @@ public class CloudConnectionManagerImpl
 
         if (PositionLockedEvent.POSITION_LOCKED_EVENT_TOPIC.contains(topic)) {
             handlePositionLockedEvent();
+            return;
         }
 
         if (ModemReadyEvent.MODEM_EVENT_READY_TOPIC.contains(topic)) {
             handleModemReadyEvent(event);
+            return;
         }
 
         if ((EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL.equals(topic)
                 || EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL.equals(topic)) && this.dataService.isConnected()) {
             logger.debug("CloudConnectionManagerImpl: received install/uninstall event, publishing BIRTH.");
             tryPublishBirthCertificate(false);
+            return;
         }
     }
     

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -328,7 +328,7 @@ public class CloudConnectionManagerImpl
 
         if ((EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL.equals(topic)
                 || EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL.equals(topic)) && this.dataService.isConnected()) {
-            logger.debug("CloudServiceImpl: received install/uninstall event, publishing BIRTH.");
+            logger.debug("CloudConnectionManagerImpl: received install/uninstall event, publishing BIRTH.");
             tryPublishBirthCertificate(false);
         }
     }
@@ -652,14 +652,14 @@ public class CloudConnectionManagerImpl
     private void publishWithDelay(LifecycleMessage message) {
         if (Objects.nonNull(this.scheduledBirthPublisherFuture)) {
             this.scheduledBirthPublisherFuture.cancel(false);
-            logger.debug("CloudServiceImpl: BIRTH message cache timer restarted.");
+            logger.debug("CloudConnectionManagerImpl: BIRTH message cache timer restarted.");
         }
 
-        logger.debug("CloudServiceImpl: BIRTH message cached for 30s.");
+        logger.debug("CloudConnectionManagerImpl: BIRTH message cached for 30s.");
         
         this.scheduledBirthPublisherFuture = this.scheduledBirthPublisher.schedule(() -> {
             try {
-                logger.debug("CloudServiceImpl: publishing cached BIRTH message.");
+                logger.debug("CloudConnectionManagerImpl: publishing cached BIRTH message.");
                 publishLifeCycleMessage(message);
             } catch (KuraException e) {
                 logger.error("Error sending cached BIRTH/APP certificate.", e);

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -92,6 +92,9 @@ public class CloudConnectionManagerImpl
 
     private static final String CONNECTION_EVENT_PID_PROPERTY_KEY = "cloud.service.pid";
 
+    static final String EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL = "org/osgi/service/deployment/INSTALL";
+    static final String EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL = "org/osgi/service/deployment/UNINSTALL";
+
     private static final int NUM_CONCURRENT_CALLBACKS = 2;
 
     private static ExecutorService callbackExecutor = Executors.newFixedThreadPool(NUM_CONCURRENT_CALLBACKS);
@@ -250,7 +253,8 @@ public class CloudConnectionManagerImpl
         // install event listener for GPS locked event
         Dictionary<String, Object> props = new Hashtable<>();
         String[] eventTopics = { PositionLockedEvent.POSITION_LOCKED_EVENT_TOPIC,
-                ModemReadyEvent.MODEM_EVENT_READY_TOPIC };
+                ModemReadyEvent.MODEM_EVENT_READY_TOPIC, EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL,
+                EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL };
         props.put(EventConstants.EVENT_TOPIC, eventTopics);
         this.cloudServiceRegistration = this.ctx.getBundleContext().registerService(EventHandler.class.getName(), this,
                 props);
@@ -312,44 +316,66 @@ public class CloudConnectionManagerImpl
 
     @Override
     public void handleEvent(Event event) {
-        if (PositionLockedEvent.POSITION_LOCKED_EVENT_TOPIC.contains(event.getTopic())) {
-            // if we get a position locked event,
-            // republish the birth certificate only if we are configured to
-            logger.info("Handling PositionLockedEvent");
-            if (this.dataService.isConnected() && this.options.getRepubBirthCertOnGpsLock()) {
-                try {
-                    publishBirthCertificate(false);
-                } catch (KuraException e) {
-                    logger.warn("Cannot publish birth certificate", e);
-                }
-            }
-        } else if (ModemReadyEvent.MODEM_EVENT_READY_TOPIC.contains(event.getTopic())) {
-            logger.info("Handling ModemReadyEvent");
-            ModemReadyEvent modemReadyEvent = (ModemReadyEvent) event;
-            // keep these identifiers around until we can publish the certificate
-            this.imei = (String) modemReadyEvent.getProperty(ModemReadyEvent.IMEI);
-            this.imsi = (String) modemReadyEvent.getProperty(ModemReadyEvent.IMSI);
-            this.iccid = (String) modemReadyEvent.getProperty(ModemReadyEvent.ICCID);
-            this.rssi = (String) modemReadyEvent.getProperty(ModemReadyEvent.RSSI);
-            this.modemFwVer = (String) modemReadyEvent.getProperty(ModemReadyEvent.FW_VERSION);
-            logger.trace("handleEvent() :: IMEI={}", this.imei);
-            logger.trace("handleEvent() :: IMSI={}", this.imsi);
-            logger.trace("handleEvent() :: ICCID={}", this.iccid);
-            logger.trace("handleEvent() :: RSSI={}", this.rssi);
-            logger.trace("handleEvent() :: FW_VERSION={}", this.modemFwVer);
+        String topic = event.getTopic();
 
-            if (this.dataService.isConnected() && this.options.getRepubBirthCertOnModemDetection()
-                    && !((this.imei == null || this.imei.length() == 0 || ERROR.equals(this.imei))
-                            && (this.imsi == null || this.imsi.length() == 0 || ERROR.equals(this.imsi))
-                            && (this.iccid == null || this.iccid.length() == 0 || ERROR.equals(this.iccid)))) {
-                logger.debug("handleEvent() :: publishing BIRTH certificate ...");
-                try {
-                    publishBirthCertificate(false);
-                } catch (KuraException e) {
-                    logger.warn("Cannot publish birth certificate", e);
-                }
-            }
+        if (PositionLockedEvent.POSITION_LOCKED_EVENT_TOPIC.contains(topic)) {
+            handlePositionLockedEvent();
+        }
 
+        if (ModemReadyEvent.MODEM_EVENT_READY_TOPIC.contains(topic)) {
+            handleModemReadyEvent(event);
+        }
+
+        if ((EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL.equals(topic)
+                || EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL.equals(topic)) && this.dataService.isConnected()) {
+            logger.debug("CloudServiceImpl: received install/uninstall event, publishing BIRTH.");
+            tryPublishBirthCertificate(false);
+        }
+    }
+    
+    private void handlePositionLockedEvent() {
+        // if we get a position locked event,
+        // republish the birth certificate only if we are configured to
+        logger.info("Handling PositionLockedEvent");
+        if (this.dataService.isConnected() && this.options.getRepubBirthCertOnGpsLock()) {
+            tryPublishBirthCertificate(false);
+        }
+    }
+
+    private void handleModemReadyEvent(Event event) {
+        logger.info("Handling ModemReadyEvent");
+        ModemReadyEvent modemReadyEvent = (ModemReadyEvent) event;
+        // keep these identifiers around until we can publish the certificate
+        this.imei = (String) modemReadyEvent.getProperty(ModemReadyEvent.IMEI);
+        this.imsi = (String) modemReadyEvent.getProperty(ModemReadyEvent.IMSI);
+        this.iccid = (String) modemReadyEvent.getProperty(ModemReadyEvent.ICCID);
+        this.rssi = (String) modemReadyEvent.getProperty(ModemReadyEvent.RSSI);
+        this.modemFwVer = (String) modemReadyEvent.getProperty(ModemReadyEvent.FW_VERSION);
+        logger.trace("handleEvent() :: IMEI={}", this.imei);
+        logger.trace("handleEvent() :: IMSI={}", this.imsi);
+        logger.trace("handleEvent() :: ICCID={}", this.iccid);
+        logger.trace("handleEvent() :: RSSI={}", this.rssi);
+        logger.trace("handleEvent() :: FW_VERSION={}", this.modemFwVer);
+
+        if (this.dataService.isConnected() && this.options.getRepubBirthCertOnModemDetection() && isModemInfoValid()) {
+            logger.debug("handleEvent() :: publishing BIRTH certificate ...");
+            tryPublishBirthCertificate(false);
+        }
+    }
+
+    private boolean isModemInfoValid(final String modemInfo) {
+        return !(modemInfo == null || modemInfo.length() == 0 || modemInfo.equals(ERROR));
+    }
+
+    public boolean isModemInfoValid() {
+        return isModemInfoValid(this.imei) && isModemInfoValid(this.imsi) && isModemInfoValid(this.iccid);
+    }
+
+    private void tryPublishBirthCertificate(boolean isNewConnection) {
+        try {
+            publishBirthCertificate(isNewConnection);
+        } catch (KuraException e) {
+            logger.warn("Cannot publish birth certificate", e);
         }
     }
 

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -404,7 +404,6 @@ public class CloudServiceImpl
                 || EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL.equals(topic)) && this.dataService.isConnected()) {
             logger.debug("CloudServiceImpl: received install/uninstall event, publishing BIRTH.");
             tryPublishBirthCertificate(false);
-            return;
         }
     }
 

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -118,6 +118,9 @@ public class CloudServiceImpl
 
     private static final String CONNECTION_EVENT_PID_PROPERTY_KEY = "cloud.service.pid";
 
+    static final String EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL = "org/osgi/service/deployment/INSTALL";
+    static final String EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL = "org/osgi/service/deployment/UNINSTALL";
+
     private static final int NUM_CONCURRENT_CALLBACKS = 2;
 
     private static ExecutorService callbackExecutor = Executors.newFixedThreadPool(NUM_CONCURRENT_CALLBACKS);
@@ -302,7 +305,8 @@ public class CloudServiceImpl
         // install event listener for GPS locked event
         Dictionary<String, Object> props = new Hashtable<>();
         String[] eventTopics = { PositionLockedEvent.POSITION_LOCKED_EVENT_TOPIC,
-                ModemReadyEvent.MODEM_EVENT_READY_TOPIC, TamperEvent.TAMPER_EVENT_TOPIC };
+                ModemReadyEvent.MODEM_EVENT_READY_TOPIC, TamperEvent.TAMPER_EVENT_TOPIC,
+                EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL, EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL };
         props.put(EventConstants.EVENT_TOPIC, eventTopics);
         this.cloudServiceRegistration = this.ctx.getBundleContext().registerService(EventHandler.class.getName(), this,
                 props);
@@ -377,12 +381,25 @@ public class CloudServiceImpl
 
     @Override
     public void handleEvent(Event event) {
-        if (PositionLockedEvent.POSITION_LOCKED_EVENT_TOPIC.contains(event.getTopic())) {
+        String topic = event.getTopic();
+
+        if (PositionLockedEvent.POSITION_LOCKED_EVENT_TOPIC.contains(topic)) {
             handlePositionLockedEvent();
-        } else if (ModemReadyEvent.MODEM_EVENT_READY_TOPIC.contains(event.getTopic())) {
+        }
+
+        if (ModemReadyEvent.MODEM_EVENT_READY_TOPIC.contains(topic)) {
             handleModemReadyEvent(event);
-        } else if (TamperEvent.TAMPER_EVENT_TOPIC.equals(event.getTopic()) && this.dataService.isConnected()
+        }
+
+        if (TamperEvent.TAMPER_EVENT_TOPIC.equals(topic) && this.dataService.isConnected()
                 && this.options.getRepubBirthCertOnTamperEvent()) {
+            logger.debug("CloudServiceImpl: received tamper event, publishing BIRTH.");
+            tryPublishBirthCertificate(false);
+        }
+
+        if ((EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL.equals(topic)
+                || EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL.equals(topic)) && this.dataService.isConnected()) {
+            logger.debug("CloudServiceImpl: received install/uninstall event, publishing BIRTH.");
             tryPublishBirthCertificate(false);
         }
     }

--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -385,22 +385,26 @@ public class CloudServiceImpl
 
         if (PositionLockedEvent.POSITION_LOCKED_EVENT_TOPIC.contains(topic)) {
             handlePositionLockedEvent();
+            return;
         }
 
         if (ModemReadyEvent.MODEM_EVENT_READY_TOPIC.contains(topic)) {
             handleModemReadyEvent(event);
+            return;
         }
 
         if (TamperEvent.TAMPER_EVENT_TOPIC.equals(topic) && this.dataService.isConnected()
                 && this.options.getRepubBirthCertOnTamperEvent()) {
             logger.debug("CloudServiceImpl: received tamper event, publishing BIRTH.");
             tryPublishBirthCertificate(false);
+            return;
         }
 
         if ((EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL.equals(topic)
                 || EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL.equals(topic)) && this.dataService.isConnected()) {
             logger.debug("CloudServiceImpl: received install/uninstall event, publishing BIRTH.");
             tryPublishBirthCertificate(false);
+            return;
         }
     }
 

--- a/kura/test/org.eclipse.kura.core.cloud.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
+++ b/kura/test/org.eclipse.kura.core.cloud.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
@@ -205,6 +205,50 @@ public class BirthMessagesTest {
         thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicAppsSuffix());
     }
 
+    @Test
+    public void shouldPublishBirthOnInstalledEvent() throws KuraException {
+        givenDeploymentAdminPackageInstallEvent();
+        givenConfiguredCloudService();
+        givenConnected();
+
+        whenHandleEvent();
+
+        thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicBirthSuffix());
+    }
+
+    @Test
+    public void shouldPublishBirthOnUninstalledEvent() throws KuraException {
+        givenDeploymentAdminPackageUninstallEvent();
+        givenConfiguredCloudService();
+        givenConnected();
+
+        whenHandleEvent();
+
+        thenBirthIsPublishedAfter(SEND_DELAY, BIRTH_TOPIC_PREFIX + CloudServiceOptions.getTopicBirthSuffix());
+    }
+
+    @Test
+    public void shouldNotPublishBirthOnInstalledEventIfNotConnected() throws KuraException {
+        givenDeploymentAdminPackageInstallEvent();
+        givenConfiguredCloudService();
+        givenDisconnected();
+
+        whenHandleEvent();
+
+        thenNoBirthIsPublished();
+    }
+
+    @Test
+    public void shouldNotPublishBirthOnUninstalledEventIfNotConnected() throws KuraException {
+        givenDeploymentAdminPackageUninstallEvent();
+        givenConfiguredCloudService();
+        givenDisconnected();
+
+        whenHandleEvent();
+
+        thenNoBirthIsPublished();
+    }
+
     /*
      * Steps
      */
@@ -244,6 +288,13 @@ public class BirthMessagesTest {
         this.event = new Event(TamperEvent.TAMPER_EVENT_TOPIC, new HashMap<String, Object>());
     }
 
+    private void givenDeploymentAdminPackageInstallEvent() {
+        this.event = new Event(CloudServiceImpl.EVENT_TOPIC_DEPLOYMENT_ADMIN_INSTALL, new HashMap<String, Object>());
+    }
+
+    private void givenDeploymentAdminPackageUninstallEvent() {
+        this.event = new Event(CloudServiceImpl.EVENT_TOPIC_DEPLOYMENT_ADMIN_UNINSTALL, new HashMap<String, Object>());
+    }
 
     /*
      * When
@@ -435,11 +486,6 @@ public class BirthMessagesTest {
         
 
         return componentContext;
-    }
-
-    private Object anyObject() {
-        // TODO Auto-generated method stub
-        return null;
     }
 
 }


### PR DESCRIPTION
This PR modifies the standard `CloudService`s to publish a BIRTH certificate message on OSGi's EventAdmin install/uninstall events.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
