### PR TITLE
fix(web2): Fixed network radio mode value passing in the old networking.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1734,7 +1734,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     private GwtWifiRadioMode radioValueToRadioMode(String radioValue) {
 
         for (GwtWifiRadioMode mode : GwtWifiRadioMode.values()) {
-            if (mode.name().equals(radioValue)) {
+            String modeName = this.isNet2 ? mode.name() : MessageUtils.get(mode.name());
+            if (modeName.equals(radioValue)) {
                 return mode;
             }
         }


### PR DESCRIPTION
Fixed the passing of the radio mode value.
For the old netwokorking we use the radio mode labe again (unfortunately).