### PR TITLE
fix(net.admin): Fix ipv6 threat manager

### DIFF
--- a/kura/org.eclipse.kura.net.admin/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.net.admin/META-INF/MANIFEST.MF
@@ -59,4 +59,5 @@ Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.kura.net.admin;version="1.6.0",
  org.eclipse.kura.net.admin.modem;version="2.0.0",
- org.eclipse.kura.net.admin.monitor;version="1.1.0"
+ org.eclipse.kura.net.admin.monitor;version="1.1.0",
+ org.eclipse.kura.net.admin.ipv6;version="1.0.0"

--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/ipv6/FirewallConfigurationServiceIPv6.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/ipv6/FirewallConfigurationServiceIPv6.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.net.admin.ipv6;
+
+import org.eclipse.kura.net.admin.FirewallConfigurationService;
+
+public interface FirewallConfigurationServiceIPv6 extends FirewallConfigurationService {
+
+    public static final String PID = "org.eclipse.kura.net.admin.ipv6.FirewallConfigurationServiceIPv6";
+
+}


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds the `FirewallConfigurationServiceIPv6` class to the `net.admin` bundle. In this way, the `network.threat.manager` can import the class and don't throw any exception at the activation. The service, however, is not exported, since the `net.admin` doesn't support IPv6.
