### PR TITLE
fix: Pass null for Context method arguments in JaxRsRequestHandlerProxy

### DIFF
--- a/kura/org.eclipse.kura.request.handler.jaxrs/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.request.handler.jaxrs/META-INF/MANIFEST.MF
@@ -16,6 +16,6 @@ Import-Package: com.google.gson,
  org.eclipse.kura.cloudconnection.request;version="[1.0,2.0)",
  org.eclipse.kura.message;version="[1.4,2.0)",
  org.slf4j;version="1.7.25"
-Export-Package: org.eclipse.kura.request.handler.jaxrs;version="1.0.0",
+Export-Package: org.eclipse.kura.request.handler.jaxrs;version="1.1.0",
  org.eclipse.kura.request.handler.jaxrs.annotation;version="1.0.0",
- org.eclipse.kura.request.handler.jaxrs.consumer;version="1.0.0"
+ org.eclipse.kura.request.handler.jaxrs.consumer;version="1.1.0"

--- a/kura/org.eclipse.kura.request.handler.jaxrs/src/main/java/org/eclipse/kura/request/handler/jaxrs/consumer/RequestArgumentHandler.java
+++ b/kura/org.eclipse.kura.request.handler.jaxrs/src/main/java/org/eclipse/kura/request/handler/jaxrs/consumer/RequestArgumentHandler.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.request.handler.jaxrs.consumer;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.cloudconnection.message.KuraMessage;
+
+public interface RequestArgumentHandler<T> {
+
+    T buildParameter(final KuraMessage request) throws KuraException;
+}


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Currently the `JaxRsRequestHandlerProxy` supports at most a single parameter per REST endpoint method.

Methods that use arguments annotated with the [Context](https://docs.oracle.com/javaee/7/api/javax/ws/rs/core/Context.html) annotation to receive for example the `HttpServletRequest`/`HttpServletResponse`/`ContainerRequestContext` associated with the current request are not supported.

This PR changes `JaxRsRequestHandlerProxy` so that it passes `null` as value for that arguments, since the injected classes are in most cases HTTP specific and it is difficult to provide an equivalent in case of MQTT connection.

* Fixes the service listing REST API not working over MQTT.


