### PR TITLE
fix: unhide keystore field and add error correction that prevents ca-cert being filled and keystore being null

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
@@ -477,6 +477,11 @@ public class Tab8021xUi extends Composite implements NetworkTab {
                 this.formgroupPassword.setValidationState(ValidationState.ERROR);
                 return false;
             }
+
+            if (this.keystorePid.getValue().isEmpty() && !this.caCertName.getValue().isEmpty()) {
+                this.identityKeystorePid.setValidationState(ValidationState.ERROR);
+                return false;
+            }
         }
 
         return true;
@@ -523,7 +528,6 @@ public class Tab8021xUi extends Composite implements NetworkTab {
         switch (Gwt8021xEap.valueOf(this.eap.getSelectedValue())) {
         case PEAP:
         case TTLS:
-            this.keystorePid.setEnabled(false);
             setInnerAuthTo(Gwt8021xInnerAuth.MSCHAPV2);
             this.publicPrivateKeyPairName.setEnabled(false);
             break;


### PR DESCRIPTION
Fixes a bug where you are unable to add a keystore pid when trying to use a optional ca-cert for eap-ttls and eap-peap.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** 
<img width="767" alt="image" src="https://github.com/eclipse/kura/assets/29900100/e47964f5-b8cc-4f88-a1b5-6d03eb224611">
<img width="783" alt="image" src="https://github.com/eclipse/kura/assets/29900100/bf67b76a-1a50-4939-8794-fb5c69bd0d8f">

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
