### PR TITLE
fix: changed bind-interfaces with bind-dynamic

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
@@ -42,10 +42,10 @@ public class DnsmasqTool implements DhcpLinuxTool {
     private String globalConfigFilename = "/etc/dnsmasq.d/dnsmasq-globals.conf";
     private static final String GLOBAL_CONFIGURATION = "port=0\nbind-dynamic\ndhcp-leasefile=/var/lib/dhcp/dnsmasq.leases\n";
 
-    static final Command IS_ACTIVE_COMMAND = new Command(
-            new String[] { "systemctl", "is-active", "--quiet", DhcpServerTool.DNSMASQ.getValue() });
-    static final Command RESTART_COMMAND = new Command(
-            new String[] { "systemctl", "restart", DhcpServerTool.DNSMASQ.getValue() });
+    static final Command IS_ACTIVE_COMMAND = new Command(new String[] { "systemctl", "is-active", "--quiet",
+            DhcpServerTool.DNSMASQ.getValue() });
+    static final Command RESTART_COMMAND = new Command(new String[] { "systemctl", "restart",
+            DhcpServerTool.DNSMASQ.getValue() });
 
     private CommandExecutorService executorService;
     private Map<String, byte[]> configsLastHash = Collections.synchronizedMap(new HashMap<>());

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
@@ -40,12 +40,12 @@ public class DnsmasqTool implements DhcpLinuxTool {
     private static final Logger logger = LoggerFactory.getLogger(DnsmasqTool.class);
 
     private String globalConfigFilename = "/etc/dnsmasq.d/dnsmasq-globals.conf";
-    private static final String GLOBAL_CONFIGURATION = "port=0\nbind-interfaces\ndhcp-leasefile=/var/lib/dhcp/dnsmasq.leases\n";
+    private static final String GLOBAL_CONFIGURATION = "port=0\nbind-dynamic\ndhcp-leasefile=/var/lib/dhcp/dnsmasq.leases\n";
 
-    static final Command IS_ACTIVE_COMMAND = new Command(new String[] { "systemctl", "is-active", "--quiet",
-            DhcpServerTool.DNSMASQ.getValue() });
-    static final Command RESTART_COMMAND = new Command(new String[] { "systemctl", "restart",
-            DhcpServerTool.DNSMASQ.getValue() });
+    static final Command IS_ACTIVE_COMMAND = new Command(
+            new String[] { "systemctl", "is-active", "--quiet", DhcpServerTool.DNSMASQ.getValue() });
+    static final Command RESTART_COMMAND = new Command(
+            new String[] { "systemctl", "restart", DhcpServerTool.DNSMASQ.getValue() });
 
     private CommandExecutorService executorService;
     private Map<String, byte[]> configsLastHash = Collections.synchronizedMap(new HashMap<>());


### PR DESCRIPTION
This changes the way DNSMASQ service operates due to a change in raspberry-pi-os bookworm.
The field bind-interfaces is replaced with bind-dynamic.

Tested with bookworm and bullseye AARCH64.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
