### PR TITLE
chore(driver): explain that PreparedRead of a Driver is optional 

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/driver/Driver.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/driver/Driver.java
@@ -230,11 +230,14 @@ public interface Driver {
      * If the validation of the channel configuration fails for some channels, the driver must not throw an exception
      * but it is required to return channel records with proper error flags set as a result of the
      * {@link PreparedRead#execute()} call.
+     * 
+     * If the driver does not implement such optimizations, null should be returned.
      *
      * @see PreparedRead
      * @param records
      *            The list of channel records that represent the request to be optimized.
-     * @return The {@link PreparedRead} instance
+     * @return The {@link PreparedRead} instance or null if the driver does not implement any protocol specific 
+     *         optimization.
      * @throws NullPointerException
      *             if the provided list is null
      */


### PR DESCRIPTION
From the javadoc it is not clear if one MUST or CAN provide a PreparedRead in a kura Driver.
One would think that the PrepareRead be optional, but this is not clearly stated.

The BaseAsset in Kura handles both cases: driver with and without PrepareRead. Therefore it should be clear that PrepareRead is optional.

The proposal is to add the following text in the javadoc:

- "If the driver does not implement such optimizations, null should be returned."
- "return The link PreparedRead instance or null if the driver does not implement any protocol specific optimization."

**Description of the solution adopted:**
Check BaseAsset.java:

```
if (preparedRead != null) {
                records = preparedRead.execute();
            } else {
                records = conf.getAllReadRecords();
                if (!records.isEmpty()) {
                    state.getDriver().read(records);
                }
            }
```

It looks that PrepareRead was always designed to be optional. It also makes sense. The javadoc is not explicit, therefore the clarification in this PR.