### PR TITLE
fix: Network Advanced tab positioning

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/NetworkTabsUi.java
@@ -287,11 +287,13 @@ public class NetworkTabsUi extends Composite {
 
         if (this.isNet2) {
             insertTab(this.ip6TabAnchorItem);
-            insertTab(this.advancedTabAnchorItem);
         }
 
         arrangeOptionalTabs();
 
+        if (this.isNet2) {
+            insertTab(this.advancedTabAnchorItem);
+        }
         insertTab(this.hardwareTabAnchorItem);
     }
 


### PR DESCRIPTION
Moved the advanced tab before the hardware one.
This would simplify the user interaction as it is expected to be less opened than the other tabs in networking.
