### PR TITLE
feat(distrib): network interface names retrieved without `nmcli`

### DIFF
--- a/kura/distrib/src/main/resources/common/comment_interfaces_file.py
+++ b/kura/distrib/src/main/resources/common/comment_interfaces_file.py
@@ -11,8 +11,6 @@
 # Contributors:
 #  Eurotech
 #
-import subprocess
-import sys
 import shutil
 import logging
 from os.path import exists

--- a/kura/distrib/src/main/resources/common/find_net_interfaces.py
+++ b/kura/distrib/src/main/resources/common/find_net_interfaces.py
@@ -39,13 +39,6 @@ def get_eth_wlan_interfaces_names():
     wireless_interface_names = list()
 
     interface_names = get_interface_names()
-
-    # en, et = ethernet
-    # wl = wireless lan
-    # ww = wireless wan
-    # eno<index> = on-board ethernet
-    # ens<slot> = hotplug on slot <slot> ethernet
-    # enp<index> = pci ethernet
     
     for ifname in interface_names:
         if ifname.startswith("en") or ifname.startswith("et"):

--- a/kura/distrib/src/main/resources/common/find_net_interfaces.py
+++ b/kura/distrib/src/main/resources/common/find_net_interfaces.py
@@ -11,57 +11,58 @@
 # Contributors:
 #  Eurotech
 #
-import subprocess
 import sys
 import logging
+import os
 
-ETHERNET_TYPES = ['ethernet', 'eth', 'wired']
-WIRELESS_TYPES = ['wifi', 'wireless']
+def get_interface_names():
+    if not os.path.exists("/sys/class/net"):
+        logging.error("'/sys/class/net' does not exists, unable to read interface names. Exiting.")
+        sys.exit(1)
+
+    return os.listdir("/sys/class/net")
 
 def get_eth_wlan_interfaces_names():
-    """Reads the network interface names using 'nmcli dev' command.
+    """Reads the network interface names present on the device.
 
     It is assumed that at least one ethernet interface is present.
+
+    Requirements:
+        "/sys/class/net" directory must exist
 
     Returns:
         tuple of lists (eth_names, wlan_names) where:
             'eth_names' are the found ethernet interface names sorted by name;
             'wlan_names' are the found wireless interface names sorted by name, might be an empty list.
     """
-    cmd_output = subprocess.check_output(['nmcli', 'dev']).decode(sys.stdout.encoding).strip()
-    # list comprehension to remove empty items
-    lines = [x.strip() for x in cmd_output.split('\n') if len(x.strip()) > 0]
+    ethernet_interface_names = list()
+    wireless_interface_names = list()
 
-    # removing header
-    del lines[0]
+    interface_names = get_interface_names()
 
-    ethernet_inteface_names = list()
-    wireless_inteface_names = list()
-
-    for line in lines:
-        row = [x.strip() for x in line.split(' ') if len(x.strip()) > 0]
-        
-        interface_name = row[0].lower()
-        interface_type = row[1].lower()
-
-        if interface_type in ETHERNET_TYPES:
-            ethernet_inteface_names.append(interface_name)
-        
-        if  interface_type in WIRELESS_TYPES:
-            wireless_inteface_names.append(interface_name)
+    # en, et = ethernet
+    # wl = wireless lan
+    # ww = wireless wan
+    # eno<index> = on-board ethernet
+    # ens<slot> = hotplug on slot <slot> ethernet
+    # enp<index> = pci ethernet
     
-    if len(ethernet_inteface_names) < 1:
-        logging.info("ERROR: no ethernet interfaces found")
+    for ifname in interface_names:
+        if ifname.startswith("en") or ifname.startswith("et"):
+            ethernet_interface_names.append(ifname)
+        if ifname.startswith("wl"):
+            wireless_interface_names.append(ifname)
+
+    ethernet_interface_names.sort()
+    wireless_interface_names.sort()
+
+    if len(ethernet_interface_names) < 1:
+        logging.error("No ethernet interfaces found, exiting.")
         sys.exit(1)
 
-    ethernet_inteface_names.sort()
-    wireless_inteface_names.sort()
-
-    logging.info("Found ethernet interfaces: %s", ethernet_inteface_names)
-    logging.info("Found wireless interfaces: %s", wireless_inteface_names)
-
-    return (ethernet_inteface_names, wireless_inteface_names)
-
+    logging.info("Found ethernet interfaces: %s", ethernet_interface_names)
+    logging.info("Found wireless interfaces: %s", wireless_interface_names)
+    return (ethernet_interface_names, wireless_interface_names)
 
 def main():
     logging.basicConfig(

--- a/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-aarch64/kura_install.sh
@@ -67,7 +67,6 @@ systemctl disable systemd-timesyncd
 systemctl stop chrony
 systemctl disable chrony
 systemctl enable NetworkManager
-systemctl start NetworkManager
 systemctl enable ModemManager
 systemctl stop dnsmasq
 systemctl disable dnsmasq

--- a/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-arm32/kura_install.sh
@@ -67,7 +67,6 @@ systemctl disable systemd-timesyncd
 systemctl stop chrony
 systemctl disable chrony
 systemctl enable NetworkManager
-systemctl start NetworkManager
 systemctl enable ModemManager
 systemctl stop dnsmasq
 systemctl disable dnsmasq

--- a/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64/kura_install.sh
@@ -67,7 +67,6 @@ systemctl disable systemd-timesyncd
 systemctl stop chrony
 systemctl disable chrony
 systemctl enable NetworkManager
-systemctl start NetworkManager
 systemctl enable ModemManager
 systemctl stop dnsmasq
 systemctl disable dnsmasq


### PR DESCRIPTION
This PR changes the installation scripts to not rely on `nmcli` anymore and instead use the information available in `/sys/class/net`.

**Related Issue:** N/A.

**Description of the solution adopted:** `/sys/class/net` contains symlinks to the network interface devices [1]. These links are named after the currently used naming convention (systemd consistent naming, hardcoded, etc.). The general rule [2] [3] for naming interfaces is as follows:

- name starts with `et` or `en` -> ethernet interface
- name starts with `wl` -> wireless lan
- name starts with `ww` -> wireless wan

If consistent network interface naming is applied [3], then:

- `o` -> on-board device (example: `eno0`, `eno1`)
- `s` -> hotplug device (example: `ens1`)
- `p` -> pci device (example: `enp3`, `wlp1`)

To determine the primary network interface the retrieved list is ordered by name, so that on-board devices have precedence over pci, that, in turn, have precedence over hotplug slots. Example: `enp3s0, eno1` -> primary is `eno1`.

**Screenshots:** N/A.

**Any side note on the changes made:** N/A.

**References:**
- [1] https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-net
- [2] https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
- [3] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/sec-understanding_the_predictable_network_interface_device_names