### PR TITLE
refactor(css): Improve Admin UI headers 

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/css/denali.css
@@ -71,6 +71,12 @@ body {
 	margin-bottom: 0.3cm;
 }
 
+.panel-default .panel-heading {
+	color: #2860a6 !important;
+	font-size: 16px;
+	font-weight: bold;
+}
+
 .panel:not(.help-panel):not(.network-interfaces-panel):not(.packages-dropzone-message), .panel-header:not(.help-panel) {
 	border: none !important;
 	border-radius: 0 !important;
@@ -83,6 +89,11 @@ body {
 
 .panel-body {
 	padding: 0 !important;
+}
+
+.panel-title {
+	color: #2860a6;
+	font-weight: bold;
 }
 
 .form-control {
@@ -656,6 +667,7 @@ Navbar START
 
 .nav-tabs li.active {
 	border-bottom: solid 0.1cm #2860A6;
+	background: #ffffff;
 }
 
 /**********************


### PR DESCRIPTION
This is a small change in the css to improve the look of the Admin UI:

1. Headers of sections "System" and "Services" are blue and bold (before just black), see `.panel-title`.
2. Headers of each page are blue, bold  and 16px (before just black and 14px), see `.panel-default .panel-heading`.
3. The tabs in the security section have white background if selected (same look&file as the tabs on the left side), see `.nav-tabs li.active`.

This is a minor improvement, but it increae the look&feel of the UI.

Example Section Header System:
![kura_header3](https://github.com/eclipse/kura/assets/36925048/d3f04580-f899-4e21-8d50-95cb0343879c)

Examples Page Header:
![kura_header2](https://github.com/eclipse/kura/assets/36925048/7fc82bf1-3547-4626-846f-67b3ff4adcc5)
![kura_header1](https://github.com/eclipse/kura/assets/36925048/190a4574-8dd4-44b2-b840-74aef7081912)

Example Tabs in Security:
![kura_tabs1](https://github.com/eclipse/kura/assets/36925048/f94df558-a333-4068-9792-b85baa690a02)
![kura_tabs2](https://github.com/eclipse/kura/assets/36925048/bb28371e-02ea-4deb-969c-eae942e75381)

Tested locally with the docker image.

I tried to avoid the !important, but the css instruction does not work without !important.

