### PR TITLE
feat: dynamic ram assignment when over 1GB

### DIFF
--- a/kura/distrib/src/main/resources/common/customize-installation.sh
+++ b/kura/distrib/src/main/resources/common/customize-installation.sh
@@ -77,6 +77,6 @@ if [ ${BOARD} = "generic-device" ]; then
             sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" "/opt/eclipse/kura/bin/$installer_name"
         done
     else
-        echo "Leaving kura ram as the default set in installer profile"
+        echo "System RAM is less than 1GB. Leaving assigned RAM as the default for the Kura profile."
     fi
 fi

--- a/kura/distrib/src/main/resources/common/customize-installation.sh
+++ b/kura/distrib/src/main/resources/common/customize-installation.sh
@@ -61,4 +61,20 @@ if [ ${BOARD} = "generic-device" ]; then
     else
         echo "python3 not found. snapshot_0.xml, and iptables.init files may have wrong interface names. Default is eth0 and wlan0. Please correct them manually if they mismatch."
     fi
+    
+    # dynamic ram assignment
+    RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+    RAM_MB=$(expr $RAM_KB / 1024)
+    RAM_MB_FOR_KURA=$(expr $RAM_MB / 4)
+    RAM_REPLACEMENT_STRING="-Xms${RAM_MB_FOR_KURA}m -Xmx${RAM_MB_FOR_KURA}m"
+
+    if RAM_MB > 1024
+    then
+        echo "Setting kura ram -Xms and -Xmx to ${RAM_MB_FOR_KURA}m"
+        sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" /opt/eclipse/kura/bin/start_kura.sh
+        sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" /opt/eclipse/kura/bin/start_kura_debug.sh
+        sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" /opt/eclipse/kura/bin/start_kura_background.sh
+    else
+        echo "Leaving kura ram as the default set in installer profile"
+    fi
 fi

--- a/kura/distrib/src/main/resources/common/customize-installation.sh
+++ b/kura/distrib/src/main/resources/common/customize-installation.sh
@@ -70,9 +70,12 @@ if [ ${BOARD} = "generic-device" ]; then
 
     if [ "$RAM_MB" -gt 1024 ]; then
         echo "Setting kura ram -Xms and -Xmx to ${RAM_MB_FOR_KURA}m"
-        sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" /opt/eclipse/kura/bin/start_kura.sh
-        sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" /opt/eclipse/kura/bin/start_kura_debug.sh
-        sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" /opt/eclipse/kura/bin/start_kura_background.sh
+        start_scripts_to_change=("start_kura.sh" "start_kura_debug.sh" "start_kura_background.sh")
+
+        for installer_name in "${start_scripts_to_change[@]}"; do
+            echo "Updating RAM values for $installer_name"
+            sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" "/opt/eclipse/kura/bin/$installer_name"
+        done
     else
         echo "Leaving kura ram as the default set in installer profile"
     fi

--- a/kura/distrib/src/main/resources/common/customize-installation.sh
+++ b/kura/distrib/src/main/resources/common/customize-installation.sh
@@ -68,8 +68,7 @@ if [ ${BOARD} = "generic-device" ]; then
     RAM_MB_FOR_KURA=$(expr $RAM_MB / 4)
     RAM_REPLACEMENT_STRING="-Xms${RAM_MB_FOR_KURA}m -Xmx${RAM_MB_FOR_KURA}m"
 
-    if RAM_MB > 1024
-    then
+    if [ "$RAM_MB" -gt 1024 ]; then
         echo "Setting kura ram -Xms and -Xmx to ${RAM_MB_FOR_KURA}m"
         sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" /opt/eclipse/kura/bin/start_kura.sh
         sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" /opt/eclipse/kura/bin/start_kura_debug.sh

--- a/kura/distrib/src/main/resources/common/customize-installation.sh
+++ b/kura/distrib/src/main/resources/common/customize-installation.sh
@@ -66,7 +66,6 @@ if [ ${BOARD} = "generic-device" ]; then
     RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
     RAM_MB=$(expr $RAM_KB / 1024)
     RAM_MB_FOR_KURA=$(expr $RAM_MB / 4)
-    RAM_REPLACEMENT_STRING="-Xms${RAM_MB_FOR_KURA}m -Xmx${RAM_MB_FOR_KURA}m"
 
     if [ "$RAM_MB" -lt 1024 ]; then
         RAM_REPLACEMENT_STRING="-Xms256m -Xmx256m"
@@ -75,6 +74,7 @@ if [ ${BOARD} = "generic-device" ]; then
     echo "Setting kura RAM to ${RAM_REPLACEMENT_STRING}"
     start_scripts_to_change=("start_kura.sh" "start_kura_debug.sh" "start_kura_background.sh")
 
+    RAM_REPLACEMENT_STRING="-Xms${RAM_MB_FOR_KURA}m -Xmx${RAM_MB_FOR_KURA}m"
     for installer_name in "${start_scripts_to_change[@]}"; do
         echo "Updating RAM values for $installer_name"
         sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" "/opt/eclipse/kura/bin/$installer_name"

--- a/kura/distrib/src/main/resources/common/customize-installation.sh
+++ b/kura/distrib/src/main/resources/common/customize-installation.sh
@@ -62,21 +62,22 @@ if [ ${BOARD} = "generic-device" ]; then
         echo "python3 not found. snapshot_0.xml, and iptables.init files may have wrong interface names. Default is eth0 and wlan0. Please correct them manually if they mismatch."
     fi
     
-    # dynamic ram assignment
+    # dynamic RAM assignment
     RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
     RAM_MB=$(expr $RAM_KB / 1024)
     RAM_MB_FOR_KURA=$(expr $RAM_MB / 4)
     RAM_REPLACEMENT_STRING="-Xms${RAM_MB_FOR_KURA}m -Xmx${RAM_MB_FOR_KURA}m"
 
-    if [ "$RAM_MB" -gt 1024 ]; then
-        echo "Setting kura ram -Xms and -Xmx to ${RAM_MB_FOR_KURA}m"
-        start_scripts_to_change=("start_kura.sh" "start_kura_debug.sh" "start_kura_background.sh")
-
-        for installer_name in "${start_scripts_to_change[@]}"; do
-            echo "Updating RAM values for $installer_name"
-            sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" "/opt/eclipse/kura/bin/$installer_name"
-        done
-    else
-        echo "System RAM is less than 1GB. Leaving assigned RAM as the default for the Kura profile."
+    if [ "$RAM_MB" -lt 1024 ]; then
+        RAM_REPLACEMENT_STRING="-Xms256m -Xmx256m"
     fi
+
+    echo "Setting kura RAM to ${RAM_REPLACEMENT_STRING}"
+    start_scripts_to_change=("start_kura.sh" "start_kura_debug.sh" "start_kura_background.sh")
+
+    for installer_name in "${start_scripts_to_change[@]}"; do
+        echo "Updating RAM values for $installer_name"
+        sed -i "s/-Xms[0-9]*m -Xmx[0-9]*m/$RAM_REPLACEMENT_STRING/g" "/opt/eclipse/kura/bin/$installer_name"
+    done
+    
 fi


### PR DESCRIPTION
Modifies the customize-installation script so that if there is more than 1GB of RAM available, kura will utilize 1/4th of it


Thinks to be figured out:
- 1) is there a better way to do this with the default Java options
- 2) is it the right implementation?
- 3) is it safe to use MemTotal

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution
changed from the default 512 -> calculated 948 
![image](https://github.com/eclipse/kura/assets/29900100/02cbe39a-8712-49e7-ba61-31375cf107b5)


**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
