### PR TITLE
ci(Jenkinsfile): set sonar.java.source

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ node {
                                 -Dsonar.login=${SONARCLOUD_TOKEN} \
                                 -Dsonar.branch.name=${BRANCH_NAME} \
                                 -Dsonar.branch.target=${CHANGE_TARGET} \
+                                -Dsonar.java.source=8 \
                                 -Dsonar.java.binaries='target/' \
                                 -Dsonar.core.codeCoveragePlugin=jacoco \
                                 -Dsonar.projectKey=org.eclipse.kura:kura \


### PR DESCRIPTION
In a couple of builds I noticed that Sonar was whining about the `sonar.java.source` not being set. See: https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&branch=PR-4872&id=org.eclipse.kura%3Akura&open=AYsbMaPX-1h4WswAMLbk

Following the [documentation](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/languages/java/#java-source-version) I added it to the Jenkisfile

