### PR TITLE
ci: 'sonar.jacoco.reportPaths' is no longer supported, using JaCoCo's xml report instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,3 @@ bin/
 maven.deps
 DEPENDENCIES
 .java-version
-
-# VS Code
-.vscode
-javaConfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ bin/
 maven.deps
 DEPENDENCIES
 .java-version
+
+# VS Code
+.vscode
+javaConfig.json

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,6 @@ node {
                                 -Dsonar.branch.name=${BRANCH_NAME} \
                                 -Dsonar.branch.target=${CHANGE_TARGET} \
                                 -Dsonar.junit.reportPaths='target/surefire-reports' \
-                                -Dsonar.jacoco.reportPaths='target/jacoco/' \
                                 -Dsonar.java.binaries='target/' \
                                 -Dsonar.core.codeCoveragePlugin=jacoco \
                                 -Dsonar.projectKey=org.eclipse.kura:kura \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,6 @@ node {
                                 -Dsonar.login=${SONARCLOUD_TOKEN} \
                                 -Dsonar.branch.name=${BRANCH_NAME} \
                                 -Dsonar.branch.target=${CHANGE_TARGET} \
-                                -Dsonar.junit.reportPaths='target/surefire-reports' \
                                 -Dsonar.java.binaries='target/' \
                                 -Dsonar.core.codeCoveragePlugin=jacoco \
                                 -Dsonar.projectKey=org.eclipse.kura:kura \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ node {
                                 -Dsonar.login=${SONARCLOUD_TOKEN} \
                                 -Dsonar.branch.name=${BRANCH_NAME} \
                                 -Dsonar.branch.target=${CHANGE_TARGET} \
+                                -Dsonar.junit.reportPaths='kura/test/*/target/surefire-reports/*.xml,kura/examples/test/*/target/surefire-reports/*.xml' \
                                 -Dsonar.java.binaries='target/' \
                                 -Dsonar.core.codeCoveragePlugin=jacoco \
                                 -Dsonar.projectKey=org.eclipse.kura:kura \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ node {
                 withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.6.3') {
                     sh "touch /tmp/isJenkins.txt"
                     sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin" 
-                    sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin"
+                    sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin -Dmaven.test.skip=true"
                     // sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
                     sh "mvn -f kura/examples/pom.xml clean install -Pcheck-exists-plugin"
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ node {
                     sh "touch /tmp/isJenkins.txt"
                     sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin" 
                     sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin"
-                    sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
+                    // sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
                     sh "mvn -f kura/examples/pom.xml clean install -Pcheck-exists-plugin"
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,8 @@ node {
                 withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.6.3') {
                     sh "touch /tmp/isJenkins.txt"
                     sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin" 
-                    sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin -Dmaven.test.skip=true"
-                    // sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
+                    sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin"
+                    sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
                     sh "mvn -f kura/examples/pom.xml clean install -Pcheck-exists-plugin"
                 }
             }
@@ -29,11 +29,11 @@ node {
         }
     }
 
-    // stage('Archive .deb artifacts') {
-    //     dir("kura") {
-    //         archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
-    //     }
-    // }
+    stage('Archive .deb artifacts') {
+        dir("kura") {
+            archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
+        }
+    }
 
     stage('Sonar') {
         timeout(time: 2, unit: 'HOURS') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,6 @@ node {
                                 -Dsonar.login=${SONARCLOUD_TOKEN} \
                                 -Dsonar.branch.name=${BRANCH_NAME} \
                                 -Dsonar.branch.target=${CHANGE_TARGET} \
-                                -Dsonar.junit.reportPaths='kura/test/*/target/surefire-reports/*.xml,kura/examples/test/*/target/surefire-reports/*.xml' \
                                 -Dsonar.java.binaries='target/' \
                                 -Dsonar.core.codeCoveragePlugin=jacoco \
                                 -Dsonar.projectKey=org.eclipse.kura:kura \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,11 +29,11 @@ node {
         }
     }
 
-    stage('Archive .deb artifacts') {
-        dir("kura") {
-            archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
-        }
-    }
+    // stage('Archive .deb artifacts') {
+    //     dir("kura") {
+    //         archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
+    //     }
+    // }
 
     stage('Sonar') {
         timeout(time: 2, unit: 'HOURS') {

--- a/kura/examples/test/pom.xml
+++ b/kura/examples/test/pom.xml
@@ -269,7 +269,8 @@
         <kura.basedir>${project.basedir}/../..</kura.basedir>
         <tycho.argline>${jacocoArgs} -Dlog4j.configurationFile=file:${kura.basedir}/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml</tycho.argline>
         <jacoco.reportDir>target/jacoco/</jacoco.reportDir>
-        <sonar.jacoco.reportPath>target/jacoco.exec</sonar.jacoco.reportPath>
+        <sonar.coverage.jacoco.xmlReportPaths>
+                ${project.basedir}/../../test/*/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <modules>

--- a/kura/examples/test/pom.xml
+++ b/kura/examples/test/pom.xml
@@ -259,6 +259,12 @@
                             <propertyName>jacocoArgs</propertyName>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/kura/examples/test/pom.xml
+++ b/kura/examples/test/pom.xml
@@ -256,7 +256,6 @@
                             <goal>prepare-agent</goal>
                         </goals>
                         <configuration>
-                            <destFile>${sonar.jacoco.reportPath}</destFile>
                             <propertyName>jacocoArgs</propertyName>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Since an update of the Eclipse Jenkins instance we can no longer build Kura correctly (see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3750 for details).

This PR hopefully fixes the issue we encountered and that was preventing us from completing the build.

---

Please note that we're still encountering some issues in the importing of the report for the `example` tests:

```
[INFO] Sensor JaCoCo XML Report Importer [jacoco]
[INFO] 'sonar.coverage.jacoco.xmlReportPaths' is not defined. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
[INFO] No report imported, no coverage information will be imported by JaCoCo XML Report Importer
[INFO] Sensor JaCoCo XML Report Importer [jacoco] (done) | time=1ms
[INFO] Sensor CSS Rules [javascript]
[INFO] No CSS, PHP, HTML or VueJS files are found in the project. CSS analysis is skipped.
[INFO] Sensor CSS Rules [javascript] (done) | time=0ms
```

This is probably due to a misconfiguration in the example's test poms. We should mimick what we already do in other modules and set the `xmlReportPaths` for each tests and then aggregate it in the parent POMs.

I would leave this as-is for now and fix that in a later PR since this issue is blocking Kura development right now