### PR TITLE
fix(api): Removed /0 from default IP6Address

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/IP6Address.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/IP6Address.java
@@ -36,7 +36,7 @@ public class IP6Address extends IPAddress {
      * @since 2.6
      */
     public static IP6Address getDefaultAddress() throws UnknownHostException {
-        return (IP6Address) IPAddress.parseHostAddress("::/0");
+        return (IP6Address) IPAddress.parseHostAddress("::");
     }
 
     /**


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR fixes the default IPv6 address, removing the /0. This prevents an exception when the address is parsed.