### PR TITLE
ci(automation): avoid branch name collision on Version Uptick workflow

### DIFF
--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -63,4 +63,4 @@ jobs:
         title: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
         commit-message: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
         body: "Automated changes by _Version uptick automation_ action: automated uptick to ${{ steps.get-version.outputs.version }} version"
-        branch-suffix: short-commit-hash
+        branch-suffix: timestamp


### PR DESCRIPTION
For the uptick workflow it can happen that you'll need to update two branches (the release and the development one) at the same time. They most probably share the last commit hash and therefore you can have a branch name collision for the uptick workflow.

We updated the `branch-suffix` to use the `timestamp` instead of the `short-commit-hash` to avoid future collisions.

Therefore we'll now see the following branch names:

![image](https://github.com/eurotech/add-ons-automation/assets/22748355/e48d1222-4756-4a01-9a88-49ab86605249)

Instead of:

![image](https://github.com/eurotech/add-ons-automation/assets/22748355/06d87cda-8e46-4e0c-abcf-347b2c0a4369)

**Note**: I didn't update the other workflows since the scenario in which we have multiple workflows running on the same commit should not happen and we might actually want PR to overwrite the same branch (Release Notes)