### PR TITLE
feat(sparkplug): added SparkplugSubscriber

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/OSGI-INF/SparkplugSubscriber.xml
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/OSGI-INF/SparkplugSubscriber.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+      SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Eurotech
+
+-->
+<scr:component  xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+                configuration-policy="require"
+                activate="activate"
+                deactivate="deactivate"
+                modified="update"
+                enabled="true"
+                immediate="true"
+                name="org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber">
+
+    <implementation class="org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber"/>
+
+    <service>
+        <provide interface="org.eclipse.kura.cloudconnection.subscriber.CloudSubscriber"/>
+        <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
+    </service>
+
+    <property name="service.pid" type="String" value="org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber"/>
+    <property name="cloud.connection.factory.pid" type="String" value="org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint.SparkplugCloudEndpoint"/>
+    <property name="kura.ui.service.hide" type="Boolean" value="true"/>
+    <property name="kura.ui.factory.hide" type="String" value="true"/>
+
+</scr:component>

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber.xml
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/OSGI-INF/metatype/org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+ 
+      SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Eurotech
+
+-->
+<MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">
+
+    <OCD id="org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber"
+         name="SparkplugSubscriber"
+         description="Component that serves as a CloudSubscriber for this Sparkplug Cloud Connection.">
+
+         <AD id="topic.filter"
+             name="Topic Filter"
+             type="String"
+             cardinality="0"
+             required="true"
+             default="A/B/C"
+             description="The MQTT subscription topic filter. For example foo/bar/baz, foo/+/bar, #, foo/#."/>
+
+         <AD id="qos"
+             name="QoS"
+             type="Integer"
+             cardinality="0"
+             required="true"
+             default="0"
+             description="The maximum desired quality of service for the subscription messages.">
+
+             <Option label="QoS 0 - at most once" value="0" />
+             <Option label="QoS 1 - at least once" value="1" />
+             <Option label="QoS 2 - exactly once" value="2" />
+         </AD>
+
+    </OCD>
+
+    <Designate pid="org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber"
+               factoryPid="org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber">
+        <Object ocdref="org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber"/>
+    </Designate>
+</MetaData>

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/SubscriptionRecord.java
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/SubscriptionRecord.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint;
+
+import org.eclipse.paho.client.mqttv3.MqttTopic;
+
+public class SubscriptionRecord {
+
+    private final String topicFilter;
+    private final Integer qos;
+
+    public SubscriptionRecord(String topicFilter, int qos) {
+        this.topicFilter = topicFilter;
+        this.qos = qos;
+    }
+
+    public String getTopicFilter() {
+        return this.topicFilter;
+    }
+
+    public Integer getQos() {
+        return this.qos;
+    }
+
+    public boolean matches(String topic, int qos) {
+        return this.qos <= qos && MqttTopic.isMatched(this.topicFilter, topic);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof SubscriptionRecord)) {
+            return false;
+        }
+
+        SubscriptionRecord otherRecord = (SubscriptionRecord) other;
+
+        return otherRecord.getTopicFilter().equals(this.topicFilter) && otherRecord.getQos().equals(this.qos);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 7;
+        int result = 1;
+        result = prime * result + this.topicFilter.hashCode();
+        result = prime * result + this.qos.hashCode();
+        return result;
+    }
+
+}

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/SubscriptionsMap.java
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/SubscriptionsMap.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.eclipse.kura.cloudconnection.subscriber.listener.CloudSubscriberListener;
+
+public class SubscriptionsMap {
+
+    private Map<SubscriptionRecord, Set<CloudSubscriberListener>> subscriptions = new HashMap<>();
+
+    public void add(String topicFilter, int qos, CloudSubscriberListener listener) {
+        SubscriptionRecord subscription = new SubscriptionRecord(topicFilter, qos);
+
+        Set<CloudSubscriberListener> listeners = this.subscriptions.computeIfAbsent(subscription,
+                key -> new CopyOnWriteArraySet<CloudSubscriberListener>());
+
+        listeners.add(listener);
+    }
+
+    public List<String> remove(CloudSubscriberListener listener) {
+        List<String> topicsToUnsubscribe = new ArrayList<>();
+
+        this.subscriptions.entrySet().removeIf(entry -> {
+            entry.getValue().remove(listener);
+
+            if (entry.getValue().isEmpty()) {
+                topicsToUnsubscribe.add(entry.getKey().getTopicFilter());
+                return true;
+            }
+
+            return false;
+        });
+
+        return topicsToUnsubscribe;
+    }
+
+    public List<CloudSubscriberListener> getMatchingListeners(String topic, int qos) {
+        List<CloudSubscriberListener> result = new ArrayList<>();
+
+        this.subscriptions.forEach((subscription, listeners) -> {
+            if (subscription.matches(topic, qos)) {
+                result.addAll(listeners);
+            }
+        });
+
+        return result;
+    }
+
+    public Set<SubscriptionRecord> getSubscriptionRecords() {
+        return this.subscriptions.keySet();
+    }
+
+
+}

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/subscriber/SparkplugSubscriber.java
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/subscriber/SparkplugSubscriber.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.eclipse.kura.cloudconnection.CloudConnectionConstants;
+import org.eclipse.kura.cloudconnection.listener.CloudConnectionListener;
+import org.eclipse.kura.cloudconnection.message.KuraMessage;
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint.SparkplugCloudEndpoint;
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.utils.InvocationUtils;
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.utils.SparkplugCloudEndpointTracker;
+import org.eclipse.kura.cloudconnection.subscriber.CloudSubscriber;
+import org.eclipse.kura.cloudconnection.subscriber.listener.CloudSubscriberListener;
+import org.eclipse.kura.configuration.ConfigurableComponent;
+import org.eclipse.kura.configuration.ConfigurationService;
+import org.eclipse.paho.client.mqttv3.MqttTopic;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SparkplugSubscriber
+        implements ConfigurableComponent, CloudSubscriber, CloudSubscriberListener, CloudConnectionListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(SparkplugSubscriber.class);
+
+    public static final String KEY_TOPIC_FILTER = "topic.filter";
+    public static final String KEY_QOS = "qos";
+
+    private Optional<SparkplugCloudEndpoint> sparkplugCloudEndpoint = Optional.empty();
+    private SparkplugCloudEndpointTracker endpointTracker;
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+    private Set<CloudSubscriberListener> cloudSubscriberListeners = new CopyOnWriteArraySet<>();
+    private Set<CloudConnectionListener> cloudConnectionListeners = new CopyOnWriteArraySet<>();
+
+    private String kuraServicePid;
+    private String topicFilter;
+    private int qos;
+
+    /*
+     * Activation APIs
+     */
+
+    public void activate(final ComponentContext componentContext, final Map<String, Object> properties)
+            throws InvalidSyntaxException {
+        this.kuraServicePid = (String) properties.get(ConfigurationService.KURA_SERVICE_PID);
+
+        logger.info("{} - Activating", this.kuraServicePid);
+
+        String endpointPid = (String) properties
+                .get(CloudConnectionConstants.CLOUD_ENDPOINT_SERVICE_PID_PROP_NAME.value());
+
+        this.endpointTracker = new SparkplugCloudEndpointTracker(componentContext.getBundleContext(),
+                this::setSparkplugCloudEndpoint, this::unsetSparkplugCloudEndpoint, endpointPid);
+        update(properties);
+
+        logger.info("{} - Activated", this.kuraServicePid);
+    }
+
+    public void update(final Map<String, Object> properties) throws InvalidSyntaxException {
+        logger.info("{} - Updating", this.kuraServicePid);
+
+        this.topicFilter = (String) properties.get(KEY_TOPIC_FILTER);
+        this.qos = (int) properties.get(KEY_QOS);
+        MqttTopic.validate(this.topicFilter, true);
+
+        this.endpointTracker.stopEndpointTracker();
+        this.endpointTracker.startEndpointTracker();
+
+        logger.info("{} - Updated", this.kuraServicePid);
+    }
+
+    public void deactivate() {
+        logger.info("{} - Deactivating", this.kuraServicePid);
+
+        this.endpointTracker.stopEndpointTracker();
+
+        logger.debug("{} - Shutting down executor service", this.kuraServicePid);
+        this.executorService.shutdownNow();
+
+        logger.info("{} - Deactivated", this.kuraServicePid);
+    }
+
+    /*
+     * CloudSubscriber APIs
+     */
+
+    @Override
+    public void registerCloudSubscriberListener(CloudSubscriberListener listener) {
+        this.cloudSubscriberListeners.add(listener);
+    }
+
+    @Override
+    public void unregisterCloudSubscriberListener(CloudSubscriberListener listener) {
+        this.cloudSubscriberListeners.remove(listener);
+    }
+
+    @Override
+    public void registerCloudConnectionListener(CloudConnectionListener cloudConnectionListener) {
+        this.cloudConnectionListeners.add(cloudConnectionListener);
+    }
+
+    @Override
+    public void unregisterCloudConnectionListener(CloudConnectionListener cloudConnectionListener) {
+        this.cloudConnectionListeners.remove(cloudConnectionListener);
+    }
+
+    /*
+     * CloudSubscriberListener APIs
+     */
+
+    @Override
+    public void onMessageArrived(KuraMessage message) {
+        this.cloudSubscriberListeners.forEach(listener -> this.executorService
+                .execute(() -> InvocationUtils.callSafely(listener::onMessageArrived, message)));
+    }
+
+    /*
+     * CloudConnectionListener APIs
+     */
+
+    @Override
+    public void onDisconnected() {
+        this.cloudConnectionListeners.forEach(
+                listener -> this.executorService.execute(() -> InvocationUtils.callSafely(listener::onDisconnected)));
+    }
+
+    @Override
+    public void onConnectionLost() {
+        this.cloudConnectionListeners.forEach(
+                listener -> this.executorService.execute(() -> InvocationUtils.callSafely(listener::onConnectionLost)));
+    }
+
+    @Override
+    public void onConnectionEstablished() {
+        this.cloudConnectionListeners.forEach(listener -> this.executorService
+                .execute(() -> InvocationUtils.callSafely(listener::onConnectionEstablished)));
+    }
+
+    /*
+     * Utils
+     */
+
+    private synchronized void setSparkplugCloudEndpoint(SparkplugCloudEndpoint endpoint) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(KEY_TOPIC_FILTER, this.topicFilter);
+        properties.put(KEY_QOS, this.qos);
+
+        this.sparkplugCloudEndpoint = Optional.of(endpoint);
+        this.sparkplugCloudEndpoint.get().registerSubscriber(properties, this);
+    }
+
+    private synchronized void unsetSparkplugCloudEndpoint(SparkplugCloudEndpoint endpoint) {
+        if (this.sparkplugCloudEndpoint.isPresent() && this.sparkplugCloudEndpoint.get() == endpoint) {
+            this.sparkplugCloudEndpoint.get().unregisterSubscriber(this);
+            this.sparkplugCloudEndpoint = Optional.empty();
+        }
+    }
+
+}

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/transport/SparkplugMqttClient.java
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/transport/SparkplugMqttClient.java
@@ -27,6 +27,7 @@ import javax.net.SocketFactory;
 import org.eclipse.kura.KuraConnectException;
 import org.eclipse.kura.cloudconnection.sparkplug.mqtt.message.SparkplugPayloads;
 import org.eclipse.kura.cloudconnection.sparkplug.mqtt.message.SparkplugTopics;
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.utils.InvocationUtils;
 import org.eclipse.kura.data.transport.listener.DataTransportListener;
 import org.eclipse.kura.ssl.SslManagerService;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
@@ -106,7 +107,7 @@ public class SparkplugMqttClient {
         SessionStatus toTerminated(boolean shouldDisconnectClient, long quiesceTimeout) {
             try {
                 SparkplugMqttClient.this.listeners
-                        .forEach(listener -> SparkplugDataTransport.callSafely(listener::onDisconnecting));
+                        .forEach(listener -> InvocationUtils.callSafely(listener::onDisconnecting));
 
                 if (SparkplugMqttClient.this.sessionStatus instanceof Established) {
                     sendEdgeNodeDeath();
@@ -117,7 +118,7 @@ public class SparkplugMqttClient {
                 }
 
                 SparkplugMqttClient.this.listeners
-                        .forEach(listener -> SparkplugDataTransport.callSafely(listener::onDisconnected));
+                        .forEach(listener -> InvocationUtils.callSafely(listener::onDisconnected));
             } catch (MqttException e) {
                 logger.error("Error terminating Sparkplug Edge Node session", e);
                 return SparkplugMqttClient.this.sessionStatus;
@@ -129,7 +130,7 @@ public class SparkplugMqttClient {
         SessionStatus toEstablished() {
             sendEdgeNodeBirth();
             SparkplugMqttClient.this.listeners
-                    .forEach(listener -> SparkplugDataTransport.callSafely(listener::onConnectionEstablished, true));
+                    .forEach(listener -> InvocationUtils.callSafely(listener::onConnectionEstablished, true));
             return new Established();
         }
 

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/utils/InvocationUtils.java
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/utils/InvocationUtils.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.cloudconnection.sparkplug.mqtt.utils;
+
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InvocationUtils {
+    
+    private static final String ERROR_MESSAGE_FORMAT = "An error occurred in listener '%s'";
+
+    private InvocationUtils() {
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(InvocationUtils.class);
+
+    public static void callSafely(Runnable f) {
+        try {
+            f.run();
+        } catch (Exception e) {
+            logger.error(String.format(ERROR_MESSAGE_FORMAT, f.getClass().getName()), e);
+        }
+    }
+
+    public static <T> void callSafely(Consumer<T> f, T argument) {
+        try {
+            f.accept(argument);
+        } catch (Exception e) {
+            logger.error(String.format(ERROR_MESSAGE_FORMAT, f.getClass().getName()), e);
+        }
+    }
+
+}

--- a/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/utils/SparkplugCloudEndpointTracker.java
+++ b/kura/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider/src/main/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/utils/SparkplugCloudEndpointTracker.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.cloudconnection.sparkplug.mqtt.utils;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.eclipse.kura.cloudconnection.CloudConnectionManager;
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint.SparkplugCloudEndpoint;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+public class SparkplugCloudEndpointTracker {
+
+    private final BundleContext bundleContext;
+    private ServiceTracker<CloudConnectionManager, CloudConnectionManager> cloudConnectionManagerTracker;
+    private final Consumer<SparkplugCloudEndpoint> serviceAddedConsumer;
+    private final Consumer<SparkplugCloudEndpoint> serviceRemovedConsumer;
+    private final String endpointPid;
+
+    public SparkplugCloudEndpointTracker(BundleContext bundleContext,
+            Consumer<SparkplugCloudEndpoint> serviceAddedConsumer,
+            Consumer<SparkplugCloudEndpoint> serviceRemovedConsumer, String endpointPid) {
+        this.bundleContext = bundleContext;
+        this.serviceAddedConsumer = serviceAddedConsumer;
+        this.serviceRemovedConsumer = serviceRemovedConsumer;
+        this.endpointPid = endpointPid;
+    }
+
+    public void startEndpointTracker() throws InvalidSyntaxException {
+        String filterString = String.format("(&(%s=%s)(kura.service.pid=%s))", Constants.OBJECTCLASS,
+                CloudConnectionManager.class.getName(), this.endpointPid);
+
+        final Filter filter = this.bundleContext.createFilter(filterString);
+        this.cloudConnectionManagerTracker = new ServiceTracker<>(this.bundleContext, filter,
+                new SparkplugCloudEndpointTrackerCustomizer());
+
+        this.cloudConnectionManagerTracker.open();
+    }
+
+    public void stopEndpointTracker() {
+        if (Objects.nonNull(this.cloudConnectionManagerTracker)) {
+            this.cloudConnectionManagerTracker.close();
+        }
+    }
+
+    private class SparkplugCloudEndpointTrackerCustomizer
+            implements ServiceTrackerCustomizer<CloudConnectionManager, CloudConnectionManager> {
+
+        @Override
+        public synchronized CloudConnectionManager addingService(
+                final ServiceReference<CloudConnectionManager> reference) {
+            CloudConnectionManager cloudConnectionManager = SparkplugCloudEndpointTracker.this.bundleContext
+                    .getService(reference);
+
+            if (cloudConnectionManager instanceof SparkplugCloudEndpoint) {
+                SparkplugCloudEndpointTracker.this.serviceAddedConsumer
+                        .accept((SparkplugCloudEndpoint) cloudConnectionManager);
+                return cloudConnectionManager;
+            } else {
+                SparkplugCloudEndpointTracker.this.bundleContext.ungetService(reference);
+            }
+
+            return null;
+        }
+
+        @Override
+        public synchronized void removedService(final ServiceReference<CloudConnectionManager> reference,
+                final CloudConnectionManager service) {
+            if (service instanceof SparkplugCloudEndpoint) {
+                SparkplugCloudEndpointTracker.this.serviceRemovedConsumer.accept((SparkplugCloudEndpoint) service);
+            }
+        }
+
+        @Override
+        public synchronized void modifiedService(final ServiceReference<CloudConnectionManager> reference,
+                final CloudConnectionManager service) {
+            // Not needed
+        }
+
+    }
+
+}

--- a/kura/test/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider.test/src/test/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/test/SubscriptionRecordTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider.test/src/test/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/test/SubscriptionRecordTest.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint.SubscriptionRecord;
+import org.junit.Test;
+
+public class SubscriptionRecordTest {
+
+    private SubscriptionRecord record1;
+    private SubscriptionRecord record2;
+    private SubscriptionRecord record3;
+    private Object otherType;
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void equalsShouldBeReflective() {
+        whenInitSubscriptionRecord1("t1", 0);
+
+        thenObjectsAreEqual(this.record1, this.record1);
+        thenHashCodesAreSame(this.record1.hashCode(), this.record1.hashCode());
+    }
+
+    @Test
+    public void equalsShouldBeSymmetric() {
+        whenInitSubscriptionRecord1("t1", 0);
+        whenInitSubscriptionRecord2("t1", 0);
+
+        thenObjectsAreEqual(this.record1, this.record2);
+        thenHashCodesAreSame(this.record1.hashCode(), this.record2.hashCode());
+    }
+
+    @Test
+    public void equalsShouldBeTransitive() {
+        whenInitSubscriptionRecord1("t1", 0);
+        whenInitSubscriptionRecord2("t1", 0);
+        whenInitSubscriptionRecord3("t1", 0);
+
+        thenObjectsAreEqual(this.record1, this.record2);
+        thenObjectsAreEqual(this.record2, this.record3);
+        thenObjectsAreEqual(this.record1, this.record3);
+        thenHashCodesAreSame(this.record1.hashCode(), this.record2.hashCode());
+        thenHashCodesAreSame(this.record2.hashCode(), this.record3.hashCode());
+        thenHashCodesAreSame(this.record1.hashCode(), this.record3.hashCode());
+    }
+
+    @Test
+    public void shouldNotEqualWithDifferentTopic() {
+        whenInitSubscriptionRecord1("t1", 0);
+        whenInitSubscriptionRecord2("t2", 0);
+        
+        thenObjectsAreNotEqual(this.record1, this.record2);
+        thenHashCodesAreDifferent(this.record1.hashCode(), this.record2.hashCode());
+    }
+
+    @Test
+    public void shouldNotEqualWithDifferentQos() {
+        whenInitSubscriptionRecord1("t1", 0);
+        whenInitSubscriptionRecord2("t1", 1);
+
+        thenObjectsAreNotEqual(this.record1, this.record2);
+        thenHashCodesAreDifferent(this.record1.hashCode(), this.record2.hashCode());
+    }
+
+    @Test
+    public void shouldNotEqualWithDifferentType() {
+        whenInitSubscriptionRecord1("t1", 0);
+        whenInitOtherTypeObject();
+
+        thenObjectsAreNotEqual(this.record1, this.otherType);
+        thenHashCodesAreDifferent(this.record1.hashCode(), this.otherType.hashCode());
+    }
+
+    /*
+     * Steps
+     */
+
+    private void whenInitSubscriptionRecord1(String topicFilter, int qos) {
+        this.record1 = new SubscriptionRecord(topicFilter, qos);
+    }
+
+    private void whenInitSubscriptionRecord2(String topicFilter, int qos) {
+        this.record2 = new SubscriptionRecord(topicFilter, qos);
+    }
+
+    private void whenInitSubscriptionRecord3(String topicFilter, int qos) {
+        this.record3 = new SubscriptionRecord(topicFilter, qos);
+    }
+
+    private void whenInitOtherTypeObject() {
+        this.otherType = new Object();
+    }
+
+    private void thenObjectsAreEqual(Object o1, Object o2) {
+        assertEquals(o1, o2);
+    }
+
+    private void thenObjectsAreNotEqual(Object o1, Object o2) {
+        assertNotEquals(o1, o2);
+    }
+
+    private void thenHashCodesAreSame(int hash1, int hash2) {
+        assertEquals(hash1, hash2);
+    }
+
+    private void thenHashCodesAreDifferent(int hash1, int hash2) {
+        assertNotEquals(hash1, hash2);
+    }
+
+}

--- a/kura/test/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider.test/src/test/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/test/SubscriptionsMapTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider.test/src/test/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/test/SubscriptionsMapTest.java
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint.SubscriptionRecord;
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint.SubscriptionsMap;
+import org.eclipse.kura.cloudconnection.subscriber.listener.CloudSubscriberListener;
+import org.junit.Test;
+
+public class SubscriptionsMapTest {
+
+    private SubscriptionsMap subscriptionsMap = new SubscriptionsMap();
+    private List<String> returnedTopicsToUnsubscribe = new LinkedList<>();
+    private List<CloudSubscriberListener> returnedMatchingListeners = new LinkedList<>();
+    private CloudSubscriberListener l1 = mock(CloudSubscriberListener.class);
+    private CloudSubscriberListener l2 = mock(CloudSubscriberListener.class);
+    private CloudSubscriberListener l3 = mock(CloudSubscriberListener.class);
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void removeSomeShouldNotReturnTopicsToUnsubscribe() {
+        givenAdd("t1", 0, this.l1);
+        givenAdd("t1", 0, this.l2);
+        
+        whenRemove(this.l1);
+
+        thenSubscriptionRecordsContains(new SubscriptionRecord("t1", 0));
+        thenMatchingListenersContains("t1", 0, this.l2);
+        thenReturnedTopicsToUnsubscribeIsEmpty();
+    }
+
+    @Test
+    public void removeAllShouldReturnTopicsToUnsubscribe() {
+        givenAdd("t1", 0, this.l1);
+        givenAdd("t1", 0, this.l2);
+        givenRemove(this.l1);
+
+        whenRemove(this.l2);
+
+        thenSubscriptionRecordsNotContains(new SubscriptionRecord("t1", 0));
+        thenMatchingListenersNotContains("t1", 0, this.l2);
+        thenReturnedTopicsToUnsubscribeContains("t1");
+    }
+
+    @Test
+    public void shouldMatchSingleLevelWildCard1() {
+        givenAdd("A/B", 0, this.l1);
+        givenAdd("A/+/C", 0, this.l2);
+        givenAdd("A/B/C", 0, this.l3);
+
+        whenGetListenersMatching("A/B/C", 0);
+
+        thenReturnedMatchingListenersNotContains(this.l1);
+        thenReturnedMatchingListenersContains(this.l2);
+        thenReturnedMatchingListenersContains(this.l3);
+    }
+
+    @Test
+    public void shouldMatchSingleLevelWildCard2() {
+        givenAdd("A/B", 0, this.l1);
+        givenAdd("A/+", 0, this.l2);
+        givenAdd("A/B/C", 0, this.l3);
+
+        whenGetListenersMatching("A/B", 0);
+
+        thenReturnedMatchingListenersContains(this.l1);
+        thenReturnedMatchingListenersContains(this.l2);
+        thenReturnedMatchingListenersNotContains(this.l3);
+    }
+
+    @Test
+    public void shouldMatchMultiLevelWildCard() {
+        givenAdd("A/B", 0, this.l1);
+        givenAdd("A/#", 0, this.l2);
+        givenAdd("A/B/C", 0, this.l3);
+
+        whenGetListenersMatching("A/B/C", 0);
+
+        thenReturnedMatchingListenersNotContains(this.l1);
+        thenReturnedMatchingListenersContains(this.l2);
+        thenReturnedMatchingListenersContains(this.l3);
+    }
+
+    @Test
+    public void shouldMatchWithCorrectQos() {
+        givenAdd("A/B", 1, this.l1);
+        givenAdd("A/#", 0, this.l2);
+        givenAdd("A/B/C", 1, this.l3);
+
+        whenGetListenersMatching("A/B/C", 0);
+
+        thenReturnedMatchingListenersNotContains(this.l1);
+        thenReturnedMatchingListenersContains(this.l2);
+        thenReturnedMatchingListenersNotContains(this.l3);
+    }
+
+    @Test
+    public void shouldMatchWithMaximumSubscribedQos() {
+        givenAdd("A/B/C", 0, this.l1);
+
+        whenGetListenersMatching("A/B/C", 1);
+
+        thenReturnedMatchingListenersContains(this.l1);
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenAdd(String topicFilter, int qos, CloudSubscriberListener listener) {
+        this.subscriptionsMap.add(topicFilter, qos, listener);
+    }
+
+    private void givenRemove(CloudSubscriberListener listener) {
+        this.returnedTopicsToUnsubscribe.addAll(this.subscriptionsMap.remove(listener));
+    }
+
+    /*
+     * When
+     */
+
+    private void whenRemove(CloudSubscriberListener listener) {
+        givenRemove(listener);
+    }
+
+    private void whenGetListenersMatching(String topic, int qos) {
+        this.returnedMatchingListeners = this.subscriptionsMap.getMatchingListeners(topic, qos);
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenSubscriptionRecordsContains(SubscriptionRecord subscription) {
+        assertTrue(this.subscriptionsMap.getSubscriptionRecords().contains(subscription));
+    }
+
+    private void thenSubscriptionRecordsNotContains(SubscriptionRecord subscription) {
+        assertFalse(this.subscriptionsMap.getSubscriptionRecords().contains(subscription));
+    }
+
+    private void thenMatchingListenersContains(String topic, int qos, CloudSubscriberListener listener) {
+        whenGetListenersMatching(topic, qos);
+        thenReturnedMatchingListenersContains(listener);
+    }
+
+    private void thenMatchingListenersNotContains(String topic, int qos, CloudSubscriberListener listener) {
+        whenGetListenersMatching(topic, qos);
+        thenReturnedMatchingListenersNotContains(listener);
+    }
+
+    private void thenReturnedTopicsToUnsubscribeIsEmpty() {
+        assertTrue(this.returnedTopicsToUnsubscribe.isEmpty());
+    }
+
+    private void thenReturnedTopicsToUnsubscribeContains(String expectedTopic) {
+        assertTrue(this.returnedTopicsToUnsubscribe.contains(expectedTopic));
+    }
+
+    private void thenReturnedMatchingListenersContains(CloudSubscriberListener listener) {
+        assertTrue(this.returnedMatchingListeners.contains(listener));
+    }
+
+    private void thenReturnedMatchingListenersNotContains(CloudSubscriberListener listener) {
+        assertFalse(this.returnedMatchingListeners.contains(listener));
+    }
+
+    /*
+     * Utils
+     */
+
+}

--- a/kura/test/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider.test/src/test/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/test/SubscriptionsMapTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider.test/src/test/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/endpoint/test/SubscriptionsMapTest.java
@@ -29,9 +29,9 @@ public class SubscriptionsMapTest {
     private SubscriptionsMap subscriptionsMap = new SubscriptionsMap();
     private List<String> returnedTopicsToUnsubscribe = new LinkedList<>();
     private List<CloudSubscriberListener> returnedMatchingListeners = new LinkedList<>();
-    private CloudSubscriberListener l1 = mock(CloudSubscriberListener.class);
-    private CloudSubscriberListener l2 = mock(CloudSubscriberListener.class);
-    private CloudSubscriberListener l3 = mock(CloudSubscriberListener.class);
+    private CloudSubscriberListener subListener1 = mock(CloudSubscriberListener.class);
+    private CloudSubscriberListener subListener2 = mock(CloudSubscriberListener.class);
+    private CloudSubscriberListener subListener3 = mock(CloudSubscriberListener.class);
 
     /*
      * Scenarios
@@ -39,88 +39,87 @@ public class SubscriptionsMapTest {
 
     @Test
     public void removeSomeShouldNotReturnTopicsToUnsubscribe() {
-        givenAdd("t1", 0, this.l1);
-        givenAdd("t1", 0, this.l2);
+        givenSubscriptionMapWith("t1", 0, this.subListener1);
+        givenSubscriptionMapWith("t1", 0, this.subListener2);
         
-        whenRemove(this.l1);
+        whenRemoveIsCalledFor(this.subListener1);
 
         thenSubscriptionRecordsContains(new SubscriptionRecord("t1", 0));
-        thenMatchingListenersContains("t1", 0, this.l2);
+        thenMatchingListenersContains("t1", 0, this.subListener2);
         thenReturnedTopicsToUnsubscribeIsEmpty();
     }
 
     @Test
     public void removeAllShouldReturnTopicsToUnsubscribe() {
-        givenAdd("t1", 0, this.l1);
-        givenAdd("t1", 0, this.l2);
-        givenRemove(this.l1);
+        givenSubscriptionMapWith("t1", 0, this.subListener1);
+        givenSubscriptionMapWith("t1", 0, this.subListener2);
 
-        whenRemove(this.l2);
+        whenRemoveIsCalledFor(this.subListener1, this.subListener2);
 
         thenSubscriptionRecordsNotContains(new SubscriptionRecord("t1", 0));
-        thenMatchingListenersNotContains("t1", 0, this.l2);
+        thenMatchingListenersNotContains("t1", 0, this.subListener2);
         thenReturnedTopicsToUnsubscribeContains("t1");
     }
 
     @Test
     public void shouldMatchSingleLevelWildCard1() {
-        givenAdd("A/B", 0, this.l1);
-        givenAdd("A/+/C", 0, this.l2);
-        givenAdd("A/B/C", 0, this.l3);
+        givenSubscriptionMapWith("A/B", 0, this.subListener1);
+        givenSubscriptionMapWith("A/+/C", 0, this.subListener2);
+        givenSubscriptionMapWith("A/B/C", 0, this.subListener3);
 
         whenGetListenersMatching("A/B/C", 0);
 
-        thenReturnedMatchingListenersNotContains(this.l1);
-        thenReturnedMatchingListenersContains(this.l2);
-        thenReturnedMatchingListenersContains(this.l3);
+        thenReturnedMatchingListenersNotContains(this.subListener1);
+        thenReturnedMatchingListenersContains(this.subListener2);
+        thenReturnedMatchingListenersContains(this.subListener3);
     }
 
     @Test
     public void shouldMatchSingleLevelWildCard2() {
-        givenAdd("A/B", 0, this.l1);
-        givenAdd("A/+", 0, this.l2);
-        givenAdd("A/B/C", 0, this.l3);
+        givenSubscriptionMapWith("A/B", 0, this.subListener1);
+        givenSubscriptionMapWith("A/+", 0, this.subListener2);
+        givenSubscriptionMapWith("A/B/C", 0, this.subListener3);
 
         whenGetListenersMatching("A/B", 0);
 
-        thenReturnedMatchingListenersContains(this.l1);
-        thenReturnedMatchingListenersContains(this.l2);
-        thenReturnedMatchingListenersNotContains(this.l3);
+        thenReturnedMatchingListenersContains(this.subListener1);
+        thenReturnedMatchingListenersContains(this.subListener2);
+        thenReturnedMatchingListenersNotContains(this.subListener3);
     }
 
     @Test
     public void shouldMatchMultiLevelWildCard() {
-        givenAdd("A/B", 0, this.l1);
-        givenAdd("A/#", 0, this.l2);
-        givenAdd("A/B/C", 0, this.l3);
+        givenSubscriptionMapWith("A/B", 0, this.subListener1);
+        givenSubscriptionMapWith("A/#", 0, this.subListener2);
+        givenSubscriptionMapWith("A/B/C", 0, this.subListener3);
 
         whenGetListenersMatching("A/B/C", 0);
 
-        thenReturnedMatchingListenersNotContains(this.l1);
-        thenReturnedMatchingListenersContains(this.l2);
-        thenReturnedMatchingListenersContains(this.l3);
+        thenReturnedMatchingListenersNotContains(this.subListener1);
+        thenReturnedMatchingListenersContains(this.subListener2);
+        thenReturnedMatchingListenersContains(this.subListener3);
     }
 
     @Test
     public void shouldMatchWithCorrectQos() {
-        givenAdd("A/B", 1, this.l1);
-        givenAdd("A/#", 0, this.l2);
-        givenAdd("A/B/C", 1, this.l3);
+        givenSubscriptionMapWith("A/B", 1, this.subListener1);
+        givenSubscriptionMapWith("A/#", 0, this.subListener2);
+        givenSubscriptionMapWith("A/B/C", 1, this.subListener3);
 
         whenGetListenersMatching("A/B/C", 0);
 
-        thenReturnedMatchingListenersNotContains(this.l1);
-        thenReturnedMatchingListenersContains(this.l2);
-        thenReturnedMatchingListenersNotContains(this.l3);
+        thenReturnedMatchingListenersNotContains(this.subListener1);
+        thenReturnedMatchingListenersContains(this.subListener2);
+        thenReturnedMatchingListenersNotContains(this.subListener3);
     }
 
     @Test
     public void shouldMatchWithMaximumSubscribedQos() {
-        givenAdd("A/B/C", 0, this.l1);
+        givenSubscriptionMapWith("A/B/C", 0, this.subListener1);
 
         whenGetListenersMatching("A/B/C", 1);
 
-        thenReturnedMatchingListenersContains(this.l1);
+        thenReturnedMatchingListenersContains(this.subListener1);
     }
 
     /*
@@ -131,20 +130,18 @@ public class SubscriptionsMapTest {
      * Given
      */
 
-    private void givenAdd(String topicFilter, int qos, CloudSubscriberListener listener) {
+    private void givenSubscriptionMapWith(String topicFilter, int qos, CloudSubscriberListener listener) {
         this.subscriptionsMap.add(topicFilter, qos, listener);
-    }
-
-    private void givenRemove(CloudSubscriberListener listener) {
-        this.returnedTopicsToUnsubscribe.addAll(this.subscriptionsMap.remove(listener));
     }
 
     /*
      * When
      */
 
-    private void whenRemove(CloudSubscriberListener listener) {
-        givenRemove(listener);
+    private void whenRemoveIsCalledFor(CloudSubscriberListener... listeners) {
+        for (CloudSubscriberListener listener : listeners) {
+            this.returnedTopicsToUnsubscribe.addAll(this.subscriptionsMap.remove(listener));
+        }
     }
 
     private void whenGetListenersMatching(String topic, int qos) {

--- a/kura/test/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider.test/src/test/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/subscriber/test/SparkplugSubscriberTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.sparkplug.mqtt.provider.test/src/test/java/org/eclipse/kura/cloudconnection/sparkplug/mqtt/subscriber/test/SparkplugSubscriberTest.java
@@ -1,0 +1,337 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.test;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.cloudconnection.listener.CloudConnectionListener;
+import org.eclipse.kura.cloudconnection.message.KuraMessage;
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.endpoint.SparkplugCloudEndpoint;
+import org.eclipse.kura.cloudconnection.sparkplug.mqtt.subscriber.SparkplugSubscriber;
+import org.eclipse.kura.cloudconnection.subscriber.CloudSubscriber;
+import org.eclipse.kura.cloudconnection.subscriber.listener.CloudSubscriberListener;
+import org.eclipse.kura.data.DataService;
+import org.eclipse.kura.message.KuraPayload;
+import org.eclipse.tahu.protobuf.SparkplugBProto;
+import org.eclipse.tahu.protobuf.SparkplugBProto.Payload;
+import org.eclipse.tahu.protobuf.SparkplugBProto.Payload.DataSet;
+import org.eclipse.tahu.protobuf.SparkplugBProto.Payload.Metric;
+import org.eclipse.tahu.protobuf.SparkplugBProto.Payload.Metric.MetricValueExtension;
+import org.eclipse.tahu.protobuf.SparkplugBProto.Payload.Template;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.osgi.service.event.EventAdmin;
+
+import com.google.protobuf.ByteString;
+
+public class SparkplugSubscriberTest {
+
+    private DataService dataService = mock(DataService.class);
+    private SparkplugCloudEndpoint endpoint = new SparkplugCloudEndpoint();
+    private SparkplugSubscriber sub1 = new SparkplugSubscriber();
+    private SparkplugSubscriber sub2 = new SparkplugSubscriber();
+    private SparkplugSubscriber sub3 = new SparkplugSubscriber();
+    private SparkplugSubscriber sub4 = new SparkplugSubscriber();
+    private CloudSubscriberListener subListener = mock(CloudSubscriberListener.class);
+    private CloudConnectionListener cloudConnectionListener = mock(CloudConnectionListener.class);
+
+    /*
+     * Scenarios
+     */
+
+    @Test
+    public void shouldForwardMessagesToCorrectSubscribers() throws Exception {
+        givenInitialSetup(true);
+        givenRegisterSubscriber("a/b/c", 0, this.sub1);
+        givenRegisterSubscriber("a/+/c", 0, this.sub2);
+        givenRegisterSubscriber("a/#", 0, this.sub3);
+        givenRegisterSubscriber("a/b", 0, this.sub4);
+        givenRegisterCloudSubscriberListener(this.sub1, this.subListener);
+        givenRegisterCloudSubscriberListener(this.sub2, this.subListener);
+        givenRegisterCloudSubscriberListener(this.sub3, this.subListener);
+        givenRegisterCloudSubscriberListener(this.sub4, this.subListener);
+
+        whenOnMessageArrivedWithAllSupportedMetrics("a/b/c", 0);
+
+        thenSubscriberListenerNotifiedOnMessageArrived(this.subListener, 3);
+    }
+
+    @Test
+    public void shouldNotForwardMessagesToUnsubscribed() throws Exception {
+        givenInitialSetup(true);
+        givenRegisterSubscriber("a/b/c", 0, this.sub1);
+        givenRegisterSubscriber("a/+/c", 0, this.sub2);
+        givenRegisterSubscriber("a/#", 0, this.sub3);
+        givenRegisterSubscriber("a/b", 0, this.sub4);
+        givenRegisterCloudSubscriberListener(this.sub1, this.subListener);
+        givenRegisterCloudSubscriberListener(this.sub2, this.subListener);
+        givenRegisterCloudSubscriberListener(this.sub3, this.subListener);
+        givenRegisterCloudSubscriberListener(this.sub4, this.subListener);
+        givenUnregisterSubscriber(this.sub1);
+        givenUnregisterSubscriber(this.sub2);
+
+        whenOnMessageArrivedWithAllSupportedMetrics("a/b/c", 0);
+
+        thenSubscriberListenerNotifiedOnMessageArrived(this.subListener, 1);
+    }
+
+    @Test
+    public void shouldSubscribeOnConnectionEstabilished() throws Exception {
+        givenInitialSetup(false);
+        givenRegisterSubscriber("a/b/c", 0, this.sub1);
+        givenRegisterSubscriber("a/+/c", 0, this.sub2);
+        givenRegisterSubscriber("a/#", 1, this.sub3);
+        givenRegisterSubscriber("a/#", 0, this.sub4);
+
+        whenEndpointEstablishConnection();
+
+        thenSubscribed("a/b/c", 0);
+        thenSubscribed("a/+/c", 0);
+        thenSubscribed("a/#", 1);
+        thenSubscribed("a/#", 0);
+    }
+
+    @Test
+    public void shouldNotifyCloudConnectionListenerOnDisconnected() {
+        givenCloudConnectionListener(this.sub1, this.cloudConnectionListener);
+        
+        whenOnDisconnected(this.sub1);
+        
+        thenConnectionListenerNotifiedOnDisconnected(this.cloudConnectionListener);
+    }
+
+    @Test
+    public void shouldNotifyCloudConnectionListenerOnConnectionLost() {
+        givenCloudConnectionListener(this.sub1, this.cloudConnectionListener);
+
+        whenOnConnectionLost(this.sub1);
+
+        thenConnectionListenerNotifiedOnConnectionLost(this.cloudConnectionListener);
+    }
+
+    @Test
+    public void shouldNotifyCloudConnectionListenerOnConnectionEstablished() {
+        givenCloudConnectionListener(this.sub1, this.cloudConnectionListener);
+
+        whenOnConnectionEstablished(this.sub1);
+
+        thenConnectionListenerNotifiedOnConnectionEstablished(this.cloudConnectionListener);
+    }
+
+    /*
+     * Steps
+     */
+
+    /*
+     * Given
+     */
+
+    private void givenInitialSetup(boolean isConnected) {
+        when(this.dataService.isConnected()).thenReturn(isConnected);
+        this.endpoint.setDataService(this.dataService);
+        
+        EventAdmin mockEventAdmin = mock(EventAdmin.class);
+        this.endpoint.setEventAdmin(mockEventAdmin);
+    }
+
+    private void givenRegisterSubscriber(String topicFilter, int qos, CloudSubscriberListener listener)
+            throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(SparkplugSubscriber.KEY_TOPIC_FILTER, topicFilter);
+        properties.put(SparkplugSubscriber.KEY_QOS, qos);
+
+        this.endpoint.registerSubscriber(properties, listener);
+    }
+
+    private void givenUnregisterSubscriber(CloudSubscriberListener listener) {
+
+        this.endpoint.unregisterSubscriber(listener);
+    }
+
+    private void givenRegisterCloudSubscriberListener(CloudSubscriber subscriber, CloudSubscriberListener listener)
+            throws Exception {
+        subscriber.registerCloudSubscriberListener(listener);
+    }
+
+    private void givenCloudConnectionListener(CloudSubscriber subscriber, CloudConnectionListener listener) {
+        subscriber.registerCloudConnectionListener(listener);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenOnMessageArrivedWithAllSupportedMetrics(String topic, int qos) {
+        SparkplugBProto.Payload.Builder builder = Payload.newBuilder();
+
+        builder.addMetrics(getBooleanMetric("metric.boolean", true));
+        builder.addMetrics(getBytesMetric("metric.bytes", "test".getBytes()));
+        builder.addMetrics(getDatasetMetric("metric.dataset", DataSet.getDefaultInstance()));
+        builder.addMetrics(getDoubleMetric("metric.double", 12.3));
+        builder.addMetrics(getExtensionValueMetric("metric.extension", MetricValueExtension.getDefaultInstance()));
+        builder.addMetrics(getFloatMetric("metric.float", 12f));
+        builder.addMetrics(getIntegerMetric("metric.int", 11));
+        builder.addMetrics(getLongMetric("metric.long", 123L));
+        builder.addMetrics(getStringMetric("metric.string", "test"));
+        builder.addMetrics(getTemplateMetric("metric.template", Template.getDefaultInstance()));
+
+        builder.setBody(ByteString.copyFrom("example".getBytes()));
+        builder.setTimestamp(1000L);
+        builder.setSeq(100L);
+
+        this.endpoint.onMessageArrived(topic, builder.build().toByteArray(), qos, false);
+    }
+
+    private void whenEndpointEstablishConnection() {
+        when(this.dataService.isConnected()).thenReturn(true);
+        this.endpoint.onConnectionEstablished();
+    }
+
+    private void whenOnDisconnected(SparkplugSubscriber subscriber) {
+        subscriber.onDisconnected();
+    }
+
+    private void whenOnConnectionLost(SparkplugSubscriber subscriber) {
+        subscriber.onConnectionLost();
+    }
+
+    private void whenOnConnectionEstablished(SparkplugSubscriber subscriber) {
+        subscriber.onConnectionEstablished();
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenSubscriberListenerNotifiedOnMessageArrived(CloudSubscriberListener subscriberListener,
+            int expectedTimes) {
+        verify(subscriberListener, timeout(1000L).times(expectedTimes))
+                .onMessageArrived(argThat(new ArgumentMatcher<KuraMessage>() {
+
+            @Override
+            public boolean matches(KuraMessage message) {
+                KuraPayload payload = message.getPayload();
+                
+                boolean bodyMatches = Arrays.equals(payload.getBody(), "example".getBytes());
+                boolean timestampMatches = payload.getTimestamp().getTime() == 1000L;
+                boolean seqMatches = ((long) payload.getMetric("seq")) == 100L;
+                
+                return bodyMatches && timestampMatches && seqMatches;
+            }
+
+        }));
+    }
+
+    private void thenConnectionListenerNotifiedOnDisconnected(CloudConnectionListener subscriberListener) {
+        verify(subscriberListener, timeout(1000L).times(1)).onDisconnected();
+    }
+
+    private void thenConnectionListenerNotifiedOnConnectionLost(CloudConnectionListener subscriberListener) {
+        verify(subscriberListener, timeout(1000L).times(1)).onConnectionLost();
+    }
+
+    private void thenConnectionListenerNotifiedOnConnectionEstablished(CloudConnectionListener subscriberListener) {
+        verify(subscriberListener, timeout(1000L).times(1)).onConnectionEstablished();
+    }
+
+    private void thenSubscribed(String expectedTopicFilter, int expectedQos) throws KuraException {
+        verify(this.dataService, times(1)).subscribe(expectedTopicFilter, expectedQos);
+    }
+
+
+
+    /*
+     * Utils
+     */
+
+    private Metric getBooleanMetric(String name, boolean value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setBooleanValue(value);
+        return metricBuilder.build();
+    }
+
+    private Metric getBytesMetric(String name, byte[] value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setBytesValue(ByteString.copyFrom(value));
+        return metricBuilder.build();
+    }
+
+    private Metric getDatasetMetric(String name, DataSet value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setDatasetValue(value);
+        return metricBuilder.build();
+    }
+
+    private Metric getDoubleMetric(String name, double value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setDoubleValue(value);
+        return metricBuilder.build();
+    }
+
+    private Metric getExtensionValueMetric(String name, MetricValueExtension value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setExtensionValue(value);
+        return metricBuilder.build();
+    }
+
+    private Metric getFloatMetric(String name, float value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setFloatValue(value);
+        return metricBuilder.build();
+    }
+
+    private Metric getIntegerMetric(String name, int value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setIntValue(value);
+        return metricBuilder.build();
+    }
+
+    private Metric getLongMetric(String name, long value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setLongValue(value);
+        return metricBuilder.build();
+    }
+    
+    private Metric getStringMetric(String name, String value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setStringValue(value);
+        return metricBuilder.build();
+    }
+
+    private Metric getTemplateMetric(String name, Template value) {
+        Payload.Metric.Builder metricBuilder = Payload.Metric.newBuilder();
+        metricBuilder.setName(name);
+        metricBuilder.setTemplateValue(value);
+        return metricBuilder.build();
+    }
+
+}


### PR DESCRIPTION
This PR adds a generic `CloudSubscriber` for the Sparkplug Cloud Connection.

**Related Issue:** Documentation https://github.com/eclipse/kura/pull/5120.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** Created utilities package to factor some common code.
