### PR TITLE
fix: Fixed web ui access for identity with limited permissions

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/DevicePanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/DevicePanelUi.java
@@ -88,13 +88,14 @@ public class DevicePanelUi extends Composite {
         this.systemProperties.addClickHandler(new Tab.RefreshHandler(this.systemPropertiesPanel));
         this.containers.addClickHandler(new Tab.RefreshHandler(this.dockerContainersPanel));
 
-        this.containers.setVisible(false); //hidden by default
-        checkIfContainerOrchestratorIsAvaliable();
+        this.containers.setVisible(false); // hidden by default
     }
 
     public void initDevicePanel() {
         this.profilePanel.refresh();
         this.commandPanel.setSession(this.session);
+        this.logPanel.initialize();
+        checkIfContainerOrchestratorIsAvaliable();
     }
 
     public void setSession(GwtSession currentSession) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -30,11 +30,11 @@ import org.eclipse.kura.web.shared.service.GwtSecurityTokenService;
 import org.eclipse.kura.web.shared.service.GwtSecurityTokenServiceAsync;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.CheckBox;
+import org.gwtbootstrap3.client.ui.Form;
 import org.gwtbootstrap3.client.ui.FormLabel;
 import org.gwtbootstrap3.client.ui.ListBox;
 import org.gwtbootstrap3.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.Row;
-import org.gwtbootstrap3.client.ui.Form;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -90,6 +90,7 @@ public class LogTabUi extends Composite {
     private final LinkedList<GwtLogEntry> logs = new LinkedList<>();
     private boolean hasLogProvider = false;
     private boolean autoFollow = true;
+    private boolean initialized = false;
 
     private final String nonce = Integer.toString(Random.nextInt());
 
@@ -159,12 +160,22 @@ public class LogTabUi extends Composite {
         this.logTextArea.setReadOnly(true);
         this.logTextArea.addFocusHandler(focus -> LogTabUi.this.autoFollow = false);
 
-        initLogProviderListBox();
-
         this.showStackTraceCheckbox.setValue(true);
         this.showMoreInfoCheckbox.setValue(false);
         this.showStackTraceCheckbox.addClickHandler(click -> displayLogs());
         this.showMoreInfoCheckbox.addClickHandler(click -> displayLogs());
+
+        this.openNewWindow.addClickHandler(handler -> {
+            Window.open(Window.Location.getHref(), "_blank", "");
+        });
+    }
+
+    public void initialize() {
+        if (initialized) {
+            return;
+        }
+
+        initLogProviderListBox();
 
         LogPollService.subscribe(entries -> {
             if (LogTabUi.this.logs.size() + entries.size() > CACHE_SIZE_LIMIT) {
@@ -177,9 +188,7 @@ public class LogTabUi extends Composite {
             displayLogs();
         });
 
-        this.openNewWindow.addClickHandler(handler -> {
-            Window.open(Window.Location.getHref(), "_blank", "");
-        });
+        initialized = true;
     }
 
     @Override
@@ -233,6 +242,10 @@ public class LogTabUi extends Composite {
                             }
 
                             LogTabUi.this.logProviderListBox.addChangeHandler(changeEvent -> displayLogs());
+
+                            if (isAttached()) {
+                                LogPollService.startLogPolling();
+                            }
                         }
                     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/firewall/FirewallPanelUi.java
@@ -91,7 +91,7 @@ public class FirewallPanelUi extends Composite {
     public FirewallPanelUi() {
 
         initWidget(uiBinder.createAndBindUi(this));
-        detectIfNet2();
+
         this.firewallIntro.add(new Span("<p>" + MSGS.firewallIntro() + "</p>"));
 
         this.openPorts.setText(MSGS.firewallOpenPorts());
@@ -133,6 +133,8 @@ public class FirewallPanelUi extends Composite {
         }
 
         this.openPorts.showTab();
+
+        detectIfNet2();
     }
 
     public boolean isDirty() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkPanelUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkPanelUi.java
@@ -13,7 +13,10 @@
 package org.eclipse.kura.web.client.ui.network;
 
 import org.eclipse.kura.web.client.messages.Messages;
+import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.shared.model.GwtSession;
+import org.eclipse.kura.web.shared.service.GwtNetworkService;
+import org.eclipse.kura.web.shared.service.GwtNetworkServiceAsync;
 import org.gwtbootstrap3.client.ui.Container;
 import org.gwtbootstrap3.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.PanelBody;
@@ -22,6 +25,7 @@ import org.gwtbootstrap3.client.ui.html.Span;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -29,6 +33,7 @@ import com.google.gwt.user.client.ui.Widget;
 public class NetworkPanelUi extends Composite {
 
     private static NetworkPanelUiUiBinder uiBinder = GWT.create(NetworkPanelUiUiBinder.class);
+    private final GwtNetworkServiceAsync gwtNetworkService = GWT.create(GwtNetworkService.class);
 
     interface NetworkPanelUiUiBinder extends UiBinder<Widget, NetworkPanelUi> {
     }
@@ -58,8 +63,26 @@ public class NetworkPanelUi extends Composite {
     }
 
     public void initNetworkPanel() {
+
+        this.gwtNetworkService.isNet2(new AsyncCallback<Boolean>() {
+
+            @Override
+            public void onFailure(Throwable caught) {
+                initNetworkPanel(false);
+                FailureHandler.handle(caught);
+            }
+
+            @Override
+            public void onSuccess(Boolean result) {
+                initNetworkPanel(result);
+            }
+        });
+    }
+
+    private void initNetworkPanel(final boolean isNet2) {
+
         if (!this.isInitialized) {
-            this.tabs = new NetworkTabsUi(this.session);
+            this.tabs = new NetworkTabsUi(this.session, isNet2);
             this.tabsPanel.add(this.tabs);
 
             table = new NetworkInterfacesTableUi(this.session, this.tabs);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -16,7 +16,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.eclipse.kura.web.client.messages.Messages;
-import org.eclipse.kura.web.client.util.FailureHandler;
 import org.eclipse.kura.web.client.util.MessageUtils;
 import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetIfStatus;
@@ -34,7 +33,6 @@ import org.gwtbootstrap3.client.ui.PanelBody;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -94,38 +92,22 @@ public class NetworkTabsUi extends Composite {
      * Initialization
      */
 
-    public NetworkTabsUi(GwtSession session) {
+    public NetworkTabsUi(GwtSession session, final boolean isNet2) {
         initWidget(uiBinder.createAndBindUi(this));
         this.visibleTabs = new LinkedList<>();
         this.session = session;
-        detectIfNet2();
-        initTabs();
+        this.isNet2 = isNet2;
+        initTabs(isNet2);
     }
 
-    private void detectIfNet2() {
-        this.gwtNetworkService.isNet2(new AsyncCallback<Boolean>() {
-
-            @Override
-            public void onFailure(Throwable caught) {
-                NetworkTabsUi.this.isNet2 = false;
-                FailureHandler.handle(caught);
-            }
-
-            @Override
-            public void onSuccess(Boolean result) {
-                NetworkTabsUi.this.isNet2 = result;
-            }
-        });
-    }
-
-    private void initTabs() {
+    private void initTabs(final boolean isNet2) {
         this.tabsPanel.clear();
         this.visibleTabs.clear();
 
-        initIp4Tab();
+        initIp4Tab(isNet2);
         initIp6Tab();
         initWireless8021xTab();
-        initWirelessTab();
+        initWirelessTab(isNet2);
         initModemTab();
         initModemGpsTab();
         initModemAntennaTab();
@@ -138,9 +120,9 @@ public class NetworkTabsUi extends Composite {
         this.content.add(this.ip4Tab);
     }
 
-    private void initIp4Tab() {
+    private void initIp4Tab(final boolean isNet2) {
         this.ip4TabAnchorItem = new AnchorListItem(MSGS.netIPv4());
-        this.ip4Tab = new TabIp4Ui(this.session, this);
+        this.ip4Tab = new TabIp4Ui(this.session, this, isNet2);
 
         this.ip4TabAnchorItem.addClickHandler(event -> {
             setSelected(NetworkTabsUi.this.ip4TabAnchorItem);
@@ -162,10 +144,10 @@ public class NetworkTabsUi extends Composite {
         });
     }
 
-    private void initWirelessTab() {
+    private void initWirelessTab(final boolean isNet2) {
         this.wirelessTabAnchorItem = new AnchorListItem(MSGS.netWifiWireless());
         this.wirelessTab = new TabWirelessUi(this.session, this.ip4Tab, this.set8021xTab, this.net8021xTabAnchorItem,
-                this);
+                this, isNet2);
 
         this.wirelessTabAnchorItem.addClickHandler(event -> {
             setSelected(NetworkTabsUi.this.wirelessTabAnchorItem);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
@@ -155,7 +155,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
     IntegerBox priority;
     @UiField
     ListBox configure;
-    
 
     @UiField
     Button renew;
@@ -171,7 +170,7 @@ public class TabIp4Ui extends Composite implements NetworkTab {
 
     @UiField
     FormControlStatic dnsRead;
-    
+
     @UiField
     IntegerBox mtu;
 
@@ -201,11 +200,15 @@ public class TabIp4Ui extends Composite implements NetworkTab {
     @UiField
     HelpButton mtuHelp;
 
-    public TabIp4Ui(GwtSession currentSession, NetworkTabsUi netTabs) {
+    public TabIp4Ui(GwtSession currentSession, NetworkTabsUi netTabs, final boolean isNet2) {
         initWidget(uiBinder.createAndBindUi(this));
         this.tabs = netTabs;
         this.helpTitle.setText(MSGS.netHelpTitle());
-        detectIfNet2();
+
+        this.isNet2 = isNet2;
+
+        initNet2FeaturesOnly(isNet2);
+
         initForm();
         this.dnsRead.setVisible(false);
 
@@ -385,23 +388,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
 
     // ---------------Private Methods------------
 
-    private void detectIfNet2() {
-        this.gwtNetworkService.isNet2(new AsyncCallback<Boolean>() {
-
-            @Override
-            public void onFailure(Throwable caught) {
-                TabIp4Ui.this.isNet2 = false;
-                FailureHandler.handle(caught);
-            }
-
-            @Override
-            public void onSuccess(Boolean result) {
-                TabIp4Ui.this.isNet2 = result;
-                initNet2FeaturesOnly(result);
-            }
-        });
-    }
-
     private void initNet2FeaturesOnly(boolean isNet2) {
         this.labelPriority.setVisible(isNet2);
         this.priority.setVisible(isNet2);
@@ -454,7 +440,7 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         initDnsServersField();
 
         initDHCPLeaseField();
-        
+
         initMtuField();
     }
 
@@ -672,7 +658,7 @@ public class TabIp4Ui extends Composite implements NetworkTab {
             this.renew.setEnabled(false);
         }
     }
-    
+
     private void initMtuField() {
         this.mtu.addMouseOverHandler(event -> {
             TabIp4Ui.this.helpText.clear();
@@ -703,7 +689,7 @@ public class TabIp4Ui extends Composite implements NetworkTab {
                 TabIp4Ui.this.helpMtu.setText("");
             }
         });
-    }    
+    }
 
     private void initStatusField() {
         initStatusValues();
@@ -790,8 +776,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
                 this.priority.setValue(this.selectedNetIfConfig.getWanPriority());
                 this.mtu.setValue(this.selectedNetIfConfig.getMtu());
             }
-
-
 
             this.tabs.updateTabs();
             this.ip.setText(this.selectedNetIfConfig.getIpAddress());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -345,7 +345,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     Text unavailableChannelErrorText;
 
     public TabWirelessUi(GwtSession currentSession, TabIp4Ui tcp, Tab8021xUi wireless8021x,
-            AnchorListItem wireless8021xTabAnchorItem, NetworkTabsUi tabs) {
+            AnchorListItem wireless8021xTabAnchorItem, NetworkTabsUi tabs, final boolean isNet2) {
         this.ssidInit = false;
         initWidget(uiBinder.createAndBindUi(this));
         this.session = currentSession;
@@ -354,7 +354,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         this.wireless8021x = wireless8021x;
         this.wireless8021xTabAnchorItem = wireless8021xTabAnchorItem;
 
-        detectIfNet2();
+        this.isNet2 = isNet2;
+        changeRadioModeToBand(isNet2);
 
         initForm();
         initHelpButtons();
@@ -512,22 +513,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     // -----Private methods-------//
-
-    private void detectIfNet2() {
-        this.gwtNetworkService.isNet2(new AsyncCallback<Boolean>() {
-
-            @Override
-            public void onFailure(Throwable caught) {
-                FailureHandler.handle(caught);
-            }
-
-            @Override
-            public void onSuccess(Boolean isNet2) {
-                TabWirelessUi.this.isNet2 = isNet2;
-                changeRadioModeToBand(isNet2);
-            }
-        });
-    }
 
     private void changeRadioModeToBand(boolean isNet2) {
         if (isNet2) {


### PR DESCRIPTION
Currently, after creating a new identity and assigning it a set of specific permissions Kura starts to flicker with an error dialog on screen (see video below).

https://github.com/eclipse/kura/assets/22748355/f292c183-8a2c-467c-a44b-0fd85f606d2c

This was due to the Web UI trying to perform some calls (trying to establish if the profile was using the new networking) even if the current identity does not have the required permissions, resulting in 403 errors.

This PR fixes the issue