### PR TITLE
build(wire.script.tools): updated GraalVM deps from 21.3.5 to 21.3.9

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -191,13 +191,13 @@ This project leverages the following third party content.
 * maven/mavencentral/org.gwtproject/gwt-user/2.10.0, Apache-2.0 AND CC0-1.0, approved, #4958
 * maven/mavencentral/org.gwtbootstrap3/gwtbootstrap3/1.0.1, Apache-2.0 AND MIT AND OFL-1.1, approved, #2020
 * maven/mavencentral/org.xerial/sqlite-jdbc/3.42.0.0, Apache-2.0 AND BSD-2-Clause AND ISC AND Artistic-2.0, approved, #9089
-* maven/mavencentral/org.graalvm.js/js/21.3.5, UPL-1.0 AND (UPL-1.0 AND GPL-2.0-only WITH Classpath-exception-2.0) AND BSD-3-Clause AND MPL-2.0, approved, #6714
-* maven/mavencentral/org.graalvm.js/js-scriptengine/21.3.5, UPL-1.0, approved, #6715
-* maven/mavencentral/org.graalvm.js/js-launcher/21.3.5, UPL-1.0, approved, #6716
-* maven/mavencentral/org.graalvm.sdk/graal-sdk/21.3.5, UPL-1.0, approved, #6717
-* maven/mavencentral/org.graalvm.truffle/truffle-api/21.3.5, UPL-1.0, approved, #6718
-* maven/mavencentral/org.graalvm.regex/regex/21.3.5, UPL-1.0 AND Unicode-TOU, approved, #6719
-* maven/mavencentral/org.graalvm.sdk/launcher-common/21.3.5, UPL-1.0, approved, #6720
+* maven/mavencentral/org.graalvm.js/js/21.3.9, UPL-1.0 AND (UPL-1.0 AND GPL-2.0-only WITH Classpath-exception-2.0) AND BSD-3-Clause AND MPL-2.0, approved, #6714
+* maven/mavencentral/org.graalvm.js/js-scriptengine/21.3.9, UPL-1.0, approved, #6715
+* maven/mavencentral/org.graalvm.js/js-launcher/21.3.9, UPL-1.0, approved, #6716
+* maven/mavencentral/org.graalvm.sdk/graal-sdk/21.3.9, UPL-1.0, approved, #6717
+* maven/mavencentral/org.graalvm.truffle/truffle-api/21.3.9, UPL-1.0, approved, #6718
+* maven/mavencentral/org.graalvm.regex/regex/21.3.9, UPL-1.0 AND Unicode-TOU, approved, #6719
+* maven/mavencentral/org.graalvm.sdk/launcher-common/21.3.9, UPL-1.0, approved, #6720
 * maven/mavencentral/com.ibm.icu/icu4j/72.1, ICU, approved, #4354
 * maven/mavencentral/com.github.hypfvieh/dbus-java/3.3.2, MIT, approved, CQ23190
 * maven/mavencentral/com.github.jnr/jffi/1.3.9, Apache-2.0 OR LGPL-3.0-or-later, approved, CQ23196

--- a/kura/org.eclipse.kura.wire.script.tools/pom.xml
+++ b/kura/org.eclipse.kura.wire.script.tools/pom.xml
@@ -26,7 +26,7 @@
     <packaging>eclipse-plugin</packaging>
 
     <properties>
-        <graalvm.version>21.3.5</graalvm.version>
+        <graalvm.version>21.3.9</graalvm.version>
         <kura.basedir>${project.basedir}/..</kura.basedir>
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../test/org.eclipse.kura.wire.script.tools.test/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -916,6 +916,7 @@
         <module>org.eclipse.kura.wire.component.provider.test</module>
         <module>org.eclipse.kura.wire.h2db.component.provider.test</module>
         <module>org.eclipse.kura.wire.db.component.provider.test</module>
+        <module>org.eclipse.kura.wire.script.tools</module>
         <module>org.eclipse.kura.wire.provider.test</module>
         <module>org.eclipse.kura.json.marshaller.unmarshaller.provider.test</module>
         <module>org.eclipse.kura.xml.marshaller.unmarshaller.provider.test</module>

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -916,7 +916,7 @@
         <module>org.eclipse.kura.wire.component.provider.test</module>
         <module>org.eclipse.kura.wire.h2db.component.provider.test</module>
         <module>org.eclipse.kura.wire.db.component.provider.test</module>
-        <module>org.eclipse.kura.wire.script.tools</module>
+        <module>org.eclipse.kura.wire.script.tools.test</module>
         <module>org.eclipse.kura.wire.provider.test</module>
         <module>org.eclipse.kura.json.marshaller.unmarshaller.provider.test</module>
         <module>org.eclipse.kura.xml.marshaller.unmarshaller.provider.test</module>


### PR DESCRIPTION
This PR updates the GraalVM dependencies of `org.eclipse.kura.wire.script.tools`. The following points hold:

- The source, test and feature compile on both Java 8 and Java 17;
- The DP is working on both Java 8 and Java 17 powered Raspberry Pi 4;
- The produced DP increased its size from 24.9 MB to 33.9 MB;
- The choosen version (21.3.x) is the only one that compiles on both Java 8 and 17.

**Related Issue:** This PR fixes [CVE-2024-20918](https://nvd.nist.gov/vuln/detail/CVE-2024-20918).

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:**:

- Updated `NOTICE` file with results from the Eclipse [dash-licenses](https://github.com/eclipse/dash-licenses) tool.
- Updated tests pom with missing module
