### PR TITLE
feat(web2): IPv6 Network on Status tab

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtStatusServiceImpl.java
@@ -61,21 +61,16 @@ import org.slf4j.LoggerFactory;
 public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements GwtStatusService {
 
     private static final String IP_ACQUISITION = "IP Acquisition: ";
-
     private static final String MODE = "Mode: ";
-
     private static final String SUBNET_MASK = "Subnet Mask: ";
-
     private static final String POSITION_STATUS = "positionStatus";
-
     private static final Logger logger = LoggerFactory.getLogger(GwtStatusServiceImpl.class);
-
     private static final long serialVersionUID = 8256280782910423734L;
-
     private static final String KURA_SERVICE_PID = ConfigurationService.KURA_SERVICE_PID;
     private static final String DATA_SERVICE_REFERENCE_NAME = "DataService";
     private static final String DATA_TRANSPORT_SERVICE_REFERENCE_NAME = "DataTransportService";
-
+    private static final String NL = "<br />";
+    private static final String tab = "&nbsp&nbsp&nbsp&nbsp";
     private static final long NETWORK_INFO_REFRESH_TIMEOUT = 30000l;
 
     private static List<GwtGroupedNVPair> networkStatus;
@@ -267,8 +262,6 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
         }
 
         List<GwtGroupedNVPair> pairs = new ArrayList<>();
-        String nl = "<br />";
-        String tab = "&nbsp&nbsp&nbsp&nbsp";
 
         GwtNetworkServiceImplFacade gwtNetworkService = new GwtNetworkServiceImplFacade();
         boolean isNet2 = gwtNetworkService.isNet2();
@@ -315,9 +308,9 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
                             gwtNetInterfaceConfig.getStatusEnum().getValue()));
                 } else {
                     pairs.add(new GwtGroupedNVPair("networkStatusEthernet", gwtNetInterfaceConfig.getName() + " - IPv4",
-                            currentAddress + nl + tab + SUBNET_MASK + currentSubnetMask + nl + tab + MODE
-                                    + gwtNetInterfaceConfig.getStatusEnum().getValue() + nl + tab + IP_ACQUISITION
-                                    + currentConfigMode + nl + tab + "Router Mode: " + currentRouterMode));
+                            currentAddress + NL + tab + SUBNET_MASK + currentSubnetMask + NL + tab + MODE
+                                    + gwtNetInterfaceConfig.getStatusEnum().getValue() + NL + tab + IP_ACQUISITION
+                                    + currentConfigMode + NL + tab + "Router Mode: " + currentRouterMode));
                 }
             } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.WIFI
                     && !gwtNetInterfaceConfig.getName().startsWith("mon")) {
@@ -337,10 +330,10 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
                             gwtNetInterfaceConfig.getStatusEnum().getValue()));
                 } else {
                     pairs.add(new GwtGroupedNVPair("networkStatusWifi", gwtNetInterfaceConfig.getName(),
-                            currentAddress + nl + tab + SUBNET_MASK + currentSubnetMask + nl + tab + MODE
-                                    + gwtNetInterfaceConfig.getStatusEnum().getValue() + nl + tab + IP_ACQUISITION
-                                    + currentConfigMode + nl + tab + "Router Mode: " + currentRouterMode + nl + tab
-                                    + "Wireless Mode:" + currentWifiMode + nl + tab + "SSID: " + currentWifiSsid + nl));
+                            currentAddress + NL + tab + SUBNET_MASK + currentSubnetMask + NL + tab + MODE
+                                    + gwtNetInterfaceConfig.getStatusEnum().getValue() + NL + tab + IP_ACQUISITION
+                                    + currentConfigMode + NL + tab + "Router Mode: " + currentRouterMode + NL + tab
+                                    + "Wireless Mode:" + currentWifiMode + NL + tab + "SSID: " + currentWifiSsid + NL));
                 }
             } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
                 String currentModemApn = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getApn();
@@ -356,9 +349,9 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
                             gwtNetInterfaceConfig.getStatusEnum().getValue()));
                 } else {
                     pairs.add(new GwtGroupedNVPair("networkStatusModem", name,
-                            currentAddress + nl + SUBNET_MASK + currentSubnetMask + nl + tab + MODE
-                                    + gwtNetInterfaceConfig.getStatusEnum().getValue() + nl + tab + IP_ACQUISITION
-                                    + currentConfigMode + nl + tab + "APN: " + currentModemApn + nl + tab
+                            currentAddress + NL + SUBNET_MASK + currentSubnetMask + NL + tab + MODE
+                                    + gwtNetInterfaceConfig.getStatusEnum().getValue() + NL + tab + IP_ACQUISITION
+                                    + currentConfigMode + NL + tab + "APN: " + currentModemApn + NL + tab
                                     + "Interface: " + interfaceName));
                 }
             }
@@ -394,8 +387,8 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
                     } else {
                         pairs.add(new GwtGroupedNVPair("networkStatusEthernet",
                                 gwtNetInterfaceConfig.getName() + " - IPv6",
-                                currentIPv6Address + nl + tab + SUBNET_MASK + currentIPv6SubnetMask + nl + tab + MODE
-                                        + convertIPv6Status(statusIPv6) + nl + tab + IP_ACQUISITION
+                                currentIPv6Address + NL + tab + SUBNET_MASK + currentIPv6SubnetMask + NL + tab + MODE
+                                        + convertIPv6Status(statusIPv6) + NL + tab + IP_ACQUISITION
                                         + currentIPv6ConfigMode));
                     }
                 } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.WIFI
@@ -416,10 +409,11 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
                                 convertIPv6Status(statusIPv6)));
                     } else {
                         pairs.add(new GwtGroupedNVPair("networkStatusWifi", gwtNetInterfaceConfig.getName() + " - IPv6",
-                                currentAddress + nl + tab + SUBNET_MASK + currentSubnetMask + nl + tab + MODE
-                                        + convertIPv6Status(statusIPv6) + nl + tab + IP_ACQUISITION
-                                        + currentConfigMode + nl + tab + "Wireless Mode:" + currentWifiMode + nl + tab
-                                        + "SSID: " + currentWifiSsid + nl));
+                                currentIPv6Address + NL + tab + SUBNET_MASK + currentIPv6SubnetMask + NL + tab + MODE
+                                        + convertIPv6Status(statusIPv6) + NL + tab + IP_ACQUISITION
+                                        + currentIPv6ConfigMode + NL + tab + "Wireless Mode:" + currentWifiMode + NL
+                                        + tab
+                                        + "SSID: " + currentWifiSsid + NL));
                     }
                 } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
                     String currentModemApn = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getApn();
@@ -435,9 +429,9 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
                                 convertIPv6Status(statusIPv6)));
                     } else {
                         pairs.add(new GwtGroupedNVPair("networkStatusModem", name + " - IPv6",
-                                currentAddress + nl + SUBNET_MASK + currentSubnetMask + nl + tab + MODE
-                                        + convertIPv6Status(statusIPv6) + nl + tab + IP_ACQUISITION
-                                        + currentConfigMode + nl + tab + "APN: " + currentModemApn + nl + tab
+                                currentIPv6Address + NL + SUBNET_MASK + currentIPv6SubnetMask + NL + tab + MODE
+                                        + convertIPv6Status(statusIPv6) + NL + tab + IP_ACQUISITION
+                                        + currentIPv6ConfigMode + NL + tab + "APN: " + currentModemApn + NL + tab
                                         + "Interface: " + interfaceName));
                     }
                 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtStatusServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.kura.cloud.CloudService;
 import org.eclipse.kura.cloudconnection.CloudConnectionManager;
@@ -70,7 +71,7 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
     private static final String DATA_SERVICE_REFERENCE_NAME = "DataService";
     private static final String DATA_TRANSPORT_SERVICE_REFERENCE_NAME = "DataTransportService";
     private static final String NL = "<br />";
-    private static final String tab = "&nbsp&nbsp&nbsp&nbsp";
+    private static final String TAB = "&nbsp&nbsp&nbsp&nbsp";
     private static final long NETWORK_INFO_REFRESH_TIMEOUT = 30000l;
 
     private static List<GwtGroupedNVPair> networkStatus;
@@ -279,163 +280,14 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
 
         for (GwtNetInterfaceConfig gwtNetInterfaceConfig : gwtNetInterfaceConfigs) {
 
-            String currentAddress = gwtNetInterfaceConfig.getIpAddress();
-            String currentSubnetMask = gwtNetInterfaceConfig.getSubnetMask();
+            Optional<String> statusGroup = getStatusGroup(gwtNetInterfaceConfig);
+            Optional<String> statusName = getStatusName(gwtNetInterfaceConfig);
+            Optional<String> statusValue = getStatusValue(gwtNetInterfaceConfig, isNet2);
 
-            String currentConfigMode;
-            if (gwtNetInterfaceConfig.getConfigModeEnum() == GwtNetIfConfigMode.netIPv4ConfigModeDHCP) {
-                currentConfigMode = "DHCP";
-            } else {
-                currentConfigMode = "Manual";
+            if (statusGroup.isPresent() && statusName.isPresent() && statusValue.isPresent()) {
+                pairs.add(new GwtGroupedNVPair(statusGroup.get(), statusName.get(), statusValue.get()));
             }
 
-            String currentRouterMode;
-            if (gwtNetInterfaceConfig.getRouterModeEnum() == GwtNetRouterMode.netRouterDchp) {
-                currentRouterMode = "DHCPD";
-            } else if (gwtNetInterfaceConfig.getRouterModeEnum() == GwtNetRouterMode.netRouterNat) {
-                currentRouterMode = "NAT";
-            } else if (gwtNetInterfaceConfig.getRouterModeEnum() == GwtNetRouterMode.netRouterDchpNat) {
-                currentRouterMode = "DHCPD & NAT";
-            } else {
-                currentRouterMode = "";
-            }
-
-            if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.ETHERNET) {
-                if (gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusDisabled
-                        || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusUnmanaged
-                        || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusL2Only) {
-                    pairs.add(new GwtGroupedNVPair("networkStatusEthernet", gwtNetInterfaceConfig.getName() + " - IPv4",
-                            gwtNetInterfaceConfig.getStatusEnum().getValue()));
-                } else {
-                    pairs.add(new GwtGroupedNVPair("networkStatusEthernet", gwtNetInterfaceConfig.getName() + " - IPv4",
-                            currentAddress + NL + tab + SUBNET_MASK + currentSubnetMask + NL + tab + MODE
-                                    + gwtNetInterfaceConfig.getStatusEnum().getValue() + NL + tab + IP_ACQUISITION
-                                    + currentConfigMode + NL + tab + "Router Mode: " + currentRouterMode));
-                }
-            } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.WIFI
-                    && !gwtNetInterfaceConfig.getName().startsWith("mon")) {
-                String currentWifiMode = ((GwtWifiNetInterfaceConfig) gwtNetInterfaceConfig)
-                        .getWirelessModeEnum() == GwtWifiWirelessMode.netWifiWirelessModeStation ? "Station Mode"
-                                : "Access Point";
-                GwtWifiConfig gwtActiveWifiConfig = ((GwtWifiNetInterfaceConfig) gwtNetInterfaceConfig)
-                        .getActiveWifiConfig();
-                String currentWifiSsid = null;
-                if (gwtActiveWifiConfig != null) {
-                    currentWifiSsid = gwtActiveWifiConfig.getWirelessSsid();
-                }
-                if (gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusDisabled
-                        || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusUnmanaged
-                        || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusL2Only) {
-                    pairs.add(new GwtGroupedNVPair("networkStatusWifi", gwtNetInterfaceConfig.getName(),
-                            gwtNetInterfaceConfig.getStatusEnum().getValue()));
-                } else {
-                    pairs.add(new GwtGroupedNVPair("networkStatusWifi", gwtNetInterfaceConfig.getName(),
-                            currentAddress + NL + tab + SUBNET_MASK + currentSubnetMask + NL + tab + MODE
-                                    + gwtNetInterfaceConfig.getStatusEnum().getValue() + NL + tab + IP_ACQUISITION
-                                    + currentConfigMode + NL + tab + "Router Mode: " + currentRouterMode + NL + tab
-                                    + "Wireless Mode:" + currentWifiMode + NL + tab + "SSID: " + currentWifiSsid + NL));
-                }
-            } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
-                String currentModemApn = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getApn();
-                String name = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getName();
-                String interfaceName = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getInterfaceName();
-                if (Objects.nonNull(interfaceName) && !interfaceName.isEmpty()) {
-                    name = name + " (" + interfaceName + ")";
-                }
-                if (gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusDisabled
-                        || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusUnmanaged
-                        || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusL2Only) {
-                    pairs.add(new GwtGroupedNVPair("networkStatusModem", name,
-                            gwtNetInterfaceConfig.getStatusEnum().getValue()));
-                } else {
-                    pairs.add(new GwtGroupedNVPair("networkStatusModem", name,
-                            currentAddress + NL + SUBNET_MASK + currentSubnetMask + NL + tab + MODE
-                                    + gwtNetInterfaceConfig.getStatusEnum().getValue() + NL + tab + IP_ACQUISITION
-                                    + currentConfigMode + NL + tab + "APN: " + currentModemApn + NL + tab
-                                    + "Interface: " + interfaceName));
-                }
-            }
-
-            if (isNet2) {
-                String currentIPv6Address = gwtNetInterfaceConfig.getIpv6Address();
-                String currentIPv6SubnetMask = String.valueOf(gwtNetInterfaceConfig.getIpv6SubnetMask());
-
-                String currentIPv6ConfigMode;
-                String currentIPv6ConfigModeString = gwtNetInterfaceConfig.getIpv6ConfigMode();
-                if (Objects.nonNull(currentIPv6ConfigModeString)) {
-                    if (gwtNetInterfaceConfig.getIpv6ConfigMode().equals("netIPv6MethodAuto")) {
-                        currentIPv6ConfigMode = "Auto";
-                    } else if (currentIPv6ConfigModeString.equals("netIPv6MethodDhcp")) {
-                        currentIPv6ConfigMode = "DHCP";
-                    } else {
-                        currentIPv6ConfigMode = "Manual";
-                    }
-                } else {
-                    currentIPv6ConfigMode = "Manual";
-                }
-
-                String statusIPv6 = gwtNetInterfaceConfig.getIpv6Status();
-
-                if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.ETHERNET) {
-
-                    if (statusIPv6.equals("netIPv6StatusDisabled")
-                            || statusIPv6.equals("netIPv6StatusUnmanaged")
-                            || statusIPv6.equals("netIPv6StatusL2Only")) {
-                        pairs.add(new GwtGroupedNVPair("networkStatusEthernet",
-                                gwtNetInterfaceConfig.getName() + " - IPv6",
-                                convertIPv6Status(statusIPv6)));
-                    } else {
-                        pairs.add(new GwtGroupedNVPair("networkStatusEthernet",
-                                gwtNetInterfaceConfig.getName() + " - IPv6",
-                                currentIPv6Address + NL + tab + SUBNET_MASK + currentIPv6SubnetMask + NL + tab + MODE
-                                        + convertIPv6Status(statusIPv6) + NL + tab + IP_ACQUISITION
-                                        + currentIPv6ConfigMode));
-                    }
-                } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.WIFI
-                        && !gwtNetInterfaceConfig.getName().startsWith("mon")) {
-                    String currentWifiMode = ((GwtWifiNetInterfaceConfig) gwtNetInterfaceConfig)
-                            .getWirelessModeEnum() == GwtWifiWirelessMode.netWifiWirelessModeStation ? "Station Mode"
-                                    : "Access Point";
-                    GwtWifiConfig gwtActiveWifiConfig = ((GwtWifiNetInterfaceConfig) gwtNetInterfaceConfig)
-                            .getActiveWifiConfig();
-                    String currentWifiSsid = null;
-                    if (gwtActiveWifiConfig != null) {
-                        currentWifiSsid = gwtActiveWifiConfig.getWirelessSsid();
-                    }
-                    if (statusIPv6.equals("netIPv6StatusDisabled")
-                            || statusIPv6.equals("netIPv6StatusUnmanaged")
-                            || statusIPv6.equals("netIPv6StatusL2Only")) {
-                        pairs.add(new GwtGroupedNVPair("networkStatusWifi", gwtNetInterfaceConfig.getName() + " - IPv6",
-                                convertIPv6Status(statusIPv6)));
-                    } else {
-                        pairs.add(new GwtGroupedNVPair("networkStatusWifi", gwtNetInterfaceConfig.getName() + " - IPv6",
-                                currentIPv6Address + NL + tab + SUBNET_MASK + currentIPv6SubnetMask + NL + tab + MODE
-                                        + convertIPv6Status(statusIPv6) + NL + tab + IP_ACQUISITION
-                                        + currentIPv6ConfigMode + NL + tab + "Wireless Mode:" + currentWifiMode + NL
-                                        + tab
-                                        + "SSID: " + currentWifiSsid + NL));
-                    }
-                } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
-                    String currentModemApn = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getApn();
-                    String name = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getName();
-                    String interfaceName = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getInterfaceName();
-                    if (Objects.nonNull(interfaceName) && !interfaceName.isEmpty()) {
-                        name = name + " (" + interfaceName + ")";
-                    }
-                    if (statusIPv6.equals("netIPv6StatusDisabled")
-                            || statusIPv6.equals("netIPv6StatusUnmanaged")
-                            || statusIPv6.equals("netIPv6StatusL2Only")) {
-                        pairs.add(new GwtGroupedNVPair("networkStatusModem", name + " - IPv6",
-                                convertIPv6Status(statusIPv6)));
-                    } else {
-                        pairs.add(new GwtGroupedNVPair("networkStatusModem", name + " - IPv6",
-                                currentIPv6Address + NL + SUBNET_MASK + currentIPv6SubnetMask + NL + tab + MODE
-                                        + convertIPv6Status(statusIPv6) + NL + tab + IP_ACQUISITION
-                                        + currentIPv6ConfigMode + NL + tab + "APN: " + currentModemApn + NL + tab
-                                        + "Interface: " + interfaceName));
-                    }
-                }
-            }
         }
 
         networkStatus = pairs;
@@ -443,7 +295,252 @@ public class GwtStatusServiceImpl extends OsgiRemoteServiceServlet implements Gw
         return networkStatus;
     }
 
+    private static Optional<String> getStatusGroup(GwtNetInterfaceConfig gwtNetInterfaceConfig) {
+        if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.ETHERNET) {
+            return Optional.of("networkStatusEthernet");
+        } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.WIFI) {
+            return Optional.of("networkStatusWifi");
+        } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
+            return Optional.of("networkStatusModem");
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<String> getStatusName(GwtNetInterfaceConfig gwtNetInterfaceConfig) {
+        if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.ETHERNET
+                || gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.WIFI) {
+            return Optional.of(gwtNetInterfaceConfig.getName());
+        } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
+            String name = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getName();
+            String interfaceName = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getInterfaceName();
+            if (Objects.nonNull(interfaceName) && !interfaceName.isEmpty()) {
+                name = name + " (" + interfaceName + ")";
+            }
+            return Optional.of(name);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<String> getStatusValue(GwtNetInterfaceConfig gwtNetInterfaceConfig, boolean isNet2) {
+        StringBuilder sb = new StringBuilder();
+        Optional<String> statusIPv4 = getIPv4Status(gwtNetInterfaceConfig);
+        statusIPv4.ifPresent(sb::append);
+
+        if (isNet2) {
+            Optional<String> statusIPv6 = getIPv6Status(gwtNetInterfaceConfig, isNet2);
+            statusIPv6.ifPresent(status -> {
+                if (sb.length() != 0) {
+                    sb.append(NL);
+                }
+                sb.append(status);
+            });
+        }
+
+        if (sb.length() == 0) {
+            return Optional.empty();
+        } else {
+            return Optional.of(sb.toString());
+        }
+
+    }
+
+    private static Optional<String> getIPv4Status(GwtNetInterfaceConfig gwtNetInterfaceConfig) {
+        String currentAddress = gwtNetInterfaceConfig.getIpAddress();
+        String currentSubnetMask = gwtNetInterfaceConfig.getSubnetMask();
+
+        String currentConfigMode;
+        if (gwtNetInterfaceConfig.getConfigModeEnum() == GwtNetIfConfigMode.netIPv4ConfigModeDHCP) {
+            currentConfigMode = "DHCP";
+        } else {
+            currentConfigMode = "Manual";
+        }
+
+        String currentRouterMode;
+        if (gwtNetInterfaceConfig.getRouterModeEnum() == GwtNetRouterMode.netRouterDchp) {
+            currentRouterMode = "DHCPD";
+        } else if (gwtNetInterfaceConfig.getRouterModeEnum() == GwtNetRouterMode.netRouterNat) {
+            currentRouterMode = "NAT";
+        } else if (gwtNetInterfaceConfig.getRouterModeEnum() == GwtNetRouterMode.netRouterDchpNat) {
+            currentRouterMode = "DHCPD & NAT";
+        } else {
+            currentRouterMode = "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.ETHERNET) {
+            if (gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusDisabled
+                    || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusUnmanaged
+                    || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusL2Only) {
+                sb.append("<b>IPv4</b>").append(NL).append(TAB)
+                        .append(gwtNetInterfaceConfig.getStatusEnum().getValue());
+            } else {
+                sb.append("<b>IPv4</b>").append(NL)
+                        .append(TAB).append(currentAddress).append(NL)
+                        .append(TAB).append(TAB).append(SUBNET_MASK).append(currentSubnetMask).append(NL)
+                        .append(TAB).append(TAB).append(MODE).append(gwtNetInterfaceConfig.getStatusEnum().getValue())
+                        .append(NL)
+                        .append(TAB).append(TAB).append(IP_ACQUISITION).append(currentConfigMode).append(NL)
+                        .append(TAB).append(TAB).append("Router Mode: ").append(currentRouterMode);
+            }
+            return Optional.of(sb.toString());
+        } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.WIFI
+                && !gwtNetInterfaceConfig.getName().startsWith("mon")) {
+            String currentWifiMode = ((GwtWifiNetInterfaceConfig) gwtNetInterfaceConfig)
+                    .getWirelessModeEnum() == GwtWifiWirelessMode.netWifiWirelessModeStation ? "Station Mode"
+                            : "Access Point";
+            GwtWifiConfig gwtActiveWifiConfig = ((GwtWifiNetInterfaceConfig) gwtNetInterfaceConfig)
+                    .getActiveWifiConfig();
+            String currentWifiSsid = null;
+            if (gwtActiveWifiConfig != null) {
+                currentWifiSsid = gwtActiveWifiConfig.getWirelessSsid();
+            }
+            if (gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusDisabled
+                    || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusUnmanaged
+                    || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusL2Only) {
+                sb.append("<b>IPv4</b>").append(NL).append(TAB)
+                        .append(gwtNetInterfaceConfig.getStatusEnum().getValue());
+            } else {
+                sb.append("<b>IPv4</b>").append(NL)
+                        .append(TAB).append(currentAddress).append(NL)
+                        .append(TAB).append(TAB).append(SUBNET_MASK).append(currentSubnetMask).append(NL)
+                        .append(TAB).append(TAB).append(MODE).append(gwtNetInterfaceConfig.getStatusEnum().getValue())
+                        .append(NL)
+                        .append(TAB).append(TAB).append(IP_ACQUISITION).append(currentConfigMode).append(NL)
+                        .append(TAB).append(TAB).append("Router Mode: ").append(currentRouterMode).append(NL)
+                        .append(TAB).append(TAB).append("Wireless Mode:").append(currentWifiMode).append(NL)
+                        .append(TAB).append(TAB).append("SSID: ").append(currentWifiSsid).append(NL);
+            }
+            return Optional.of(sb.toString());
+        } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
+            String currentModemApn = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getApn();
+            String name = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getName();
+            String interfaceName = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getInterfaceName();
+            if (Objects.nonNull(interfaceName) && !interfaceName.isEmpty()) {
+                name = name + " (" + interfaceName + ")";
+            }
+            if (gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusDisabled
+                    || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusUnmanaged
+                    || gwtNetInterfaceConfig.getStatusEnum() == GwtNetIfStatus.netIPv4StatusL2Only) {
+                sb.append("<b>IPv4</b>").append(NL).append(TAB)
+                        .append(gwtNetInterfaceConfig.getStatusEnum().getValue());
+            } else {
+                sb.append("<b>IPv4</b>").append(NL)
+                        .append(TAB).append(currentAddress).append(NL)
+                        .append(TAB).append(TAB).append(SUBNET_MASK).append(currentSubnetMask)
+                        .append(NL).append(TAB).append(TAB).append(MODE)
+                        .append(gwtNetInterfaceConfig.getStatusEnum().getValue()).append(NL)
+                        .append(TAB).append(TAB).append(IP_ACQUISITION)
+                        .append(currentConfigMode).append(NL)
+                        .append(TAB).append(TAB).append("APN: ").append(currentModemApn).append(NL)
+                        .append(TAB).append(TAB).append("Interface: ").append(interfaceName);
+            }
+            return Optional.of(sb.toString());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<String> getIPv6Status(GwtNetInterfaceConfig gwtNetInterfaceConfig, boolean isNet2) {
+        if (!isNet2) {
+            return Optional.empty();
+        }
+
+        String currentIPv6Address = gwtNetInterfaceConfig.getIpv6Address();
+        String currentIPv6SubnetMask = String.valueOf(gwtNetInterfaceConfig.getIpv6SubnetMask());
+
+        String currentIPv6ConfigMode;
+        String currentIPv6ConfigModeString = gwtNetInterfaceConfig.getIpv6ConfigMode();
+        if (Objects.nonNull(currentIPv6ConfigModeString)) {
+            if (gwtNetInterfaceConfig.getIpv6ConfigMode().equals("netIPv6MethodAuto")) {
+                currentIPv6ConfigMode = "Auto";
+            } else if (currentIPv6ConfigModeString.equals("netIPv6MethodDhcp")) {
+                currentIPv6ConfigMode = "DHCP";
+            } else {
+                currentIPv6ConfigMode = "Manual";
+            }
+        } else {
+            currentIPv6ConfigMode = "Manual";
+        }
+
+        String statusIPv6 = gwtNetInterfaceConfig.getIpv6Status();
+        if (Objects.isNull(statusIPv6)) {
+            statusIPv6 = "netIPv6StatusDisabled";
+
+        }
+
+        StringBuilder sb = new StringBuilder();
+        if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.ETHERNET) {
+            if (statusIPv6.equals("netIPv6StatusDisabled")
+                    || statusIPv6.equals("netIPv6StatusUnmanaged")
+                    || statusIPv6.equals("netIPv6StatusL2Only")) {
+                sb.append("<b>IPv6</b>").append(NL).append(TAB)
+                        .append(convertIPv6Status(statusIPv6));
+            } else {
+                sb.append("<b>IPv6</b>").append(NL)
+                        .append(TAB).append(currentIPv6Address).append(NL)
+                        .append(TAB).append(TAB).append(SUBNET_MASK).append(currentIPv6SubnetMask).append(NL)
+                        .append(TAB).append(TAB).append(MODE).append(convertIPv6Status(statusIPv6)).append(NL)
+                        .append(TAB).append(TAB).append(IP_ACQUISITION).append(currentIPv6ConfigMode);
+            }
+            return Optional.of(sb.toString());
+        } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.WIFI
+                && !gwtNetInterfaceConfig.getName().startsWith("mon")) {
+            String currentWifiMode = ((GwtWifiNetInterfaceConfig) gwtNetInterfaceConfig)
+                    .getWirelessModeEnum() == GwtWifiWirelessMode.netWifiWirelessModeStation ? "Station Mode"
+                            : "Access Point";
+            GwtWifiConfig gwtActiveWifiConfig = ((GwtWifiNetInterfaceConfig) gwtNetInterfaceConfig)
+                    .getActiveWifiConfig();
+            String currentWifiSsid = null;
+            if (gwtActiveWifiConfig != null) {
+                currentWifiSsid = gwtActiveWifiConfig.getWirelessSsid();
+            }
+            if (statusIPv6.equals("netIPv6StatusDisabled")
+                    || statusIPv6.equals("netIPv6StatusUnmanaged")
+                    || statusIPv6.equals("netIPv6StatusL2Only")) {
+                sb.append("<b>IPv6</b>").append(NL).append(TAB).append(convertIPv6Status(statusIPv6));
+            } else {
+                sb.append("<b>IPv6</b>").append(NL)
+                        .append(TAB).append(currentIPv6Address).append(NL)
+                        .append(TAB).append(TAB).append(SUBNET_MASK).append(currentIPv6SubnetMask).append(NL)
+                        .append(TAB).append(TAB).append(MODE).append(convertIPv6Status(statusIPv6)).append(NL)
+                        .append(TAB).append(TAB).append(IP_ACQUISITION).append(currentIPv6ConfigMode).append(NL)
+                        .append(TAB).append(TAB).append("Wireless Mode:").append(currentWifiMode).append(NL)
+                        .append(TAB).append(TAB).append("SSID: ").append(currentWifiSsid).append(NL);
+            }
+            return Optional.of(sb.toString());
+        } else if (gwtNetInterfaceConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
+            String currentModemApn = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getApn();
+            String name = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getName();
+            String interfaceName = ((GwtModemInterfaceConfig) gwtNetInterfaceConfig).getInterfaceName();
+            if (Objects.nonNull(interfaceName) && !interfaceName.isEmpty()) {
+                name = name + " (" + interfaceName + ")";
+            }
+            if (statusIPv6.equals("netIPv6StatusDisabled")
+                    || statusIPv6.equals("netIPv6StatusUnmanaged")
+                    || statusIPv6.equals("netIPv6StatusL2Only")) {
+                sb.append("<b>IPv6</b>").append(NL).append(TAB).append(convertIPv6Status(statusIPv6));
+            } else {
+                sb.append("<b>IPv6</b>").append(NL)
+                        .append(TAB).append(currentIPv6Address).append(NL)
+                        .append(TAB).append(TAB).append(SUBNET_MASK).append(currentIPv6SubnetMask).append(NL)
+                        .append(TAB).append(TAB).append(MODE).append(convertIPv6Status(statusIPv6)).append(NL)
+                        .append(TAB).append(TAB).append(IP_ACQUISITION).append(currentIPv6ConfigMode).append(NL)
+                        .append(TAB).append(TAB).append("APN: ").append(currentModemApn).append(NL)
+                        .append(TAB).append(TAB).append("Interface: ").append(interfaceName);
+            }
+            return Optional.of(sb.toString());
+        } else {
+            return Optional.empty();
+        }
+
+    }
+
     private static String convertIPv6Status(String status) {
+        if (Objects.isNull(status)) {
+            return "netIPv6StatusDisabled";
+        }
         switch (status) {
             case "netIPv6StatusDisabled":
                 return "Disabled";


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds the network status for IPv6 on the main Status tab.

**Screenshots:** 
<img width="1417" alt="Screenshot 2023-11-02 at 16 49 23" src="https://github.com/eclipse/kura/assets/2919570/cd991ee1-f2e8-46ab-b0bf-5560f936846e">
