### PR TITLE
docs: Added a note in the CloudService configuration page

### DIFF
--- a/docs/gateway-configuration/cloud-service-configuration.md
+++ b/docs/gateway-configuration/cloud-service-configuration.md
@@ -28,7 +28,7 @@ The **CloudService** provides the following configuration parameters:
 
 - **republish.mqtt.birth.cert.on.gps.lock**: when set to true, forces a republish of the MQTT Birth Certificate when a GPS correct position lock is received. The device is then registered with its real coordinates. (Required field).
 
-- **republish.mqtt.birth.cert.on.modem.detect**: when set to true, forces a republish of the MQTT Birth Certificate when the service receives a modem detection event. (Required field).
+- **republish.mqtt.birth.cert.on.modem.detect**: when set to true, forces a republish of the MQTT Birth Certificate when the service receives a modem detection event. For devices configured to use [NetworkManager](https://networkmanager.dev), this property is not available. (Required field).
 
 - **enable.default.subscriptions**: manages the default subscriptions to the gateway management MQTT topics. When disabled, the gateway will not be remotely manageable.
 

--- a/docs/gateway-configuration/cloud-service-configuration.md
+++ b/docs/gateway-configuration/cloud-service-configuration.md
@@ -28,7 +28,7 @@ The **CloudService** provides the following configuration parameters:
 
 - **republish.mqtt.birth.cert.on.gps.lock**: when set to true, forces a republish of the MQTT Birth Certificate when a GPS correct position lock is received. The device is then registered with its real coordinates. (Required field).
 
-- **republish.mqtt.birth.cert.on.modem.detect**: when set to true, forces a republish of the MQTT Birth Certificate when the service receives a modem detection event. For devices configured to use [NetworkManager](https://networkmanager.dev), this property is not available. (Required field).
+- **republish.mqtt.birth.cert.on.modem.detect**: when set to true, forces a republish of the MQTT Birth Certificate when the service receives a modem detection event. This functionality is currently not supported on devices configured to use [NetworkManager](https://networkmanager.dev), in this case the property value is ignored. (Required field).
 
 - **enable.default.subscriptions**: manages the default subscriptions to the gateway management MQTT topics. When disabled, the gateway will not be remotely manageable.
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds a note in the `CloudService` configuration page for the `republish.mqtt.birth.cert.on.modem.detect` property.
