### PR TITLE
fix(Container.orchestrator): add default log limit to created docker containers

### DIFF
--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -152,7 +152,7 @@
          </AD>
             
        <AD id="container.loggerParameters" name="Logger Parameters"
-            description="Used to pass logger parameters to a container's logging driver. Example: max-buffer-size=4m, labels=location." type="String" cardinality="1"
+            description="Used to pass logger parameters to a container's logging driver. Example: max-buffer-size=5m, max-file=2." type="String" cardinality="1"
             required="false" default="max-buffer-size=5m, max-file=2" />
 
         <AD id="container.restart.onfailure" name="Restart Container On Failure" type="Boolean" cardinality="1" required="true" default="false"

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -153,7 +153,7 @@
             
        <AD id="container.loggerParameters" name="Logger Parameters"
             description="Used to pass logger parameters to a container's logging driver. Example: max-buffer-size=4m, labels=location." type="String" cardinality="1"
-            required="false" default="" />
+            required="false" default="max-buffer-size=5m, max-file=2" />
 
         <AD id="container.restart.onfailure" name="Restart Container On Failure" type="Boolean" cardinality="1" required="true" default="false"
             description="Automatically restart the container when it has failed.">


### PR DESCRIPTION
Kura targets constrained devices, this sets a basic default log size so constrained devices are not overwhelmed by logs.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
