### PR TITLE
fix(BaseKeystoreService): Add missing key generator provider

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/BaseKeystoreService.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/BaseKeystoreService.java
@@ -106,6 +106,10 @@ public abstract class BaseKeystoreService implements KeystoreService, Configurab
 
     private CRLManagerOptions crlManagerOptions;
 
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
     public void setEventAdmin(EventAdmin eventAdmin) {
         this.eventAdmin = eventAdmin;
     }
@@ -275,6 +279,7 @@ public abstract class BaseKeystoreService implements KeystoreService, Configurab
             setEntry(alias, new PrivateKeyEntry(keyPair.getPrivate(),
                     generateCertificateChain(keyPair, signatureAlgorithm, attributes)));
         } catch (GeneralSecurityException | OperatorCreationException e) {
+            logger.error("Error occured. Exception: {}.", e.getClass());
             throw new KuraException(KuraErrorCode.BAD_REQUEST);
         }
     }


### PR DESCRIPTION
## Problem
If you try to generate a key pair through the Rest API of the key store, you will get a `NoSuchProviderException`.

The reason is the following line:
```
KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm, "BC");
```
The bouncycastle provider is not registered, so the exception is thrown.
## Solution

The solution is to to register and instantiate the provider in a static {} method. This is similar to what other bundles have already.
```
  static {
        Security.addProvider(new BouncyCastleProvider());
    }
```

To replicate, just follow the instructions in https://eclipse.github.io/kura/docs-release-5.3/gateway-configuration/keys-and-certificates/#generate-keypair
## Replicate the problem
If you send this:
```
https://<gateway-ip>/services/keystores/v1/entries/keypair
{
    "keystoreServicePid":"MyKeystore",
    "alias":"keypair1",
    "algorithm" : "RSA",
    "size": 1024,
    "signatureAlgorithm" : "SHA256WithRSA",
    "attributes" : "CN=Kura, OU=IoT, O=Eclipse, C=US"
}
```

You get this:
```
2023-09-20T19:05:32,515 [MQTT Call: ***] INFO  o.e.k.c.c.CloudServiceImpl - Message arrived on topic: EDC/***/***/KEYS-V1/POST/keystores/entries/keypair
2023-09-20T19:05:32,518 [pool-21-thread-1] ERROR o.e.k.c.k.BaseKeystoreService - Error occured. Exception: class java.security.NoSuchProviderException
2023-09-20T19:05:32,519 [pool-21-thread-1] ERROR o.e.k.c.c.MessageHandlerCallable - Unexpected failure handling response
javax.ws.rs.WebApplicationException: HTTP 500 Internal Server Error
        at org.eclipse.kura.core.keystore.util.KeystoreRemoteService.storeKeyPairEntryInternal(KeystoreRemoteService.java:284)
        at org.eclipse.kura.core.keystore.request.handler.KeystoreServiceRequestHandlerV1.doPost(KeystoreServiceRequestHandlerV1.java:152)
        at org.eclipse.kura.core.cloud.MessageHandlerCallable.call(MessageHandlerCallable.java:147)
        at org.eclipse.kura.core.cloud.MessageHandlerCallable.call(MessageHandlerCallable.java:1)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
Caused by: org.eclipse.kura.KuraException: Bad request. {0}
        at org.eclipse.kura.core.keystore.BaseKeystoreService.createKeyPair(BaseKeystoreService.java:283)
        at org.eclipse.kura.core.keystore.BaseKeystoreService.createKeyPair(BaseKeystoreService.java:259)
        at org.eclipse.kura.core.keystore.util.KeystoreRemoteService.storeKeyPairEntryInternal(KeystoreRemoteService.java:280)
        ... 7 more
```
Note that another instance of the bc provider is created in the class inside the generateCertificateChain method:
```
Provider bcProvider = new BouncyCastleProvider();
Security.addProvider(bcProvider);
```
## Notes
One could probably reuse the new instance in the static{} method, but the actual solution works anyways. Security.addProvider() returns the following: _the preference position in which the provider was added, or -1 **if the provider was not added because it is already installed.**_ So it is not a problem to add the provider twice.
## Checks
After this change, the new rest api returns 200 and the keys are visible in the UI.
