### PR TITLE
fix(data.service): correctly stopping reconnection thread

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/data/DataServiceImpl.java
@@ -260,6 +260,7 @@ public class DataServiceImpl implements DataService, DataTransportListener, Conf
         logger.info("Updating {}...", properties.get(ConfigurationService.KURA_SERVICE_PID));
 
         shutdownAutoConnectStrategy();
+        stopConnectionTask();
 
         final String oldDbServicePid = this.dataServiceOptions.getDbServiceInstancePid();
 


### PR DESCRIPTION
This PR fixes a problem related to the management of the reconnection executor created by enabling the *Connection Schedule* option in the **Data Service** section of the **Cloud Connections** tab.

Before this change, when an update of the section was performed, no one stopped the reconnection executor, so the CloudConnection continously tried to reconnect with the old parameters, and could happen that the scheduled connections overlap, making the general behaviour not coherent with the expected one.

**Related Issue:**

**Description of the solution adopted:** This PR adds the correct stopping of the executor, which is then correctly update, so the next scheduled connections are coherent with the CRON expression set in the related option.

**Screenshots:**

**Manual Tests**:

1. Configure the CloudConnections MqttDataTransport tab with parameters that would let a succesful cloud connection, then enable the `Connect Auto-on-startup` option, enable the `Scheduled Connection` of DataService tab under CloudConnections with a CRON expression `0/30 0/1 * 1/1 * ? *` and Apply.
2. Copy the content of the `Message Store Provider Service PID` and changed it to a fake one `fake.pid` and Apply.
3. Wait that the Disconnection, then set the Pid as the correct one and Apply.
4. The connection should be scheduled and only in that moment the system should try reconnection (it's not necessary that the time is perfectly matched, couple of seconds delay is acceptable).
5. Logger should print a line like `"Reconnect task running. Stopping it"`

**Any side note on the changes made:**
