### PR TITLE
feat: adding IPv6 firewall rules when in NAT mode

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -576,7 +576,7 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
         Optional<String> ip4InterfaceStatus = this.networkProperties.getOpt(String.class,
                 "net.interface.%s.config.ip4.status", interfaceName);
         Optional<String> ip6InterfaceStatus = this.networkProperties.getOpt(String.class,
-                "net.interface.%s.config.ip4.status", interfaceName);
+                "net.interface.%s.config.ip6.status", interfaceName);
 
         if (ip4InterfaceStatus.isPresent()) {
             returnList.add(Optional.of(NetInterfaceStatus.valueOf(ip4InterfaceStatus.get())));

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/FirewallNatConfigWriter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/writer/FirewallNatConfigWriter.java
@@ -20,6 +20,7 @@ import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.linux.net.iptables.LinuxFirewall;
+import org.eclipse.kura.linux.net.iptables.LinuxFirewallIPv6;
 import org.eclipse.kura.linux.net.iptables.NATRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,7 @@ public class FirewallNatConfigWriter {
 
     private final CommandExecutorService executorService;
     private final LinuxFirewall firewall;
+    private final LinuxFirewallIPv6 firewallIpv6;
     private final List<String> wanInterfaceNames;
     private final List<String> natInterfaceNames;
 
@@ -39,6 +41,7 @@ public class FirewallNatConfigWriter {
         this.wanInterfaceNames = wanInterfaceNames;
         this.natInterfaceNames = natInterfaceNames;
         this.firewall = LinuxFirewall.getInstance(this.executorService);
+        this.firewallIpv6 = LinuxFirewallIPv6.getInstance(this.executorService);
     }
 
     public void writeConfiguration() throws KuraException {
@@ -54,6 +57,7 @@ public class FirewallNatConfigWriter {
             }
 
             this.firewall.replaceAllNatRules(natRules);
+            this.firewallIpv6.replaceAllNatRules(natRules);
         } catch (Exception e) {
             throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR,
                     "Failed to replace all NAT rules with new ones for interfaces: " + this.natInterfaceNames, e);

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImplTest.java
@@ -23,13 +23,12 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.security.PrivateKey;
 import java.security.KeyStore.PrivateKeyEntry;
 import java.security.KeyStore.TrustedCertificateEntry;
+import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -89,6 +88,7 @@ public class NMConfigurationServiceImplTest {
     public void shouldPostEventAfterUpdateTest() throws InterruptedException, KuraException {
         givenPropertiesWithModifiedInterfaces();
         givenNetworkConfigurationService();
+        whenServiceIsActivated();
         whenServiceIsUpdated();
         thenEventIsPosted();
     }
@@ -567,7 +567,7 @@ public class NMConfigurationServiceImplTest {
     }
 
     private void whenServiceIsUpdated() {
-        this.networkConfigurationService.activate(null, this.properties);
+        this.networkConfigurationService.update(this.properties);
     }
 
     private void whenComponentDefinitionIsRetrieved() throws KuraException {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImplTest.java
@@ -264,6 +264,58 @@ public class NMConfigurationServiceImplTest {
         thenDhcpConfigWriterIsCreatedForInterfaces();
     }
 
+    @Test
+    public void shouldCreateFirewallNatRules() throws InterruptedException, KuraException {
+        givenPropertiesThatTriggerNatRules();
+        givenNetworkConfigurationService();
+
+        whenServiceIsActivated();
+
+        thenEventIsPosted();
+    }
+
+    private void givenPropertiesThatTriggerNatRules() {
+
+        this.properties.clear();
+        this.properties.put("modified.interface.names", "eno1,enp2s0");
+        this.properties.put("net.interface.eno1.config.ip4.status", "netIPv4StatusEnabledLAN");
+        this.properties.put("net.interface.eno1.config.ip4.address", "172.16.0.1");
+        this.properties.put("net.interface.eno1.config.dhcpClient4.enabled", false);
+        this.properties.put("net.interface.eno1.config.ip4.prefix", 24);
+        this.properties.put("net.interface.eno1.config.dhcpServer4.rangeEnd", "172.16.0.110");
+        this.properties.put("net.interface.eno1.config.dhcpServer4.defaultLeaseTime", 7200);
+        this.properties.put("net.interface.eno1.config.dhcpServer4.enabled", false);
+        this.properties.put("net.interface.eno1.config.dhcpServer4.prefix", 24);
+        this.properties.put("net.interface.eno1.config.ip4.dnsServers", "");
+        this.properties.put("net.interface.eno1.config.dhcpServer4.passDns", false);
+        this.properties.put("net.interface.eno1.type", "ETHERNET");
+        this.properties.put("net.interface.eno1.config.dhcpServer4.rangeStart", "172.16.0.100");
+        this.properties.put("net.interface.eno1.config.nat.enabled", false);
+        this.properties.put("net.interface.eno1.config.ip4.gateway", "");
+        this.properties.put("net.interface.eno1.config.dhcpServer4.maxLeaseTime", 7200);
+
+        this.properties.put("net.interface.eno1.config.ip6.status", "netIPv6StatusEnabledLAN");
+        this.properties.put("net.interface.eno1.config.dhcpClient6.enabled", false);
+        this.properties.put("net.interface.eno1.config.ip6.dnsServers", "");
+        this.properties.put("net.interface.eno1.config.ip6.address.method", "netIPv6MethodManual");
+        this.properties.put("net.interface.eno1.config.ip6.prefix", 64);
+        this.properties.put("net.interface.enp2s0.config.ip6.privacy", "netIPv6PrivacyDisabled");
+        this.properties.put("net.interface.eno1.config.ip6.address", "2001:0000::FFFF");
+
+        this.properties.put("net.interface.enp2s0.type", "ETHERNET");
+        this.properties.put("net.interface.enp2s0.config.ip4.dnsServers", "");
+        this.properties.put("net.interface.enp2s0.config.dhcpClient4.enabled", true);
+        this.properties.put("net.interface.enp2s0.config.ip4.status", "netIPv4StatusEnabledWAN");
+
+        this.properties.put("net.interface.enp2s0.config.ip6.address.method", "netIPv6MethodAuto");
+        this.properties.put("net.interface.enp2s0.config.ip6.privacy", "netIPv6PrivacyDisabled");
+        this.properties.put("net.interface.enp2s0.config.ip6.dnsServers", "");
+        this.properties.put("net.interface.enp2s0.config.ip6.addr.gen.mode", "netIPv6AddressGenModeEUI64");
+        this.properties.put("net.interface.enp2s0.config.nat.enabled", false);
+        this.properties.put("net.interface.enp2s0.config.dhcpServer4.passDns", false);
+        this.properties.put("net.interface.enp2s0.config.ip6.status", "netIPv6StatusEnabledWAN");
+    }
+
     private void givenPropertiesWithModifiedInterfaces() {
         this.properties.clear();
         this.properties.put("modified.interface.names", "eth0");

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/writer/FirewallNatConfigWriterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/writer/FirewallNatConfigWriterTest.java
@@ -26,6 +26,7 @@ import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.linux.net.iptables.LinuxFirewall;
+import org.eclipse.kura.linux.net.iptables.LinuxFirewallIPv6;
 import org.eclipse.kura.linux.net.iptables.NATRule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -38,6 +39,7 @@ public class FirewallNatConfigWriterTest {
     private List<String> natInterfaces;
     private Exception occurredException;
     private LinuxFirewall mockLinuxFirewall;
+    private LinuxFirewallIPv6 mockLinuxFirewallIPv6;
     private ArgumentCaptor<Object> appliedRuleCaptor = ArgumentCaptor.forClass(Object.class);
 
     /*
@@ -121,14 +123,17 @@ public class FirewallNatConfigWriterTest {
         CommandExecutorService mockExecutor = Mockito.mock(CommandExecutorService.class);
 
         this.mockLinuxFirewall = Mockito.mock(LinuxFirewall.class);
+        this.mockLinuxFirewallIPv6 = Mockito.mock(LinuxFirewallIPv6.class);
 
         setPrivateStaticField(LinuxFirewall.class.getDeclaredField("linuxFirewall"), this.mockLinuxFirewall);
+        setPrivateStaticField(LinuxFirewallIPv6.class.getDeclaredField("linuxFirewall"), this.mockLinuxFirewallIPv6);
 
         this.writer = new FirewallNatConfigWriter(mockExecutor, this.wanInterfaces, this.natInterfaces);
     }
 
     private void givenBrokenFirewall() throws Exception {
         Mockito.doThrow(KuraException.class).when(this.mockLinuxFirewall).replaceAllNatRules(Mockito.any());
+        Mockito.doThrow(KuraException.class).when(this.mockLinuxFirewallIPv6).replaceAllNatRules(Mockito.any());
     }
 
     /*
@@ -161,7 +166,8 @@ public class FirewallNatConfigWriterTest {
     @SuppressWarnings("unchecked")
     private void thenNATRuleApplied(String expectedSource, String expectedDestination) throws KuraException {
         Mockito.verify(this.mockLinuxFirewall).replaceAllNatRules((Set<NATRule>) this.appliedRuleCaptor.capture());
-        
+        Mockito.verify(this.mockLinuxFirewallIPv6).replaceAllNatRules((Set<NATRule>) this.appliedRuleCaptor.capture());
+
         assertTrue(
                 natRuleExists((Set<NATRule>) this.appliedRuleCaptor.getValue(), expectedSource, expectedDestination));
     }
@@ -169,6 +175,7 @@ public class FirewallNatConfigWriterTest {
     @SuppressWarnings("unchecked")
     private void thenNATRuleNotApplied(String expectedSource, String expectedDestination) throws KuraException {
         Mockito.verify(this.mockLinuxFirewall).replaceAllNatRules((Set<NATRule>) this.appliedRuleCaptor.capture());
+        Mockito.verify(this.mockLinuxFirewallIPv6).replaceAllNatRules((Set<NATRule>) this.appliedRuleCaptor.capture());
 
         assertFalse(
                 natRuleExists((Set<NATRule>) this.appliedRuleCaptor.getValue(), expectedSource, expectedDestination));

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/writer/FirewallNatConfigWriterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/writer/FirewallNatConfigWriterTest.java
@@ -142,7 +142,8 @@ public class FirewallNatConfigWriterTest {
 
     private void whenWriteConfiguration() {
         try {
-            this.writer.writeConfiguration();
+            this.writer.writeConfiguration(true);
+            this.writer.writeConfiguration(false);
         } catch (Exception e) {
             this.occurredException = e;
         }


### PR DESCRIPTION
This PR adds in the firewall NM firewall implementation the writing of the IPv6 firewall rules when two interfaces are set respectively set as WAN and LAN, trying to share the internet connection between them.

**Related Issue:** 

**Description of the solution adopted:** 

**Screenshots:** 

**Manual Tests:**

**Any side note on the changes made:**
