### PR TITLE
fix(docker): display logs in console

### DIFF
--- a/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2023 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
@@ -2,16 +2,16 @@
 <!--
 
     Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
-  
+
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
- 
+
 	SPDX-License-Identifier: EPL-2.0
-	
+
 	Contributors:
      Eurotech
-     
+
 -->
 <Configuration status="warn" strict="true" name="KuraConfig" monitorInterval="30">
 
@@ -20,17 +20,13 @@
         <Property name="log_name">kura</Property>
     </Properties>
     <Filter type="ThresholdFilter" level="trace"/>
- 
+
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <Console name="console" target="SYSTEM_OUT" follow="true">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </Console>
         <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
@@ -46,17 +42,17 @@
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
     </Appenders>
- 
+
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="console"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="console"/>
         </Root>
   </Loggers>
- 
+
 </Configuration>

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
@@ -27,6 +27,15 @@
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
         </Console>
+        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+            <PatternLayout>
+                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="20 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
         <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
@@ -46,6 +55,9 @@
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
             <AppenderRef ref="console"/>
+        </Logger>
+        <Logger name="org.eclipse" level="info" additivity="false">
+            <AppenderRef ref="RollingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
@@ -22,7 +22,7 @@
     <Filter type="ThresholdFilter" level="trace"/>
 
     <Appenders>
-        <Console name="console" target="SYSTEM_OUT" follow="true">
+        <Console name="Console" target="SYSTEM_OUT" follow="true">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
@@ -54,16 +54,15 @@
 
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="console"/>
-        </Logger>
-        <Logger name="org.eclipse" level="info" additivity="false">
+            <AppenderRef ref="Console"/>
             <AppenderRef ref="RollingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="console"/>
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="RollingFile"/>
         </Root>
   </Loggers>
 


### PR DESCRIPTION
This PR fixes the `log4j.xml` file for Docker containers such that the Kura logs are redirected to the console instead of being logged in the `kura.log` and the `kura-audit.log` files only

This means that we can now leverage Docker logging features correctly (i.e. `docker logs` command, [logging drivers](https://docs.docker.com/config/containers/logging/configure/) etc.)

Tested working on my machine:

```
 docker run -d -p 443:443 -t kura-alpine:5.4.0-SNAPSHOT
```

```
docker logs 42c5bc0676ff
...
2023-10-24T07:37:02,007 [qtp1441166080-132] WARN  o.e.k.w.s.s.SkinServlet - Failed to load skin resource, Resource File /skin.css does not exist
2023-10-24T07:37:02,229 [qtp1441166080-95] INFO  o.e.j.s.h.C.ROOT - org.eclipse.kura.web.server.GwtSecurityTokenServiceImpl: Trying /www/denali/C4B854B7238B3EA217FC8866316BBBE0.gwt.rpc
2023-10-24T07:37:02,251 [qtp1441166080-134] INFO  o.e.j.s.h.C.ROOT - org.eclipse.kura.web.server.GwtSessionServiceImpl: Trying /www/denali/5A21EE31D321D780E189CF9BF1EF3D12.gwt.rpc
2023-10-24T07:37:02,270 [qtp1441166080-95] INFO  o.e.j.s.h.C.ROOT - org.eclipse.kura.web.server.GwtDeviceServiceImpl: Trying /www/denali/D7B4D0DFFC28F8590948229B5CD77144.gwt.rpc
2023-10-24T07:37:02,281 [qtp1441166080-94] INFO  o.e.j.s.h.C.ROOT - org.eclipse.kura.web.server.GwtSecurityServiceImpl: Trying /www/denali/C5596B3342ABD1F1C576A50D7834430D.gwt.rpc
2023-10-24T07:37:02,297 [qtp1441166080-95] INFO  o.e.j.s.h.C.ROOT - org.eclipse.kura.web.server.GwtEventServiceImpl: Trying /www/denali/4441F1D8E6F0BF356378969A22D4A213.gwt.rpc
2023-10-24T07:37:02,397 [qtp1441166080-137] INFO  o.e.j.s.h.C.ROOT - org.eclipse.kura.web.server.GwtExtensionServiceImpl: Trying /www/denali/D1CE14447D3866B4A6E6FA6921757AEF.gwt.rpc
2023-10-24T07:37:02,463 [qtp1441166080-134] INFO  o.e.j.s.h.C.ROOT - org.eclipse.kura.web.server.GwtLogServiceImpl: Trying /www/denali/FE0A6D238771B85E40362A1E8FC32048.gwt.rpc
2023-10-24T07:37:02,472 [qtp1441166080-134] INFO  o.e.k.w.s.GwtLogServiceImpl - LogProvider filesystem-kura-log loaded.
2023-10-24T07:37:02,474 [qtp1441166080-134] INFO  o.e.k.w.s.GwtLogServiceImpl - LogProvider filesystem-kura-audit-log loaded.
2023-10-24T07:37:02,500 [qtp1441166080-127] INFO  o.e.j.s.h.C.ROOT - org.eclipse.kura.web.server.GwtStatusServiceImpl: Trying /www/denali/D2699310707841215567171587551E4A.gwt.rpc
2023-10-24T07:37:02,526 [qtp1441166080-127] INFO  o.e.j.s.h.C.ROOT - org.eclipse.kura.web.server.GwtComponentServiceImpl: Trying /www/denali/58535A5C98F1E514899ADE2185A43E60.gwt.rpc
2023-10-24T07:37:06,880 [pool-8-thread-1] INFO  o.e.k.c.c.ConfigurationServiceImpl - Loading init configurations from: 1698132982249...
2023-10-24T07:37:06,886 [pool-8-thread-1] INFO  o.e.k.c.c.ConfigurationServiceImpl - Merging configuration for pid: org.eclipse.kura.internal.useradmin.store.RoleRepositoryStoreImpl
2023-10-24T07:37:06,889 [pool-8-thread-1] INFO  o.e.k.c.c.ConfigurationServiceImpl - Updating Configuration of ConfigurableComponent org.eclipse.kura.internal.useradmin.store.RoleRepositoryStoreImpl ... Done.
2023-10-24T07:37:06,892 [ConfigurationListener Event Queue] INFO  o.e.k.i.u.s.RoleRepositoryStoreImpl - Ignoring self update
2023-10-24T07:37:06,898 [pool-8-thread-1] INFO  o.e.k.c.c.ConfigurationServiceImpl - Writing snapshot - Saving /opt/eclipse/kura/user/snapshots/snapshot_1698133026890.xml...
2023-10-24T07:37:06,910 [pool-8-thread-1] INFO  o.e.k.c.c.ConfigurationServiceImpl - Writing snapshot - Saving /opt/eclipse/kura/user/snapshots/snapshot_1698133026890.xml... Done.
```

One small thing @MMaiero: in other projects we **only log** in the console for our containers (i.e. there's no `kura.log` file). Should we follow the same policy here?