### PR TITLE
fix: enforced mandatory UserAdmin static reference on rest bundles that create permissions

### DIFF
--- a/kura/org.eclipse.kura.rest.cloudconnection.provider/OSGI-INF/CloudConnectionRestService.xml
+++ b/kura/org.eclipse.kura.rest.cloudconnection.provider/OSGI-INF/CloudConnectionRestService.xml
@@ -35,7 +35,7 @@
 
     <reference interface="org.osgi.service.useradmin.UserAdmin"
                bind="bindUserAdmin"
-               cardinality="0..1"
+               cardinality="1..1"
                name="UserAdmin"
                policy="static" />
                

--- a/kura/org.eclipse.kura.rest.configuration.provider/OSGI-INF/configuration_rest_service.xml
+++ b/kura/org.eclipse.kura.rest.configuration.provider/OSGI-INF/configuration_rest_service.xml
@@ -20,7 +20,7 @@
    
    <reference bind="setConfigurationService" cardinality="1..1" interface="org.eclipse.kura.configuration.ConfigurationService" name="ConfigurationService" policy="static"/>
    <reference bind="setOCDService" cardinality="1..1" interface="org.eclipse.kura.configuration.metatype.OCDService" name="OCDService" policy="static"/>
-   <reference bind="setUserAdmin" cardinality="0..1" interface="org.osgi.service.useradmin.UserAdmin" name="UserAdmin" policy="static"/>
+   <reference bind="setUserAdmin" cardinality="1..1" interface="org.osgi.service.useradmin.UserAdmin" name="UserAdmin" policy="static"/>
    <reference bind="setRequestHandlerRegistry" cardinality="0..n" interface="org.eclipse.kura.cloudconnection.request.RequestHandlerRegistry" name="RequestHandlerRegistry" policy="dynamic" unbind="unsetRequestHandlerRegistry"/>
    <service>
       <provide interface="org.eclipse.kura.internal.rest.configuration.ConfigurationRestService"/>

--- a/kura/org.eclipse.kura.rest.network.configuration.provider/OSGI-INF/network_configuration_rest_service.xml
+++ b/kura/org.eclipse.kura.rest.network.configuration.provider/OSGI-INF/network_configuration_rest_service.xml
@@ -24,7 +24,7 @@
 	<reference bind="setConfigurationService" cardinality="1..1"
 		interface="org.eclipse.kura.configuration.ConfigurationService"
 		name="ConfigurationService" policy="static" />
-	<reference bind="setUserAdmin" cardinality="0..1"
+	<reference bind="setUserAdmin" cardinality="1..1"
 		interface="org.osgi.service.useradmin.UserAdmin" name="UserAdmin"
 		policy="static" />
 	<service>

--- a/kura/org.eclipse.kura.rest.network.status.provider/OSGI-INF/org.eclipse.kura.internal.network.status.provider.NetworkStatusRestServiceImpl.xml
+++ b/kura/org.eclipse.kura.rest.network.status.provider/OSGI-INF/org.eclipse.kura.internal.network.status.provider.NetworkStatusRestServiceImpl.xml
@@ -20,5 +20,5 @@
    </service>
    <reference bind="setNetworkStatusService" cardinality="1..1" interface="org.eclipse.kura.net.status.NetworkStatusService" name="NetworkStatusService" policy="static"/>
    <reference bind="setRequestHandlerRegistry" cardinality="0..n" interface="org.eclipse.kura.cloudconnection.request.RequestHandlerRegistry" name="RequestHandlerRegistry" policy="dynamic" unbind="unsetRequestHandlerRegistry"/>
-   <reference bind="setUserAdmin" cardinality="0..1" interface="org.osgi.service.useradmin.UserAdmin" name="UserAdmin" policy="dynamic"/>
+   <reference bind="setUserAdmin" cardinality="1..1" interface="org.osgi.service.useradmin.UserAdmin" name="UserAdmin" policy="static"/>
 </scr:component>

--- a/kura/org.eclipse.kura.rest.packages.provider/OSGI-INF/deployment_rest_service.xml
+++ b/kura/org.eclipse.kura.rest.packages.provider/OSGI-INF/deployment_rest_service.xml
@@ -30,7 +30,7 @@
        bind="setDeploymentAdmin"
        policy="static"/>
    <reference name="UserAdmin"
-       cardinality="0..1"
+       cardinality="1..1"
        interface="org.osgi.service.useradmin.UserAdmin"
        bind="setUserAdmin"
        policy="static"/>

--- a/kura/org.eclipse.kura.rest.position.provider/OSGI-INF/position_rest_service.xml
+++ b/kura/org.eclipse.kura.rest.position.provider/OSGI-INF/position_rest_service.xml
@@ -18,7 +18,7 @@
    
    <property name="kura.service.pid" type="String" value="org.eclipse.kura.internal.rest.position.PositionRestService"/>
    
-   <reference bind="setUserAdmin" cardinality="0..1" interface="org.osgi.service.useradmin.UserAdmin" name="UserAdmin" policy="static"/>
+   <reference bind="setUserAdmin" cardinality="1..1" interface="org.osgi.service.useradmin.UserAdmin" name="UserAdmin" policy="static"/>
    <reference bind="setRequestHandlerRegistry" cardinality="0..n" interface="org.eclipse.kura.cloudconnection.request.RequestHandlerRegistry" name="RequestHandlerRegistry" policy="dynamic" unbind="unsetRequestHandlerRegistry"/>
    <reference bind="setPositionServiceImpl" cardinality="1..1" interface="org.eclipse.kura.position.PositionService" name="PositionService" policy="static"/>
    <service>

--- a/kura/org.eclipse.kura.rest.security.provider/OSGI-INF/SecurityRestService.xml
+++ b/kura/org.eclipse.kura.rest.security.provider/OSGI-INF/SecurityRestService.xml
@@ -33,7 +33,7 @@
 
     <reference interface="org.osgi.service.useradmin.UserAdmin"
                bind="bindUserAdmin"
-               cardinality="0..1"
+               cardinality="1..1"
                name="UserAdmin"
                policy="static"/>
 

--- a/kura/org.eclipse.kura.rest.system.provider/OSGI-INF/SystemRestService.xml
+++ b/kura/org.eclipse.kura.rest.system.provider/OSGI-INF/SystemRestService.xml
@@ -33,7 +33,7 @@
 
     <reference interface="org.osgi.service.useradmin.UserAdmin"
                bind="bindUserAdmin"
-               cardinality="0..1"
+               cardinality="1..1"
                name="UserAdmin"
                policy="static"/>
 


### PR DESCRIPTION
With this PR, REST request handler bundles that require a particular `kura.permission` role and creates it on binding the `UserAdmin` reference, will now have the `UserAdmin` reference **static** and **mandatory**.

This avoids situations where the role is not present on the snapshot and the bundle comes up before the `UserAdmin`. In such case, the permission will never be created and the bundle remain unutilizable.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
