### PR TITLE
refactor(core.keystore): remove deprecated use of DERIA5String

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CRLUtil.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CRLUtil.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ExecutorService;
 
 import org.bouncycastle.asn1.ASN1IA5String;
 import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.DistributionPoint;

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CRLUtil.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CRLUtil.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
+import org.bouncycastle.asn1.ASN1IA5String;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
@@ -79,7 +80,7 @@ public class CRLUtil {
 
                 for (final GeneralName name : generalNames) {
                     if (name.getTagNo() == GeneralName.uniformResourceIdentifier) {
-                        final String uriString = DERIA5String.getInstance(name.getName()).getString();
+                        final String uriString = ASN1IA5String.getInstance(name.getName()).getString();
                         parseURI(uriString).ifPresent(result::add);
                     }
                 }


### PR DESCRIPTION
Remove deprecated use of `DERIA5String` in `core.keystore` to fix failure in Sonar Quality gate.

With the update of BouncyCastle in #5027 our Sonar Quality pipeline reported a new critial issue with the use of `DERIA5String`. See: [Use static access with "org.bouncycastle.asn1.ASN1IA5String" for "getInstance"](https://sonarcloud.io/project/issues?resolved=false&severities=CRITICAL&sinceLeakPeriod=true&id=org.eclipse.kura%3Akura&open=AYzpy5rgxRbSWnOc6nTp).

This PR addresses the issue by using the base class method as suggested by the BouncyCastle documentation:

![image](https://github.com/eclipse/kura/assets/22748355/ca8ac27c-2a0b-4da2-93a9-f08c8deb8f99)

Reference: https://javadoc.io/static/org.bouncycastle/bcprov-jdk15on/1.70/org/bouncycastle/asn1/DERIA5String.html