### PR TITLE
fix(rest.identity): adding specific error messages when user is not found

### DIFF
--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestService.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestService.java
@@ -22,7 +22,10 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
 import org.eclipse.kura.cloudconnection.request.RequestHandler;
 import org.eclipse.kura.cloudconnection.request.RequestHandlerRegistry;
 import org.eclipse.kura.configuration.ConfigurationService;
@@ -138,6 +141,12 @@ public class IdentityRestService {
         try {
             logger.debug(DEBUG_MESSAGE, "getUser");
             return this.identityService.getUser(userName.getUserName());
+        } catch (KuraException e) {
+            if (e.getCode().equals(KuraErrorCode.NOT_FOUND)) {
+                throw DefaultExceptionHandler.buildWebApplicationException(Status.NOT_FOUND, "Identity does not exist");
+            } else {
+                throw DefaultExceptionHandler.toWebApplicationException(e);
+            }
         } catch (Exception e) {
             throw DefaultExceptionHandler.toWebApplicationException(e);
         }
@@ -152,6 +161,12 @@ public class IdentityRestService {
         try {
             logger.debug(DEBUG_MESSAGE, "deleteUser");
             this.identityService.deleteUser(userName.getUserName());
+        } catch (KuraException e) {
+            if (e.getCode().equals(KuraErrorCode.NOT_FOUND)) {
+                throw DefaultExceptionHandler.buildWebApplicationException(Status.NOT_FOUND, "Identity does not exist");
+            } else {
+                throw DefaultExceptionHandler.toWebApplicationException(e);
+            }
         } catch (Exception e) {
             throw DefaultExceptionHandler.toWebApplicationException(e);
         }

--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityService.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityService.java
@@ -23,16 +23,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response.Status;
-
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.crypto.CryptoService;
 import org.eclipse.kura.internal.rest.identity.provider.dto.UserDTO;
-import org.eclipse.kura.request.handler.jaxrs.DefaultExceptionHandler;
 import org.eclipse.kura.util.useradmin.UserAdminHelper;
 import org.eclipse.kura.util.useradmin.UserAdminHelper.FallibleConsumer;
 import org.eclipse.kura.util.validation.PasswordStrengthValidators;
@@ -81,24 +77,24 @@ public class IdentityService {
         }
     }
 
-    public void deleteUser(String userName) throws WebApplicationException {
+    public void deleteUser(String userName) throws KuraException {
 
         if (this.userAdminHelper.getUser(userName).isPresent()) {
             this.userAdminHelper.deleteUser(userName);
         } else {
-            throw DefaultExceptionHandler.buildWebApplicationException(Status.NOT_FOUND, "Identity does not exist");
+            throw new KuraException(KuraErrorCode.NOT_FOUND, "Identity does not exist");
         }
 
     }
 
-    public UserDTO getUser(String userName) throws WebApplicationException {
+    public UserDTO getUser(String userName) throws KuraException {
         Optional<User> user = this.userAdminHelper.getUser(userName);
         if (user.isPresent()) {
             UserDTO userFound = initUserConfig(user.get());
             fillPermissions(Collections.singletonMap(user.get().getName(), userFound));
             return userFound;
         } else {
-            throw DefaultExceptionHandler.buildWebApplicationException(Status.NOT_FOUND, "Identity does not exist");
+            throw new KuraException(KuraErrorCode.NOT_FOUND, "Identity does not exist");
         }
     }
 

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityEndpointsTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityEndpointsTest.java
@@ -81,6 +81,10 @@ public class IdentityEndpointsTest extends AbstractRequestHandlerTest {
             IdentityEndpointsTest.class.getResourceAsStream("/getPasswordRequirementsResponse.json"), "UTF-8")
                     .useDelimiter("\\A").next().replace(" ", "");
 
+    private static final String EXPECTED_NON_EXISTING_USER_RESPONSE = new Scanner(
+            IdentityEndpointsTest.class.getResourceAsStream("/getNonExistingUserResponse.json"), "UTF-8")
+                    .useDelimiter("\\A").next().replace(" ", "");
+
     private static Set<UserDTO> userConfigs;
 
     private static ServiceRegistration<IdentityService> identityServiceRegistration;
@@ -176,6 +180,28 @@ public class IdentityEndpointsTest extends AbstractRequestHandlerTest {
 
         thenRequestSucceeds();
         thenResponseBodyEqualsJson(EXPECTED_GET_PASSWORD_REQUIREMENTS_RESPONSE);
+    }
+
+    @Test
+    public void shouldReturnNonExistingUserDeleteResponse() throws KuraException {
+        givenIdentityService();
+
+        whenRequestIsPerformed(new MethodSpec(METHOD_SPEC_DELETE, MQTT_METHOD_SPEC_DEL), "/identities",
+                "{\"userName\":\"nonExistingUser\"}");
+
+        thenResponseCodeIs(404);
+        thenResponseBodyEqualsJson(EXPECTED_NON_EXISTING_USER_RESPONSE);
+    }
+
+    @Test
+    public void shouldReturnNonExistingUserPostResponse() throws KuraException {
+        givenIdentityService();
+
+        whenRequestIsPerformed(new MethodSpec(METHOD_SPEC_POST), "/identities/byName",
+                "{\"userName\":\"nonExistingUser\"}");
+
+        thenResponseCodeIs(404);
+        thenResponseBodyEqualsJson(EXPECTED_NON_EXISTING_USER_RESPONSE);
     }
 
     private void givenUser(UserDTO userParam) {

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/resources/getNonExistingUserResponse.json
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/resources/getNonExistingUserResponse.json
@@ -1,3 +1,1 @@
-{
-    "message": "Identity does not exist"
-}
+{"message" : "Identity does not exist"}

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/resources/getNonExistingUserResponse.json
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/resources/getNonExistingUserResponse.json
@@ -1,0 +1,3 @@
+{
+    "message": "Identity does not exist"
+}

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.kura.internal.rest.identity.provider.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -186,6 +187,24 @@ public class IdentityServiceTest {
         thenPasswordValidationIs(false);
     }
 
+    @Test
+    public void shouldThrowExceptionWhenDeletingNonExistingUser() {
+        givenIdentityService();
+
+        whenDeleting("NonExistingUser");
+
+        thenExceptionOccurred(KuraException.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenGettingNonExistingUser() {
+        givenIdentityService();
+
+        whenGettingUser("NonExistingUser");
+
+        thenExceptionOccurred(KuraException.class);
+    }
+
     private void whenValidatingPassword(String password) {
         try {
             this.identityService.validateUserPassword(password);
@@ -328,6 +347,11 @@ public class IdentityServiceTest {
         }
 
         assertNull(errorMessage, this.occurredException);
+    }
+
+    private <E extends Exception> void thenExceptionOccurred(Class<E> expectedExceptionClass) {
+        assertNotNull(this.occurredException);
+        assertEquals(expectedExceptionClass.getName(), this.occurredException.getClass().getName());
     }
 
     public static class PermissionRole implements Group {

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceTest.java
@@ -13,7 +13,6 @@
 package org.eclipse.kura.internal.rest.identity.provider.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -187,24 +186,6 @@ public class IdentityServiceTest {
         thenPasswordValidationIs(false);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenDeletingNonExistingUser() {
-        givenIdentityService();
-
-        whenDeleting("NonExistingUser");
-
-        thenExceptionOccurred(KuraException.class);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenGettingNonExistingUser() {
-        givenIdentityService();
-
-        whenGettingUser("NonExistingUser");
-
-        thenExceptionOccurred(KuraException.class);
-    }
-
     private void whenValidatingPassword(String password) {
         try {
             this.identityService.validateUserPassword(password);
@@ -347,11 +328,6 @@ public class IdentityServiceTest {
         }
 
         assertNull(errorMessage, this.occurredException);
-    }
-
-    private <E extends Exception> void thenExceptionOccurred(Class<E> expectedExceptionClass) {
-        assertNotNull(this.occurredException);
-        assertEquals(expectedExceptionClass.getName(), this.occurredException.getClass().getName());
     }
 
     public static class PermissionRole implements Group {

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceTest.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.ws.rs.WebApplicationException;
+
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.ConfigurationService;
@@ -119,7 +121,7 @@ public class IdentityServiceTest {
     private void whenGettingUser(String username) {
         try {
             this.user = this.identityService.getUser(username);
-        } catch (KuraException e) {
+        } catch (WebApplicationException e) {
             this.occurredException = e;
         }
     }

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceTest.java
@@ -36,8 +36,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.ws.rs.WebApplicationException;
-
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.ConfigurationService;
@@ -121,7 +119,7 @@ public class IdentityServiceTest {
     private void whenGettingUser(String username) {
         try {
             this.user = this.identityService.getUser(username);
-        } catch (WebApplicationException e) {
+        } catch (KuraException e) {
             this.occurredException = e;
         }
     }


### PR DESCRIPTION
This PR adds a more exhaustive response when an user tries to execute the following REST APIs:

- POST services/identity/v1/identities
- DELETE services/identity/v1/identities

with a non-existing `userName` in the request json.

Before this variation, an unspecific message would have been received, whic could be misleading.

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
