### PR TITLE
fix: added catch to exception to prevent failure when keystores don't exist

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -204,7 +204,7 @@ public class NMSettingsConverter {
                 logger.error("Unable to find or decode Private Key");
             }
         } catch (ClassCastException e) {
-            logger.error("Unable to find Client Certificate");
+            logger.error("Unable to find Private Key");
         }
 
         Optional<Password> privateKeyPassword = props.getOpt(Password.class,

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -195,13 +195,16 @@ public class NMSettingsConverter {
             logger.error("Unable to find Client Certificate");
         }
 
-        PrivateKey privateKey = props.get(PrivateKey.class, "net.interface.%s.config.802-1x.private-key-name",
-                deviceId);
-
-        if (privateKey.getEncoded() != null) {
-            settings.put("private-key", new Variant<>(privateKey.getEncoded()));
-        } else {
-            logger.error("Unable to find or decode Private Key");
+        try {
+            PrivateKey privateKey = props.get(PrivateKey.class, "net.interface.%s.config.802-1x.private-key-name",
+                    deviceId);
+            if (privateKey.getEncoded() != null) {
+                settings.put("private-key", new Variant<>(privateKey.getEncoded()));
+            } else {
+                logger.error("Unable to find or decode Private Key");
+            }
+        } catch (ClassCastException e) {
+            logger.error("Unable to find Client Certificate");
         }
 
         Optional<Password> privateKeyPassword = props.getOpt(Password.class,
@@ -308,7 +311,7 @@ public class NMSettingsConverter {
         return settings;
     }
 
-    public static Map<String, Variant<?>> buildIpv6Settings(NetworkProperties props, String deviceId, 
+    public static Map<String, Variant<?>> buildIpv6Settings(NetworkProperties props, String deviceId,
             SemanticVersion nmVersion) {
 
         // buildIpv6Settings doesn't support Unmanaged status. Therefore if ip6.status
@@ -406,9 +409,9 @@ public class NMSettingsConverter {
             logger.warn("Unexpected ip status received: \"{}\". Ignoring", ip6Status);
         }
 
-        Optional<Integer> mtu = props.getOpt(Integer.class, "net.interface.%s.config.ip6.mtu", deviceId);        
+        Optional<Integer> mtu = props.getOpt(Integer.class, "net.interface.%s.config.ip6.mtu", deviceId);
         if (nmVersion.isGreaterEqualThan("1.40")) {
-            //ipv6.mtu only supported in NetworkManager 1.40 and above
+            // ipv6.mtu only supported in NetworkManager 1.40 and above
             mtu.ifPresent(value -> settings.put("mtu", new Variant<>(new UInt32(value))));
         } else {
             logger.warn("Ignoring parameter ipv6.mtu: NetworkManager 1.40 or above is required");
@@ -442,7 +445,7 @@ public class NMSettingsConverter {
 
         Optional<Integer> mtu = props.getOpt(Integer.class, KURA_PROPS_IPV4_MTU, deviceId);
         mtu.ifPresent(value -> settings.put("mtu", new Variant<>(new UInt32(value))));
-        
+
         return settings;
     }
 
@@ -538,7 +541,7 @@ public class NMSettingsConverter {
 
         Optional<Integer> mtu = props.getOpt(Integer.class, KURA_PROPS_IPV4_MTU, deviceId);
         mtu.ifPresent(value -> settings.put("mtu", new Variant<>(new UInt32(value))));
-        
+
         return settings;
     }
 
@@ -574,12 +577,12 @@ public class NMSettingsConverter {
         settings.put("egress-priority-map", new Variant<>(egressMap.orElse(new ArrayList<>()), listType));
         return settings;
     }
-    
+
     public static Map<String, Variant<?>> buildEthernetSettings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
         Optional<Integer> mtu = props.getOpt(Integer.class, KURA_PROPS_IPV4_MTU, deviceId);
         mtu.ifPresent(value -> settings.put("mtu", new Variant<>(new UInt32(value))));
-        return settings;        
+        return settings;
     }
 
     public static Map<String, Variant<?>> buildConnectionSettings(Optional<Connection> connection, String iface,

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -190,7 +190,9 @@ public class NMSettingsConverter {
                     deviceId);
             settings.put("client-cert", new Variant<>(clientCert.getEncoded()));
         } catch (CertificateEncodingException e) {
-            logger.error("Unable to find or decode Client Certificate");
+            logger.error("Unable to decode Client Certificate");
+        } catch (ClassCastException e) {
+            logger.error("Unable to find Client Certificate");
         }
 
         PrivateKey privateKey = props.get(PrivateKey.class, "net.interface.%s.config.802-1x.private-key-name",


### PR DESCRIPTION

adds an extra catch statement.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
