### PR TITLE
feat: add support for same alias in different keystores

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui.security;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -372,16 +375,29 @@ public class CertificateListTabUi extends Composite implements Tab, CertificateM
         this.certAddModal.setTitle("Add Certificate");
         this.certAddModalBody.clear();
 
-        List<String> storageAliases = this.certificatesDataProvider.getList().stream().map(GwtKeystoreEntry::getAlias)
-                .collect(Collectors.toList());
-
-        this.keyPairTabUi = new KeyPairTabUi(selectedCertType.getType(), this.pids, storageAliases, this,
+        this.keyPairTabUi = new KeyPairTabUi(selectedCertType.getType(), this.pids, getStorageAliases(), this,
                 this.resetModalButton, this.applyModalButton, this.closeModalButton);
         this.certAddModalBody.add(keyPairTabUi);
 
         this.nextStepButton.setVisible(false);
         this.resetModalButton.setVisible(true);
         this.applyModalButton.setVisible(true);
+    }
+
+    private Map<String, List<String>> getStorageAliases() {
+        Map<String, List<String>> storageAliases = new HashMap<>();
+
+        this.certificatesDataProvider.getList().forEach(e -> {
+            if (storageAliases.containsKey(e.getKeystoreName())) {
+                storageAliases.get(e.getKeystoreName()).add(e.getAlias());
+            } else {
+                List<String> aliases = new ArrayList<>();
+                aliases.add(e.getAlias());
+                storageAliases.put(e.getKeystoreName(), aliases);
+            }
+        });
+
+        return storageAliases;
     }
 
     private void uninstall(final GwtKeystoreEntry selected) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/KeyPairTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/KeyPairTabUi.java
@@ -13,6 +13,7 @@
 package org.eclipse.kura.web.client.ui.security;
 
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.Tab;
@@ -84,7 +85,10 @@ public class KeyPairTabUi extends Composite implements Tab {
     private final Button applyButton;
     private final Button closeButton;
 
-    public KeyPairTabUi(final Type type, final List<String> keyStorePids, final List<String> usedAliases,
+    private Validator<String> storageAliasValidator;
+    private Map<String, List<String>> usedAliases;
+
+    public KeyPairTabUi(final Type type, final List<String> keyStorePids, final Map<String, List<String>> usedAliases,
             final CertificateModalListener listener, Button resetButton, Button applyButton, Button closeButton) {
         this.listener = listener;
         this.type = type;
@@ -93,8 +97,10 @@ public class KeyPairTabUi extends Composite implements Tab {
         this.resetButton = resetButton;
         this.closeButton = closeButton;
 
+        this.usedAliases = usedAliases;
+
         initWidget(uiBinder.createAndBindUi(this));
-        initForm(keyStorePids, usedAliases);
+        initForm(keyStorePids);
 
         setDirty(false);
     }
@@ -129,7 +135,7 @@ public class KeyPairTabUi extends Composite implements Tab {
         }
     }
 
-    private void initForm(final List<String> keyStorePids, List<String> usedAliases) {
+    private void initForm(final List<String> keyStorePids) {
         StringBuilder title = new StringBuilder();
         title.append("<p style=\"margin-right: 5%;\">");
         title.append(
@@ -150,10 +156,25 @@ public class KeyPairTabUi extends Composite implements Tab {
         this.storageAliasInput.addValidator(GwtValidators.stringLength(ALIAS_MAX_LENGTH,
                 MSGS.certificateAliasMaxLength(String.valueOf(ALIAS_MAX_LENGTH))));
         this.storageAliasInput.setMaxLength(ALIAS_MAX_LENGTH);
-        this.storageAliasInput.addValidator(GwtValidators.stringNotInList(usedAliases, MSGS.certificateAliasUsed()));
+
+        storageAliasValidator = GwtValidators.stringNotInList(this.usedAliases.get(this.pidListBox.getSelectedValue()),
+                MSGS.certificateAliasUsed());
+        this.storageAliasInput.addValidator(storageAliasValidator);
 
         this.certificateInput.addValidator(notEmptyValidator);
         this.certificateInput.addValidator(GwtValidators.pem(MSGS.securityCertificateFormat()));
+
+        this.pidListBox.addChangeHandler(e -> {
+            if (this.storageAliasValidator != null) {
+                this.storageAliasInput.removeValidator(this.storageAliasValidator);
+            }
+
+            List<String> listOfUsedAliasForPid = this.usedAliases.get(this.pidListBox.getSelectedValue());
+            storageAliasValidator = GwtValidators.stringNotInList(listOfUsedAliasForPid, MSGS.certificateAliasUsed());
+            this.storageAliasInput.addValidator(storageAliasValidator);
+
+            this.storageAliasInput.validate();
+        });
 
         this.storageAliasInput.addKeyUpHandler(e -> {
             this.storageAliasInput.validate();


### PR DESCRIPTION
This PR modifies that validator of the name alias field.

1) instead of passing in a List<String> of all names flattened a map is passed
2) when the pid is changed, the validator for the alias is also modified to the appropriate string<list> as per the passed-in map.

This allows us to use the same alias across multiple key stores. 

Backend already support's this, only changes in the front end were needed.


**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** 
localhost 3x 
![image](https://github.com/eclipse/kura/assets/29900100/30cde7c5-484a-417f-aff0-8fef1275b4b7)


**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
