### PR TITLE
fix: Gwt error message consistency with wire graph

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtDriverAndAssetServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtDriverAndAssetServiceImpl.java
@@ -215,9 +215,6 @@ public class GwtDriverAndAssetServiceImpl extends OsgiRemoteServiceServlet imple
         }
 
         if (exceptionMessage != null && !exceptionMessage.equals(userMessage)) {
-            if (userMessage != null) {
-                exceptionMessageBuilder.append(" - ");
-            }
             exceptionMessageBuilder.append(exceptionMessage);
         }
 


### PR DESCRIPTION
The change allows to make consistent the messages reported in the Web UI and in the wire graph:

https://github.com/eclipse/kura/blob/develop/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtDriverAndAssetServiceImpl.java#L219

https://github.com/eclipse/kura/blob/develop/kura/org.eclipse.kura.wire.component.provider/src/main/java/org/eclipse/kura/internal/wire/asset/RecordFillers.java#L125
