### PR TITLE
fix: resolved inconsistency for empty string csv input

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
@@ -145,11 +145,15 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
     @UiField
     CheckBox appendCheck;
     @UiField
+    CheckBox emptyStringCheck;
+    @UiField
     Hidden xsrfTokenField;
     @UiField
     Hidden assetPidField;
     @UiField
     Hidden driverPidField;
+    @UiField
+    Hidden emptyStringCheckField;
     @UiField
     Hidden appendCheckField;
     @UiField
@@ -229,6 +233,8 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
                             .getParameterValue(AssetConstants.ASSET_DRIVER_PROP.value()));
                     AssetConfigurationUi.this.appendCheckField
                             .setValue(AssetConfigurationUi.this.appendCheck.getValue().toString());
+                    AssetConfigurationUi.this.emptyStringCheckField
+                            .setValue(AssetConfigurationUi.this.emptyStringCheck.getValue().toString());
                     AssetConfigurationUi.this.uploadForm.submit();
                     AssetConfigurationUi.this.uploadModal.hide();
                     AssetConfigurationUi.this.formSubmitCallback = context.callback(completeEvent -> {
@@ -679,6 +685,12 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
         this.appendCheckField.setID("doReplace");
         this.appendCheckField.setName("doReplace");
         this.appendCheckField.setValue("");
+
+        this.emptyStringCheck.setName("emptyStringCheck");
+        this.emptyStringCheck.setValue(false);
+        this.emptyStringCheckField.setID("doEmptyStringConversion");
+        this.emptyStringCheckField.setName("doEmptyStringConversion");
+        this.emptyStringCheckField.setValue("");
 
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.ui.xml
@@ -104,6 +104,8 @@
                                     <b:FormGroup>
                                         <b:FormLabel>File</b:FormLabel>
                                         <g:FileUpload ui:field="filePath"></g:FileUpload>
+                                        <b:CheckBox ui:field="emptyStringCheck" text="{msgs.wiresEmptyStringCheck}"/>
+                                        <b:HelpBlock text="{msgs.wiresEmptyStringCheckHelpText}"/>
                                         <b:CheckBox ui:field="appendCheck" text="{msgs.wiresAppendChannelsCheck}"/>
                                         <b:HelpBlock text="{msgs.wiresAppendChannelsHelpText}"/>
                                     </b:FormGroup>
@@ -115,6 +117,7 @@
                                     <g:Hidden ui:field="assetPidField"></g:Hidden>
                                     <g:Hidden ui:field="driverPidField"></g:Hidden>
                                     <g:Hidden ui:field="appendCheckField"></g:Hidden>
+                                    <g:Hidden ui:field="emptyStringCheckField"></g:Hidden>
                                 </b:FieldSet>
                             </b:Form>
                         </b:Container>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/servlet/FileServlet.java
@@ -450,9 +450,10 @@ public class FileServlet extends AuditServlet {
             String csvString = new String(data, StandardCharsets.UTF_8);
             String assetPid = formFields.get("assetPid");
             String driverPid = formFields.get("driverPid");
+            Boolean nullValueAsEmptyString = Boolean.parseBoolean(formFields.get("doEmptyStringConversion"));
 
             List<GwtConfigParameter> parametersFromCsv = AssetConfigValidator.get().validateCsv(csvString, driverPid,
-                    errors);
+                    errors, nullValueAsEmptyString);
 
             final GwtConfigComponent config = new GwtConfigComponent();
             config.setParameters(parametersFromCsv);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/AssetConfigValidator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/AssetConfigValidator.java
@@ -88,10 +88,10 @@ public class AssetConfigValidator {
         private final List<Tad> adsByIndex;
         private final List<GwtConfigParameter> defaultValues;
 
-        public LineScanner(final List<Tad> fullChannelMetatype, final List<String> columnHeaders)
-                throws ValidationException {
+        public LineScanner(final List<Tad> fullChannelMetatype, final List<String> columnHeaders,
+                Boolean nullValueAsEmptyString) throws ValidationException {
             this.adsByIndex = probeAdsByIndex(fullChannelMetatype, columnHeaders);
-            this.defaultValues = probeDefaultValues(fullChannelMetatype, this.adsByIndex);
+            this.defaultValues = probeDefaultValues(fullChannelMetatype, this.adsByIndex, nullValueAsEmptyString);
         }
 
         private <T> Optional<T> findLast(final Collection<T> collection, final Predicate<T> predicate) {
@@ -170,7 +170,7 @@ public class AssetConfigValidator {
         }
 
         private List<GwtConfigParameter> probeDefaultValues(final List<Tad> fullChannelMetatype,
-                final List<Tad> boundAds) {
+                final List<Tad> boundAds, Boolean nullValueAsEmptyString) {
             final List<Tad> missing = fullChannelMetatype.stream()
                     .filter(c -> boundAds.stream().noneMatch(b -> b.getId().equals(c.getId())))
                     .collect(Collectors.toList());
@@ -184,7 +184,8 @@ public class AssetConfigValidator {
                 }
 
                 try {
-                    final Object defaultValue = validate(ad, ad.getDefault(), new ArrayList<>(), 0);
+                    final Object defaultValue = validate(ad, ad.getDefault(), new ArrayList<>(), 0,
+                            nullValueAsEmptyString);
                     result.add(GwtServerUtil.toGwtConfigParameter(ad, defaultValue));
                 } catch (final Exception e) {
                     logger.warn("Ad default value is probably not valid", e);
@@ -195,7 +196,7 @@ public class AssetConfigValidator {
         }
 
         public String scan(final CSVRecord line, final Consumer<GwtConfigParameter> parameterConsumer,
-                List<String> errors) {
+                List<String> errors, Boolean nullValueAsEmptyString) {
             String channelName = "";
             boolean errorInChannel = false;
             if (line.size() != adsByIndex.size()) {
@@ -213,7 +214,7 @@ public class AssetConfigValidator {
                             channelName = token;
                         }
                         final Tad ad = adsByIndex.get(i);
-                        final Object value = validate(ad, token, errors, lineNumber);
+                        final Object value = validate(ad, token, errors, lineNumber, nullValueAsEmptyString);
 
                         parameterConsumer.accept(GwtServerUtil.toGwtConfigParameter(ad, value));
                     } catch (Exception ex) {
@@ -231,8 +232,8 @@ public class AssetConfigValidator {
         }
     }
 
-    public List<GwtConfigParameter> validateCsv(String csv, String driverPid, List<String> errors)
-            throws ServletException {
+    public List<GwtConfigParameter> validateCsv(String csv, String driverPid, List<String> errors,
+            Boolean nullValueAsEmptyString) throws ServletException {
 
         try (CSVParser parser = CSVParser.parse(csv, CSVFormat.RFC4180)) {
             errors.clear();
@@ -250,11 +251,11 @@ public class AssetConfigValidator {
             final List<String> header = StreamSupport.stream(lines.remove(0).spliterator(), false)
                     .collect(Collectors.toList());
 
-            final LineScanner scanner = new LineScanner(fullChannelMetatype, header);
+            final LineScanner scanner = new LineScanner(fullChannelMetatype, header, nullValueAsEmptyString);
 
             lines.forEach(record -> {
                 final List<GwtConfigParameter> params = new ArrayList<>();
-                String channelName = scanner.scan(record, params::add, errors);
+                String channelName = scanner.scan(record, params::add, errors, nullValueAsEmptyString);
                 if (!channelName.isEmpty() && !channels.contains(channelName)) {
                     channels.add(channelName);
                     for (final GwtConfigParameter param : params) {
@@ -302,17 +303,18 @@ public class AssetConfigValidator {
     }
 
     // Validates all the entered values
-    protected Object validate(Tad field, String value, List<String> errors, int lineNumber) throws ValidationException {
+    protected Object validate(Tad field, String value, List<String> errors, int lineNumber,
+            Boolean nullValueAsEmptyString) throws ValidationException {
 
         String trimmedValue = value.trim();
         final boolean isEmpty = trimmedValue.isEmpty();
-        final boolean isEmptyString = field.getType().equals(Scalar.STRING);
+        final boolean convertNullToEmptyString = nullToEmptyStringValueManagement(field, nullValueAsEmptyString);
 
         if (field.isRequired() && isEmpty) {
             throw new ValidationException();
         }
 
-        if (isEmptyOrEmptyString(isEmpty, isEmptyString)) {
+        if (validateTrimmedValue(isEmpty, convertNullToEmptyString)) {
             // Validate "Options" field first. Data type will be taken care of next.
             if (!field.getOption().isEmpty()) {
                 boolean foundEqual = false;
@@ -363,8 +365,18 @@ public class AssetConfigValidator {
         return null;
     }
 
-    private boolean isEmptyOrEmptyString(boolean isEmpty, boolean isEmptyString) {
-        return !isEmpty || isEmptyString;
+    private boolean nullToEmptyStringValueManagement(Tad field, Boolean nullValueAsEmptyString) {
+
+        boolean returnValue = false;
+
+        if (nullValueAsEmptyString.booleanValue()) {
+            returnValue = field.getType().equals(Scalar.STRING);
+        }
+        return returnValue;
+    }
+
+    private boolean validateTrimmedValue(boolean isEmpty, boolean convertNullToEmptyString) {
+        return !isEmpty || convertNullToEmptyString;
     }
 
     protected interface ValidationErrorConsumer {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/AssetConfigValidator.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/AssetConfigValidator.java
@@ -34,6 +34,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.eclipse.kura.configuration.metatype.Option;
+import org.eclipse.kura.configuration.metatype.Scalar;
 import org.eclipse.kura.core.configuration.metatype.Tad;
 import org.eclipse.kura.driver.Driver;
 import org.eclipse.kura.internal.wire.asset.WireAssetChannelDescriptor;
@@ -305,12 +306,13 @@ public class AssetConfigValidator {
 
         String trimmedValue = value.trim();
         final boolean isEmpty = trimmedValue.isEmpty();
+        final boolean isEmptyString = field.getType().equals(Scalar.STRING);
 
         if (field.isRequired() && isEmpty) {
             throw new ValidationException();
         }
 
-        if (!isEmpty) {
+        if (isEmptyOrEmptyString(isEmpty, isEmptyString)) {
             // Validate "Options" field first. Data type will be taken care of next.
             if (!field.getOption().isEmpty()) {
                 boolean foundEqual = false;
@@ -359,6 +361,10 @@ public class AssetConfigValidator {
             }
         }
         return null;
+    }
+
+    private boolean isEmptyOrEmptyString(boolean isEmpty, boolean isEmptyString) {
+        return !isEmpty || isEmptyString;
     }
 
     protected interface ValidationErrorConsumer {

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -771,6 +771,8 @@ wiresDownloadChannels=Download Channels
 wiresUploadChannels=Upload Channels
 wiresNewChannel=New Channel
 wiresDeleteChannel=Delete Channel
+wiresEmptyStringCheck=Import empty values as empty strings.
+wiresEmptyStringCheckHelpText=If checked, empty values contained in the csv will be parsed as empty strings, for all those fields whose type is <String>.
 wiresAppendChannelsCheck=Replace current channels.
 wiresAppendChannelsHelpText=If checked, channels will be replaced by the imported ones. Otherwise, existing Asset configuration will be merged with the imported one, parameters values of imported channels will override the existing ones. The change will not be applied until Asset configuration is saved.
 

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -771,10 +771,10 @@ wiresDownloadChannels=Download Channels
 wiresUploadChannels=Upload Channels
 wiresNewChannel=New Channel
 wiresDeleteChannel=Delete Channel
-wiresEmptyStringCheck=Import empty values as empty strings.
+wiresEmptyStringCheck=Force import empty string policy.
 wiresEmptyStringCheckHelpText=If checked, empty values contained in the csv will be parsed as empty strings, for all those fields whose type is <String>.
 wiresAppendChannelsCheck=Replace current channels.
-wiresAppendChannelsHelpText=If checked, channels will be replaced by the imported ones. Otherwise, existing Asset configuration will be merged with the imported one, parameters values of imported channels will override the existing ones. The change will not be applied until Asset configuration is saved.
+wiresAppendChannelsHelpText=If checked, all typed channel fields that have an empty value in the input csv will be parsed as empty strings.
 
 wiresEmitters=Emitters
 wiresReceivers=Receivers


### PR DESCRIPTION
This PR fixes a bug occurring in the CSV channels upload in the asset section.

If the CSV file contained an empty value for a field that should be casted in string format, it was treated as a "null" value, so the default one from the metatype was set. The correct behaviour should be that an empty csv value should be considered as an empty string, not a null value.

This change can be very impactful on the behavior of all those drivers/assets/channels that read variables in fields like String. Let’s say the case of a string field `value` which is then casted in the code to an integer with a `Integer.decode`: at the current state of the art, if this channel is load from csv null field, the validator would set this to a default value from the metatype (for example "10") which would then be casted into an integer; with the modification of this PR, the csv would be read as "" and then would fail the decode because you would try to cast an empty value as integer.

An example of this variation is depicted in the image below: the cannels were loaded from a CSV cotaining all the `value` field empty (first image). The driver in reading phase, reads the values set in the `value` channel field and tries to cast it to the `value.type` type. The metatype set the default value to `0`, but passing a null value from the CSV, all values are considered as `""`, so the different casts fail (second image).

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** The validator will now check which is the field type of the CSV field, and if it's a string of type "", it's admitted and not considered as a null value.

**Screenshots:**
![csv_uploaded_channels](https://github.com/eclipse/kura/assets/109297780/24c85521-3097-4cee-bb3c-4c7f808c3550)
![csv_uploaded_channels_result](https://github.com/eclipse/kura/assets/109297780/e0d4ada5-5459-4596-a549-8cbc47ed45e7)


**Manual Tests**: Tested on Raspberry Pi 3b, Kura version: generic-aarch64

**Any side note on the changes made:**
