### PR TITLE
fix: wire record query unbind error

### DIFF
--- a/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/WireRecordQueryComponent.xml
+++ b/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/WireRecordQueryComponent.xml
@@ -35,8 +35,7 @@
               cardinality="1..1"
               interface="org.eclipse.kura.wire.WireHelperService"
               name="WireHelperService"
-              policy="static"
-              unbind="unbindWireHelperService"/>
+              policy="static"/>
    <reference name="QueryableWireRecordStoreProvider"
            policy="dynamic"
            bind="bindQueryableWireRecordStoreProvider"

--- a/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/WireRecordStoreComponent.xml
+++ b/kura/org.eclipse.kura.wire.db.component.provider/OSGI-INF/WireRecordStoreComponent.xml
@@ -35,8 +35,7 @@
    	          cardinality="1..1"
    	          interface="org.eclipse.kura.wire.WireHelperService"
    	          name="WireHelperService"
-   	          policy="static"
-   	          unbind="unbindWireHelperService"/>
+   	          policy="static"/>
    <reference name="WireRecordStoreProvider"
            policy="dynamic"
            bind="bindWireRecordStoreProvider"

--- a/kura/org.eclipse.kura.wire.db.component.provider/src/main/java/org/eclipse/kura/internal/wire/query/WireRecordQueryComponent.java
+++ b/kura/org.eclipse.kura.wire.db.component.provider/src/main/java/org/eclipse/kura/internal/wire/query/WireRecordQueryComponent.java
@@ -74,6 +74,12 @@ public class WireRecordQueryComponent implements WireEmitter, WireReceiver, Conf
 
         logger.debug("Updating Wire Record Query component... Done");
     }
+    
+    protected void deactivate() {
+        logger.debug("Deactivating Wire Record Query Component...");
+
+        logger.debug("Deactivating Wire Record Query Component... Done");
+    }
 
     @Override
     public void consumersConnected(final Wire[] wires) {


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]


**Description of the solution adopted:** Removed not needed references in definition to unbind methods. Added missing deactivate method.

**Screenshots:** N/A

**Manual Tests**: Performed build and installation and verified that the previously reported errors are not anymore present

**Any side note on the changes made:** No
