### PR TITLE
ci(Jenkinsfile): remove build discarder overrides

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,14 @@
 node {
-    properties([disableConcurrentBuilds(abortPrevious: true), gitLabConnection('gitlab.eclipse.org'), [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false], [$class: 'JobLocalConfiguration', changeReasonComment: '']])
+    properties([
+        disableConcurrentBuilds(abortPrevious: true),
+        gitLabConnection('gitlab.eclipse.org'),
+        [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+        [$class: 'JobLocalConfiguration', changeReasonComment: '']
+    ])
 
     deleteDir()
 
-    stage('Preparation') { 
+    stage('Preparation') {
         dir("kura") {
             checkout scm
         }
@@ -14,7 +19,7 @@ node {
             dir("kura") {
                 withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.6.3') {
                     sh "touch /tmp/isJenkins.txt"
-                    sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin" 
+                    sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin"
                     sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin"
                     sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
                     sh "mvn -f kura/examples/pom.xml clean install -Pcheck-exists-plugin"
@@ -41,17 +46,19 @@ node {
                 withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.6.3') {
                     withCredentials([string(credentialsId: 'sonarcloud-token', variable: 'SONARCLOUD_TOKEN')]) {
                         withSonarQubeEnv {
-                            sh '''mvn -f kura/pom.xml sonar:sonar \
-                                -Dmaven.test.failure.ignore=true \
-                                -Dsonar.organization=eclipse \
-                                -Dsonar.host.url=${SONAR_HOST_URL} \
-                                -Dsonar.login=${SONARCLOUD_TOKEN} \
-                                -Dsonar.branch.name=${BRANCH_NAME} \
-                                -Dsonar.branch.target=${CHANGE_TARGET} \
-                                -Dsonar.java.binaries='target/' \
-                                -Dsonar.core.codeCoveragePlugin=jacoco \
-                                -Dsonar.projectKey=org.eclipse.kura:kura \
-                                -Dsonar.exclusions=test/**/*.java,test-util/**/*.java,org.eclipse.kura.web2/**/*.java,org.eclipse.kura.nm/src/main/java/org/freedesktop/**/*,org.eclipse.kura.nm/src/main/java/fi/w1/**/*'''
+                            sh '''
+                                mvn -f kura/pom.xml sonar:sonar \
+                                    -Dmaven.test.failure.ignore=true \
+                                    -Dsonar.organization=eclipse \
+                                    -Dsonar.host.url=${SONAR_HOST_URL} \
+                                    -Dsonar.login=${SONARCLOUD_TOKEN} \
+                                    -Dsonar.branch.name=${BRANCH_NAME} \
+                                    -Dsonar.branch.target=${CHANGE_TARGET} \
+                                    -Dsonar.java.binaries='target/' \
+                                    -Dsonar.core.codeCoveragePlugin=jacoco \
+                                    -Dsonar.projectKey=org.eclipse.kura:kura \
+                                    -Dsonar.exclusions=test/**/*.java,test-util/**/*.java,org.eclipse.kura.web2/**/*.java,org.eclipse.kura.nm/src/main/java/org/freedesktop/**/*,org.eclipse.kura.nm/src/main/java/fi/w1/**/*
+                            '''
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 node {
-    properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')), gitLabConnection('gitlab.eclipse.org'), [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false], [$class: 'JobLocalConfiguration', changeReasonComment: '']])
+    properties([disableConcurrentBuilds(abortPrevious: true), gitLabConnection('gitlab.eclipse.org'), [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false], [$class: 'JobLocalConfiguration', changeReasonComment: '']])
 
     deleteDir()
 


### PR DESCRIPTION
We're currently suffering from a pile up in orphaned Jenkins builds with 300+ old builds on our Jenkins instance.

![image](https://github.com/eclipse/kura/assets/22748355/f7d0a6e8-e359-4372-97bd-f5ff4963e465)

This is probably due to the fact that we're overriding the Orphaned Item Strategy in our Jenkinsfile by specifing a different Build Discarder configuration. See: https://plugins.jenkins.io/build-discarder/

By removing the override in the Jenkinsfile the old builds should be removed.
