### PR TITLE
fix: wireless tab and cellular tab will show up when only ipv6 is enabled

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -45,7 +45,7 @@ public class NetworkTabsUi extends Composite {
             .get(GwtNetIfStatus.netIPv4StatusUnmanaged.name());
     private static final String IPV4_STATUS_ENABLED_LAN_MESSAGE = MessageUtils
             .get(GwtNetIfStatus.netIPv4StatusEnabledLAN.name());
-
+    private static final String IPV6_STATUS_DISABLED_MESSAGE = MessageUtils.get("netIPv6StatusDisabled");
     private static NetworkTabsUiUiBinder uiBinder = GWT.create(NetworkTabsUiUiBinder.class);
 
     interface NetworkTabsUiUiBinder extends UiBinder<Widget, NetworkTabsUi> {
@@ -287,6 +287,7 @@ public class NetworkTabsUi extends Composite {
     private void arrangeOptionalTabs() {
         boolean isIpv4EnabledLAN = this.ip4Tab.getStatus().equals(IPV4_STATUS_ENABLED_LAN_MESSAGE);
         boolean isIpv4Disabled = this.ip4Tab.getStatus().equals(IPV4_STATUS_DISABLED_MESSAGE);
+        boolean isIpv6Disabled = this.ip6Tab.getStatus().equals(IPV6_STATUS_DISABLED_MESSAGE);
         boolean isWirelessAP = this.wirelessTab.getWirelessMode() != null
                 && this.wirelessTab.getWirelessMode().name().equals(WIFI_ACCESS_POINT);
         boolean isDhcp = this.ip4Tab.isDhcp();
@@ -296,14 +297,14 @@ public class NetworkTabsUi extends Composite {
         InterfaceConfigWrapper wrapper = new InterfaceConfigWrapper(this.netIfConfig);
 
         if (wrapper.isWireless()) {
-            showWirelessTabs(isIpv4Disabled || isUnmanagedSelected());
+            showWirelessTabs((isIpv4Disabled && isIpv6Disabled) || isUnmanagedSelected());
             if (!isWirelessAP) {
                 includeDhcpNat = false;
             }
         } else if (wrapper.isModem()) {
             includeDhcpNat = false;
             this.modemGpsTabAnchorItem.setEnabled(wrapper.isGpsSupported() && !isUnmanagedSelected());
-            showModemTabs(isIpv4Disabled || isUnmanagedSelected());
+            showModemTabs((isIpv4Disabled && isIpv6Disabled) || isUnmanagedSelected());
         } else {
             showEthernetTabs();
             if (wrapper.isLoopback()) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -24,8 +24,6 @@ import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtSession;
 import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiWirelessMode;
-import org.eclipse.kura.web.shared.service.GwtNetworkService;
-import org.eclipse.kura.web.shared.service.GwtNetworkServiceAsync;
 import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.NavbarNav;
 import org.gwtbootstrap3.client.ui.PanelBody;
@@ -45,13 +43,14 @@ public class NetworkTabsUi extends Composite {
             .get(GwtNetIfStatus.netIPv4StatusUnmanaged.name());
     private static final String IPV4_STATUS_ENABLED_LAN_MESSAGE = MessageUtils
             .get(GwtNetIfStatus.netIPv4StatusEnabledLAN.name());
-    private static final String IPV6_STATUS_DISABLED_MESSAGE = MessageUtils.get("netIPv6StatusDisabled");
+    private static final String IPV6_STATUS_DISABLED_MESSAGE = MessageUtils
+            .get(GwtNetIfStatus.netIPv6StatusDisabled.name());
+
     private static NetworkTabsUiUiBinder uiBinder = GWT.create(NetworkTabsUiUiBinder.class);
 
     interface NetworkTabsUiUiBinder extends UiBinder<Widget, NetworkTabsUi> {
     }
 
-    private final GwtNetworkServiceAsync gwtNetworkService = GWT.create(GwtNetworkService.class);
     private static final Messages MSGS = GWT.create(Messages.class);
 
     private boolean isNet2 = false;
@@ -146,8 +145,8 @@ public class NetworkTabsUi extends Composite {
 
     private void initWirelessTab(final boolean isNet2) {
         this.wirelessTabAnchorItem = new AnchorListItem(MSGS.netWifiWireless());
-        this.wirelessTab = new TabWirelessUi(this.session, this.ip4Tab, this.set8021xTab, this.net8021xTabAnchorItem,
-                this, isNet2);
+        this.wirelessTab = new TabWirelessUi(this.session, this.ip4Tab, this.ip6Tab, this.set8021xTab,
+                this.net8021xTabAnchorItem, this, isNet2);
 
         this.wirelessTabAnchorItem.addClickHandler(event -> {
             setSelected(NetworkTabsUi.this.wirelessTabAnchorItem);
@@ -297,14 +296,14 @@ public class NetworkTabsUi extends Composite {
         InterfaceConfigWrapper wrapper = new InterfaceConfigWrapper(this.netIfConfig);
 
         if (wrapper.isWireless()) {
-            showWirelessTabs((isIpv4Disabled && isIpv6Disabled) || isUnmanagedSelected());
+            showWirelessTabs(isIPInterfacesDisabled(isIpv4Disabled, isIpv6Disabled) || isUnmanagedSelected());
             if (!isWirelessAP) {
                 includeDhcpNat = false;
             }
         } else if (wrapper.isModem()) {
             includeDhcpNat = false;
             this.modemGpsTabAnchorItem.setEnabled(wrapper.isGpsSupported() && !isUnmanagedSelected());
-            showModemTabs((isIpv4Disabled && isIpv6Disabled) || isUnmanagedSelected());
+            showModemTabs(isIPInterfacesDisabled(isIpv4Disabled, isIpv6Disabled) || isUnmanagedSelected());
         } else {
             showEthernetTabs();
             if (wrapper.isLoopback()) {
@@ -317,9 +316,13 @@ public class NetworkTabsUi extends Composite {
         this.dhcp4NatTabAnchorItem.setEnabled(includeDhcpNat);
         this.ip6TabAnchorItem.setEnabled(!isUnmanagedSelected());
 
-        if (isIpv4Disabled || isUnmanagedSelected()) {
+        if (isIPInterfacesDisabled(isIpv4Disabled, isIpv6Disabled) || isUnmanagedSelected()) {
             removeOptionalTabs();
         }
+    }
+
+    private boolean isIPInterfacesDisabled(boolean isIpv4Disabled, boolean isIpv6Disabled) {
+        return isIpv4Disabled && isIpv6Disabled;
     }
 
     private void showWirelessTabs(boolean interfaceNotEnabled) {
@@ -413,11 +416,7 @@ public class NetworkTabsUi extends Composite {
      */
 
     public boolean isDirty() {
-        if (this.visibleTabs.contains(this.ip4TabAnchorItem) && this.ip4Tab.isDirty()) {
-            return true;
-        }
-
-        if (this.visibleTabs.contains(this.ip6TabAnchorItem) && this.ip6Tab.isDirty()) {
+        if ((this.visibleTabs.contains(this.ip4TabAnchorItem) && this.ip4Tab.isDirty()) || (this.visibleTabs.contains(this.ip6TabAnchorItem) && this.ip6Tab.isDirty())) {
             return true;
         }
 
@@ -541,11 +540,7 @@ public class NetworkTabsUi extends Composite {
             return false;
         }
 
-        if (this.visibleTabs.contains(this.wirelessTabAnchorItem) && !this.wirelessTab.isValid()) {
-            return false;
-        }
-
-        if (this.visibleTabs.contains(this.modemTabAnchorItem) && !this.modemTab.isValid()) {
+        if ((this.visibleTabs.contains(this.wirelessTabAnchorItem) && !this.wirelessTab.isValid()) || (this.visibleTabs.contains(this.modemTabAnchorItem) && !this.modemTab.isValid())) {
             return false;
         }
 
@@ -605,18 +600,18 @@ public class NetworkTabsUi extends Composite {
 
     class InterfaceConfigWrapper {
 
-        private GwtNetInterfaceConfig config;
+        private final GwtNetInterfaceConfig config;
 
         public InterfaceConfigWrapper(GwtNetInterfaceConfig config) {
             this.config = config;
         }
 
         public boolean isWireless() {
-            return (this.config instanceof GwtWifiNetInterfaceConfig);
+            return this.config instanceof GwtWifiNetInterfaceConfig;
         }
 
         public boolean isModem() {
-            return (this.config instanceof GwtModemInterfaceConfig);
+            return this.config instanceof GwtModemInterfaceConfig;
         }
 
         public boolean isGpsSupported() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -355,7 +355,7 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             }
         });
     }
-    
+
     private void initMtuField() {
         this.mtu.addMouseOverHandler(event -> {
             if (this.mtu.isEnabled()) {
@@ -685,7 +685,7 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         }
 
         updatedNetIf.setIpv6Privacy(this.privacy.getSelectedValue());
-        
+
         if (this.mtu.getValue() != null) {
             updatedNetIf.setIpv6Mtu(this.mtu.getValue());
         }
@@ -802,7 +802,7 @@ public class TabIp6Ui extends Composite implements NetworkTab {
                 break;
             }
         }
-        
+
         this.mtu.setValue(this.selectedNetIfConfig.get().getIpv6Mtu());
 
         this.tabs.updateTabs();
@@ -812,6 +812,10 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     @Override
     public void clear() {
         // Not needed
+    }
+
+    public String getStatus() {
+        return this.status.getSelectedValue();
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2023 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -190,6 +190,10 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         initListBoxes();
         initTextBoxes();
     }
+    
+    public String getStatus() {
+        return this.status.getSelectedItemText();
+    }
 
     private void initLabels() {
         this.labelStatus.setText(MSGS.netIPv6Status());
@@ -225,6 +229,7 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     }
 
     private void initStatusField() {
+        this.status.clear();
         this.status.addItem(MessageUtils.get(STATUS_DISABLED), STATUS_DISABLED);
         this.status.addItem(MessageUtils.get(STATUS_LAN), STATUS_LAN);
         this.status.addItem(MessageUtils.get(STATUS_WAN), STATUS_WAN);
@@ -812,10 +817,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     @Override
     public void clear() {
         // Not needed
-    }
-
-    public String getStatus() {
-        return this.status.getSelectedValue();
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -385,7 +385,10 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             // set the default values for wireless mode if tcp/ip status was changed
             String tcpIp4Status = TabWirelessUi.this.tcp4Tab.getStatus();
             String tcpIp6Status = TabWirelessUi.this.tcp6Tab.getStatus();
-            if (!tcpIp4Status.equals(TabWirelessUi.this.tcp4Status) && !tcpIp6Status.equals(TabWirelessUi.this.tcp6Status)) {
+            boolean isStatusChanged = !tcpIp4Status.equals(TabWirelessUi.this.tcp4Status)
+                    || !tcpIp6Status.equals(TabWirelessUi.this.tcp6Status);
+
+            if (isStatusChanged) {
                 if (tcpIp4Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv4StatusEnabledWAN.name())) || tcpIp6Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv4StatusEnabledWAN.name()))) {
                     TabWirelessUi.this.activeConfig = TabWirelessUi.this.selectedNetIfConfig.getStationWifiConfig();
                 } else {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetIfStatus.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetIfStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,10 @@ public enum GwtNetIfStatus implements Serializable, IsSerializable {
     netIPv4StatusUnmanaged("Unmanaged"),
     netIPv4StatusL2Only("L2Only"),
     netIPv4StatusEnabledLAN("LAN"),
-    netIPv4StatusEnabledWAN("WAN");
+    netIPv4StatusEnabledWAN("WAN"),
+    netIPv6StatusDisabled("Disabled"),
+    netIPv6StatusEnabledLAN("LAN"),
+    netIPv6StatusEnabledWAN("WAN");
 
     private String status;
 


### PR DESCRIPTION
minor change to how weather to show the wireless and cellular tab is computers.

I am using the string literal for "netIPv6StatusDisabled", since these variables are not exposed in a public manor from the ipv6 tab.   This must be adjusted in a future PR. I do not want to change any API's since we are feature-frozen.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
