### PR TITLE
docs: updated README with working links on shield badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ Eclipse Kura™
 
 <div align="center">
 
-![GitHub Tag](https://img.shields.io/github/v/tag/eclipse/kura?label=Latest%20Tag)
-![GitHub](https://img.shields.io/github/license/eclipse/kura?label=License)
+[![GitHub Tag](https://img.shields.io/github/v/tag/eclipse/kura?label=Latest%20Tag)](https://github.com/eclipse/kura/tags)
+[![GitHub](https://img.shields.io/github/license/eclipse/kura?label=License)](https://github.com/eclipse/kura/blob/develop/LICENSE)
 
-![GitHub Issues](https://img.shields.io/github/issues-raw/eclipse/kura?label=Open%20Issues)
-![GitHub Pull Requests](https://img.shields.io/github/issues-pr/eclipse/kura?label=Pull%20Requests&color=blue)
-![GitHub Contributors](https://img.shields.io/github/contributors/eclipse/kura?label=Contributors)
-![GitHub Forks](https://img.shields.io/github/forks/eclipse/kura?label=Forks)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/eclipse/kura?label=Open%20Issues)](https://github.com/eclipse/kura/issues)
+[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/eclipse/kura?label=Pull%20Requests&color=blue)](https://github.com/eclipse/kura/pulls)
+[![GitHub Contributors](https://img.shields.io/github/contributors/eclipse/kura?label=Contributors)](https://github.com/eclipse/kura/graphs/contributors)
+[![GitHub Forks](https://img.shields.io/github/forks/eclipse/kura?label=Forks)](https://github.com/eclipse/kura/forks)
 
-![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https:%2F%2Fci.eclipse.org%2Fkura%2Fjob%2Fmultibranch%2Fjob%2Fdevelop&label=Jenkins%20Build&logo=jenkins)
-![Jenkins](https://img.shields.io/jenkins/tests?compact_message&failed_label=%E2%9D%8C&jobUrl=https:%2F%2Fci.eclipse.org%2Fkura%2Fjob%2Fmultibranch%2Fjob%2Fdevelop%2F&label=Jenkins%20CI&passed_label=%E2%9C%85&skipped_label=%E2%9D%95&logo=jenkins) <br/>
+[![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https:%2F%2Fci.eclipse.org%2Fkura%2Fjob%2Fmultibranch%2Fjob%2Fdevelop&label=Jenkins%20Build&logo=jenkins)](https://ci.eclipse.org/kura/job/multibranch/job/develop/)
+[![Jenkins](https://img.shields.io/jenkins/tests?compact_message&failed_label=%E2%9D%8C&jobUrl=https:%2F%2Fci.eclipse.org%2Fkura%2Fjob%2Fmultibranch%2Fjob%2Fdevelop%2F&label=Jenkins%20CI&passed_label=%E2%9C%85&skipped_label=%E2%9D%95&logo=jenkins)](https://ci.eclipse.org/kura/job/multibranch/) <br/>
   
 </div>
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ Eclipse Kura™
 [![GitHub Tag](https://img.shields.io/github/v/tag/eclipse/kura?label=Latest%20Tag)](https://github.com/eclipse/kura/tags)
 [![GitHub](https://img.shields.io/github/license/eclipse/kura?label=License)](https://github.com/eclipse/kura/blob/develop/LICENSE)
 
-[![GitHub Issues](https://img.shields.io/github/issues-raw/eclipse/kura?label=Open%20Issues)](https://github.com/eclipse/kura/issues)
-[![GitHub Pull Requests](https://img.shields.io/github/issues-pr/eclipse/kura?label=Pull%20Requests&color=blue)](https://github.com/eclipse/kura/pulls)
-[![GitHub Contributors](https://img.shields.io/github/contributors/eclipse/kura?label=Contributors)](https://github.com/eclipse/kura/graphs/contributors)
-[![GitHub Forks](https://img.shields.io/github/forks/eclipse/kura?label=Forks)](https://github.com/eclipse/kura/forks)
-
 [![Jenkins](https://img.shields.io/jenkins/build?jobUrl=https:%2F%2Fci.eclipse.org%2Fkura%2Fjob%2Fmultibranch%2Fjob%2Fdevelop&label=Jenkins%20Build&logo=jenkins)](https://ci.eclipse.org/kura/job/multibranch/job/develop/)
 [![Jenkins](https://img.shields.io/jenkins/tests?compact_message&failed_label=%E2%9D%8C&jobUrl=https:%2F%2Fci.eclipse.org%2Fkura%2Fjob%2Fmultibranch%2Fjob%2Fdevelop%2F&label=Jenkins%20CI&passed_label=%E2%9C%85&skipped_label=%E2%9D%95&logo=jenkins)](https://ci.eclipse.org/kura/job/multibranch/) <br/>
   


### PR DESCRIPTION
Prior this PR, clicking on the badges in the README does just redirect you to the image hosted at `img.shields`. This PR adds some meaningful links.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
