### PR TITLE
fix(nm): load dhcp server configuration after change

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -38,7 +38,6 @@ import org.eclipse.kura.configuration.SelfConfiguringComponent;
 import org.eclipse.kura.crypto.CryptoService;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.internal.linux.net.dns.DnsServerService;
-import org.eclipse.kura.linux.net.dhcp.DhcpServerTool;
 import org.eclipse.kura.linux.net.util.LinuxNetworkUtil;
 import org.eclipse.kura.net.NetInterfaceStatus;
 import org.eclipse.kura.net.NetInterfaceType;
@@ -509,8 +508,9 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
                 try {
                     dhcpServerConfigWriter.writeConfiguration();
                     this.dhcpServerMonitor.putDhcpServerInterfaceConfiguration(interfaceName, true);
-                    this.dhcpServerMonitor.disable(); // Side effect: we rely on the monitor bringing the server back up
-                                                      // so that the configuration can change take effect
+                    this.dhcpServerMonitor.disable(interfaceName); // Side effect: we rely on the monitor bringing the
+                                                                   // server back up so that the configuration can
+                                                                   // change take effect
 
                 } catch (UnknownHostException | KuraException e) {
                     logger.error("Failed to write DHCP Server configuration", e);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -38,6 +38,7 @@ import org.eclipse.kura.configuration.SelfConfiguringComponent;
 import org.eclipse.kura.crypto.CryptoService;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.internal.linux.net.dns.DnsServerService;
+import org.eclipse.kura.linux.net.dhcp.DhcpServerTool;
 import org.eclipse.kura.linux.net.util.LinuxNetworkUtil;
 import org.eclipse.kura.net.NetInterfaceStatus;
 import org.eclipse.kura.net.NetInterfaceType;
@@ -508,6 +509,9 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
                 try {
                     dhcpServerConfigWriter.writeConfiguration();
                     this.dhcpServerMonitor.putDhcpServerInterfaceConfiguration(interfaceName, true);
+                    this.dhcpServerMonitor.disable(); // Side effect: we rely on the monitor bringing the server back up
+                                                      // so that the configuration can change take effect
+
                 } catch (UnknownHostException | KuraException e) {
                     logger.error("Failed to write DHCP Server configuration", e);
                     this.dhcpServerMonitor.putDhcpServerInterfaceConfiguration(interfaceName, false);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -509,8 +509,8 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
                     dhcpServerConfigWriter.writeConfiguration();
                     this.dhcpServerMonitor.putDhcpServerInterfaceConfiguration(interfaceName, true);
                     this.dhcpServerMonitor.disable(interfaceName); // Side effect: we rely on the monitor bringing the
-                                                                   // server back up so that the configuration can
-                                                                   // change take effect
+                                                                   // server back up so that the configuration change
+                                                                   // takes effect
 
                 } catch (UnknownHostException | KuraException e) {
                     logger.error("Failed to write DHCP Server configuration", e);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/monitor/DhcpServerMonitor.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/monitor/DhcpServerMonitor.java
@@ -65,6 +65,16 @@ public class DhcpServerMonitor {
         this.dhcpServerInterfaceConfiguration.clear();
     }
 
+    public void disable(String interfaceName) {
+        try {
+            if (this.dhcpServerManager.isRunning(interfaceName)) {
+                stopDhcpServer(interfaceName);
+            }
+        } catch (KuraException e) {
+            logger.warn("Failed to stop DHCP server for the interface " + interfaceName, e);
+        }
+    }
+
     private void monitor() {
         this.dhcpServerInterfaceConfiguration.entrySet().forEach(entry -> {
             String interfaceName = entry.getKey();


### PR DESCRIPTION
While performing some tests we discovered an issue affecting the DHCP servers: when changing a DHCP server configuration (i.e. on a network interface already running a DHCP server, we just change the DHCP Address range) the configuration change was not taking effect. We could see the DHCP server configuration file changing on disk, but the server was still serving the same address ranges.

This was due to the fact that, when migrating to the new networking, we preserved the [monitors](https://github.com/eclipse/kura/blob/aa87f66ab3e31fcf6b681da78ac62673c2ef50d4/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/monitor/DhcpServerMonitor.java#L28) but, when updating DHCP server configurations, we forgot to add the required step to reload the configuration.

You can see that, in the old networking, the step for updating the DHCP server configuration includes a `disable` call which later relies on the monitors to set the DHCP server back up.

https://github.com/eclipse/kura/blob/aa87f66ab3e31fcf6b681da78ac62673c2ef50d4/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerImpl.java#L231-L250

https://github.com/eclipse/kura/blob/aa87f66ab3e31fcf6b681da78ac62673c2ef50d4/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerImpl.java#L168-L192

This step was missing in the new networking (i.e. org.eclipse.kura.nm). This PR introduces the `disable` step back but delegates the responsibility to the monitors themselves, since the DHCP server monitor is responsible for the DHCP server service lifecycle.