### PR TITLE
feat(web2): added 'Advanced' tab for MTUs and Promiscuous mode

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *  Eurotech
+ *  Areti
  *******************************************************************************/
 package org.eclipse.kura.web.client.ui.network;
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -70,6 +70,7 @@ public class NetworkTabsUi extends Composite {
     AnchorListItem modemGpsTabAnchorItem;
     AnchorListItem modemAntennaTabAnchorItem;
     AnchorListItem hardwareTabAnchorItem;
+    AnchorListItem advancedTabAnchorItem;
     List<AnchorListItem> visibleTabs;
 
     NetworkTab selectedTab;
@@ -82,6 +83,7 @@ public class NetworkTabsUi extends Composite {
     TabModemUi modemTab;
     TabModemGpsUi modemGpsTab;
     TabModemAntennaUi modemAntennaTab;
+    TabAdvancedUi advancedTab;
 
     GwtNetInterfaceConfig netIfConfig;
     NetworkButtonBarUi buttons;
@@ -118,6 +120,7 @@ public class NetworkTabsUi extends Composite {
         initModemAntennaTab();
         initDhcp4NatTab();
         initHardwareTab();
+        initAdvancedTab();
 
         setSelected(this.ip4TabAnchorItem);
         this.selectedTab = this.ip4Tab;
@@ -234,6 +237,18 @@ public class NetworkTabsUi extends Composite {
         });
     }
 
+    private void initAdvancedTab() {
+        this.advancedTabAnchorItem = new AnchorListItem(MSGS.netAdvanced());
+        this.advancedTab = new TabAdvancedUi(this.session, this);
+
+        this.advancedTabAnchorItem.addClickHandler(event -> {
+            setSelected(NetworkTabsUi.this.advancedTabAnchorItem);
+            NetworkTabsUi.this.selectedTab = NetworkTabsUi.this.advancedTab;
+            NetworkTabsUi.this.content.clear();
+            NetworkTabsUi.this.content.add(NetworkTabsUi.this.advancedTab);
+        });
+    }
+
     public void setButtons(NetworkButtonBarUi buttons) {
         this.buttons = buttons;
     }
@@ -258,6 +273,7 @@ public class NetworkTabsUi extends Composite {
         this.modemGpsTab.setNetInterface(selection);
         this.modemAntennaTab.setNetInterface(selection);
         this.hardwareTab.setNetInterface(selection);
+        this.advancedTab.setNetInterface(selection);
 
         updateTabs();
         refreshAllVisibleTabs();
@@ -270,6 +286,7 @@ public class NetworkTabsUi extends Composite {
 
         if (this.isNet2) {
             insertTab(this.ip6TabAnchorItem);
+            insertTab(this.advancedTabAnchorItem);
         }
 
         arrangeOptionalTabs();
@@ -287,6 +304,7 @@ public class NetworkTabsUi extends Composite {
         removeTab(this.modemGpsTabAnchorItem);
         removeTab(this.modemAntennaTabAnchorItem);
         removeTab(this.hardwareTabAnchorItem);
+        removeTab(this.advancedTabAnchorItem);
     }
 
     private void arrangeOptionalTabs() {
@@ -418,6 +436,9 @@ public class NetworkTabsUi extends Composite {
         if (this.visibleTabs.contains(this.net8021xTabAnchorItem)) {
             this.set8021xTab.refresh();
         }
+        if(this.visibleTabs.contains(this.advancedTabAnchorItem)) {
+        	this.advancedTab.refresh();
+        }
     }
 
     /*
@@ -457,6 +478,10 @@ public class NetworkTabsUi extends Composite {
         if (this.visibleTabs.contains(this.net8021xTabAnchorItem) && this.set8021xTab.isDirty()) {
             return true;
         }
+        
+        if (this.visibleTabs.contains(this.advancedTabAnchorItem) && this.advancedTab.isDirty()) {
+            return true;
+        }
 
         return false;
     }
@@ -471,6 +496,7 @@ public class NetworkTabsUi extends Composite {
         this.modemTab.setDirty(isDirty);
         this.modemGpsTab.setDirty(isDirty);
         this.modemAntennaTab.setDirty(isDirty);
+        this.advancedTab.setDirty(isDirty);
     }
 
     public void refresh() {
@@ -483,6 +509,7 @@ public class NetworkTabsUi extends Composite {
         this.modemTab.refresh();
         this.modemGpsTab.refresh();
         this.modemAntennaTab.refresh();
+        this.advancedTab.refresh();
     }
 
     public GwtNetInterfaceConfig getUpdatedInterface() {
@@ -523,6 +550,9 @@ public class NetworkTabsUi extends Composite {
         if (this.visibleTabs.contains(this.net8021xTabAnchorItem)) {
             this.set8021xTab.getUpdatedNetInterface(updatedNetIf);
         }
+        if (this.visibleTabs.contains(this.advancedTabAnchorItem)) {
+        	this.advancedTab.getUpdatedNetInterface(updatedNetIf);
+        }
 
         return updatedNetIf;
     }
@@ -542,6 +572,7 @@ public class NetworkTabsUi extends Composite {
         clearErrorTab(this.modemGpsTabAnchorItem);
         clearErrorTab(this.modemAntennaTabAnchorItem);
         clearErrorTab(this.net8021xTabAnchorItem);
+        clearErrorTab(this.advancedTabAnchorItem);
 
         if (this.visibleTabs.contains(this.ip4TabAnchorItem) && !this.ip4Tab.isValid()) {
             errorTab(this.ip4TabAnchorItem);
@@ -589,6 +620,12 @@ public class NetworkTabsUi extends Composite {
             errorTab(this.net8021xTabAnchorItem);
             return false;
         }
+        
+        if (this.visibleTabs.contains(this.advancedTabAnchorItem) && this.advancedTabAnchorItem.isEnabled()
+                && !this.advancedTab.isValid()) {
+            errorTab(this.advancedTabAnchorItem);
+            return false;
+        }
 
         return true;
     }
@@ -634,6 +671,7 @@ public class NetworkTabsUi extends Composite {
         this.modemTabAnchorItem.setActive(false);
         this.modemGpsTabAnchorItem.setActive(false);
         this.modemAntennaTabAnchorItem.setActive(false);
+        this.advancedTabAnchorItem.setActive(false);
         item.setActive(true);
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.java
@@ -1,0 +1,370 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Areti and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Areti
+ *******************************************************************************/
+package org.eclipse.kura.web.client.ui.network;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.kura.web.client.messages.Messages;
+import org.eclipse.kura.web.client.util.HelpButton;
+import org.eclipse.kura.web.client.util.MessageUtils;
+import org.eclipse.kura.web.shared.model.GwtNetIfType;
+import org.eclipse.kura.web.shared.model.GwtNetInterfaceConfig;
+import org.eclipse.kura.web.shared.model.GwtSession;
+import org.gwtbootstrap3.client.ui.Form;
+import org.gwtbootstrap3.client.ui.FormControlStatic;
+import org.gwtbootstrap3.client.ui.FormGroup;
+import org.gwtbootstrap3.client.ui.FormLabel;
+import org.gwtbootstrap3.client.ui.HelpBlock;
+import org.gwtbootstrap3.client.ui.IntegerBox;
+import org.gwtbootstrap3.client.ui.ListBox;
+import org.gwtbootstrap3.client.ui.PanelHeader;
+import org.gwtbootstrap3.client.ui.TextArea;
+import org.gwtbootstrap3.client.ui.TextBox;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
+import org.gwtbootstrap3.client.ui.html.Span;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.ScrollPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+public class TabAdvancedUi extends Composite implements NetworkTab {
+	
+    private static final String PROMISC_DEFAULT = "netAdvPromiscDefault";
+    private static final String PROMISC_ENABLED = "netAdvPromiscEnabled";
+    private static final String PROMISC_DISABLED = "netAdvPromiscDisabled";
+
+    interface TabAdvancedUiUiBinder extends UiBinder<Widget, TabAdvancedUi> {
+    }
+
+    @UiField
+    FormGroup groupMtu;
+    @UiField
+    FormGroup groupIp6Mtu;
+    @UiField
+    FormGroup groupPromisc;
+
+    @UiField
+    FormLabel labelMtu;
+    @UiField
+    FormLabel labelIp6Mtu;
+    @UiField
+    FormLabel labelPromisc;
+
+    @UiField
+    HelpBlock wrongInputMtu;
+    @UiField
+    HelpBlock wrongInputIp6Mtu;
+
+    @UiField
+    HelpButton helpButtonMtu;
+    @UiField
+    HelpButton helpButtonIp6Mtu;
+    @UiField
+    HelpButton helpButtonPromisc;
+
+    
+    @UiField
+    IntegerBox mtu;
+    @UiField
+    IntegerBox ip6Mtu;
+    @UiField
+    ListBox promisc;
+
+    @UiField
+    PanelHeader helpTitle;
+    @UiField
+    ScrollPanel helpText;
+
+    @UiField
+    Form form;
+
+    private static TabAdvancedUiUiBinder uiBinder = GWT.create(TabAdvancedUiUiBinder.class);
+    private static final Messages MSGS = GWT.create(Messages.class);
+
+    private boolean dirty = false;
+    private final NetworkTabsUi tabs;
+    private Optional<GwtNetInterfaceConfig> selectedNetIfConfig = Optional.empty();
+
+    public TabAdvancedUi(GwtSession currentSession, NetworkTabsUi netTabs) {
+        initWidget(uiBinder.createAndBindUi(this));
+
+        this.helpTitle.setText(MSGS.netHelpTitle());
+        this.tabs = netTabs;
+
+        initLabels();
+        initHelpButtons();
+        initListBoxes();
+        initTextBoxes();
+    }
+
+    private void initLabels() {
+        this.labelMtu.setText(MSGS.netIPv4Mtu());
+        this.labelIp6Mtu.setText(MSGS.netIPv6Mtu());
+        this.labelPromisc.setText(MSGS.netAdvPromisc());
+    }
+
+    private void initHelpButtons() {
+        this.helpButtonMtu.setHelpText(MSGS.netIPv4ToolTipMtu());
+        this.helpButtonIp6Mtu.setHelpText(MSGS.netIPv6ToolTipMtu());
+        this.helpButtonPromisc.setHelpText(MSGS.netAdvToolTipPromisc());
+    }
+
+    private void initListBoxes() {
+        initPromiscField();
+    }
+
+    private void initPromiscField() {
+        this.promisc.clear();
+        this.promisc.addItem(MessageUtils.get(PROMISC_DEFAULT), "-1");
+        this.promisc.addItem(MessageUtils.get(PROMISC_ENABLED), "1");
+        this.promisc.addItem(MessageUtils.get(PROMISC_DISABLED), "0");
+
+        this.promisc.addMouseOverHandler(event -> {
+            if (this.promisc.isEnabled()) {
+                setHelpText(MSGS.netAdvToolTipPromisc());
+            }
+        });
+
+        this.promisc.addMouseOutHandler(event -> resetHelpText());
+
+        this.promisc.addChangeHandler(event -> {
+            setDirty(true);
+            this.tabs.updateTabs();
+
+            refreshForm();
+            resetValidations();
+        });
+    }
+
+    private void initTextBoxes() {
+    	initMtuField();
+    	initIp6MtuField();
+    }
+    
+    private void initMtuField() {
+        this.mtu.addMouseOverHandler(event -> {
+            this.helpText.clear();
+            this.helpText.add(new Span(MSGS.netIPv4ToolTipMtu()));
+        });
+        this.mtu.addMouseOutHandler(event -> resetHelpText());
+        this.mtu.addValueChangeHandler(valChangeEvent -> {
+            setDirty(true);
+
+            String inputText = this.mtu.getText();
+            boolean isValidValue = false;
+
+            if (inputText != null) {
+                if (inputText.trim().isEmpty()) {
+                    isValidValue = true;
+                } else {
+                    isValidValue = isValidIntegerInRange(inputText, 0, Integer.MAX_VALUE);
+                }
+            }
+
+            if (isValidValue) {
+                this.groupMtu.setValidationState(ValidationState.NONE);
+                this.wrongInputMtu.setText("");
+            } else {
+                this.groupMtu.setValidationState(ValidationState.ERROR);
+                this.wrongInputMtu.setText(MSGS.netIPv4InvalidMtu());
+            }
+        });
+    }
+
+    private void initIp6MtuField() {
+        this.ip6Mtu.addMouseOverHandler(event -> {
+            if (this.ip6Mtu.isEnabled()) {
+                setHelpText(MSGS.netIPv6ToolTipMtu());
+            }
+        });
+        this.ip6Mtu.addMouseOutHandler(event -> resetHelpText());
+
+        this.ip6Mtu.addValueChangeHandler(valChangeEvent -> {
+            setDirty(true);
+
+            String inputText = this.ip6Mtu.getText();
+            boolean isValidValue = false;
+
+            if (inputText != null) {
+                if (inputText.trim().isEmpty()) {
+                    isValidValue = true;
+                } else {
+                    isValidValue = isValidIntegerInRange(inputText, 0, Integer.MAX_VALUE);
+                }
+            }
+
+            if (isValidValue) {
+                this.groupMtu.setValidationState(ValidationState.NONE);
+                this.wrongInputMtu.setText("");
+            } else {
+                this.groupMtu.setValidationState(ValidationState.ERROR);
+                this.wrongInputMtu.setText(MSGS.netIPv6InvalidMtu());
+            }
+        });
+    }
+
+    private boolean isValidIntegerInRange(String integerText, int min, int max) {
+        try {
+            int value = Integer.parseInt(integerText.trim());
+            return value >= min && value <= max;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+
+
+    private void setHelpText(String message) {
+        this.helpText.clear();
+        this.helpText.add(new Span(message));
+    }
+
+    private void resetHelpText() {
+        this.helpText.clear();
+        setHelpText(MSGS.netHelpDefaultHint());
+    }
+
+    private void resetValidations() {
+        this.groupMtu.setValidationState(ValidationState.NONE);
+        this.wrongInputMtu.setText("");
+        this.groupIp6Mtu.setValidationState(ValidationState.NONE);
+        this.wrongInputIp6Mtu.setText("");
+    }
+
+    private void refreshForm() {
+        this.mtu.setEnabled(true);
+        this.ip6Mtu.setEnabled(true);
+        this.promisc.setEnabled(false);
+
+        if (this.selectedNetIfConfig.isPresent()) {
+            refreshFieldsBasedOnInterface(this.selectedNetIfConfig.get());
+        }
+    }
+
+    private void refreshFieldsBasedOnInterface(GwtNetInterfaceConfig config) {
+        switch (config.getHwTypeEnum()) {
+        case ETHERNET:
+        	this.promisc.setEnabled(true);
+            break;
+        case LOOPBACK:
+            this.mtu.setEnabled(false);
+            this.ip6Mtu.setEnabled(false);
+            break;
+        case MODEM:
+            break;
+        case WIFI:
+            break;
+        default:
+            break;
+
+        }
+    }
+
+    @Override
+    public void setDirty(boolean isDirty) {
+        this.dirty = isDirty;
+        if (this.tabs.getButtons() != null) {
+            this.tabs.getButtons().setButtonsDirty(isDirty);
+        }
+    }
+
+    @Override
+    public boolean isDirty() {
+        return this.dirty;
+    }
+
+    @Override
+    public void setNetInterface(GwtNetInterfaceConfig config) {
+        setDirty(true);
+        this.selectedNetIfConfig = Optional.of(config);
+    }
+
+    @Override
+    public void getUpdatedNetInterface(GwtNetInterfaceConfig updatedNetIf) {
+        if (this.form != null) {
+            updateConfigWithSelectedValues(updatedNetIf);
+        }
+    }
+
+    private void updateConfigWithSelectedValues(GwtNetInterfaceConfig updatedNetIf) {
+    	if (this.mtu.getValue() != null) {
+            updatedNetIf.setMtu(this.mtu.getValue());
+        }
+
+    	if (this.ip6Mtu.getValue() != null) {
+            updatedNetIf.setIpv6Mtu(this.ip6Mtu.getValue());
+        }
+        
+        if(!nullOrEmpty(this.promisc.getSelectedValue())) {
+            updatedNetIf.setPromisc(Integer.parseInt(this.promisc.getSelectedValue()));
+        }
+    }
+
+    private boolean nullOrEmpty(String value) {
+        return Objects.isNull(value) || value.trim().isEmpty();
+    }
+
+    @Override
+    public boolean isValid() {
+        if (this.groupMtu.getValidationState().equals(ValidationState.ERROR)
+                || this.groupIp6Mtu.getValidationState().equals(ValidationState.ERROR)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void refresh() {
+        if (isDirty()) {
+            setDirty(false);
+            resetValidations();
+
+            if (this.selectedNetIfConfig.isPresent()) {
+                fillFormWithCachedConfig();
+            } else {
+                reset();
+            }
+        }
+    }
+
+    private void reset() {
+        this.mtu.setText("");
+        this.ip6Mtu.setText("");
+        this.promisc.setSelectedIndex(0);
+    }
+
+    private void fillFormWithCachedConfig() {
+        this.mtu.setValue(this.selectedNetIfConfig.get().getMtu());
+        this.ip6Mtu.setValue(this.selectedNetIfConfig.get().getIpv6Mtu());
+        for (int i = 0; i < this.promisc.getItemCount(); i++) {
+            if (this.promisc.getValue(i).equals(this.selectedNetIfConfig.get().getPromisc().toString())) {
+                this.promisc.setSelectedIndex(i);
+                break;
+            }
+        }
+
+        this.tabs.updateTabs();
+        refreshForm();
+    }
+
+    @Override
+    public void clear() {
+        // Not needed
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Areti and others
+ * Copyright (c) 2024 Areti and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.java
@@ -112,14 +112,14 @@ public class TabAdvancedUi extends Composite implements NetworkTab {
     }
 
     private void initLabels() {
-        this.labelMtu.setText(MSGS.netIPv4Mtu());
-        this.labelIp6Mtu.setText(MSGS.netIPv6Mtu());
+        this.labelMtu.setText(MSGS.netAdvIPv4Mtu());
+        this.labelIp6Mtu.setText(MSGS.netAdvIPv6Mtu());
         this.labelPromisc.setText(MSGS.netAdvPromisc());
     }
 
     private void initHelpButtons() {
-        this.helpButtonMtu.setHelpText(MSGS.netIPv4ToolTipMtu());
-        this.helpButtonIp6Mtu.setHelpText(MSGS.netIPv6ToolTipMtu());
+        this.helpButtonMtu.setHelpText(MSGS.netAdvIPv4ToolTipMtu());
+        this.helpButtonIp6Mtu.setHelpText(MSGS.netAdvIPv6ToolTipMtu());
         this.helpButtonPromisc.setHelpText(MSGS.netAdvToolTipPromisc());
     }
 
@@ -158,7 +158,7 @@ public class TabAdvancedUi extends Composite implements NetworkTab {
     private void initMtuField() {
         this.mtu.addMouseOverHandler(event -> {
             this.helpText.clear();
-            this.helpText.add(new Span(MSGS.netIPv4ToolTipMtu()));
+            this.helpText.add(new Span(MSGS.netAdvIPv4ToolTipMtu()));
         });
         this.mtu.addMouseOutHandler(event -> resetHelpText());
         this.mtu.addValueChangeHandler(valChangeEvent -> {
@@ -180,7 +180,7 @@ public class TabAdvancedUi extends Composite implements NetworkTab {
                 this.wrongInputMtu.setText("");
             } else {
                 this.groupMtu.setValidationState(ValidationState.ERROR);
-                this.wrongInputMtu.setText(MSGS.netIPv4InvalidMtu());
+                this.wrongInputMtu.setText(MSGS.netAdvIPv4InvalidMtu());
             }
         });
     }
@@ -188,7 +188,7 @@ public class TabAdvancedUi extends Composite implements NetworkTab {
     private void initIp6MtuField() {
         this.ip6Mtu.addMouseOverHandler(event -> {
             if (this.ip6Mtu.isEnabled()) {
-                setHelpText(MSGS.netIPv6ToolTipMtu());
+                setHelpText(MSGS.netAdvIPv6ToolTipMtu());
             }
         });
         this.ip6Mtu.addMouseOutHandler(event -> resetHelpText());
@@ -208,11 +208,11 @@ public class TabAdvancedUi extends Composite implements NetworkTab {
             }
 
             if (isValidValue) {
-                this.groupMtu.setValidationState(ValidationState.NONE);
-                this.wrongInputMtu.setText("");
+                this.groupIp6Mtu.setValidationState(ValidationState.NONE);
+                this.wrongInputIp6Mtu.setText("");
             } else {
-                this.groupMtu.setValidationState(ValidationState.ERROR);
-                this.wrongInputMtu.setText(MSGS.netIPv6InvalidMtu());
+                this.groupIp6Mtu.setValidationState(ValidationState.ERROR);
+                this.wrongInputIp6Mtu.setText(MSGS.netAdvIPv6InvalidMtu());
             }
         });
     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2023 Areti and/or its affiliates and others
+    Copyright (c) 2024 Areti and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.ui.xml
@@ -1,0 +1,93 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+
+<!--
+
+    Copyright (c) 2023 Areti and/or its affiliates and others
+  
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+ 
+	SPDX-License-Identifier: EPL-2.0
+	
+	Contributors:
+	 Areti
+
+-->
+
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:b="urn:import:org.gwtbootstrap3.client.ui"
+    xmlns:b.html="urn:import:org.gwtbootstrap3.client.ui.html" xmlns:g="urn:import:com.google.gwt.user.client.ui"
+    xmlns:gwt="urn:import:org.gwtbootstrap3.client.ui.gwt" xmlns:util="urn:import:org.eclipse.kura.web.client.util">
+
+    <ui:style>
+    .important {
+        font-weight: bold;
+    }
+    
+    .center-panel {
+        font-size: 12px;
+        font-weight: normal;
+    }
+    
+    .padding {
+        margin-bottom: 50px;
+    }
+    
+    .help {
+        height: auto;
+    }
+    
+    .help-header {
+        font-size: 14px;
+    }
+    </ui:style>
+    <b:Container fluid="true">
+        <b:Column size="MD_7" addStyleNames="{style.center-panel}">
+            <b:Row>
+                <g:ScrollPanel addStyleNames="{style.center-panel}">
+                    <b:Form ui:field="form">
+                        <b:FieldSet>
+
+                            <b:FormGroup ui:field="groupMtu">
+                                <b:FormLabel for="mtu" ui:field="labelMtu"></b:FormLabel>
+                                <util:HelpButton ui:field="helpButtonMtu" />
+                                <b:HelpBlock color="red" ui:field="wrongInputMtu" />
+                                <b:IntegerBox b:id="mtu" ui:field="mtu" />
+                            </b:FormGroup>
+
+                            <b:FormGroup ui:field="groupIp6Mtu">
+                                <b:FormLabel for="ip6Mtu" ui:field="labelIp6Mtu"></b:FormLabel>
+                                <util:HelpButton ui:field="helpButtonIp6Mtu" />
+                                <b:HelpBlock color="red" ui:field="wrongInputIp6Mtu" />
+                                <b:IntegerBox b:id="ip6Mtu" ui:field="ip6Mtu" />
+                            </b:FormGroup>
+
+                            <b:FormGroup ui:field="groupPromisc">
+                                <b:FormLabel for="promisc" ui:field="labelPromisc"></b:FormLabel>
+                                <util:HelpButton ui:field="helpButtonPromisc" />
+                                <g:FlowPanel>
+                                    <b:ListBox b:id="promisc" ui:field="promisc" />
+                                </g:FlowPanel>
+                            </b:FormGroup>
+                            
+                        </b:FieldSet>
+                    </b:Form>
+                </g:ScrollPanel>
+            </b:Row>
+        </b:Column>
+
+        <b:Column size="MD_5" addStyleNames="{style.center-panel}" visibleOn="MD_LG">
+            <b:Column size="MD_12">
+                <b:Row b:id="help">
+                    <b:Panel>
+                        <b:PanelHeader addStyleNames="{style.help-header}" ui:field="helpTitle" />
+                        <b:PanelBody>
+                            <g:ScrollPanel addStyleNames="{style.help}" ui:field="helpText" />
+                        </b:PanelBody>
+                    </b:Panel>
+                </b:Row>
+            </b:Column>
+        </b:Column>
+
+    </b:Container>
+</ui:UiBinder> 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
@@ -108,8 +108,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
     FormGroup groupGateway;
     @UiField
     FormGroup groupDns;
-    @UiField
-    FormGroup groupMtu;
 
     @UiField
     FormLabel labelStatus;
@@ -125,8 +123,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
     FormLabel labelGateway;
     @UiField
     FormLabel labelDns;
-    @UiField
-    FormLabel labelMtu;
 
     @UiField
     HelpBlock helpPriority;
@@ -138,8 +134,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
     HelpBlock helpGateway;
     @UiField
     HelpBlock helpDns;
-    @UiField
-    HelpBlock helpMtu;
 
     @UiField
     TextBox ip;
@@ -172,9 +166,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
     FormControlStatic dnsRead;
 
     @UiField
-    IntegerBox mtu;
-
-    @UiField
     Modal wanModal;
 
     @UiField
@@ -197,8 +188,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
     HelpButton gatewayHelp;
     @UiField
     HelpButton dnsHelp;
-    @UiField
-    HelpButton mtuHelp;
 
     public TabIp4Ui(GwtSession currentSession, NetworkTabsUi netTabs, final boolean isNet2) {
         initWidget(uiBinder.createAndBindUi(this));
@@ -307,9 +296,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
             } else {
                 updatedNetIf.setDnsServers("");
             }
-            if (this.mtu.getValue() != null && this.isNet2) {
-                updatedNetIf.setMtu(this.mtu.getValue());
-            }
         }
     }
 
@@ -335,8 +321,7 @@ public class TabIp4Ui extends Composite implements NetworkTab {
                 || this.groupIp.getValidationState().equals(ValidationState.ERROR)
                 || this.groupSubnet.getValidationState().equals(ValidationState.ERROR)
                 || this.groupGateway.getValidationState().equals(ValidationState.ERROR)
-                || this.groupDns.getValidationState().equals(ValidationState.ERROR)
-                || this.groupMtu.getValidationState().equals(ValidationState.ERROR)) {
+                || this.groupDns.getValidationState().equals(ValidationState.ERROR)) {
             flag = false;
         }
         return flag;
@@ -392,10 +377,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         this.labelPriority.setVisible(isNet2);
         this.priority.setVisible(isNet2);
         this.priorityHelp.setVisible(isNet2);
-
-        this.labelMtu.setVisible(isNet2);
-        this.mtu.setVisible(isNet2);
-        this.mtuHelp.setVisible(isNet2);
     }
 
     private void initHelpButtons() {
@@ -406,7 +387,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         this.subnetHelp.setHelpText(MSGS.netIPv4ToolTipSubnetMask());
         this.gatewayHelp.setHelpText(MSGS.netIPv4ToolTipGateway());
         this.dnsHelp.setHelpText(MSGS.netIPv4ToolTipDns());
-        this.mtuHelp.setHelpText(MSGS.netIPv4ToolTipMtu());
     }
 
     private void initForm() {
@@ -419,7 +399,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         this.labelSubnet.setText(MSGS.netIPv4SubnetMask());
         this.labelGateway.setText(MSGS.netIPv4Gateway());
         this.labelDns.setText(MSGS.netIPv4DNSServers());
-        this.labelMtu.setText(MSGS.netIPv4Mtu());
 
         for (GwtNetIfConfigMode mode : GwtNetIfConfigMode.values()) {
             this.configure.addItem(MessageUtils.get(mode.name()));
@@ -440,8 +419,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         initDnsServersField();
 
         initDHCPLeaseField();
-
-        initMtuField();
     }
 
     private void initPriorityField() {
@@ -659,38 +636,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         }
     }
 
-    private void initMtuField() {
-        this.mtu.addMouseOverHandler(event -> {
-            TabIp4Ui.this.helpText.clear();
-            TabIp4Ui.this.helpText.add(new Span(MSGS.netIPv4ToolTipMtu()));
-        });
-        this.mtu.addMouseOutHandler(event -> resetHelp());
-        this.mtu.addValueChangeHandler(valChangeEvent -> {
-            setDirty(true);
-
-            String inputText = TabIp4Ui.this.mtu.getText();
-            boolean isInvalidValue = false;
-
-            if (!Objects.isNull(inputText) && !inputText.trim().isEmpty()) {
-                try {
-                    if (Integer.parseInt(inputText) < 0) {
-                        isInvalidValue = true;
-                    }
-                } catch (NumberFormatException e) {
-                    isInvalidValue = true;
-                }
-            }
-
-            if (isInvalidValue) {
-                TabIp4Ui.this.groupMtu.setValidationState(ValidationState.ERROR);
-                TabIp4Ui.this.helpMtu.setText(MSGS.netIPv4InvalidMtu());
-            } else {
-                TabIp4Ui.this.groupMtu.setValidationState(ValidationState.NONE);
-                TabIp4Ui.this.helpMtu.setText("");
-            }
-        });
-    }
-
     private void initStatusField() {
         initStatusValues();
 
@@ -774,7 +719,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
 
             if (this.isNet2) {
                 this.priority.setValue(this.selectedNetIfConfig.getWanPriority());
-                this.mtu.setValue(this.selectedNetIfConfig.getMtu());
             }
 
             this.tabs.updateTabs();
@@ -809,7 +753,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         this.gateway.setEnabled(true);
         this.dns.setEnabled(true);
         this.renew.setEnabled(true);
-        this.mtu.setEnabled(true);
 
         // disabling fields based on the interface
         if (this.selectedNetIfConfig != null && this.selectedNetIfConfig.getHwTypeEnum() == GwtNetIfType.MODEM) {
@@ -834,7 +777,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
             this.gateway.setEnabled(false);
             this.dns.setEnabled(false);
             this.renew.setEnabled(false);
-            this.mtu.setEnabled(false);
         } else {
             if (VMSGS.netIPv4StatusDisabled().equals(this.status.getSelectedValue())
                     || VMSGS.netIPv4StatusUnmanaged().equals(this.status.getSelectedValue())
@@ -851,8 +793,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
                 this.gateway.setText("");
                 this.dns.setText("");
                 this.renew.setEnabled(false);
-                this.mtu.setEnabled(false);
-                this.mtu.setText("");
             } else {
                 String configureValue = this.configure.getSelectedValue();
                 if (configureValue.equals(IPV4_MODE_DHCP_MESSAGE)) {
@@ -895,7 +835,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         this.subnet.setText("");
         this.gateway.setText("");
         this.dns.setText("");
-        this.mtu.setText("");
         update();
     }
 
@@ -910,8 +849,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         this.helpGateway.setText("");
         this.groupDns.setValidationState(ValidationState.NONE);
         this.helpDns.setText("");
-        this.groupMtu.setValidationState(ValidationState.NONE);
-        this.helpMtu.setText("");
     }
 
     private void initModal() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.ui.xml
@@ -106,15 +106,6 @@
                                 <b:TextArea b:id="dns" ui:field="dns" />
                                 <b:FormControlStatic b:id="dnsRead" ui:field="dnsRead" />
                             </b:FormGroup>
-
-                            <b:FormGroup ui:field="groupMtu">
-                                <b:FormLabel for="mtu" ui:field="labelMtu"></b:FormLabel>
-                                <util:HelpButton ui:field="mtuHelp" />
-                                <b:HelpBlock color="red" ui:field="helpMtu" />
-                                <g:FlowPanel>
-                                    <b:IntegerBox b:id="mtu" ui:field="mtu" />
-                                </g:FlowPanel>
-                            </b:FormGroup>
                         </b:FieldSet>
                     </b:Form>
                 </g:ScrollPanel>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.java
@@ -81,8 +81,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     FormGroup groupDns;
     @UiField
     FormGroup groupPrivacy;
-    @UiField
-    FormGroup groupMtu;
 
     @UiField
     FormLabel labelStatus;
@@ -102,8 +100,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     FormLabel labelDns;
     @UiField
     FormLabel labelPrivacy;
-    @UiField
-    FormLabel labelMtu;
 
     @UiField
     HelpBlock wrongInputPriority;
@@ -115,8 +111,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     HelpBlock wrongInputGateway;
     @UiField
     HelpBlock wrongInputDns;
-    @UiField
-    HelpBlock wrongInputMtu;
 
     @UiField
     HelpButton helpButtonStatus;
@@ -136,8 +130,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     HelpButton helpButtonDns;
     @UiField
     HelpButton helpButtonPrivacy;
-    @UiField
-    HelpButton helpButtonMtu;
 
     @UiField
     ListBox status;
@@ -157,8 +149,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
     TextArea dns;
     @UiField
     ListBox privacy;
-    @UiField
-    IntegerBox mtu;
 
     @UiField
     PanelHeader helpTitle;
@@ -205,7 +195,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         this.labelGateway.setText(MSGS.netIPv6Gateway());
         this.labelDns.setText(MSGS.netIPv6DNSServers());
         this.labelPrivacy.setText(MSGS.netIPv6Privacy());
-        this.labelMtu.setText(MSGS.netIPv6Mtu());
     }
 
     private void initHelpButtons() {
@@ -218,7 +207,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         this.helpButtonGateway.setHelpText(MSGS.netIPv6ToolTipGateway());
         this.helpButtonDns.setHelpText(MSGS.netIPv6ToolTipDns());
         this.helpButtonPrivacy.setHelpText(MSGS.netIPv6ToolTipPrivacy());
-        this.helpButtonMtu.setHelpText(MSGS.netIPv6ToolTipMtu());
     }
 
     private void initListBoxes() {
@@ -326,7 +314,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         initSubnetField();
         initGatewayField();
         initDnsField();
-        initMtuField();
     }
 
     private void initPriorityField() {
@@ -357,38 +344,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             } else {
                 this.groupPriority.setValidationState(ValidationState.ERROR);
                 this.wrongInputPriority.setText(MSGS.netIPv6InvalidPriority());
-            }
-        });
-    }
-
-    private void initMtuField() {
-        this.mtu.addMouseOverHandler(event -> {
-            if (this.mtu.isEnabled()) {
-                setHelpText(MSGS.netIPv6ToolTipMtu());
-            }
-        });
-        this.mtu.addMouseOutHandler(event -> resetHelpText());
-
-        this.mtu.addValueChangeHandler(valChangeEvent -> {
-            setDirty(true);
-
-            String inputText = this.mtu.getText();
-            boolean isValidValue = false;
-
-            if (inputText != null) {
-                if (inputText.trim().isEmpty()) {
-                    isValidValue = true;
-                } else {
-                    isValidValue = isValidIntegerInRange(inputText, 0, Integer.MAX_VALUE);
-                }
-            }
-
-            if (isValidValue) {
-                this.groupMtu.setValidationState(ValidationState.NONE);
-                this.wrongInputMtu.setText("");
-            } else {
-                this.groupMtu.setValidationState(ValidationState.ERROR);
-                this.wrongInputMtu.setText(MSGS.netIPv6InvalidMtu());
             }
         });
     }
@@ -527,8 +482,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         this.wrongInputGateway.setText("");
         this.groupDns.setValidationState(ValidationState.NONE);
         this.wrongInputDns.setText("");
-        this.groupMtu.setValidationState(ValidationState.NONE);
-        this.wrongInputMtu.setText("");
     }
 
     private void refreshForm() {
@@ -541,7 +494,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         this.gateway.setEnabled(true);
         this.dns.setEnabled(true);
         this.privacy.setEnabled(true);
-        this.mtu.setEnabled(true);
 
         if (this.selectedNetIfConfig.isPresent()) {
             refreshFieldsBasedOnInterface(this.selectedNetIfConfig.get());
@@ -563,7 +515,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             this.gateway.setEnabled(false);
             this.dns.setEnabled(false);
             this.privacy.setEnabled(false);
-            this.mtu.setEnabled(false);
             break;
         case MODEM:
             this.configure.setEnabled(false);
@@ -598,8 +549,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
             this.dns.setText("");
             this.privacy.setEnabled(false);
             this.privacy.setSelectedIndex(0);
-            this.mtu.setEnabled(false);
-            this.mtu.setText("");
         }
 
         if (this.status.getSelectedValue().equals(STATUS_LAN)) {
@@ -690,10 +639,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         }
 
         updatedNetIf.setIpv6Privacy(this.privacy.getSelectedValue());
-
-        if (this.mtu.getValue() != null) {
-            updatedNetIf.setIpv6Mtu(this.mtu.getValue());
-        }
     }
 
     private boolean nullOrEmpty(String value) {
@@ -721,8 +666,7 @@ public class TabIp6Ui extends Composite implements NetworkTab {
                 || this.groupIp.getValidationState().equals(ValidationState.ERROR)
                 || this.groupSubnet.getValidationState().equals(ValidationState.ERROR)
                 || this.groupGateway.getValidationState().equals(ValidationState.ERROR)
-                || this.groupDns.getValidationState().equals(ValidationState.ERROR)
-                || this.groupMtu.getValidationState().equals(ValidationState.ERROR)) {
+                || this.groupDns.getValidationState().equals(ValidationState.ERROR)) {
             return false;
         }
 
@@ -753,7 +697,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
         this.gateway.setText("");
         this.dns.setText("");
         this.privacy.setSelectedIndex(0);
-        this.mtu.setText("");
     }
 
     private void fillFormWithCachedConfig() {
@@ -807,8 +750,6 @@ public class TabIp6Ui extends Composite implements NetworkTab {
                 break;
             }
         }
-
-        this.mtu.setValue(this.selectedNetIfConfig.get().getIpv6Mtu());
 
         this.tabs.updateTabs();
         refreshForm();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.ui.xml
@@ -115,13 +115,6 @@
                                     <b:ListBox b:id="privacy" ui:field="privacy" />
                                 </g:FlowPanel>
                             </b:FormGroup>
-
-                            <b:FormGroup ui:field="groupMtu">
-                                <b:FormLabel for="mtu" ui:field="labelMtu"></b:FormLabel>
-                                <util:HelpButton ui:field="helpButtonMtu" />
-                                <b:HelpBlock color="red" ui:field="wrongInputMtu" />
-                                <b:IntegerBox b:id="mtu" ui:field="mtu" />
-                            </b:FormGroup>
                             
                         </b:FieldSet>
                     </b:Form>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.ui.xml
@@ -2,7 +2,7 @@
 
 <!--
 
-    Copyright (c) 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
 	
 	Contributors:
 	 Eurotech
+     Areti
 
 -->
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp6Ui.ui.xml
@@ -12,7 +12,7 @@
 	
 	Contributors:
 	 Eurotech
-     Areti
+	 Areti
 
 -->
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  *  Eurotech
+ *  Areti
  *******************************************************************************/
 package org.eclipse.kura.web.server.net2.configuration;
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/GwtNetInterfaceConfigBuilder.java
@@ -34,6 +34,7 @@ public class GwtNetInterfaceConfigBuilder {
     private static final String NA = "N/A";
     private static final Integer DEFAULT_WAN_PRIORITY = -1;
     private static final Integer DEFAULT_MTU = 0;
+    private static final Integer DEFAULT_PROMISC = -1;
 
     private final NetworkConfigurationServiceProperties properties;
     private GwtNetInterfaceConfig gwtConfig;
@@ -69,6 +70,7 @@ public class GwtNetInterfaceConfigBuilder {
         setWifiProperties();
         setModemProperties();
         set8021xProperties();
+        setAdvancedProperties();
 
         return this.gwtConfig;
     }
@@ -123,9 +125,6 @@ public class GwtNetInterfaceConfigBuilder {
         this.gwtConfig.setSubnetMask(this.properties.getIp4Netmask(this.ifName));
         this.gwtConfig.setGateway(this.properties.getIp4Gateway(this.ifName));
         this.gwtConfig.setDnsServers(this.properties.getIp4DnsServers(this.ifName));
-
-        Optional<Integer> mtu = this.properties.getIp4Mtu(this.ifName);
-        this.gwtConfig.setMtu(mtu.orElse(DEFAULT_MTU));
     }
 
     private void setIpv6Properties() {
@@ -165,9 +164,6 @@ public class GwtNetInterfaceConfigBuilder {
         if (privacy.isPresent()) {
             this.gwtConfig.setIpv6Privacy(privacy.get());
         }
-
-        Optional<Integer> mtu = this.properties.getIp6Mtu(this.ifName);
-        this.gwtConfig.setIpv6Mtu(mtu.orElse(DEFAULT_MTU));
     }
 
     private void setIpv4DhcpClientProperties() {
@@ -352,6 +348,17 @@ public class GwtNetInterfaceConfigBuilder {
         gwt8021xConfig.setCaCertName(this.properties.get8021xCaCertName(this.ifName));
         gwt8021xConfig.setPublicPrivateKeyPairName(this.properties.get8021xPublicPrivateKeyPairName(this.ifName));
 
+    }
+
+    private void setAdvancedProperties() {
+    	Optional<Integer> mtu = this.properties.getIp4Mtu(this.ifName);
+        this.gwtConfig.setMtu(mtu.orElse(DEFAULT_MTU));
+        
+        Optional<Integer> ip6mtu = this.properties.getIp6Mtu(this.ifName);
+        this.gwtConfig.setIpv6Mtu(ip6mtu.orElse(DEFAULT_MTU));
+        
+        Optional<Integer> promisc = this.properties.getPromisc(this.ifName);
+        this.gwtConfig.setPromisc(promisc.orElse(DEFAULT_PROMISC));
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -84,7 +84,6 @@ public class NetworkConfigurationServiceProperties {
     private static final String NET_INTERFACE_CONFIG_IP4_NETMASK = "net.interface.%s.config.ip4.prefix";
     private static final String NET_INTERFACE_CONFIG_IP4_GATEWAY = "net.interface.%s.config.ip4.gateway";
     private static final String NET_INTERFACE_CONFIG_IP4_DNS_SERVERS = "net.interface.%s.config.ip4.dnsServers";
-    private static final String NET_INTERFACE_CONFIG_IP4_MTU = "net.interface.%s.config.ip4.mtu";
 
     public Optional<String> getIp4Status(String ifname) {
         return getNonEmptyStringProperty(this.properties.get(String.format(NET_INTERFACE_CONFIG_IP4_STATUS, ifname)));
@@ -146,15 +145,6 @@ public class NetworkConfigurationServiceProperties {
         this.properties.put(String.format(NET_INTERFACE_CONFIG_IP4_DNS_SERVERS, ifname), dnsServers);
     }
     
-    public Optional<Integer> getIp4Mtu(String ifName) {
-    	return Optional.ofNullable(
-                (Integer) properties.get(String.format(NET_INTERFACE_CONFIG_IP4_MTU, ifName)));
-    }
-
-    public void setIp4Mtu(String ifName, int mtu) {
-    	this.properties.put(String.format(NET_INTERFACE_CONFIG_IP4_MTU, ifName), mtu);
-    }
-
     /*
      * IPv6 properties
      */
@@ -168,7 +158,6 @@ public class NetworkConfigurationServiceProperties {
     private static final String NET_INTERFACE_CONFIG_IP6_NETMASK = "net.interface.%s.config.ip6.prefix";
     private static final String NET_INTERFACE_CONFIG_IP6_GATEWAY = "net.interface.%s.config.ip6.gateway";
     private static final String NET_INTERFACE_CONFIG_IP6_DNS_SERVERS = "net.interface.%s.config.ip6.dnsServers";
-    private static final String NET_INTERFACE_CONFIG_IP6_MTU = "net.interface.%s.config.ip6.mtu";
     
     public Optional<String> getIp6Status(String ifname) {
         return getNonEmptyStringProperty(this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_STATUS, ifname)));
@@ -250,18 +239,6 @@ public class NetworkConfigurationServiceProperties {
         this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_DNS_SERVERS, ifname), dnsServers);
     }
     
-    public Optional<Integer> getIp6Mtu(String ifname) {
-        if (this.properties.containsKey(String.format(NET_INTERFACE_CONFIG_IP6_MTU, ifname))) {
-            Integer mtu = (Integer) this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_MTU, ifname));
-            return Optional.ofNullable(mtu);
-        }
-        return Optional.empty();
-    }
-
-    public void setIp6Mtu(String ifname, Integer mtu) {
-    	this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_MTU, ifname), mtu);
-    }
-
     /*
      * IPv4 DHCP Server properties
      */
@@ -908,6 +885,46 @@ public class NetworkConfigurationServiceProperties {
     public String get8021xPublicPrivateKeyPairName(String ifname) {
         return (String) this.properties
                 .get(String.format(NET_INTERFACE_CONFIG_8021X_PUBLIC_PRIVATE_KEY_PAIR_NAME, ifname));
+    }
+    
+    /**
+     * Advanced properties
+     */
+    private static final String NET_INTERFACE_CONFIG_IP4_MTU = "net.interface.%s.config.ip4.mtu";
+    private static final String NET_INTERFACE_CONFIG_IP6_MTU = "net.interface.%s.config.ip6.mtu";
+    private static final String NET_INTERFACE_CONFIG_PROMISC_MODE = "net.interface.%s.config.promisc";
+    
+    public Optional<Integer> getIp4Mtu(String ifName) {
+    	return Optional.ofNullable(
+                (Integer) properties.get(String.format(NET_INTERFACE_CONFIG_IP4_MTU, ifName)));
+    }
+
+    public void setIp4Mtu(String ifName, int mtu) {
+    	this.properties.put(String.format(NET_INTERFACE_CONFIG_IP4_MTU, ifName), mtu);
+    }
+    
+    public Optional<Integer> getIp6Mtu(String ifname) {
+        if (this.properties.containsKey(String.format(NET_INTERFACE_CONFIG_IP6_MTU, ifname))) {
+            Integer mtu = (Integer) this.properties.get(String.format(NET_INTERFACE_CONFIG_IP6_MTU, ifname));
+            return Optional.ofNullable(mtu);
+        }
+        return Optional.empty();
+    }
+
+    public void setIp6Mtu(String ifname, Integer mtu) {
+    	this.properties.put(String.format(NET_INTERFACE_CONFIG_IP6_MTU, ifname), mtu);
+    }
+    
+    public Optional<Integer> getPromisc(String ifname) {
+        if (this.properties.containsKey(String.format(NET_INTERFACE_CONFIG_PROMISC_MODE, ifname))) {
+            Integer mtu = (Integer) this.properties.get(String.format(NET_INTERFACE_CONFIG_PROMISC_MODE, ifname));
+            return Optional.ofNullable(mtu);
+        }
+        return Optional.empty();
+    }
+
+    public void setPromisc(String ifname, Integer promisc) {
+    	this.properties.put(String.format(NET_INTERFACE_CONFIG_PROMISC_MODE, ifname), promisc);
     }
 
     /**

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  * 
  * Contributors:
  *  Eurotech
+ *  Areti
  *******************************************************************************/
 package org.eclipse.kura.web.server.net2.configuration;
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -36,6 +36,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
     private static final Integer DEFAULT_WAN_PRIORITY = -1;
     private static final Integer DEFAULT_MTU = 0;
+    private static final Integer DEFAULT_PROMISC = -1;
 
     private final GwtNetInterfaceConfig gwtConfig;
     private final NetworkConfigurationServiceProperties properties;
@@ -76,6 +77,8 @@ public class NetworkConfigurationServicePropertiesBuilder {
         // Manage GPS independently of device ip status
         setModemGpsProperties();
 
+        setAdvancedProperties();
+
         return this.properties.getProperties();
     }
 
@@ -115,8 +118,6 @@ public class NetworkConfigurationServicePropertiesBuilder {
             this.properties.setIp4Gateway(this.ifname, this.gwtConfig.getGateway());
         }
 
-        this.properties.setIp4Mtu(this.ifname,
-                Objects.nonNull(this.gwtConfig.getMtu()) ? this.gwtConfig.getMtu() : DEFAULT_MTU);
     }
 
     private void setIpv6Properties() {
@@ -156,9 +157,6 @@ public class NetworkConfigurationServicePropertiesBuilder {
             this.properties.setIp6AddressGenMode(this.ifname, this.gwtConfig.getIpv6AutoconfigurationMode());
             this.properties.setIp6Privacy(this.ifname, this.gwtConfig.getIpv6Privacy());
         }
-
-        this.properties.setIp6Mtu(this.ifname,
-                Objects.nonNull(this.gwtConfig.getIpv6Mtu()) ? this.gwtConfig.getIpv6Mtu() : DEFAULT_MTU);
     }
 
     private void setIpv4DhcpClientProperties() {
@@ -420,6 +418,15 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
             this.properties.setModemGpsEnabled(this.ifname, gwtModemConfig.isGpsEnabled());
         }
+    }
+
+    private void setAdvancedProperties() {
+        this.properties.setIp4Mtu(this.ifname,
+                Objects.nonNull(this.gwtConfig.getMtu()) ? this.gwtConfig.getMtu() : DEFAULT_MTU);
+        this.properties.setIp6Mtu(this.ifname,
+                Objects.nonNull(this.gwtConfig.getIpv6Mtu()) ? this.gwtConfig.getIpv6Mtu() : DEFAULT_MTU);
+        this.properties.setPromisc(this.ifname,
+        		Objects.nonNull(this.gwtConfig.getPromisc()) ? this.gwtConfig.getPromisc() : DEFAULT_PROMISC);
     }
 
     private static GwtNetInterfaceConfig getConfigsAndStatuses(String ifName) throws GwtKuraException, KuraException {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *  Eurotech
+ *  Areti
  *******************************************************************************/
 package org.eclipse.kura.web.server.net2.configuration;
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
@@ -395,6 +395,14 @@ public class GwtNetInterfaceConfig extends KuraBaseModel implements Serializable
     public void setIpv6Mtu(Integer mtu) {
     	set("ipv6.mtu", mtu);
     }
+    
+    public Integer getPromisc() {
+        return get("promisc");
+    }
+
+    public void setPromisc(Integer promisc) {
+        set("promisc", promisc);
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -338,7 +338,7 @@ netIPv4ToolTipSubnetMask=For static configuration, enter the subnet mask that wi
 netIPv4ToolTipGateway=For static configuration, enter the default gateway for the device.
 netIPv4ToolTipRenew=For DHCP configuration, clicking this button will release the current IP address and acquire a new lease from the server.
 netIPv4ToolTipDns=List of DNS servers.<br/>New servers can be added by entering an address and clicking apply.<br/>To remove a server, delete the address from the list and click apply.<br/>Servers MUST be separated by a comma (,).<br/><br/>When configured for DHCP, manually entered DNS entries will replace the ones provided by the DHCP server.  Removing them will restore the DHCP entries.
-netIPv4Mtu=MTU
+netIPv4Mtu=IPv4 MTU
 netIPv4InvalidMtu=MTU must be an Integer.
 netIPv4ToolTipMtu=Selects the Maximum Transition Unit (MTU) for IPv4 traffic over this interface.<br/> A value of 0 allows MTU auto-discovery.
 
@@ -356,7 +356,7 @@ netIPv6SubnetMask=Subnet Mask
 netIPv6Gateway=Gateway
 netIPv6DNSServers=DNS Servers
 netIPv6Privacy=Privacy
-netIPv6Mtu=MTU
+netIPv6Mtu=IPv6 MTU
 
 netIPv6InvalidPriority=Priority allowed values are only integers from -1 to 2147483647
 netIPv6InvalidAddress=IPv6 addresses range from 0000:0000:0000:0000:0000:0000:0000:0000 to ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
@@ -377,6 +377,10 @@ netIPv6ToolTipGateway=For static configuration, enter the IPv6 address of the de
 netIPv6ToolTipDns=List of DNS servers.<br><br>Servers MUST be separated by a space or a newline.<br><br>When configured for DHCP, manually entered DNS entries will replace the ones provided by the DHCP server. Removing them will restore the DHCP entries.
 netIPv6ToolTipPrivacy=Configure IPv6 Privacy Extensions for SLAAC, described in RFC4941. If enabled, it makes the kernel generate a temporary IPv6 address in addition to the public one generated from MAC address via modified EUI-64. Note that this setting is distinct from the Stable Privacy addresses that can be enabled with the Address Generation Mode property as another way of avoiding host tracking with IPv6 addresses
 netIPv6ToolTipMtu=Selects the Maximum Transition Unit (MTU) for IPv6 traffic over this interface.<br/> A value of 0 allows MTU auto-discovery.<br/>Requires NetworkManager 1.40 or newer.
+
+netAdvanced=Advanced
+netAdvPromisc=Promiscuous Mode
+netAdvToolTipPromisc=Configures the promiscuous mode for current interface.<br/>Requires NetworkManager 1.32 or newer.
 
 firewallIntro=Enable ports to be opened and port forwarding
 

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
 #
 #  This program and the accompanying materials are made
 #  available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
 #
 #  Contributors:
 #   Eurotech
+#   Areti
 #
 
 yesButton=Yes

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -338,9 +338,6 @@ netIPv4ToolTipSubnetMask=For static configuration, enter the subnet mask that wi
 netIPv4ToolTipGateway=For static configuration, enter the default gateway for the device.
 netIPv4ToolTipRenew=For DHCP configuration, clicking this button will release the current IP address and acquire a new lease from the server.
 netIPv4ToolTipDns=List of DNS servers.<br/>New servers can be added by entering an address and clicking apply.<br/>To remove a server, delete the address from the list and click apply.<br/>Servers MUST be separated by a comma (,).<br/><br/>When configured for DHCP, manually entered DNS entries will replace the ones provided by the DHCP server.  Removing them will restore the DHCP entries.
-netIPv4Mtu=IPv4 MTU
-netIPv4InvalidMtu=MTU must be an Integer.
-netIPv4ToolTipMtu=Selects the Maximum Transition Unit (MTU) for IPv4 traffic over this interface.<br/> A value of 0 allows MTU auto-discovery.
 
 netConfigChangeConfirm=You are about to perform a network configuration change. Please be aware that:  
 netConfigConsoleUnavailable=The Web Console might be unavailable for a few seconds.
@@ -356,12 +353,10 @@ netIPv6SubnetMask=Subnet Mask
 netIPv6Gateway=Gateway
 netIPv6DNSServers=DNS Servers
 netIPv6Privacy=Privacy
-netIPv6Mtu=IPv6 MTU
 
 netIPv6InvalidPriority=Priority allowed values are only integers from -1 to 2147483647
 netIPv6InvalidAddress=IPv6 addresses range from 0000:0000:0000:0000:0000:0000:0000:0000 to ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
 netIpv6InvalidSubnet=Subnet mask must be an integer between 1 and 128
-netIPv6InvalidMtu=MTU must be an Integer.
 
 netIPv6ToolTipStatus=<b>Disabled</b><br>The interface is disabled.<br><br><b>Enabled for LAN</b><br>Interface is used to create a local network. Use this for creating an access point that other devices can connect to.<br><br><b>Enabled for WAN</b><br>Interface is enabled for use as a gateway to an external network. Use this to connect to a router, wireless access point, or cellular network.
 netIPv6ModemToolTipStatus=<b>Disabled</b><br>The interface is disabled.<br><br><b>Enabled for WAN</b><br>Interface is enabled for use as a gateway to an external network.
@@ -376,9 +371,14 @@ netIPv6ToolTipSubnetMask=For static configuration, enter the subnet mask that wi
 netIPv6ToolTipGateway=For static configuration, enter the IPv6 address of the default gateway for the device.
 netIPv6ToolTipDns=List of DNS servers.<br><br>Servers MUST be separated by a space or a newline.<br><br>When configured for DHCP, manually entered DNS entries will replace the ones provided by the DHCP server. Removing them will restore the DHCP entries.
 netIPv6ToolTipPrivacy=Configure IPv6 Privacy Extensions for SLAAC, described in RFC4941. If enabled, it makes the kernel generate a temporary IPv6 address in addition to the public one generated from MAC address via modified EUI-64. Note that this setting is distinct from the Stable Privacy addresses that can be enabled with the Address Generation Mode property as another way of avoiding host tracking with IPv6 addresses
-netIPv6ToolTipMtu=Selects the Maximum Transition Unit (MTU) for IPv6 traffic over this interface.<br/> A value of 0 allows MTU auto-discovery.<br/>Requires NetworkManager 1.40 or newer.
 
 netAdvanced=Advanced
+netAdvIPv4Mtu=IPv4 MTU
+netAdvIPv4InvalidMtu=IPv4 MTU must be a positive Integer.
+netAdvIPv4ToolTipMtu=Selects the Maximum Transition Unit (MTU) for IPv4 traffic over this interface.<br/> A value of 0 allows MTU auto-discovery.
+netAdvIPv6Mtu=IPv6 MTU
+netAdvIPv6InvalidMtu=IPv6 MTU must be an positive Integer.
+netAdvIPv6ToolTipMtu=Selects the Maximum Transition Unit (MTU) for IPv6 traffic over this interface.<br/> A value of 0 allows MTU auto-discovery.<br/>Requires NetworkManager 1.40 or newer.
 netAdvPromisc=Promiscuous Mode
 netAdvToolTipPromisc=Configures the promiscuous mode for current interface.<br/>Requires NetworkManager 1.32 or newer.
 

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages_ja.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages_ja.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2022, 2023 Eurotech and/or its affiliates and others
+#  Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
 #
 #  This program and the accompanying materials are made
 #  available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
 #
 #  Contributors:
 #   Eurotech
+#   Areti
 #
 
 yesButton=はい
@@ -358,6 +359,16 @@ netIPv6ToolTipSubnetMask=静的構成の場合、デバイスに割り当てら�
 netIPv6ToolTipGateway=静的構成の場合、デバイスのデフォルト ゲートウェイの IPv6 アドレスを入力します。
 netIPv6ToolTipDns=DNS サーバーのリスト。<br><br>サーバーはスペースまたは改行で区切る必要があります。<br><br>DHCP 用に構成されている場合、手動で入力された DNS エントリは、DHCP サーバーによって提供されたエントリと置き換えられます。 それらを削除すると、DHCP エントリが復元されます。
 netIPv6ToolTipPrivacy=RFC4941 で説明されているように、SLAAC の IPv6 プライバシー拡張機能を構成します。 有効にすると、カーネルは、修正された EUI-64 を介して MAC アドレスから生成されるパブリック アドレスに加えて、一時的な IPv6 アドレスを生成します。 この設定は、IPv6 アドレスによるホスト追跡を回避する別の方法として [アドレス生成モード] プロパティで有効にできる安定したプライバシー アドレスとは異なることに注意してください。
+
+netAdvanced=高度な
+netAdvIPv4Mtu=IPv4 MTU
+netAdvIPv4InvalidMtu=IPv4 MTU は正の整数である必要があります。
+netAdvIPv4ToolTipMtu=このインターフェイス上の IPv4 トラフィックの最大移行ユニット (MTU) を選択します。<br/> 値 0 では、MTU 自動検出が許可されます。
+netAdvIPv6Mtu=IPv6 MTU
+netAdvIPv6InvalidMtu=IPv6 MTU は正の整数である必要があります。
+netAdvIPv6ToolTipMtu=このインターフェイス上の IPv6 トラフィックの最大移行ユニット (MTU) を選択します。<br/> 値 0 では、MTU 自動検出が許可されます。<br/> NetworkManager 1.40 以降が必要です。
+netAdvPromisc=無差別モード
+netAdvToolTipPromisc=現在のインターフェイスの無差別モードを構成します。<br/>NetworkManager 1.32 以降が必要です。
 
 firewallIntro=ポートの開放とポート転送を有効にする
 

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/ValidationMessages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/ValidationMessages.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
 #
 #  This program and the accompanying materials are made
 #  available under the terms of the Eclipse Public License 2.0
@@ -9,6 +9,7 @@
 #
 #  Contributors:
 #   Eurotech
+#   Areti
 #
 
 # Exception Messages

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/ValidationMessages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/ValidationMessages.properties
@@ -187,6 +187,10 @@ netModemPdpIP=IP
 netModemPdpPPP=PPP
 netModemPdpIPv6=IPv6
 
+netAdvPromiscDefault=System default
+netAdvPromiscEnabled=Enabled
+netAdvPromiscDisabled=Disabled
+
 passwordRegexMsg=Passwords must be at least 6 characters and contain at least one lower case letter, one upper case letter, one digit and one special character.
 passwordToolTipMsg=Must be at least 6 characters and contain at least one lower case letter, one upper case letter, one digit and one special character.
 passwordRequiredMsg=Password is required.


### PR DESCRIPTION
This PR adds an 'Advanced' tab in Kura Network Manager to configure MTUs for both IPv4 and IPv6 and Promiscuous mode configuration, as discussed in #5068 

The old MTU fields in Ip4 and Ip6 tab have been removed.
