### PR TITLE
docs: remove links to gitter and forum, add Kura Dev Meeting info

### DIFF
--- a/docs/java-application-development/contributing.md
+++ b/docs/java-application-development/contributing.md
@@ -6,5 +6,13 @@ The steps required to submit code to the project can be found on [Github Contrib
 
 If you face any issues, or just want to get involved with the kura community feel free to join us on:
 
-  * [Gitter](https://gitter.im/eclipse/kura)
-  * [Kura Support Forum](https://www.eclipse.org/forums/index.php/f/273/)
+- [**Github Issues**](https://github.com/eclipse/kura/issues): for bug reporting.
+- [**Github Discussions**](https://github.com/eclipse/kura/discussions): for receiving feedback, making new proposals and generally talking about the project.
+
+## Kura Dev Meeting 
+
+If you want to get involved in the development process you can join us at the Kura Dev Meeting. The meeting is held every 2 weeks on Wednesday, at 5 PM CEST on Microsoft Teams. 
+
+You can join by using [this link](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2I1OTc3ZWEtZGNkYy00NjVkLWJhNTUtYjJjNzEwMWZkMTM5%40thread.v2/0?context=%7b%22Tid%22%3a%22fc01f1f7-7425-4de2-ba8a-a7cc0ded6b72%22%2c%22Oid%22%3a%22dc13c82d-2440-47da-a2cb-6b581115fbf4%22%7d).
+
+The scheduled dates for the meeting can be found [here](https://github.com/eclipse/kura/files/12539667/kura-dev-meeting.zip). Unzip the calendar file and double-click on it to add the scheduled dates to your calendar.


### PR DESCRIPTION
This PR updates the Contributing page of the docs to not refer to obsolete channels (gitter, Kura forum). In addition to that it adds info about the Kura Dev Meeting
