### PR TITLE
fix(nm): remove unusable 802.1x password parameters

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -204,14 +204,7 @@ public class NMSettingsConverter {
         } else {
             logger.error("Unable to decode Private Key for interface \"{}\"", deviceId);
         }
-
-        Optional<Password> privateKeyPassword = props.getOpt(Password.class,
-                "net.interface.%s.config.802-1x.private-key-password", deviceId);
-
-        privateKeyPassword.ifPresent(value -> settings.put("private-key-password", new Variant<>(value.toString())));
-
         settings.put("private-key-password-flags", new Variant<>(NM_SECRET_FLAGS_NOT_REQUIRED));
-
     }
 
     private static void create8021xOptionalCaCertAndAnonIdentity(NetworkProperties props, String deviceId,
@@ -230,10 +223,6 @@ public class NMSettingsConverter {
                 logger.warn("Unable to decode CA Certificate for interface \"{}\", caused by: ", deviceId, e);
             }
         });
-
-        Optional<Password> caCertPassword = props.getOpt(Password.class,
-                "net.interface.%s.config.802-1x.ca-cert-password", deviceId);
-        caCertPassword.ifPresent(value -> settings.put("ca-cert-password", new Variant<>(value.toString())));
     }
 
     private static void create8021xMschapV2(NetworkProperties props, String deviceId,

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -567,7 +567,6 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.802-1x.anonymous-identity", "anonymous-identity-test-var");
         givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-name",
                 buildMockedCertificateWithCert("binary ca cert"));
-        givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-password", new Password("secure-password"));
         givenMapWith("net.interface.wlan0.config.802-1x.identity", "example-user-name");
         givenMapWith("net.interface.wlan0.config.802-1x.password", new Password("secure-test-password-123!@#"));
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
@@ -580,10 +579,10 @@ public class NMSettingsConverterTest {
         thenResultingMapContains("phase2-auth", "mschapv2");
         thenResultingMapContains("anonymous-identity", "anonymous-identity-test-var");
         thenResultingMapContainsBytes("ca-cert", "binary ca cert");
-        thenResultingMapContains("ca-cert-password", "secure-password");
         thenResultingMapContains("identity", "example-user-name");
         thenResultingMapContains("password", "secure-test-password-123!@#");
 
+        thenResultingMapNotContains("ca-cert-password");
     }
 
     @Test
@@ -599,12 +598,13 @@ public class NMSettingsConverterTest {
         thenNoExceptionOccurred();
 
         thenResultingMapContainsArray("eap", new Variant<>(new String[] { "peap" }).getValue());
-        thenResultingMapNotContains("anonymous-identity");
-        thenResultingMapNotContains("ca-cert");
-        thenResultingMapNotContains("ca-cert-password");
         thenResultingMapContains("phase2-auth", "mschapv2");
         thenResultingMapContains("identity", "example-user-name");
         thenResultingMapContains("password", "secure-test-password-123!@#");
+
+        thenResultingMapNotContains("anonymous-identity");
+        thenResultingMapNotContains("ca-cert");
+        thenResultingMapNotContains("ca-cert-password");
     }
 
     @Test
@@ -613,7 +613,6 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.802-1x.anonymous-identity", "anonymous-identity-test-var");
         givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-name",
                 buildMockedCertificateWithCert("binary ca cert"));
-        givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-password", new Password("secure-password"));
         givenMapWith("net.interface.wlan0.config.802-1x.innerAuth", "Kura8021xInnerAuthMschapv2");
         givenMapWith("net.interface.wlan0.config.802-1x.identity", "example-user-name");
         givenMapWith("net.interface.wlan0.config.802-1x.password", new Password("secure-test-password-123!@#"));
@@ -626,10 +625,11 @@ public class NMSettingsConverterTest {
         thenResultingMapContainsArray("eap", new Variant<>(new String[] { "peap" }).getValue());
         thenResultingMapContains("anonymous-identity", "anonymous-identity-test-var");
         thenResultingMapContainsBytes("ca-cert", "binary ca cert");
-        thenResultingMapContains("ca-cert-password", "secure-password");
         thenResultingMapContains("phase2-auth", "mschapv2");
         thenResultingMapContains("identity", "example-user-name");
         thenResultingMapContains("password", "secure-test-password-123!@#");
+
+        thenResultingMapNotContains("ca-cert-password");
     }
 
     @Test
@@ -652,7 +652,6 @@ public class NMSettingsConverterTest {
                 buildMockedCertificateWithCert("binary client cert"));
         givenMapWith("net.interface.wlan0.config.802-1x.private-key-name",
                 buildMockedPrivateKeyWithKey("binary private key"));
-        givenMapWith("net.interface.wlan0.config.802-1x.private-key-password", new Password("secure-password"));
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuild8021xSettingsIsRunWith(this.networkProperties, "wlan0");
@@ -666,7 +665,10 @@ public class NMSettingsConverterTest {
         thenResultingMapContainsBytes("client-cert", "binary client cert");
         thenResultingMapContainsBytes("private-key",
                 "-----BEGIN PRIVATE KEY-----\nYmluYXJ5IHByaXZhdGUga2V5\n-----END PRIVATE KEY-----\n");
-        thenResultingMapContains("private-key-password", "secure-password");
+
+        thenResultingMapNotContains("private-key-password");
+        thenResultingMapNotContains("ca-cert-password");
+        thenResultingMapNotContains("client-cert-password");
     }
 
     @Test
@@ -679,7 +681,6 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.802-1x.client-cert-name",
                 buildMockedCertificateWithCert("binary client cert"));
         givenMapWith("net.interface.wlan0.config.802-1x.private-key-name", null);
-        givenMapWith("net.interface.wlan0.config.802-1x.private-key-password", new Password("secure-password"));
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuild8021xSettingsIsRunWith(this.networkProperties, "wlan0");
@@ -697,7 +698,6 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.802-1x.client-cert-name",
                 buildMockedCertificateWithCert("binary client cert"));
         givenMapWith("net.interface.wlan0.config.802-1x.private-key-name", "");
-        givenMapWith("net.interface.wlan0.config.802-1x.private-key-password", new Password("secure-password"));
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuild8021xSettingsIsRunWith(this.networkProperties, "wlan0");
@@ -715,7 +715,6 @@ public class NMSettingsConverterTest {
                 buildMockedCertificateWithCert("binary client cert"));
         givenMapWith("net.interface.wlan0.config.802-1x.private-key-name",
                 buildMockedPrivateKeyWithKey("binary private key"));
-        givenMapWith("net.interface.wlan0.config.802-1x.private-key-password", new Password("secure-password"));
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuild8021xSettingsIsRunWith(this.networkProperties, "wlan0");
@@ -727,10 +726,12 @@ public class NMSettingsConverterTest {
         thenResultingMapContainsBytes("client-cert", "binary client cert");
         thenResultingMapContainsBytes("private-key",
                 "-----BEGIN PRIVATE KEY-----\nYmluYXJ5IHByaXZhdGUga2V5\n-----END PRIVATE KEY-----\n");
-        thenResultingMapContains("private-key-password", "secure-password");
 
         thenResultingMapNotContains("phase2-auth");
         thenResultingMapNotContains("ca-cert");
+        thenResultingMapNotContains("private-key-password");
+        thenResultingMapNotContains("ca-cert-password");
+        thenResultingMapNotContains("client-cert-password");
     }
 
     @Test
@@ -744,7 +745,6 @@ public class NMSettingsConverterTest {
                 buildMockedCertificateWithCert("binary client cert"));
         givenMapWith("net.interface.wlan0.config.802-1x.private-key-name",
                 buildMockedPrivateKeyWithKey("binary private key"));
-        givenMapWith("net.interface.wlan0.config.802-1x.private-key-password", new Password("secure-password"));
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuild8021xSettingsIsRunWith(this.networkProperties, "wlan0");
@@ -756,10 +756,12 @@ public class NMSettingsConverterTest {
         thenResultingMapContainsBytes("client-cert", "binary client cert");
         thenResultingMapContainsBytes("private-key",
                 "-----BEGIN PRIVATE KEY-----\nYmluYXJ5IHByaXZhdGUga2V5\n-----END PRIVATE KEY-----\n");
-        thenResultingMapContains("private-key-password", "secure-password");
 
         thenResultingMapNotContains("phase2-auth");
         thenResultingMapNotContains("ca-cert");
+        thenResultingMapNotContains("private-key-password");
+        thenResultingMapNotContains("ca-cert-password");
+        thenResultingMapNotContains("client-cert-password");
     }
 
     @Test
@@ -1447,7 +1449,6 @@ public class NMSettingsConverterTest {
         givenMapWith("net.interface.wlan0.config.802-1x.anonymous-identity", "anonymous-identity-test-var");
         givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-name",
                 buildMockedCertificateWithCert("binary ca cert"));
-        givenMapWith("net.interface.wlan0.config.802-1x.ca-cert-password", new Password("secure-password"));
         givenMapWith("net.interface.wlan0.config.802-1x.identity", "example-user-name");
         givenMapWith("net.interface.wlan0.config.802-1x.password", new Password("secure-test-password-123!@#"));
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
@@ -1472,7 +1473,6 @@ public class NMSettingsConverterTest {
         thenResultingBuildAllMapContains("802-1x", "phase2-auth", "mschapv2");
         thenResultingBuildAllMapContains("802-1x", "anonymous-identity", "anonymous-identity-test-var");
         thenResultingBuildAllMapContainsBytes("802-1x", "ca-cert", "binary ca cert");
-        thenResultingBuildAllMapContains("802-1x", "ca-cert-password", "secure-password");
         thenResultingBuildAllMapContains("802-1x", "identity", "example-user-name");
         thenResultingBuildAllMapContains("802-1x", "password", "secure-test-password-123!@#");
     }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -1475,6 +1475,8 @@ public class NMSettingsConverterTest {
         thenResultingBuildAllMapContainsBytes("802-1x", "ca-cert", "binary ca cert");
         thenResultingBuildAllMapContains("802-1x", "identity", "example-user-name");
         thenResultingBuildAllMapContains("802-1x", "password", "secure-test-password-123!@#");
+
+        thenResultingBuildAllMapNotContains("802-1x", "ca-cert-password");
     }
 
     @Test


### PR DESCRIPTION
Currently, we allow the user to set the CA cert and private key passwords in the snapshot via the following optional snapshot parameters (they are not exposed in the UI):

- `net.interface.%s.config.802-1x.private-key-password`: see [here](https://github.com/eclipse/kura/blob/990fc4dc790985389c68a5e9473f92ac65777ee4/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java#L215)
- `net.interface.%s.config.802-1x.ca-cert-password`: see [here](https://github.com/eclipse/kura/blob/990fc4dc790985389c68a5e9473f92ac65777ee4/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java#L237)

These are mapped [to NetworkManager’s](https://networkmanager.dev/docs/api/latest/settings-802-1x.html):
- `private-key-password`: The password used to decrypt the private key specified in the "private-key" property when the private key either uses the path scheme, or if the private key is a PKCS#12 format key.
- `ca-cert-password`: The password used to access the CA certificate stored in "ca-cert" property. Only makes sense if the certificate is stored on a PKCS#11 token that requires a login.

This is wrong because, since we’re using the Kura Keystore to store the keys we:
- don't support password-protected keys 
- keys are returned in the PKCS#8 format

Therefore these settings **can’t be used**.

In addition to that, to solve Issue-6767 "[NetworkManager][802.1x] Authentication keys are saved in cleartext on filesystem by NetworkManager" we need to use the `private-key-password` parameter and cannot allow the user to override this field.

Fortunately(!?) we didn’t document any of the 802.1x parameters in the [docs](https://eclipse.github.io/kura/docs-release-5.4/gateway-configuration/network-configuration/)

After a discussion we @MMaiero we decided to remove any use of these parameters in our current codebase since they were *optional* and *undocumented*.