### PR TITLE
ci(automation): fix labels and nr of operations for stale issues bot

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -17,12 +17,13 @@ jobs:
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 60 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
-          exempt-issue-labels: ExemptStale
+          exempt-issue-labels: exempt-stale
           days-before-pr-stale: 60
           days-before-pr-close: 14
           stale-pr-message: "This pull request is stale because it has been open for 60 days with no activity."
           close-pr-message: "This pull request was closed because it has been inactive for 14 days since being marked as stale."
-          exempt-pr-labels: ExemptStale
+          exempt-pr-labels: exempt-stale
           debug-only: true
+          operations-per-run: 300
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR fixes some small issues we found when running the stale bot for the first time:
1. Changed exempt labels to be more consistent with existing ones (`exempt-stale` instead of `ExemptStale`)
2. Higher [`operation-per-run`](https://github.com/actions/stale#operations-per-run) since we were hitting the limit due to the high number of open issues and PRs we have. Please note that this have a chance of hitting the [rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting) of Github APIs when running in production mode (we're running the workflow in debug mode for now)