### PR TITLE
ci(automation): add bot for closing stale issues and PRs

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,28 @@
+name: "Close inactive issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          exempt-issue-labels: ExemptStale
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-message: "This pull request is stale because it has been open for 60 days with no activity."
+          close-pr-message: "This pull request was closed because it has been inactive for 14 days since being marked as stale."
+          exempt-pr-labels: ExemptStale
+          debug-only: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
This PR adds a Github workflows that check for inactive Github Issues and PRs and closes them.
Documentation:
- https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues
- https://github.com/marketplace/actions/close-stale-issues

**Changelog**
This PR adds the "close-stale-issues" bot so that, everyday at 1:30 a.m., the bot will check open Issues and PRs and will set as "stale" those that do not have updates since 60 days. After 14 days being tagged as stale the bot will automatically close the Issues/PRs.

I also added an exeption label: if the PR or Issue is labeled "_ExemptStale_", it will not be checked by the bot.

**Note**: for now I only set it in debug mode so that we can check its output and see if it performs as expected.