### PR TITLE
docs(DataTransportService): clarify that quiesceTimeout  is in milliseconds

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/data/DataTransportService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/data/DataTransportService.java
@@ -69,7 +69,7 @@ public interface DataTransportService {
      * in-flight messages before actually disconnecting from the broker.
      *
      * @param quiesceTimeout
-     *            - timeout that will be used before forcing a disconnect
+     *            - timeout in milliseconds that will be used before forcing a disconnect
      */
     public void disconnect(long quiesceTimeout);
 


### PR DESCRIPTION
In `public void disconnect(long quiesceTimeout); `there is the following javadoc:
```
 * @param quiesceTimeout 
 *            - timeout that will be used before forcing a disconnect 
```

Is it seconds or milliseconds?
I clarified that it is in milliseconds.

```
 * @param quiesceTimeout 
 *            - timeout in milliseconds that will be used before forcing a disconnect 
```

Source from paho mqtt: https://github.com/eclipse/paho.mqtt.java/blob/master/org.eclipse.paho.client.mqttv3/src/main/java/org/eclipse/paho/client/mqttv3/MqttClient.java#L386

