### PR TITLE
docs: added basic WPA enterprise documentation

### DIFF
--- a/docs/gateway-configuration/wifi-configuration.md
+++ b/docs/gateway-configuration/wifi-configuration.md
@@ -29,7 +29,7 @@ The **Wireless** tab contains the following configuration parameters:
     - WEP: Wired Equivalent Privacy
     - WPA: Wi-Fi Protected Access
     - WPA2: Wi-Fi Protected Access II
-    - WPA2/WPA3-Enterprise: Wi-Fi Protected Access II & III with 802.1x Support (Only available in station mode with generic profiles)
+    - WPA2/WPA3-Enterprise: Wi-Fi Protected Access II & III with 802.1x Support (Only available in station mode with [generic profiles](/getting-started/install-kura/#installer-types))
 
 - **Wireless Password**: sets the password for the wireless network.
     - WEP: 64-bit or 128-bit encryption key

--- a/docs/gateway-configuration/wifi-configuration.md
+++ b/docs/gateway-configuration/wifi-configuration.md
@@ -29,7 +29,7 @@ The **Wireless** tab contains the following configuration parameters:
     - WEP: Wired Equivalent Privacy
     - WPA: Wi-Fi Protected Access
     - WPA2: Wi-Fi Protected Access II
-    - WPA2/WPA3-Enterprise: Wi-Fi Protected Access II && III with 802.1x Support
+    - WPA2/WPA3-Enterprise: Wi-Fi Protected Access II & III with 802.1x Support (Only available in station mode with generic profiles)
 
 - **Wireless Password**: sets the password for the wireless network.
     - WEP: 64-bit or 128-bit encryption key

--- a/docs/gateway-configuration/wifi-configuration.md
+++ b/docs/gateway-configuration/wifi-configuration.md
@@ -29,6 +29,7 @@ The **Wireless** tab contains the following configuration parameters:
     - WEP: Wired Equivalent Privacy
     - WPA: Wi-Fi Protected Access
     - WPA2: Wi-Fi Protected Access II
+    - WPA2/WPA3-Enterprise: Wi-Fi Protected Access II && III with 802.1x Support
 
 - **Wireless Password**: sets the password for the wireless network.
     - WEP: 64-bit or 128-bit encryption key


### PR DESCRIPTION

This PR adds Wifi Enterprise as one of the options under Wi-Fi Security.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** 

![image](https://github.com/eclipse/kura/assets/29900100/92a74eca-41cd-401c-806d-a6db767f9b06)

