### PR TITLE
fix(nm): 802.1x EAP-TLS on platforms where NetworkManager uses `nss`

### DIFF
--- a/kura/org.eclipse.kura.nm/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.nm/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: org.eclipse.kura.nm;singleton:=true
 Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse Kura
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
-Import-Package: org.apache.commons.io;version="2.4.0",
+Import-Package: javax.xml.bind;version="2.3.3",
+ org.apache.commons.io;version="2.4.0",
  org.apache.commons.lang3.tuple;version="3.12.0",
  org.eclipse.kura;version="[1.0,2.0)",
  org.eclipse.kura.configuration;version="[1.1,2.0)",

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -204,7 +204,8 @@ public class NMSettingsConverter {
             if (derPrivateKey != null) {
                 // Convert DER to PEM
                 String pemPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
-                        + DatatypeConverter.printBase64Binary(derPrivateKey) + "\n-----END PRIVATE KEY-----\n";
+                        + DatatypeConverter.printBase64Binary(derPrivateKey).replaceAll("(.{64})", "$1\n") + "\n-----END PRIVATE KEY-----\n";
+                logger.info("Private Key: {}", pemPrivateKey);
                 settings.put("private-key", new Variant<>(pemPrivateKey.getBytes(StandardCharsets.UTF_8)));
             } else {
                 logger.error("Unable to find or decode Private Key");

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -795,5 +795,4 @@ public class NMSettingsConverter {
                 + "\n-----END CERTIFICATE-----\n";
         return pem.getBytes(StandardCharsets.UTF_8);
     }
-
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -200,12 +200,17 @@ public class NMSettingsConverter {
         try {
             PrivateKey privateKey = props.get(PrivateKey.class, "net.interface.%s.config.802-1x.private-key-name",
                     deviceId);
-            // Convert DER to PEM
-            String pemPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
-                    + DatatypeConverter.printBase64Binary(privateKey.getEncoded()) + "\n-----END PRIVATE KEY-----\n";
-            settings.put("private-key", new Variant<>(pemPrivateKey.getBytes(StandardCharsets.UTF_8)));
-        } catch (ClassCastException | IllegalArgumentException e) {
-            logger.error("Unable to find or decode Private Key");
+            byte[] derPrivateKey = privateKey.getEncoded();
+            if (derPrivateKey != null) {
+                // Convert DER to PEM
+                String pemPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
+                        + DatatypeConverter.printBase64Binary(derPrivateKey) + "\n-----END PRIVATE KEY-----\n";
+                settings.put("private-key", new Variant<>(pemPrivateKey.getBytes(StandardCharsets.UTF_8)));
+            } else {
+                logger.error("Unable to find or decode Private Key");
+            }
+        } catch (ClassCastException e) {
+            logger.error("Unable to find Private Key");
         }
 
         Optional<Password> privateKeyPassword = props.getOpt(Password.class,

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -790,9 +790,9 @@ public class NMSettingsConverter {
     }
 
     private static byte[] convertToPem(byte[] derKey) {
-        String pem = "-----BEGIN CERTIFICATE-----\n"
+        String pem = "-----BEGIN PRIVATE KEY-----\n"
                 + DatatypeConverter.printBase64Binary(derKey).replaceAll("(.{64})", "$1\n")
-                + "\n-----END CERTIFICATE-----\n";
+                + "\n-----END PRIVATE KEY-----\n";
         return pem.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.xml.bind.DatatypeConverter;
+
 import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.nm.Kura8021xEAP;
 import org.eclipse.kura.nm.Kura8021xInnerAuth;
@@ -198,8 +200,12 @@ public class NMSettingsConverter {
         try {
             PrivateKey privateKey = props.get(PrivateKey.class, "net.interface.%s.config.802-1x.private-key-name",
                     deviceId);
-            if (privateKey.getEncoded() != null) {
-                settings.put("private-key", new Variant<>(privateKey.getEncoded()));
+            byte[] derPrivateKey = privateKey.getEncoded();
+            if (derPrivateKey != null) {
+                // Convert DER to PEM
+                String pemPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
+                        + DatatypeConverter.printBase64Binary(derPrivateKey) + "\n-----END PRIVATE KEY-----\n";
+                settings.put("private-key", new Variant<>(pemPrivateKey.getBytes(StandardCharsets.UTF_8)));
             } else {
                 logger.error("Unable to find or decode Private Key");
             }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -200,13 +200,8 @@ public class NMSettingsConverter {
         try {
             PrivateKey privateKey = props.get(PrivateKey.class, "net.interface.%s.config.802-1x.private-key-name",
                     deviceId);
-            byte[] derPrivateKey = privateKey.getEncoded();
-            if (derPrivateKey != null) {
-                // Convert DER to PEM
-                String pemPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
-                        + DatatypeConverter.printBase64Binary(derPrivateKey).replaceAll("(.{64})", "$1\n") + "\n-----END PRIVATE KEY-----\n";
-                logger.info("Private Key: {}", pemPrivateKey);
-                settings.put("private-key", new Variant<>(pemPrivateKey.getBytes(StandardCharsets.UTF_8)));
+            if (privateKey.getEncoded() != null) {
+                settings.put("private-key", new Variant<>(convertToPem(privateKey.getEncoded())));
             } else {
                 logger.error("Unable to find or decode Private Key");
             }
@@ -792,6 +787,13 @@ public class NMSettingsConverter {
             throw new IllegalArgumentException(String
                     .format("Unsupported connection type conversion from NMDeviceType \"%s\"", deviceType.toString()));
         }
+    }
+
+    private static byte[] convertToPem(byte[] derKey) {
+        String pem = "-----BEGIN CERTIFICATE-----\n"
+                + DatatypeConverter.printBase64Binary(derKey).replaceAll("(.{64})", "$1\n")
+                + "\n-----END CERTIFICATE-----\n";
+        return pem.getBytes(StandardCharsets.UTF_8);
     }
 
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -200,17 +200,12 @@ public class NMSettingsConverter {
         try {
             PrivateKey privateKey = props.get(PrivateKey.class, "net.interface.%s.config.802-1x.private-key-name",
                     deviceId);
-            byte[] derPrivateKey = privateKey.getEncoded();
-            if (derPrivateKey != null) {
-                // Convert DER to PEM
-                String pemPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
-                        + DatatypeConverter.printBase64Binary(derPrivateKey) + "\n-----END PRIVATE KEY-----\n";
-                settings.put("private-key", new Variant<>(pemPrivateKey.getBytes(StandardCharsets.UTF_8)));
-            } else {
-                logger.error("Unable to find or decode Private Key");
-            }
-        } catch (ClassCastException e) {
-            logger.error("Unable to find Private Key");
+            // Convert DER to PEM
+            String pemPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
+                    + DatatypeConverter.printBase64Binary(privateKey.getEncoded()) + "\n-----END PRIVATE KEY-----\n";
+            settings.put("private-key", new Variant<>(pemPrivateKey.getBytes(StandardCharsets.UTF_8)));
+        } catch (ClassCastException | IllegalArgumentException e) {
+            logger.error("Unable to find or decode Private Key");
         }
 
         Optional<Password> privateKeyPassword = props.getOpt(Password.class,

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -663,7 +663,8 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("identity", "username@email.com");
         thenResultingMapContainsBytes("ca-cert", "binary ca cert");
         thenResultingMapContainsBytes("client-cert", "binary client cert");
-        thenResultingMapContainsBytes("private-key", "binary private key");
+        thenResultingMapContainsBytes("private-key",
+                "-----BEGIN PRIVATE KEY-----\nYmluYXJ5IHByaXZhdGUga2V5\n-----END PRIVATE KEY-----\n");
         thenResultingMapContains("private-key-password", "secure-password");
 
     }


### PR DESCRIPTION
As detailed here: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1449, on platforms where NetworkManager was using `nss` as crypto engine, the private keys passed to NetworkManager in DER format were wrongly detected as PKCS#12 instead of PKCS#8. This resulted in an error being thrown by NetworkManager (i.e. "_802-1x.client-cert: has to match 'private-key' property for PKCS#12_") and no connection to the WPA Enterprise access point.

On platforms where NetworkManager was using `gnutls` (i.e. Raspberry Pi OS, Ubuntu) no error was thrown.

Passing the private key in PEM seems to be fixing the issue and works both on `gnutls` and `nss`. This PR updates the Kura code such that, when retrieving the private key, it gets converted from DER to PEM format.

### Converting DER to PEM

A note about conversion: Java stores the keys in PKCS#8 format and the `PrivateKey.getEncoded()` returns them in the DER binary format. [The PEM format is just the base64-encoded version of the DER one with a header and a footer (and newlines every 64 characters as per RFC 1421)](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail). Therefore the `convertToPem` method, implemented in this PR, does just that.
