### PR TITLE
fix: 802.1x tab displaying and refresh

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -14,6 +14,7 @@ package org.eclipse.kura.web.client.ui.network;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.util.MessageUtils;
@@ -142,10 +143,22 @@ public class NetworkTabsUi extends Composite {
             NetworkTabsUi.this.content.add(NetworkTabsUi.this.ip6Tab);
         });
     }
+    
+    private void initWireless8021xTab() {
+        this.net8021xTabAnchorItem = new AnchorListItem(MSGS.netWifiWireless8021x());
+        this.set8021xTab = new Tab8021xUi(this.session, this, this.ip4Tab, this.ip6Tab);
+
+        this.net8021xTabAnchorItem.addClickHandler(event -> {
+            setSelected(NetworkTabsUi.this.net8021xTabAnchorItem);
+            NetworkTabsUi.this.selectedTab = NetworkTabsUi.this.set8021xTab;
+            NetworkTabsUi.this.content.clear();
+            NetworkTabsUi.this.content.add(NetworkTabsUi.this.set8021xTab);
+        });
+    }
 
     private void initWirelessTab(final boolean isNet2) {
         this.wirelessTabAnchorItem = new AnchorListItem(MSGS.netWifiWireless());
-        this.wirelessTab = new TabWirelessUi(this.session, this.ip4Tab, this.ip6Tab, this.set8021xTab,
+        this.wirelessTab = new TabWirelessUi(this.session, this.ip4Tab, this.ip6Tab,
                 this.net8021xTabAnchorItem, this, isNet2);
 
         this.wirelessTabAnchorItem.addClickHandler(event -> {
@@ -153,18 +166,6 @@ public class NetworkTabsUi extends Composite {
             NetworkTabsUi.this.selectedTab = NetworkTabsUi.this.wirelessTab;
             NetworkTabsUi.this.content.clear();
             NetworkTabsUi.this.content.add(NetworkTabsUi.this.wirelessTab);
-        });
-    }
-
-    private void initWireless8021xTab() {
-        this.net8021xTabAnchorItem = new AnchorListItem(MSGS.netWifiWireless8021x());
-        this.set8021xTab = new Tab8021xUi(this.session, this);
-
-        this.net8021xTabAnchorItem.addClickHandler(event -> {
-            setSelected(NetworkTabsUi.this.net8021xTabAnchorItem);
-            NetworkTabsUi.this.selectedTab = NetworkTabsUi.this.set8021xTab;
-            NetworkTabsUi.this.content.clear();
-            NetworkTabsUi.this.content.add(NetworkTabsUi.this.set8021xTab);
         });
     }
 
@@ -334,8 +335,10 @@ public class NetworkTabsUi extends Composite {
 
         insertTab(this.wirelessTabAnchorItem);
         if (this.isNet2) {
+            if(interfaceNotEnabled) {
+                this.net8021xTabAnchorItem.setEnabled(false);
+            }
             insertTab(this.net8021xTabAnchorItem);
-            this.net8021xTabAnchorItem.setEnabled(!interfaceNotEnabled);
         }
 
         insertTab(this.dhcp4NatTabAnchorItem);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/Tab8021xUi.java
@@ -49,8 +49,6 @@ public class Tab8021xUi extends Composite implements NetworkTab {
     interface Tab8021xUiUiBinder extends UiBinder<Widget, Tab8021xUi> {
     }
 
-    private static final Logger logger = Logger.getLogger(Tab8021xUi.class.getSimpleName());
-
     private final NetworkTabsUi netTabs;
 
     Gwt8021xConfig activeConfig;
@@ -353,11 +351,9 @@ public class Tab8021xUi extends Composite implements NetworkTab {
     }
 
     private void update() {
-        logger.info("update");
         setValues();
         refreshForm();
         this.netTabs.updateTabs();
-        logger.info("update... done");
     }
 
     private void resetValidations() {
@@ -382,7 +378,6 @@ public class Tab8021xUi extends Composite implements NetworkTab {
     }
 
     private void reset() {
-        logger.info("reset");
         for (int i = 0; i < this.eap.getItemCount(); i++) {
             if (this.eap.getSelectedItemText().equals(Gwt8021xEap.TTLS.name())) {
                 this.eap.setSelectedIndex(i);
@@ -404,7 +399,6 @@ public class Tab8021xUi extends Composite implements NetworkTab {
         this.caCertName.setValue("");
         this.publicPrivateKeyPairName.setValue("");
         update();
-        logger.info("reset... done");
     }
 
     private void setValues() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -147,7 +147,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     private final TabIp4Ui tcp4Tab;
     private final TabIp6Ui tcp6Tab;
     private final NetworkTabsUi netTabs;
-    private final Tab8021xUi wireless8021x;
     private final ListDataProvider<GwtWifiHotspotEntry> ssidDataProvider = new ListDataProvider<>();
     private final SingleSelectionModel<GwtWifiHotspotEntry> ssidSelectionModel = new SingleSelectionModel<>();
 
@@ -346,7 +345,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     @UiField
     Text unavailableChannelErrorText;
 
-    public TabWirelessUi(GwtSession currentSession, TabIp4Ui tcp4, TabIp6Ui tcp6, Tab8021xUi wireless8021x,
+    public TabWirelessUi(GwtSession currentSession, TabIp4Ui tcp4, TabIp6Ui tcp6,
             AnchorListItem wireless8021xTabAnchorItem, NetworkTabsUi tabs, final boolean isNet2) {
         this.ssidInit = false;
         initWidget(uiBinder.createAndBindUi(this));
@@ -354,7 +353,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         this.tcp4Tab = tcp4;
         this.tcp6Tab = tcp6;
         this.netTabs = tabs;
-        this.wireless8021x = wireless8021x;
         this.wireless8021xTabAnchorItem = wireless8021xTabAnchorItem;
 
         this.isNet2 = isNet2;
@@ -463,9 +461,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
             this.activeConfig = this.selectedNetIfConfig.getActiveWifiConfig();
             if (Objects.nonNull(this.activeConfig)) {
-                logger.info("Active config: " + this.activeConfig.getProperties());
-                logger.info("Wireless mode: " + this.activeConfig.getWirelessMode());
-                logger.info("Channels " + this.activeConfig.getChannels());
                 if (this.activeConfig.getChannels() != null
                         && !TabWirelessUi.this.activeConfig.getChannels().isEmpty()) {
                     updateChanneList(TabWirelessUi.this.activeConfig);
@@ -548,7 +543,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private void setValues() {
-        logger.info("Start setValues");
 
         if (this.activeConfig == null) {
             return;
@@ -618,8 +612,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         this.radio2.setValue(!this.activeConfig.pingAccessPoint());
         this.radio3.setValue(this.activeConfig.ignoreSSID());
         this.radio4.setValue(!this.activeConfig.ignoreSSID());
-
-        logger.info("Finished setValues");
     }
 
     private void setRadioModeByValue(String radioModeValue) {
@@ -662,7 +654,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private void refreshForm() {
-        logger.info("Start refreshForm");
 
         String tcpip4Status = this.tcp4Tab.getStatus();
         String tcpip6Status = this.tcp6Tab.getStatus();
@@ -723,7 +714,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             if (WIFI_MODE_STATION_MESSAGE.equals(this.wireless.getSelectedItemText())) {
                 this.ssid.setEnabled(true);
                 this.buttonSsid.setEnabled(true);
-                logger.info("buttonSsid value: " + this.buttonSsid);
                 this.verify.setEnabled(false);
                 if (!this.security.getSelectedItemText().equals(WIFI_SECURITY_NONE_MESSAGE)) {
                     if (this.password.getValue() != null && this.password.getValue().length() > 0) {
@@ -752,7 +742,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             } else {
                 this.ssid.setEnabled(true);
                 this.buttonSsid.setEnabled(false);
-                logger.info("buttonSsid value: " + this.buttonSsid);
                 if (!this.security.getSelectedItemText().equals(WIFI_SECURITY_NONE_MESSAGE)) {
                     this.password.setEnabled(true);
                     this.buttonPassword.setEnabled(false);
@@ -787,8 +776,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         }
 
         this.netTabs.updateTabs();
-
-        logger.info("Finish refreshForm");
     }
 
     private void reset() {
@@ -872,7 +859,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private void initForm() {
-        logger.info("Start initForm");
 
         // Wireless Mode
 
@@ -1229,8 +1215,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         this.labelCountryCode.setText(MSGS.netWifiCountryCodeLabel());
 
         this.noChannelsText.setText(MSGS.netWifiAlertNoChannels());
-
-        logger.info("Finish initForm");
     }
 
     private void initRegDomErrorModal() {
@@ -1333,7 +1317,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
                     @Override
                     public void onSuccess(String countryCode) {
-                        logger.info("getWifiCountryCode Success - " + countryCode);
                         TabWirelessUi.this.countryCode.setText(countryCode);
                         TabWirelessUi.this.activeConfig.setCountryCode(countryCode);
 
@@ -1467,7 +1450,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                 } else {
                     this.channelList.setSelectedIndex(channelToSelect);
                     this.activeConfig.setChannels(Collections.singletonList(wifiHotspotEntry.getChannel()));
-                    logger.info("SSID Selected channel: " + wifiHotspotEntry.getChannel());
                 }
 
                 TabWirelessUi.this.ssid.setValue(GwtSafeHtmlUtils.htmlUnescape(wifiHotspotEntry.getSSID()));
@@ -1597,8 +1579,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     }
 
     private int getChannelIndexFromValue(int channelValue) {
-
-        logger.info("getChannelIndexFromValue for channel: " + channelValue);
 
         if (channelValue == 0) {
             return 0;
@@ -1834,9 +1814,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                                 @Override
                                 public void onSuccess(List<GwtWifiChannelFrequency> freqChannels) {
 
-                                    logger.info("Processing result from findFrequencies for "
-                                            + TabWirelessUi.this.selectedNetIfConfig.getName() + "/" + radioMode);
-
                                     TabWirelessUi.this.channelList.clear();
 
                                     addAutomaticChannel(freqChannels);
@@ -1851,7 +1828,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                                         int selectedChannelIndex = getChannelIndexFromValue(channel);
                                         int channelIndex = selectedChannelIndex == -1 ? 0 : selectedChannelIndex;
 
-                                        logger.info("Setting channel to: " + channel);
                                         TabWirelessUi.this.channelList.setSelectedIndex(channelIndex);
 
                                     }
@@ -1859,9 +1835,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                                     boolean hasChannels = TabWirelessUi.this.channelList.getItemCount() > 0;
 
                                     TabWirelessUi.this.noChannels.setVisible(!hasChannels);
-
-                                    logger.info("Finished processing result from findFrequencies for "
-                                            + TabWirelessUi.this.selectedNetIfConfig.getName() + "/" + radioMode);
 
                                 }
                             });
@@ -1920,11 +1893,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                                 fillRadioMode(acSupported);
 
                                 if (selectedRadioMode != null) {
-                                    logger.info("selectedRadioModeText: " + selectedRadioMode);
                                     setRadioModeByValue(selectedRadioMode);
                                 } else {
-                                    logger.info("TabWirelessUi.this.activeConfig.getRadioMode(): "
-                                            + TabWirelessUi.this.activeConfig.getRadioMode());
                                     setRadioModeByValue(TabWirelessUi.this.activeConfig.getRadioMode());
                                 }
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** N/A

**Description of the solution adopted:** Another attempt to improve the availability and refresh for the 802.1x tab in the wireless section

**Screenshots:** N/A

**Manual Tests**: Tested with ipv4 and ipv6 disabled as well enabling each of them. All the tests done first without and then with the selection of the enterprise security.

**Any side note on the changes made:** N/A
