### PR TITLE
fix: optional fields wpa enterprise

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui.network;
 
+import java.awt.Color;
+import java.nio.channels.AsynchronousCloseException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -34,6 +36,9 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
+
+import com.google.gwt.dom.client.Style.BorderStyle;
+import com.google.gwt.dom.client.Style.Unit;
 
 public class NetworkTabsUi extends Composite {
 
@@ -143,7 +148,7 @@ public class NetworkTabsUi extends Composite {
             NetworkTabsUi.this.content.add(NetworkTabsUi.this.ip6Tab);
         });
     }
-    
+
     private void initWireless8021xTab() {
         this.net8021xTabAnchorItem = new AnchorListItem(MSGS.netWifiWireless8021x());
         this.set8021xTab = new Tab8021xUi(this.session, this, this.ip4Tab, this.ip6Tab);
@@ -158,8 +163,8 @@ public class NetworkTabsUi extends Composite {
 
     private void initWirelessTab(final boolean isNet2) {
         this.wirelessTabAnchorItem = new AnchorListItem(MSGS.netWifiWireless());
-        this.wirelessTab = new TabWirelessUi(this.session, this.ip4Tab, this.ip6Tab,
-                this.net8021xTabAnchorItem, this, isNet2);
+        this.wirelessTab = new TabWirelessUi(this.session, this.ip4Tab, this.ip6Tab, this.net8021xTabAnchorItem, this,
+                isNet2);
 
         this.wirelessTabAnchorItem.addClickHandler(event -> {
             setSelected(NetworkTabsUi.this.wirelessTabAnchorItem);
@@ -335,7 +340,7 @@ public class NetworkTabsUi extends Composite {
 
         insertTab(this.wirelessTabAnchorItem);
         if (this.isNet2) {
-            if(interfaceNotEnabled) {
+            if (interfaceNotEnabled) {
                 this.net8021xTabAnchorItem.setEnabled(false);
             }
             insertTab(this.net8021xTabAnchorItem);
@@ -420,7 +425,8 @@ public class NetworkTabsUi extends Composite {
      */
 
     public boolean isDirty() {
-        if ((this.visibleTabs.contains(this.ip4TabAnchorItem) && this.ip4Tab.isDirty()) || (this.visibleTabs.contains(this.ip6TabAnchorItem) && this.ip6Tab.isDirty())) {
+        if ((this.visibleTabs.contains(this.ip4TabAnchorItem) && this.ip4Tab.isDirty())
+                || (this.visibleTabs.contains(this.ip6TabAnchorItem) && this.ip6Tab.isDirty())) {
             return true;
         }
 
@@ -527,41 +533,60 @@ public class NetworkTabsUi extends Composite {
 
     public boolean isValid() {
         if (this.visibleTabs.contains(this.ip4TabAnchorItem) && !this.ip4Tab.isValid()) {
+            errorTab(this.ip4TabAnchorItem);
             return false;
         }
 
         if (this.visibleTabs.contains(this.ip6TabAnchorItem) && this.ip6TabAnchorItem.isEnabled()
                 && !this.ip6Tab.isValid()) {
+            errorTab(this.ip6TabAnchorItem);
             return false;
         }
 
         if (this.visibleTabs.contains(this.hardwareTabAnchorItem) && !this.hardwareTab.isValid()) {
+            errorTab(this.hardwareTabAnchorItem);
             return false;
         }
 
         if (this.visibleTabs.contains(this.dhcp4NatTabAnchorItem) && this.dhcp4NatTabAnchorItem.isEnabled()
                 && !this.dhcp4NatTab.isValid()) {
+            errorTab(this.dhcp4NatTabAnchorItem);
             return false;
         }
 
-        if ((this.visibleTabs.contains(this.wirelessTabAnchorItem) && !this.wirelessTab.isValid()) || (this.visibleTabs.contains(this.modemTabAnchorItem) && !this.modemTab.isValid())) {
+        if ((this.visibleTabs.contains(this.wirelessTabAnchorItem) && !this.wirelessTab.isValid())
+                || (this.visibleTabs.contains(this.modemTabAnchorItem) && !this.modemTab.isValid())) {
+            errorTab(this.wirelessTabAnchorItem);
             return false;
         }
 
         if (this.visibleTabs.contains(this.modemGpsTabAnchorItem) && this.modemGpsTabAnchorItem.isEnabled()
                 && !this.modemGpsTab.isValid()) {
+            errorTab(this.modemGpsTabAnchorItem);
             return false;
         }
 
         if (this.visibleTabs.contains(this.modemAntennaTabAnchorItem) && this.modemAntennaTabAnchorItem.isEnabled()
                 && !this.modemAntennaTab.isValid()) {
+            errorTab(this.modemAntennaTabAnchorItem);
             return false;
         }
 
         if (this.visibleTabs.contains(this.net8021xTabAnchorItem) && this.net8021xTabAnchorItem.isEnabled()
                 && !this.set8021xTab.isValid()) {
+            errorTab(this.net8021xTabAnchorItem);
             return false;
         }
+
+        clearErrorTab(this.ip4TabAnchorItem);
+        clearErrorTab(this.ip4TabAnchorItem);
+        clearErrorTab(this.hardwareTabAnchorItem);
+        clearErrorTab(this.dhcp4NatTabAnchorItem);
+        clearErrorTab(this.wirelessTabAnchorItem);
+        clearErrorTab(this.modemTabAnchorItem);
+        clearErrorTab(this.modemGpsTabAnchorItem);
+        clearErrorTab(this.modemAntennaTabAnchorItem);
+        clearErrorTab(this.net8021xTabAnchorItem);
 
         return true;
     }
@@ -573,6 +598,14 @@ public class NetworkTabsUi extends Composite {
     /*
      * Utilities
      */
+
+    private void errorTab(AnchorListItem tab) {
+        tab.addStyleName("alert-danger");
+    }
+
+    private void clearErrorTab(AnchorListItem tab) {
+        tab.removeStyleName("alert-danger");
+    }
 
     private void removeTab(AnchorListItem tab) {
         this.visibleTabs.remove(tab);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -534,7 +534,7 @@ public class NetworkTabsUi extends Composite {
     public boolean isValid() {
 
         clearErrorTab(this.ip4TabAnchorItem);
-        clearErrorTab(this.ip4TabAnchorItem);
+        clearErrorTab(this.ip6TabAnchorItem);
         clearErrorTab(this.hardwareTabAnchorItem);
         clearErrorTab(this.dhcp4NatTabAnchorItem);
         clearErrorTab(this.wirelessTabAnchorItem);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -568,6 +568,7 @@ public class NetworkTabsUi extends Composite {
         if ((this.visibleTabs.contains(this.wirelessTabAnchorItem) && !this.wirelessTab.isValid())
                 || (this.visibleTabs.contains(this.modemTabAnchorItem) && !this.modemTab.isValid())) {
             errorTab(this.wirelessTabAnchorItem);
+            errorTab(this.modemTabAnchorItem);
             return false;
         }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -532,6 +532,17 @@ public class NetworkTabsUi extends Composite {
     }
 
     public boolean isValid() {
+
+        clearErrorTab(this.ip4TabAnchorItem);
+        clearErrorTab(this.ip4TabAnchorItem);
+        clearErrorTab(this.hardwareTabAnchorItem);
+        clearErrorTab(this.dhcp4NatTabAnchorItem);
+        clearErrorTab(this.wirelessTabAnchorItem);
+        clearErrorTab(this.modemTabAnchorItem);
+        clearErrorTab(this.modemGpsTabAnchorItem);
+        clearErrorTab(this.modemAntennaTabAnchorItem);
+        clearErrorTab(this.net8021xTabAnchorItem);
+
         if (this.visibleTabs.contains(this.ip4TabAnchorItem) && !this.ip4Tab.isValid()) {
             errorTab(this.ip4TabAnchorItem);
             return false;
@@ -577,16 +588,6 @@ public class NetworkTabsUi extends Composite {
             errorTab(this.net8021xTabAnchorItem);
             return false;
         }
-
-        clearErrorTab(this.ip4TabAnchorItem);
-        clearErrorTab(this.ip4TabAnchorItem);
-        clearErrorTab(this.hardwareTabAnchorItem);
-        clearErrorTab(this.dhcp4NatTabAnchorItem);
-        clearErrorTab(this.wirelessTabAnchorItem);
-        clearErrorTab(this.modemTabAnchorItem);
-        clearErrorTab(this.modemGpsTabAnchorItem);
-        clearErrorTab(this.modemAntennaTabAnchorItem);
-        clearErrorTab(this.net8021xTabAnchorItem);
 
         return true;
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui.network;
 
-import java.util.logging.Logger;
-
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.NewPasswordInput;
 import org.eclipse.kura.web.client.util.HelpButton;
@@ -159,6 +157,7 @@ public class Tab8021xUi extends Composite implements NetworkTab {
         this.netTabs = tabs;
         this.tcp4Tab = tcp4;
         this.tcp6Tab = tcp6;
+        this.helpTitle.setText(MSGS.netHelpTitle());
 
         initLabels();
         initHelpButtons();
@@ -455,42 +454,47 @@ public class Tab8021xUi extends Composite implements NetworkTab {
         boolean isPEAP = Gwt8021xEap.valueOf(this.eap.getSelectedValue()) == Gwt8021xEap.PEAP;
         boolean isTTLS = Gwt8021xEap.valueOf(this.eap.getSelectedValue()) == Gwt8021xEap.TTLS;
 
+        boolean result = true;
+
         if (isTLS) {
 
-            if (this.username.getValue().isEmpty()) {
+            if (isNonEmptyString(this.username)) {
                 this.formgroupIdentityUsername.setValidationState(ValidationState.ERROR);
-                return false;
             }
 
-            if (this.keystorePid.getValue().isEmpty()) {
+            if (isNonEmptyString(this.keystorePid)) {
                 this.identityKeystorePid.setValidationState(ValidationState.ERROR);
-                return false;
+                result = false;
             }
 
-            if (this.publicPrivateKeyPairName.getValue().isEmpty()) {
+            if (isNonEmptyString(this.publicPrivateKeyPairName)) {
                 this.identityPublicPrivateKeyPairName.setValidationState(ValidationState.ERROR);
-                return false;
+                result = false;
             }
         }
 
         if (isPEAP || isTTLS) {
-            if (this.username.getValue().isEmpty()) {
+            if (isNonEmptyString(this.username)) {
                 this.formgroupIdentityUsername.setValidationState(ValidationState.ERROR);
-                return false;
+                result = false;
             }
 
-            if (this.password.getValue().isEmpty()) {
+            if (this.password.getValue() == null || this.password.getValue().trim().isEmpty()) {
                 this.formgroupPassword.setValidationState(ValidationState.ERROR);
-                return false;
+                result = false;
             }
 
-            if (this.keystorePid.getValue().isEmpty() && !this.caCertName.getValue().isEmpty()) {
+            if (isNonEmptyString(this.keystorePid) && !isNonEmptyString(this.caCertName)) {
                 this.identityKeystorePid.setValidationState(ValidationState.ERROR);
-                return false;
+                result = false;
             }
         }
 
-        return true;
+        return result;
+    }
+
+    private boolean isNonEmptyString(TextBox value) {
+        return value.getValue() == null || value.getValue().trim().isEmpty();
     }
 
     @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
@@ -453,6 +453,7 @@ public class Tab8021xUi extends Composite implements NetworkTab {
 
             if (isNonEmptyString(this.username)) {
                 this.formgroupIdentityUsername.setValidationState(ValidationState.ERROR);
+                result = false;
             }
 
             if (isNonEmptyString(this.keystorePid)) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
@@ -230,18 +230,10 @@ public class Tab8021xUi extends Composite implements NetworkTab {
         }
 
         this.innerAuth.addMouseOverHandler(event -> {
-            if (this.innerAuth.isEnabled()) {
-                setHelpText(MSGS.net8021xInnerAuthHelp());
-            }
+            setHelpText(MSGS.net8021xInnerAuthHelp());
         });
 
         this.innerAuth.addMouseOutHandler(event -> resetHelpText());
-
-        this.innerAuth.addChangeHandler(event -> {
-            setDirty(true);
-            refreshForm();
-            resetValidations();
-        });
     }
 
     private void initUsernameTextBox() {
@@ -279,6 +271,7 @@ public class Tab8021xUi extends Composite implements NetworkTab {
         this.password.addMouseOutHandler(event -> resetHelpText());
 
         this.password.addChangeHandler(event -> {
+            setDirty(true);
 
             if (!this.password.validate() && this.password.isEnabled()) {
                 this.formgroupPassword.setValidationState(ValidationState.ERROR);
@@ -538,6 +531,7 @@ public class Tab8021xUi extends Composite implements NetworkTab {
         switch (Gwt8021xEap.valueOf(this.eap.getSelectedValue())) {
         case PEAP:
         case TTLS:
+            this.innerAuth.setEnabled(false);
             setInnerAuthTo(Gwt8021xInnerAuth.MSCHAPV2);
             this.publicPrivateKeyPairName.setEnabled(false);
             break;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -114,9 +114,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
         if (isManual && isWan) {
             this.properties.setIp4Gateway(this.ifname, this.gwtConfig.getGateway());
         }
-        
-        this.properties.setIp4Mtu(this.ifname, Objects.nonNull(this.gwtConfig.getMtu()) ? 
-        		this.gwtConfig.getMtu() : DEFAULT_MTU);
+
+        this.properties.setIp4Mtu(this.ifname,
+                Objects.nonNull(this.gwtConfig.getMtu()) ? this.gwtConfig.getMtu() : DEFAULT_MTU);
     }
 
     private void setIpv6Properties() {
@@ -156,9 +156,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
             this.properties.setIp6AddressGenMode(this.ifname, this.gwtConfig.getIpv6AutoconfigurationMode());
             this.properties.setIp6Privacy(this.ifname, this.gwtConfig.getIpv6Privacy());
         }
-        
-        this.properties.setIp6Mtu(this.ifname, Objects.nonNull(this.gwtConfig.getIpv6Mtu()) ? 
-                this.gwtConfig.getIpv6Mtu() : DEFAULT_MTU);
+
+        this.properties.setIp6Mtu(this.ifname,
+                Objects.nonNull(this.gwtConfig.getIpv6Mtu()) ? this.gwtConfig.getIpv6Mtu() : DEFAULT_MTU);
     }
 
     private void setIpv4DhcpClientProperties() {
@@ -284,18 +284,15 @@ public class NetworkConfigurationServicePropertiesBuilder {
     }
 
     private void set8021xCertificatesAndPublicPrivateKeyPairs() {
-        if (this.gwtConfig.get8021xConfig().getKeystorePid() != null
-                && !this.gwtConfig.get8021xConfig().getKeystorePid().isEmpty()) {
+        if (this.gwtConfig.get8021xConfig().getKeystorePid() != null) {
             this.properties.set8021xKeystorePid(this.ifname, this.gwtConfig.get8021xConfig().getKeystorePid());
         }
 
-        if (this.gwtConfig.get8021xConfig().getCaCertName() != null
-                && !this.gwtConfig.get8021xConfig().getCaCertName().isEmpty()) {
+        if (this.gwtConfig.get8021xConfig().getCaCertName() != null) {
             this.properties.set8021xCaCertName(this.ifname, this.gwtConfig.get8021xConfig().getCaCertName());
         }
 
-        if (this.gwtConfig.get8021xConfig().getPublicPrivateKeyPairName() != null
-                && !this.gwtConfig.get8021xConfig().getPublicPrivateKeyPairName().isEmpty()) {
+        if (this.gwtConfig.get8021xConfig().getPublicPrivateKeyPairName() != null) {
             this.properties.set8021xPublicPrivateKeyPairName(this.ifname,
                     this.gwtConfig.get8021xConfig().getPublicPrivateKeyPairName());
             this.properties.set8021xClientCertName(this.ifname,

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2023 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -21,6 +21,7 @@ import org.eclipse.kura.net.wifi.WifiMode;
 import org.eclipse.kura.web.server.net2.utils.EnumsParser;
 import org.eclipse.kura.web.server.util.GwtServerUtil;
 import org.eclipse.kura.web.shared.GwtKuraException;
+import org.eclipse.kura.web.shared.model.Gwt8021xConfig;
 import org.eclipse.kura.web.shared.model.GwtModemInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetIfConfigMode;
 import org.eclipse.kura.web.shared.model.GwtNetIfStatus;
@@ -28,7 +29,6 @@ import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
 import org.eclipse.kura.web.shared.model.GwtNetRouterMode;
 import org.eclipse.kura.web.shared.model.GwtWifiConfig;
 import org.eclipse.kura.web.shared.model.GwtWifiNetInterfaceConfig;
-import org.eclipse.kura.web.shared.model.GwtWifiSecurity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,9 +98,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
         if (isWan) {
             if (Objects.nonNull(this.gwtConfig.getWanPriority())) {
-                this.properties.setIp4WanPriority(ifname, this.gwtConfig.getWanPriority());
+                this.properties.setIp4WanPriority(this.ifname, this.gwtConfig.getWanPriority());
             } else {
-                this.properties.setIp4WanPriority(ifname, DEFAULT_WAN_PRIORITY);
+                this.properties.setIp4WanPriority(this.ifname, DEFAULT_WAN_PRIORITY);
             }
 
             this.properties.setIp4DnsServers(this.ifname, this.gwtConfig.getDnsServers());
@@ -114,9 +114,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
         if (isManual && isWan) {
             this.properties.setIp4Gateway(this.ifname, this.gwtConfig.getGateway());
         }
-        
-        this.properties.setIp4Mtu(this.ifname, Objects.nonNull(this.gwtConfig.getMtu()) ? 
-        		this.gwtConfig.getMtu() : DEFAULT_MTU);
+
+        this.properties.setIp4Mtu(this.ifname,
+                Objects.nonNull(this.gwtConfig.getMtu()) ? this.gwtConfig.getMtu() : DEFAULT_MTU);
     }
 
     private void setIpv6Properties() {
@@ -137,7 +137,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
             if (Objects.nonNull(this.gwtConfig.getIpv6WanPriority())) {
                 this.properties.setIp6WanPriority(this.ifname, this.gwtConfig.getIpv6WanPriority());
             } else {
-                this.properties.setIp6WanPriority(ifname, DEFAULT_WAN_PRIORITY);
+                this.properties.setIp6WanPriority(this.ifname, DEFAULT_WAN_PRIORITY);
             }
 
             this.properties.setIp6DnsServers(this.ifname, this.gwtConfig.getIpv6DnsServers());
@@ -157,8 +157,8 @@ public class NetworkConfigurationServicePropertiesBuilder {
             this.properties.setIp6Privacy(this.ifname, this.gwtConfig.getIpv6Privacy());
         }
 
-        this.properties.setIp6Mtu(this.ifname, Objects.nonNull(this.gwtConfig.getIpv6Mtu()) ? 
-                this.gwtConfig.getIpv6Mtu() : DEFAULT_MTU);
+        this.properties.setIp6Mtu(this.ifname,
+                Objects.nonNull(this.gwtConfig.getIpv6Mtu()) ? this.gwtConfig.getIpv6Mtu() : DEFAULT_MTU);
     }
 
     private void setIpv4DhcpClientProperties() {
@@ -222,8 +222,8 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
         if (gwtWifiConfig.getPassword() != null) {
             if (GwtServerUtil.PASSWORD_PLACEHOLDER.equals(gwtWifiConfig.getPassword())
-                    && oldGwtNetInterfaceConfig instanceof GwtWifiNetInterfaceConfig) {
-                GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig = (GwtWifiNetInterfaceConfig) oldGwtNetInterfaceConfig;
+                    && this.oldGwtNetInterfaceConfig instanceof GwtWifiNetInterfaceConfig) {
+                GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig = (GwtWifiNetInterfaceConfig) this.oldGwtNetInterfaceConfig;
                 gwtWifiNetInterfaceConfig.setUnescaped(true);
 
                 GwtWifiConfig gwtApConfig = gwtWifiNetInterfaceConfig.getAccessPointWifiConfig();
@@ -253,7 +253,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
     }
 
-    private void set8021xConfig() {
+    private void set8021xConfig() throws GwtKuraException {
         if (this.gwtConfig.get8021xConfig() == null || !(this.gwtConfig instanceof GwtWifiNetInterfaceConfig)) {
             return;
         }
@@ -264,23 +264,36 @@ public class NetworkConfigurationServicePropertiesBuilder {
             this.properties.set8021xEap(this.ifname, this.gwtConfig.get8021xConfig().getEap());
         }
 
-        if (this.gwtConfig.get8021xConfig().getInnerAuth() != null
-                && !this.gwtConfig.get8021xConfig().getInnerAuth().isEmpty()) {
+        if (isValidStringProperty(this.gwtConfig.get8021xConfig().getInnerAuth())) {
             this.properties.set8021xInnerAuth(this.ifname, this.gwtConfig.get8021xConfig().getInnerAuth());
         }
 
-        if (this.gwtConfig.get8021xConfig().getUsername() != null
-                && !this.gwtConfig.get8021xConfig().getUsername().isEmpty()) {
+        if (isValidStringProperty(this.gwtConfig.get8021xConfig().getUsername())) {
             this.properties.set8021xIdentity(this.ifname, this.gwtConfig.get8021xConfig().getUsername());
         }
 
-        if (this.gwtConfig.get8021xConfig().getPassword() != null
-                && !this.gwtConfig.get8021xConfig().getPassword().isEmpty()) {
-            this.properties.set8021xPassword(this.ifname, this.gwtConfig.get8021xConfig().getPassword());
+        if (isValidStringProperty(this.gwtConfig.get8021xConfig().getPassword())) {
+            String password8021x = this.gwtConfig.get8021xConfig().getPassword();
+
+            if (GwtServerUtil.PASSWORD_PLACEHOLDER.equals(password8021x)
+                    && this.oldGwtNetInterfaceConfig instanceof GwtWifiNetInterfaceConfig) {
+                GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig = (GwtWifiNetInterfaceConfig) this.oldGwtNetInterfaceConfig;
+
+                Gwt8021xConfig gwt8021xConfig = gwtWifiNetInterfaceConfig.get8021xConfig();
+
+                this.properties.set8021xPassword(this.ifname, gwt8021xConfig.getPassword());
+            } else {
+                GwtServerUtil.validateUserPassword(password8021x);
+                this.properties.set8021xPassword(this.ifname, password8021x);
+            }
         }
 
         set8021xCertificatesAndPublicPrivateKeyPairs();
         logger.info("DONE - setting 802-1x config");
+    }
+
+    private boolean isValidStringProperty(String value) {
+        return value != null && !value.isEmpty();
     }
 
     private void set8021xCertificatesAndPublicPrivateKeyPairs() {
@@ -311,8 +324,8 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
         if (gwtWifiConfig.getPassword() != null) {
             if (GwtServerUtil.PASSWORD_PLACEHOLDER.equals(gwtWifiConfig.getPassword())
-                    && oldGwtNetInterfaceConfig instanceof GwtWifiNetInterfaceConfig) {
-                GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig = (GwtWifiNetInterfaceConfig) oldGwtNetInterfaceConfig;
+                    && this.oldGwtNetInterfaceConfig instanceof GwtWifiNetInterfaceConfig) {
+                GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig = (GwtWifiNetInterfaceConfig) this.oldGwtNetInterfaceConfig;
                 gwtWifiNetInterfaceConfig.setUnescaped(true);
 
                 GwtWifiConfig gwtStationConfig = gwtWifiNetInterfaceConfig.getStationWifiConfig();
@@ -372,9 +385,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
             if (gwtModemConfig.getPassword() != null) {
                 if (GwtServerUtil.PASSWORD_PLACEHOLDER.equals(gwtModemConfig.getPassword())
-                        && oldGwtNetInterfaceConfig instanceof GwtModemInterfaceConfig) {
+                        && this.oldGwtNetInterfaceConfig instanceof GwtModemInterfaceConfig) {
 
-                    GwtModemInterfaceConfig gwtModemInterfaceConfig = (GwtModemInterfaceConfig) oldGwtNetInterfaceConfig;
+                    GwtModemInterfaceConfig gwtModemInterfaceConfig = (GwtModemInterfaceConfig) this.oldGwtNetInterfaceConfig;
                     gwtModemInterfaceConfig.setUnescaped(true);
 
                     this.properties.setModemPassword(this.ifname, gwtModemInterfaceConfig.getPassword());
@@ -390,7 +403,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
             this.properties.setModemMaxFail(this.ifname, gwtModemConfig.getMaxFail());
             this.properties.setModemIdle(this.ifname, gwtModemConfig.getIdle());
             this.properties.setModemActiveFilter(this.ifname, gwtModemConfig.getActiveFilter());
-            this.properties.setModemLpcEchoInterval(ifname, gwtModemConfig.getLcpEchoInterval());
+            this.properties.setModemLpcEchoInterval(this.ifname, gwtModemConfig.getLcpEchoInterval());
             this.properties.setModemLpcEchoFailure(this.ifname, gwtModemConfig.getLcpEchoFailure());
             this.properties.setModemDiversityEnabled(this.ifname, gwtModemConfig.isDiversityEnabled());
             this.properties.setModemApn(this.ifname, gwtModemConfig.getApn());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -114,9 +114,9 @@ public class NetworkConfigurationServicePropertiesBuilder {
         if (isManual && isWan) {
             this.properties.setIp4Gateway(this.ifname, this.gwtConfig.getGateway());
         }
-
-        this.properties.setIp4Mtu(this.ifname,
-                Objects.nonNull(this.gwtConfig.getMtu()) ? this.gwtConfig.getMtu() : DEFAULT_MTU);
+        
+        this.properties.setIp4Mtu(this.ifname, Objects.nonNull(this.gwtConfig.getMtu()) ? 
+        		this.gwtConfig.getMtu() : DEFAULT_MTU);
     }
 
     private void setIpv6Properties() {
@@ -157,8 +157,8 @@ public class NetworkConfigurationServicePropertiesBuilder {
             this.properties.setIp6Privacy(this.ifname, this.gwtConfig.getIpv6Privacy());
         }
 
-        this.properties.setIp6Mtu(this.ifname,
-                Objects.nonNull(this.gwtConfig.getIpv6Mtu()) ? this.gwtConfig.getIpv6Mtu() : DEFAULT_MTU);
+        this.properties.setIp6Mtu(this.ifname, Objects.nonNull(this.gwtConfig.getIpv6Mtu()) ? 
+                this.gwtConfig.getIpv6Mtu() : DEFAULT_MTU);
     }
 
     private void setIpv4DhcpClientProperties() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/util/GwtServerUtil.java
@@ -53,6 +53,7 @@ import org.eclipse.kura.web.Console;
 import org.eclipse.kura.web.server.servlet.DeviceSnapshotsServlet;
 import org.eclipse.kura.web.shared.GwtKuraErrorCode;
 import org.eclipse.kura.web.shared.GwtKuraException;
+import org.eclipse.kura.web.shared.model.Gwt8021xConfig;
 import org.eclipse.kura.web.shared.model.GwtComponentInstanceInfo;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter;
@@ -773,6 +774,11 @@ public final class GwtServerUtil {
                 if (gwtStationWifiConfig != null) {
                     gwtStationWifiConfig.setPassword(PASSWORD_PLACEHOLDER);
                 }
+                Gwt8021xConfig gwt8021xConfig = wifiConfig.get8021xConfig();
+                if (gwt8021xConfig != null) {
+                    gwt8021xConfig.setPassword(PASSWORD_PLACEHOLDER);
+                }
+                
             } else if (netConfig instanceof GwtModemInterfaceConfig) {
                 GwtModemInterfaceConfig modemConfig = (GwtModemInterfaceConfig) netConfig;
                 modemConfig.setPassword(PASSWORD_PLACEHOLDER);


### PR DESCRIPTION
This PR aims to fix the optional bug, where when clearing and applying a field, the original value persists. 

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution
<img width="1046" alt="image" src="https://github.com/eclipse/kura/assets/29900100/fe276e52-b9dd-4211-80ec-d84110b5c6d9">
now able to clear fields after applying

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
