### PR TITLE
fix(nm): 802.1x CA cert should be really "Optional"

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
@@ -47,8 +47,9 @@ public class NetworkProperties {
         }
 
         if (!clazz.isAssignableFrom(rawValue.getClass())) {
-            throw new IllegalArgumentException(
-                    String.format("The \"%s\" key contains a value of incompatible type \"%s\" (desired type: \"%s\").",
+            // Criteria: there's no such element in the map that matches the requested type(clazz)
+            throw new NoSuchElementException(
+                    String.format("The \"%s\" key contains a value of type \"%s\" (requested type: \"%s\").",
                             formattedKey, rawValue.getClass().getName(), clazz.getName()));
         }
 
@@ -84,9 +85,8 @@ public class NetworkProperties {
         }
 
         if (!clazz.isAssignableFrom(rawValue.getClass())) {
-            throw new IllegalArgumentException(
-                    String.format("The \"%s\" key contains a value of incompatible type \"%s\" (desired type: \"%s\").",
-                            formattedKey, rawValue.getClass().getName(), clazz.getName()));
+            // Criteria: there's no such element in the map that matches the requested type (clazz)
+            return Optional.empty();
         }
 
         if (clazz == String.class || clazz == Password.class) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
@@ -47,7 +47,7 @@ public class NetworkProperties {
         }
 
         if (!clazz.isAssignableFrom(rawValue.getClass())) {
-            // Criteria: there's no such element in the map that matches the requested type(clazz)
+            // Criteria: there's no such element in the map that matches the requested type (clazz)
             throw new NoSuchElementException(
                     String.format("The \"%s\" key contains a value of type \"%s\" (requested type: \"%s\").",
                             formattedKey, rawValue.getClass().getName(), clazz.getName()));

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkProperties.java
@@ -46,6 +46,12 @@ public class NetworkProperties {
             throw new NoSuchElementException(String.format("The \"%s\" key contains a null value.", formattedKey));
         }
 
+        if (!clazz.isAssignableFrom(rawValue.getClass())) {
+            throw new IllegalArgumentException(
+                    String.format("The \"%s\" key contains a value of incompatible type \"%s\" (desired type: \"%s\").",
+                            formattedKey, rawValue.getClass().getName(), clazz.getName()));
+        }
+
         if (clazz == String.class || clazz == Password.class) {
             String value = "";
 
@@ -75,6 +81,12 @@ public class NetworkProperties {
         Object rawValue = this.properties.get(formattedKey);
         if (Objects.isNull(rawValue)) {
             return Optional.empty();
+        }
+
+        if (!clazz.isAssignableFrom(rawValue.getClass())) {
+            throw new IllegalArgumentException(
+                    String.format("The \"%s\" key contains a value of incompatible type \"%s\" (desired type: \"%s\").",
+                            formattedKey, rawValue.getClass().getName(), clazz.getName()));
         }
 
         if (clazz == String.class || clazz == Password.class) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -347,7 +347,7 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
         final List<String> keyCertStrings = Arrays.asList(clientCertString, caCertString, privateKeyString);
 
         for (String key : keyCertStrings) {
-            if (!modifiedProps.containsKey(key)) {
+            if (!modifiedProps.containsKey(key) || modifiedProps.get(key) == null || modifiedProps.get(key) == "") {
                 continue;
             }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -347,11 +347,11 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
         final List<String> keyCertStrings = Arrays.asList(clientCertString, caCertString, privateKeyString);
 
         for (String key : keyCertStrings) {
-            if (!modifiedProps.containsKey(key) || modifiedProps.get(key) == null || modifiedProps.get(key) == "") {
+            Object value = modifiedProps.get(key);
+            if (Objects.isNull(value) || value.toString().isEmpty()) {
                 continue;
             }
 
-            Object value = modifiedProps.get(key);
             try {
                 String valueString = value.toString();
                 if (isCertificate(key)) {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -361,7 +361,6 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
                 }
             } catch (KuraException e) {
                 logger.error("Unable to decode key/certificate {} from keystore.", key, e);
-                modifiedProps.put(key, value);
             }
         }
     }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -348,7 +348,7 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
 
         for (String key : keyCertStrings) {
             Object value = modifiedProps.get(key);
-            if (Objects.isNull(value) || value.toString().isEmpty()) {
+            if (Objects.isNull(value) || !(value instanceof String) || value.toString().isEmpty()) {
                 continue;
             }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NetworkPropertiesTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NetworkPropertiesTest.java
@@ -121,6 +121,22 @@ public class NetworkPropertiesTest {
     }
 
     @Test
+    public void getShouldThrowWithTypePassword() {
+        givenMapWith("Wrong-Type-Password", new String(""));
+        givenNetworkPropertiesBuiltWith(this.properties);
+        whenGetIsCalledWith("Wrong-Type-Password", Password.class);
+        thenExceptionOccurred(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void getShouldThrowWithWrongType() {
+        givenMapWith("Wrong-Type-Key", new Float(5.5));
+        givenNetworkPropertiesBuiltWith(this.properties);
+        whenGetIsCalledWith("Wrong-Type-Key", Boolean.class);
+        thenExceptionOccurred(IllegalArgumentException.class);
+    }
+
+    @Test
     public void getShouldWorkWithEmptyStringKey() {
         givenMapWith("", "Empty String Test");
         givenNetworkPropertiesBuiltWith(this.properties);
@@ -226,6 +242,22 @@ public class NetworkPropertiesTest {
         whenGetOptIsCalledWith("testKeyNull", String.class);
         thenNoExceptionsOccured();
         thenOptionalResultEquals(Optional.empty());
+    }
+
+    @Test
+    public void getOptShouldThrowWithTypePassword() {
+        givenMapWith("Wrong-Type-Password", new String(""));
+        givenNetworkPropertiesBuiltWith(this.properties);
+        whenGetOptIsCalledWith("Wrong-Type-Password", Password.class);
+        thenExceptionOccurred(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void getOptShouldThrowWithWrongType() {
+        givenMapWith("Wrong-Type-Key", new Float(5.5));
+        givenNetworkPropertiesBuiltWith(this.properties);
+        whenGetOptIsCalledWith("Wrong-Type-Key", Boolean.class);
+        thenExceptionOccurred(IllegalArgumentException.class);
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NetworkPropertiesTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NetworkPropertiesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NetworkPropertiesTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NetworkPropertiesTest.java
@@ -125,7 +125,7 @@ public class NetworkPropertiesTest {
         givenMapWith("Wrong-Type-Password", new String(""));
         givenNetworkPropertiesBuiltWith(this.properties);
         whenGetIsCalledWith("Wrong-Type-Password", Password.class);
-        thenExceptionOccurred(IllegalArgumentException.class);
+        thenExceptionOccurred(NoSuchElementException.class);
     }
 
     @Test
@@ -133,7 +133,7 @@ public class NetworkPropertiesTest {
         givenMapWith("Wrong-Type-Key", new Float(5.5));
         givenNetworkPropertiesBuiltWith(this.properties);
         whenGetIsCalledWith("Wrong-Type-Key", Boolean.class);
-        thenExceptionOccurred(IllegalArgumentException.class);
+        thenExceptionOccurred(NoSuchElementException.class);
     }
 
     @Test
@@ -249,7 +249,8 @@ public class NetworkPropertiesTest {
         givenMapWith("Wrong-Type-Password", new String(""));
         givenNetworkPropertiesBuiltWith(this.properties);
         whenGetOptIsCalledWith("Wrong-Type-Password", Password.class);
-        thenExceptionOccurred(IllegalArgumentException.class);
+        thenNoExceptionsOccured();
+        thenOptionalResultEquals(Optional.empty());
     }
 
     @Test
@@ -257,7 +258,8 @@ public class NetworkPropertiesTest {
         givenMapWith("Wrong-Type-Key", new Float(5.5));
         givenNetworkPropertiesBuiltWith(this.properties);
         whenGetOptIsCalledWith("Wrong-Type-Key", Boolean.class);
-        thenExceptionOccurred(IllegalArgumentException.class);
+        thenNoExceptionsOccured();
+        thenOptionalResultEquals(Optional.empty());
     }
 
     @Test

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -667,7 +667,99 @@ public class NMSettingsConverterTest {
         thenResultingMapContainsBytes("private-key",
                 "-----BEGIN PRIVATE KEY-----\nYmluYXJ5IHByaXZhdGUga2V5\n-----END PRIVATE KEY-----\n");
         thenResultingMapContains("private-key-password", "secure-password");
+    }
 
+    @Test
+    public void build8021xSettingsShouldThrowWithTlsWithNullPrivateKey() {
+        givenMapWith("net.interface.wlan0.config.802-1x.eap", "Kura8021xEapTls");
+        givenMapWith("net.interface.wlan0.config.802-1x.innerAuth", "Kura8021xInnerAuthNone");
+        givenMapWith("net.interface.wlan0.config.802-1x.identity", "username@email.com");
+        givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-name",
+                buildMockedCertificateWithCert("binary ca cert"));
+        givenMapWith("net.interface.wlan0.config.802-1x.client-cert-name",
+                buildMockedCertificateWithCert("binary client cert"));
+        givenMapWith("net.interface.wlan0.config.802-1x.private-key-name", null);
+        givenMapWith("net.interface.wlan0.config.802-1x.private-key-password", new Password("secure-password"));
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild8021xSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenExceptionOccurred(NoSuchElementException.class);
+    }
+
+    @Test
+    public void build8021xSettingsShouldThrowWithTlsWithWrongTypePrivateKey() {
+        givenMapWith("net.interface.wlan0.config.802-1x.eap", "Kura8021xEapTls");
+        givenMapWith("net.interface.wlan0.config.802-1x.innerAuth", "Kura8021xInnerAuthNone");
+        givenMapWith("net.interface.wlan0.config.802-1x.identity", "username@email.com");
+        givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-name",
+                buildMockedCertificateWithCert("binary ca cert"));
+        givenMapWith("net.interface.wlan0.config.802-1x.client-cert-name",
+                buildMockedCertificateWithCert("binary client cert"));
+        givenMapWith("net.interface.wlan0.config.802-1x.private-key-name", "");
+        givenMapWith("net.interface.wlan0.config.802-1x.private-key-password", new Password("secure-password"));
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild8021xSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenExceptionOccurred(NoSuchElementException.class);
+    }
+
+    @Test
+    public void build8021xSettingsShouldWorkWithTlsWithNullCACert() {
+        givenMapWith("net.interface.wlan0.config.802-1x.eap", "Kura8021xEapTls");
+        givenMapWith("net.interface.wlan0.config.802-1x.innerAuth", "Kura8021xInnerAuthNone");
+        givenMapWith("net.interface.wlan0.config.802-1x.identity", "username@email.com");
+        givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-name", null);
+        givenMapWith("net.interface.wlan0.config.802-1x.client-cert-name",
+                buildMockedCertificateWithCert("binary client cert"));
+        givenMapWith("net.interface.wlan0.config.802-1x.private-key-name",
+                buildMockedPrivateKeyWithKey("binary private key"));
+        givenMapWith("net.interface.wlan0.config.802-1x.private-key-password", new Password("secure-password"));
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild8021xSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionOccurred();
+
+        thenResultingMapContainsArray("eap", new Variant<>(new String[] { "tls" }).getValue());
+        thenResultingMapContains("identity", "username@email.com");
+        thenResultingMapContainsBytes("client-cert", "binary client cert");
+        thenResultingMapContainsBytes("private-key",
+                "-----BEGIN PRIVATE KEY-----\nYmluYXJ5IHByaXZhdGUga2V5\n-----END PRIVATE KEY-----\n");
+        thenResultingMapContains("private-key-password", "secure-password");
+
+        thenResultingMapNotContains("phase2-auth");
+        thenResultingMapNotContains("ca-cert");
+    }
+
+    @Test
+    public void build8021xSettingsShouldWorkWithTlsWithWrongTypeCACert() {
+        givenMapWith("net.interface.wlan0.config.802-1x.eap", "Kura8021xEapTls");
+        givenMapWith("net.interface.wlan0.config.802-1x.innerAuth", "Kura8021xInnerAuthNone");
+        givenMapWith("net.interface.wlan0.config.802-1x.identity", "username@email.com");
+        givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-name",
+                new Password("When I grow up I want to be a certificate"));
+        givenMapWith("net.interface.wlan0.config.802-1x.client-cert-name",
+                buildMockedCertificateWithCert("binary client cert"));
+        givenMapWith("net.interface.wlan0.config.802-1x.private-key-name",
+                buildMockedPrivateKeyWithKey("binary private key"));
+        givenMapWith("net.interface.wlan0.config.802-1x.private-key-password", new Password("secure-password"));
+        givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
+
+        whenBuild8021xSettingsIsRunWith(this.networkProperties, "wlan0");
+
+        thenNoExceptionOccurred();
+
+        thenResultingMapContainsArray("eap", new Variant<>(new String[] { "tls" }).getValue());
+        thenResultingMapContains("identity", "username@email.com");
+        thenResultingMapContainsBytes("client-cert", "binary client cert");
+        thenResultingMapContainsBytes("private-key",
+                "-----BEGIN PRIVATE KEY-----\nYmluYXJ5IHByaXZhdGUga2V5\n-----END PRIVATE KEY-----\n");
+        thenResultingMapContains("private-key-password", "secure-password");
+
+        thenResultingMapNotContains("phase2-auth");
+        thenResultingMapNotContains("ca-cert");
     }
 
     @Test


### PR DESCRIPTION
**Brief description**: CA cert parameter was set as "Optional" but the backend code was throwing errors upon finding it missing. This PR fixes the issue.

**Background**: When submitting a configuration for the 802.1x tab and the Certificate Authority Certificate is not set, the following error is thrown:

```
2024-01-08T11:20:26,100 [ConfigurationListener Event Queue] ERROR o.e.k.n.c.NMConfigurationServiceImpl - Unable to decode key/certificate net.interface.wlan0.config.802-1x.ca-cert-name from keystore.
org.eclipse.kura.KuraException: Configuration Error: Certificate "" is not of the expected key type or not found.
	at org.eclipse.kura.nm.configuration.NMConfigurationServiceImpl.getTrustedCertificateFromKeystore(NMConfigurationServiceImpl.java:382)
	at org.eclipse.kura.nm.configuration.NMConfigurationServiceImpl.findAndDecodeCertificatesForInterface(NMConfigurationServiceImpl.java:358)
	at org.eclipse.kura.nm.configuration.NMConfigurationServiceImpl.lambda$0(NMConfigurationServiceImpl.java:329)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.eclipse.kura.nm.configuration.NMConfigurationServiceImpl.decryptAndConvertCertificatesProperties(NMConfigurationServiceImpl.java:320)
	at org.eclipse.kura.nm.configuration.NMConfigurationServiceImpl.update(NMConfigurationServiceImpl.java:242)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.apache.felix.scr.impl.inject.methods.BaseMethod.invokeMethod(BaseMethod.java:228)
	at org.apache.felix.scr.impl.inject.methods.BaseMethod.access$500(BaseMethod.java:41)
	at org.apache.felix.scr.impl.inject.methods.BaseMethod$Resolved.invoke(BaseMethod.java:664)
	at org.apache.felix.scr.impl.inject.methods.BaseMethod.invoke(BaseMethod.java:510)
	at org.apache.felix.scr.impl.inject.methods.ActivateMethod.invoke(ActivateMethod.java:317)
	at org.apache.felix.scr.impl.inject.methods.ActivateMethod.invoke(ActivateMethod.java:307)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.invokeModifiedMethod(SingleComponentManager.java:836)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.modify(SingleComponentManager.java:791)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.reconfigure(SingleComponentManager.java:709)
	at org.apache.felix.scr.impl.manager.SingleComponentManager.reconfigure(SingleComponentManager.java:673)
	at org.apache.felix.scr.impl.manager.ConfigurableComponentHolder.configurationUpdated(ConfigurableComponentHolder.java:435)
	at org.apache.felix.scr.impl.manager.RegionConfigurationSupport.configurationEvent(RegionConfigurationSupport.java:316)
	at org.apache.felix.scr.impl.manager.RegionConfigurationSupport$2.configurationEvent(RegionConfigurationSupport.java:118)
	at org.eclipse.equinox.internal.cm.EventDispatcher$1.run(EventDispatcher.java:92)
	at org.eclipse.equinox.internal.cm.SerializedTaskQueue$1.run(SerializedTaskQueue.java:40)
```

The error is due to a wrong implementation of the Certificate decryption stage in the [NMConfigurationServiceImpl](https://github.com/eclipse/kura/blob/f4994ee59d78d68f6a98cc04eb805ddc45039fe0/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java#L318).

In the [findAndDecodeCertificatesForInterface](https://github.com/eclipse/kura/blob/f4994ee59d78d68f6a98cc04eb805ddc45039fe0/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java#L336), the case in which the ca-cert-name is an empty string, was not taken into account. Leaving the field blank falls into this case and result in the error reported.

### Changelog

This PR:
- updates the code to take into account the empty string case in the NMConfigurationServiceImpl:findAndDecodeCertificatesForInterface method (see [here](https://github.com/eclipse/kura/blob/db9add1eb494265554e26ba3daf8afb42f2e824b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java#L351))
- additionally, fixes an issue in the `NetworkProperties` class which was not taking into account the case in which the Map contained the requested element but it was of the wrong type. By updating it, it is now much clearer that the CA cert is **optional** in the code (we can now use `getOpt` correctly)

It would be nice to have some feedback on the changes I made to the `NetworkProperties`: it's quite a delicate thing and want to ensure the criteria is sound before committing (pun intended) to it.