### PR TITLE
fix(linux.net): Replaced HashSet with LinkedHashSet

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/AbstractLinuxFirewall.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/iptables/AbstractLinuxFirewall.java
@@ -16,7 +16,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -42,9 +41,9 @@ public abstract class AbstractLinuxFirewall {
     protected Set<NATRule> autoNatRules = new LinkedHashSet<>();
     protected Set<NATRule> natRules = new LinkedHashSet<>();
     protected boolean allowIcmp = false;
-    protected final Set<String> additionalFilterRules = new HashSet<>();
-    protected final Set<String> additionalNatRules = new HashSet<>();
-    protected final Set<String> additionalMangleRules = new HashSet<>();
+    protected final Set<String> additionalFilterRules = new LinkedHashSet<>();
+    protected final Set<String> additionalNatRules = new LinkedHashSet<>();
+    protected final Set<String> additionalMangleRules = new LinkedHashSet<>();
     protected IptablesConfig iptables;
     protected CommandExecutorService executorService;
 

--- a/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/AbstractFirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin.firewall/src/main/java/org/eclipse/kura/net/admin/AbstractFirewallConfigurationServiceImpl.java
@@ -14,8 +14,8 @@ package org.eclipse.kura.net.admin;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -357,7 +357,7 @@ public abstract class AbstractFirewallConfigurationServiceImpl<U extends IPAddre
 
     public void addFloodingProtectionRules(Set<String> floodingRules) {
         // The flooding protection rules are applied only to the mangle table.
-        addFloodingProtectionRules(new HashSet<>(), new HashSet<>(), floodingRules);
+        addFloodingProtectionRules(new LinkedHashSet<>(), new LinkedHashSet<>(), floodingRules);
     }
 
     public void addFloodingProtectionRules(Set<String> filterFloodingRules, Set<String> natFloodingRules,

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/FirewallConfigurationServiceImpl.java
@@ -17,8 +17,8 @@ import static org.osgi.framework.Constants.SERVICE_PID;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -407,7 +407,7 @@ public class FirewallConfigurationServiceImpl implements FirewallConfigurationSe
     @Override
     public void addFloodingProtectionRules(Set<String> floodingRules) {
         // The flooding protection rules are applied only to the mangle table.
-        addFloodingProtectionRules(new HashSet<>(), new HashSet<>(), floodingRules);
+        addFloodingProtectionRules(new LinkedHashSet<>(), new LinkedHashSet<>(), floodingRules);
     }
 
     @Override


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

In order to preserve the firewall rules ordering, the `HashSet` are replaced by `LinkedHashSet`.
