### PR TITLE
fix(core.cloud): Set min value to command timeout metatype

### DIFF
--- a/kura/org.eclipse.kura.core.cloud/OSGI-INF/metatype/org.eclipse.kura.cloud.app.command.CommandCloudApp.xml
+++ b/kura/org.eclipse.kura.core.cloud/OSGI-INF/metatype/org.eclipse.kura.cloud.app.command.CommandCloudApp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -53,6 +53,7 @@
         	cardinality="0"
         	required="false"
         	default="60"
+                min="1"
         	description="Timeout (in seconds) for the command execution.">
         </AD>
         


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds a minimum value to the timeout parameter in the command service.
