### PR TITLE
docs(rest.identity): Resolved typo in delete json

### DIFF
--- a/docs/references/rest-apis/rest-identity-api.md
+++ b/docs/references/rest-apis/rest-identity-api.md
@@ -196,7 +196,7 @@ No specific permission is required to access this resource.
 ##### Request
 ```JSON
 {
-    "userName": "username",
+    "userName": "username"
 }
 ```
 


### PR DESCRIPTION
This PR resolves a typo in the example json of the rest identity documentation

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
