### PR TITLE
ci(Jenkinsfile): correctly import examples test coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,15 @@
 node {
-    properties([disableConcurrentBuilds(abortPrevious: true), buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')), gitLabConnection('gitlab.eclipse.org'), [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false], [$class: 'JobLocalConfiguration', changeReasonComment: '']])
+    properties([
+        disableConcurrentBuilds(abortPrevious: true),
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')),
+        gitLabConnection('gitlab.eclipse.org'),
+        [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+        [$class: 'JobLocalConfiguration', changeReasonComment: '']
+    ])
 
     deleteDir()
 
-    stage('Preparation') { 
+    stage('Preparation') {
         dir("kura") {
             checkout scm
         }
@@ -14,7 +20,7 @@ node {
             dir("kura") {
                 withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.6.3') {
                     sh "touch /tmp/isJenkins.txt"
-                    sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin" 
+                    sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin"
                     sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin -Dmaven.test.skip=true"
                     // sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
                     sh "mvn -f kura/examples/pom.xml clean install -Pcheck-exists-plugin"
@@ -41,17 +47,19 @@ node {
                 withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.6.3') {
                     withCredentials([string(credentialsId: 'sonarcloud-token', variable: 'SONARCLOUD_TOKEN')]) {
                         withSonarQubeEnv {
-                            sh '''mvn -f kura/pom.xml sonar:sonar \
-                                -Dmaven.test.failure.ignore=true \
-                                -Dsonar.organization=eclipse \
-                                -Dsonar.host.url=${SONAR_HOST_URL} \
-                                -Dsonar.login=${SONARCLOUD_TOKEN} \
-                                -Dsonar.branch.name=${BRANCH_NAME} \
-                                -Dsonar.branch.target=${CHANGE_TARGET} \
-                                -Dsonar.java.binaries='target/' \
-                                -Dsonar.core.codeCoveragePlugin=jacoco \
-                                -Dsonar.projectKey=org.eclipse.kura:kura \
-                                -Dsonar.exclusions=test/**/*.java,test-util/**/*.java,org.eclipse.kura.web2/**/*.java,org.eclipse.kura.nm/src/main/java/org/freedesktop/**/*,org.eclipse.kura.nm/src/main/java/fi/w1/**/*'''
+                            sh '''
+                                mvn -f kura/pom.xml sonar:sonar \
+                                    -Dmaven.test.failure.ignore=true \
+                                    -Dsonar.organization=eclipse \
+                                    -Dsonar.host.url=${SONAR_HOST_URL} \
+                                    -Dsonar.login=${SONARCLOUD_TOKEN} \
+                                    -Dsonar.branch.name=${BRANCH_NAME} \
+                                    -Dsonar.branch.target=${CHANGE_TARGET} \
+                                    -Dsonar.java.binaries='target/' \
+                                    -Dsonar.core.codeCoveragePlugin=jacoco \
+                                    -Dsonar.projectKey=org.eclipse.kura:kura \
+                                    -Dsonar.exclusions=test/**/*.java,test-util/**/*.java,org.eclipse.kura.web2/**/*.java,org.eclipse.kura.nm/src/main/java/org/freedesktop/**/*,org.eclipse.kura.nm/src/main/java/fi/w1/**/*
+                            '''
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,8 @@ node {
                 withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.6.3') {
                     sh "touch /tmp/isJenkins.txt"
                     sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin" 
-                    sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin"
-                    sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
+                    sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin -Dmaven.test.skip=true"
+                    // sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
                     sh "mvn -f kura/examples/pom.xml clean install -Pcheck-exists-plugin"
                 }
             }
@@ -29,11 +29,11 @@ node {
         }
     }
 
-    stage('Archive .deb artifacts') {
-        dir("kura") {
-            archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
-        }
-    }
+    // stage('Archive .deb artifacts') {
+    //     dir("kura") {
+    //         archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
+    //     }
+    // }
 
     stage('Sonar') {
         timeout(time: 2, unit: 'HOURS') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,8 +21,8 @@ node {
                 withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-3.6.3') {
                     sh "touch /tmp/isJenkins.txt"
                     sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin"
-                    sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin -Dmaven.test.skip=true"
-                    // sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
+                    sh "mvn -f kura/pom.xml clean install -Pcheck-exists-plugin"
+                    sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
                     sh "mvn -f kura/examples/pom.xml clean install -Pcheck-exists-plugin"
                 }
             }
@@ -35,11 +35,11 @@ node {
         }
     }
 
-    // stage('Archive .deb artifacts') {
-    //     dir("kura") {
-    //         archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
-    //     }
-    // }
+    stage('Archive .deb artifacts') {
+        dir("kura") {
+            archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
+        }
+    }
 
     stage('Sonar') {
         timeout(time: 2, unit: 'HOURS') {

--- a/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.dbus.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.dbus.test/pom.xml
@@ -28,6 +28,7 @@
 
     <properties>
         <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.test/pom.xml
@@ -28,6 +28,7 @@
 
     <properties>
         <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/org.eclipse.kura.example.wire.logic.multiport.provider.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.wire.logic.multiport.provider.test/pom.xml
@@ -24,6 +24,7 @@
 
     <properties>
 	    <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/org.eclipse.kura.example.wire.math.singleport.provider.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.wire.math.singleport.provider.test/pom.xml
@@ -28,6 +28,7 @@
 
     <properties>
 	    <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/org.eclipse.kura.example.wire.math.trig.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.wire.math.trig.test/pom.xml
@@ -28,6 +28,7 @@
 
     <properties>
 	    <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/pom.xml
+++ b/kura/examples/test/pom.xml
@@ -273,9 +273,6 @@
     <properties>
         <kura.basedir>${project.basedir}/../..</kura.basedir>
         <tycho.argline>${jacocoArgs} -Dlog4j.configurationFile=file:${kura.basedir}/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml</tycho.argline>
-        <jacoco.reportDir>target/jacoco/</jacoco.reportDir>
-        <sonar.coverage.jacoco.xmlReportPaths>
-                ${project.basedir}/../../test/*/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <modules>


### PR DESCRIPTION
After #4882  we're still encountering some issues in the importing of the report for the example tests:

```
[INFO] Sensor JaCoCo XML Report Importer [jacoco]
[INFO] 'sonar.coverage.jacoco.xmlReportPaths' is not defined. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml
[INFO] No report imported, no coverage information will be imported by JaCoCo XML Report Importer
[INFO] Sensor JaCoCo XML Report Importer [jacoco] (done) | time=1ms
[INFO] Sensor CSS Rules [javascript]
[INFO] No CSS, PHP, HTML or VueJS files are found in the project. CSS analysis is skipped.
[INFO] Sensor CSS Rules [javascript] (done) | time=0ms
```

This is probably due to a misconfiguration in the example's test poms. We should mimik what we already do in other modules and set the xmlReportPaths for each tests and then aggregate it in the parent POMs.

This PR addresses the issue