### PR TITLE
docs(development-environment-setup): fix workspace download link

### DIFF
--- a/docs/java-application-development/development-environment-setup.md
+++ b/docs/java-application-development/development-environment-setup.md
@@ -99,7 +99,7 @@ After the new workspace opens, click the Workbench icon to display the developme
 
 ### Importing the Kura User Workspace
 
-To set up your Kura project workspace, you will need to download the Kura User Workspace archive from [Eclipse Kura Download Page](https://websites.eclipseprojects.io/kura/downloads.php).
+To set up your Kura project workspace, you will need to download the Kura User Workspace archive from [Eclipse Kura Download Page](https://eclipse.dev/kura/downloads.php).
 
 From the Eclipse File menu, select the **Import** option.  In the Import dialog box, expand the **General** heading, select **Existing Projects into Workspace**, and then click **Next**.
 


### PR DESCRIPTION
Updates the Eclipse Kura Download Page in the environment setup, as the previous url linked to a unavailable webpage (see screenshot). If this is only a temporary issue, please close this PR.

**Related Issue:** N/A

**Description of the solution adopted:** The link was changed.

**Screenshots:** 

![image](https://github.com/eclipse/kura/assets/4940804/00317369-1a7a-4b66-bd0b-4acb0a8e6324)

