### PR TITLE
test(packages.provider): remove unnecessary dependencies from IT

### DIFF
--- a/kura/test/org.eclipse.kura.rest.packages.provider.test/pom.xml
+++ b/kura/test/org.eclipse.kura.rest.packages.provider.test/pom.xml
@@ -409,31 +409,6 @@
                             <autoStart>true</autoStart>
                         </bundle>
                         <bundle>
-                            <id>org.eclipse.kura.wire.provider</id>
-                            <level>4</level>
-                            <autoStart>true</autoStart>
-                        </bundle>
-                        <bundle>
-                            <id>org.eclipse.kura.wire.helper.provider</id>
-                            <level>4</level>
-                            <autoStart>true</autoStart>
-                        </bundle>
-                        <bundle>
-                            <id>org.eclipse.kura.wire.component.provider</id>
-                            <level>4</level>
-                            <autoStart>true</autoStart>
-                        </bundle>
-                        <bundle>
-                            <id>org.eclipse.kura.wire.script.filter.provider</id>
-                            <level>4</level>
-                            <autoStart>true</autoStart>
-                        </bundle>
-                        <bundle>
-                            <id>org.eclipse.kura.protocol.can</id>
-                            <level>4</level>
-                            <autoStart>true</autoStart>
-                        </bundle>
-                        <bundle>
                             <id>org.eclipse.kura.broker.artemis.core</id>
                             <level>4</level>
                             <autoStart>true</autoStart>

--- a/kura/test/org.eclipse.kura.rest.packages.provider.test/pom.xml
+++ b/kura/test/org.eclipse.kura.rest.packages.provider.test/pom.xml
@@ -610,21 +610,6 @@
                             </requirement>
                             <requirement>
                                 <type>eclipse-plugin</type>
-                                <id>org.eclipse.kura.wire.provider</id>
-                                <versionRange>0.0.0</versionRange>
-                            </requirement>
-                            <requirement>
-                                <type>eclipse-plugin</type>
-                                <id>org.eclipse.kura.wire.helper.provider</id>
-                                <versionRange>0.0.0</versionRange>
-                            </requirement>
-                            <requirement>
-                                <type>eclipse-plugin</type>
-                                <id>org.eclipse.kura.wire.component.provider</id>
-                                <versionRange>0.0.0</versionRange>
-                            </requirement>
-                            <requirement>
-                                <type>eclipse-plugin</type>
                                 <id>org.eclipse.kura.xml.marshaller.unmarshaller.provider</id>
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
@@ -671,11 +656,6 @@
                             <requirement>
                                 <type>eclipse-plugin</type>
                                 <id>org.eclipse.kura.deployment.agent</id>
-                                <versionRange>0.0.0</versionRange>
-                            </requirement>
-                            <requirement>
-                                <type>eclipse-plugin</type>
-                                <id>org.eclipse.kura.wire.script.filter.provider</id>
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
                             <requirement>


### PR DESCRIPTION
**Related Issue:** This PR fixes/closes #5116

**Description of the solution adopted:** Removed unnecessary requirements from `rest.packages.provider` integration tests.

**Manual Tests**: 

Performed a full build on Ubuntu 22.04LTS with:

```
Apache Maven 3.6.3
Maven home: /usr/share/maven
Java version: 17.0.2, vendor: Private Build, runtime: /usr/lib/jvm/java-17-openjdk-amd64
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "6.5.11-7-pve", arch: "amd64", family: "unix"
```

@alexcorvis84 feel free to drop by and give it a spin if you want ;)