### PR TITLE
build: downgrade helper-maven-plugin for better compatibility

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/pom.xml
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>


### PR DESCRIPTION
The plugin `helper-maven-plugin` works only with maven > 3.6.3, so this PR downgrades the plugin to the 3.3.0 version for better compatibility.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
