### PR TITLE
fix: Disable REST basic and legacy certificate auth by default

### DIFF
--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
@@ -537,4 +537,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-intelup2
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-intelup2
@@ -517,4 +517,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-jetson-nano
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-jetson-nano
@@ -481,4 +481,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
@@ -537,4 +537,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/snapshot_0.xml
@@ -398,4 +398,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/snapshot_0.xml
@@ -398,4 +398,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/snapshot_0.xml
@@ -505,4 +505,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/snapshot_0.xml
@@ -398,4 +398,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/snapshot_0.xml
@@ -472,4 +472,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/raspberry-pi-arm64-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-arm64-nn/snapshot_0.xml
@@ -373,4 +373,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/raspberry-pi-arm64/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-arm64/snapshot_0.xml
@@ -534,4 +534,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/raspberry-pi-armhf-nn/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-armhf-nn/snapshot_0.xml
@@ -373,4 +373,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/distrib/src/main/resources/raspberry-pi-armhf/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/raspberry-pi-armhf/snapshot_0.xml
@@ -540,4 +540,20 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.rest.provider.RestService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="auth.basic.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="auth.certificate.stateless.enabled" type="Boolean">
+                <esf:value>false</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.pid" type="String">
+                <esf:value>org.eclipse.kura.internal.rest.provider.RestService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Disables all REST authentication methods leaving only session based authentication enabled by default.
