### PR TITLE
refactor(sparkplug): applied State pattern to SparkplugMqttClient, fixed onConnectionLost status reset

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/transport/SparkplugDataTransport.java
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/transport/SparkplugDataTransport.java
@@ -230,8 +230,8 @@ public class SparkplugDataTransport implements ConfigurableComponent, DataTransp
     @Override
     public void connectionLost(Throwable arg0) {
         logger.info("{} - Connection lost", this.kuraServicePid);
+        this.client.handleConnectionLost();
         this.dataTransportListeners.forEach(listener -> callSafely(listener::onConnectionLost, arg0));
-
     }
 
     @Override

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/transport/SparkplugDataTransport.java
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/transport/SparkplugDataTransport.java
@@ -140,7 +140,7 @@ public class SparkplugDataTransport implements ConfigurableComponent, DataTransp
             throw new IllegalStateException("MQTT client is already connected");
         }
 
-        this.client.estabilishSession(true);
+        this.client.establishSession(true);
 
         stopExecutorService();
         this.executorService = Executors.newSingleThreadExecutor();
@@ -149,7 +149,7 @@ public class SparkplugDataTransport implements ConfigurableComponent, DataTransp
 
     @Override
     public boolean isConnected() {
-        return Objects.nonNull(this.client) && this.client.isSessionEstabilished();
+        return Objects.nonNull(this.client) && this.client.isSessionEstablished();
     }
 
     @Override

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/transport/SparkplugMqttClient.java
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/transport/SparkplugMqttClient.java
@@ -75,7 +75,7 @@ public class SparkplugMqttClient {
 
     private abstract class SessionStatus {
 
-        public abstract SessionStatus estabilishSession(boolean shouldConnectClient) throws KuraConnectException;
+        public abstract SessionStatus establishSession(boolean shouldConnectClient) throws KuraConnectException;
 
         public abstract SessionStatus terminateSession(boolean shouldDisconnectClient, long quiesceTimeout);
 
@@ -218,7 +218,7 @@ public class SparkplugMqttClient {
     private class Terminated extends SessionStatus {
 
         @Override
-        public SessionStatus estabilishSession(boolean shouldConnectClient) throws KuraConnectException {
+        public SessionStatus establishSession(boolean shouldConnectClient) throws KuraConnectException {
             return toEstabilishing(shouldConnectClient);
         }
 
@@ -237,7 +237,7 @@ public class SparkplugMqttClient {
     private class Estabilishing extends SessionStatus {
 
         @Override
-        public SessionStatus estabilishSession(boolean shouldConnectClient) throws KuraConnectException {
+        public SessionStatus establishSession(boolean shouldConnectClient) throws KuraConnectException {
             return this;
         }
 
@@ -256,7 +256,7 @@ public class SparkplugMqttClient {
     private class Estabilished extends SessionStatus {
 
         @Override
-        public SessionStatus estabilishSession(boolean shouldConnectClient) throws KuraConnectException {
+        public SessionStatus establishSession(boolean shouldConnectClient) throws KuraConnectException {
             return this;
         }
 
@@ -309,7 +309,7 @@ public class SparkplugMqttClient {
 
     public synchronized void estabilishSession(boolean shouldConnectClient) throws KuraConnectException {
         logger.debug("Requested session estabilishment");
-        doSessionTransition(this.sessionStatus.estabilishSession(shouldConnectClient));
+        doSessionTransition(this.sessionStatus.establishSession(shouldConnectClient));
     }
     
     public synchronized void terminateSession(boolean shouldDisconnectClient, long quiesceTimeout) {


### PR DESCRIPTION
This PR applies the State design pattern to the `SparkplugMqttClient` class. In addition, it fixes the behavior in which `onConnectionLost` callback was not setting the state to terminated, leaving the client unable to connect again.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
