### PR TITLE
ci(Jenkinsfile): 'sonar.login' is deprecated use 'sonar.token' property instead

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ node {
                                     -Dmaven.test.failure.ignore=true \
                                     -Dsonar.organization=eclipse \
                                     -Dsonar.host.url=${SONAR_HOST_URL} \
-                                    -Dsonar.login=${SONARCLOUD_TOKEN} \
+                                    -Dsonar.token=${SONARCLOUD_TOKEN} \
                                     -Dsonar.branch.name=${BRANCH_NAME} \
                                     -Dsonar.branch.target=${CHANGE_TARGET} \
                                     -Dsonar.java.source=8 \


### PR DESCRIPTION
Fix Sonar warning

![image](https://github.com/eclipse/kura/assets/22748355/e87a776e-e9ce-4e77-8371-1c78155721f4)
