### PR TITLE
refactor: fixed spelling in logs

### DIFF
--- a/kura/org.eclipse.kura.core.inventory/src/main/java/org/eclipse/kura/core/inventory/InventoryHandlerV1.java
+++ b/kura/org.eclipse.kura.core.inventory/src/main/java/org/eclipse/kura/core/inventory/InventoryHandlerV1.java
@@ -394,7 +394,7 @@ public class InventoryHandlerV1 implements ConfigurableComponent, RequestHandler
         // get Docker Containers
         if (this.containerOrchestrationService != null) {
             try {
-                logger.info("Creating docker invenetory");
+                logger.info("Creating docker inventory");
                 List<ContainerInstanceDescriptor> containers = this.containerOrchestrationService
                         .listContainerDescriptors();
                 containers.stream().forEach(
@@ -410,7 +410,7 @@ public class InventoryHandlerV1 implements ConfigurableComponent, RequestHandler
         // get Container Images
         if (this.containerOrchestrationService != null) {
             try {
-                logger.info("Creating container images invenetory");
+                logger.info("Creating container images inventory");
                 List<ImageInstanceDescriptor> images = this.containerOrchestrationService
                         .listImageInstanceDescriptors();
                 images.stream().forEach(image -> inventory.add(new SystemResourceInfo(image.getImageName(),


### PR DESCRIPTION

This PR corrects a minor spelling mistake in the logs of the container orchestrator.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
