### PR TITLE
chore: add `nohup.out` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 site
 
 .venv
+
+# Codespace mkdocs log
+nohup.out


### PR DESCRIPTION
Lately I noticed that a couple of contributor committed the `nohup.out` file by accident while working inside our documentation codespace. To avoid this annoying thing I added `nohup.out` file to the `.gitignore`.