### PR TITLE
feat(container.signature): add image digest to ContainerSignatureValidationService API output

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ContainerSignatureValidationService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ContainerSignatureValidationService.java
@@ -51,10 +51,10 @@ public interface ContainerSignatureValidationService {
      * @param verifyInTransparencyLog
      *            Sets the transparency log verification, to be used when an artifact signature has been uploaded to the
      *            transparency log. Artifacts cannot be publicly verified when not included in a log.
-     * @return
+     * @return {@link:ValidationResult}
      */
-    public boolean verify(String imageName, String imageReference, String trustAnchor, boolean verifyInTransparencyLog)
-            throws KuraException;
+    public ValidationResult verify(String imageName, String imageReference, String trustAnchor,
+            boolean verifyInTransparencyLog) throws KuraException;
 
     /**
      * Verifies the signature of a container image using the provided trust anchor and the provided registry
@@ -90,10 +90,10 @@ public interface ContainerSignatureValidationService {
      * @param registryPassword
      *            Optional password for registry authentication. If the registry requires authentication,
      *            both username and password must be provided.
-     * @return
+     * @return {@link:ValidationResult}
      */
-    public boolean verify(String imageName, String imageReference, String trustAnchor, boolean verifyInTransparencyLog,
-            String registryUsername, Password registryPassword) throws KuraException;
+    public ValidationResult verify(String imageName, String imageReference, String trustAnchor,
+            boolean verifyInTransparencyLog, String registryUsername, Password registryPassword) throws KuraException;
 
     /**
      * Verifies the signature of a container image using the provided trust anchor. The trust anchor format depends on
@@ -116,10 +116,10 @@ public interface ContainerSignatureValidationService {
      * @param verifyInTransparencyLog
      *            Sets the transparency log verification, to be used when an artifact signature has been uploaded to the
      *            transparency log. Artifacts cannot be publicly verified when not included in a log.
-     * @return
+     * @return {@link:ValidationResult}
      */
-    public boolean verify(ImageInstanceDescriptor imageDescriptor, String trustAnchor, boolean verifyInTransparencyLog)
-            throws KuraException;
+    public ValidationResult verify(ImageInstanceDescriptor imageDescriptor, String trustAnchor,
+            boolean verifyInTransparencyLog) throws KuraException;
 
     /**
      * Verifies the signature of a container image using the provided trust anchor and the provided registry
@@ -151,8 +151,8 @@ public interface ContainerSignatureValidationService {
      * @param registryPassword
      *            Optional password for registry authentication. If the registry requires authentication,
      *            both username and password must be provided.
-     * @return
+     * @return {@link:ValidationResult}
      */
-    public boolean verify(ImageInstanceDescriptor imageDescriptor, String trustAnchor, boolean verifyInTransparencyLog,
-            String registryUsername, Password registryPassword) throws KuraException;
+    public ValidationResult verify(ImageInstanceDescriptor imageDescriptor, String trustAnchor,
+            boolean verifyInTransparencyLog, String registryUsername, Password registryPassword) throws KuraException;
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -9,7 +9,9 @@ import org.osgi.annotation.versioning.ProviderType;
  * Class representing the result of the signature validation performed by {@link:ContainerSignatureValidationService}
  * 
  * The result of the validation is composed of two main parts: whether or not the container image signature was
- * validated and the container image digest (in the "shaXXX:YYY" format).
+ * validated and the container image digest (in the "algorithm:encoded" format, @see
+ * <a href="https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests">Opencontainers specs
+ * </a>)
  *
  * If the signature is valid, the image digest MUST be provided.
  *

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -10,8 +10,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * 
  * The result of the validation is composed of two main parts: whether or not the container image signature was
  * validated and the container image digest (in the "algorithm:encoded" format, @see
- * <a href="https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests">Opencontainers specs
- * </a>)
+ * <a href="https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests">Opencontainers specs</a>)
  *
  * If the signature is valid, the image digest MUST be provided.
  *

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -22,8 +22,12 @@ public final class ValidationResult {
     private boolean isSignatureValid = false;
     private Optional<String> imageDigest = Optional.empty();
 
-    public ValidationResult(boolean signatureValid, Optional<String> digest) {
-        this.imageDigest = Objects.requireNonNull(digest);
+    public ValidationResult() {
+        // Nothing to do
+    }
+
+    public ValidationResult(boolean signatureValid, String digest) {
+        this.imageDigest = Optional.of(Objects.requireNonNull(digest));
         this.isSignatureValid = Objects.requireNonNull(signatureValid);
 
         if (this.isSignatureValid && (!this.imageDigest.isPresent() || this.imageDigest.get().isEmpty())) {

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -27,7 +27,7 @@ public final class ValidationResult {
         this.isSignatureValid = Objects.requireNonNull(signatureValid);
 
         if (this.isSignatureValid && (!this.imageDigest.isPresent() || this.imageDigest.get().isEmpty())) {
-            throw new IllegalArgumentException("Digest cannot be empty when signature is valid.");
+            throw new IllegalArgumentException("Image digest must be provided when signature is valid.");
         }
     }
 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -1,0 +1,31 @@
+package org.eclipse.kura.container.signature;
+
+import java.util.Optional;
+
+/**
+ * Class representing the result of the signature validation performed by {@link:ContainerSignatureValidationService}
+ * 
+ * The result of the validation is composed of two main parts: whether or not the container image signature was
+ * validated and the container image digest (in the "shaXXX:YYY" format).
+ *
+ * @since 2.7
+ */
+public final class ValidationResult {
+
+    private boolean isSignatureValid = false;
+    private Optional<String> imageDigest = Optional.empty();
+
+    public ValidationResult(boolean signatureValid, Optional<String> digest) {
+        this.imageDigest = digest;
+        this.isSignatureValid = signatureValid;
+    }
+
+    public boolean isSignatureValid() {
+        return this.isSignatureValid;
+    }
+
+    public Optional<String> imageDigest() {
+        return this.imageDigest;
+    }
+
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -1,5 +1,6 @@
 package org.eclipse.kura.container.signature;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -10,6 +11,8 @@ import org.osgi.annotation.versioning.ProviderType;
  * The result of the validation is composed of two main parts: whether or not the container image signature was
  * validated and the container image digest (in the "shaXXX:YYY" format).
  *
+ * If the signature is valid, the image digest MUST be provided.
+ *
  * @since 2.7
  */
 @ProviderType
@@ -19,8 +22,12 @@ public final class ValidationResult {
     private Optional<String> imageDigest = Optional.empty();
 
     public ValidationResult(boolean signatureValid, Optional<String> digest) {
-        this.imageDigest = digest;
-        this.isSignatureValid = signatureValid;
+        this.imageDigest = Objects.requireNonNull(digest);
+        this.isSignatureValid = Objects.requireNonNull(signatureValid);
+
+        if (this.isSignatureValid && (!this.imageDigest.isPresent() || this.imageDigest.get().isEmpty())) {
+            throw new IllegalArgumentException("Digest cannot be empty when signature is valid.");
+        }
     }
 
     public boolean isSignatureValid() {

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -20,7 +20,7 @@ import org.osgi.annotation.versioning.ProviderType;
 /**
  * Class representing the result of the signature validation performed by {@link:ContainerSignatureValidationService}
  * 
- * The result of the validation is composed of two main parts: whether or not the container image signature was
+ * The validation result is composed of two main parts: whether or not the container image signature was
  * validated and the container image digest (in the "algorithm:encoded" format, @see
  * <a href="https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests">Opencontainers specs</a>)
  *

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -10,6 +10,7 @@ import java.util.Optional;
  *
  * @since 2.7
  */
+@ProviderType
 public final class ValidationResult {
 
     private boolean isSignatureValid = false;

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -39,12 +39,16 @@ public final class ValidationResult {
     }
 
     public ValidationResult(boolean signatureValid, String digest) {
-        this.imageDigest = Optional.of(Objects.requireNonNull(digest));
-        this.isSignatureValid = Objects.requireNonNull(signatureValid);
+        if (Objects.isNull(signatureValid) || Objects.isNull(digest)) {
+            throw new NullPointerException("Signature results and digest cannot be null.");
+        }
 
-        if (this.isSignatureValid && (!this.imageDigest.isPresent() || this.imageDigest.get().isEmpty())) {
+        if (signatureValid && digest.isEmpty()) {
             throw new IllegalArgumentException("Image digest must be provided when signature is valid.");
         }
+
+        this.imageDigest = Optional.of(digest);
+        this.isSignatureValid = signatureValid;
     }
 
     public boolean isSignatureValid() {

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -43,4 +43,31 @@ public final class ValidationResult {
         return this.imageDigest;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ValidationResult other = (ValidationResult) obj;
+
+        return this.isSignatureValid == other.isSignatureValid && this.imageDigest.equals(other.imageDigest);
+
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (this.imageDigest == null ? 0 : this.imageDigest.hashCode());
+        result = prime * result + Boolean.hashCode(isSignatureValid);
+        return result;
+
+    }
+
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.eclipse.kura.container.signature;
 
 import java.util.Objects;

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -2,6 +2,8 @@ package org.eclipse.kura.container.signature;
 
 import java.util.Optional;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * Class representing the result of the signature validation performed by {@link:ContainerSignatureValidationService}
  * 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -71,19 +71,16 @@ public final class ValidationResult {
             return false;
         }
         ValidationResult other = (ValidationResult) obj;
-
         return this.isSignatureValid == other.isSignatureValid && this.imageDigest.equals(other.imageDigest);
-
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + (this.imageDigest == null ? 0 : this.imageDigest.hashCode());
+        result = prime * result + this.imageDigest.hashCode();
         result = prime * result + Boolean.hashCode(isSignatureValid);
         return result;
-
     }
 
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ValidationResult.java
@@ -76,11 +76,6 @@ public final class ValidationResult {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + this.imageDigest.hashCode();
-        result = prime * result + Boolean.hashCode(isSignatureValid);
-        return result;
+        return Objects.hash(this.isSignatureValid, this.imageDigest);
     }
-
 }


### PR DESCRIPTION
While working on #5129 I realised we didn't have a easy way to extract the image digest from a remote image (i.e. an image that was not already pulled on the system). I thought about expanding thee `container.orchestration` APIs to this end (see #5131) but the juice doesn't seem to be worth the squeeze. Even more so realising that all the tools I tested for the container signature validation already return the image digest as output

Therefore this PR updates the `ContainerSignatureValidationService` APIs so that, upon verifying the signature, it returns also the image digest. This can be later used to reference the verified image in a unique and robust way.

Merging this PR will impact #5126 and #5129 and avoid the need for #5131 entirely.

**Cosign**

```
cosign-linux-amd64 verify --key cosign.pub mattiadibieth/cosign-test:latest  --insecure-ignore-tlog

WARNING: Skipping tlog verification is an insecure practice that lacks of transparency and auditability verification for the signature.

Verification for index.docker.io/mattiadibieth/cosign-test:latest --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key
[
  {
    "critical": {
      "identity": {
        "docker-reference": "index.docker.io/mattiadibieth/cosign-test"
      },
      "image": {
        "docker-manifest-digest": "sha256:da53a44247cdffda84f979b73eb2064a75ec46378a0a53d4df1e064269842324"
      },
      "type": "cosign container image signature"
    },
    "optional": null
  }
]
```

**Notary V1**

```
docker trust inspect mattiadibieth/notary-test:latest
[
    {
        "Name": "mattiadibieth/notary-test:latest",
        "SignedTags": [
            {
                "SignedTag": "latest",
                "Digest": "da53a44247cdffda84f979b73eb2064a75ec46378a0a53d4df1e064269842324",
                "Signers": [
                    "Repo Admin"
                ]
            }
        ],
        "Signers": [],
        "AdministrativeKeys": [
            {
                "Name": "Root",
                "Keys": [
                    {
                        "ID": "2561662fba4201f4e7bb7226b7ad669f8c09bd5366215acd47c906c8ae137a4b"
                    }
                ]
            },
            {
                "Name": "Repository",
                "Keys": [
                    {
                        "ID": "ae3ccd530d445fc78458d73e0b3a32e1a3e99bce72c67da479fcbc004ec4bcb5"
                    }
                ]
            }
        ]
    }
]
```

**Notary V2**

```
notation verify $IMAGE
Successfully verified signature for localhost:5001/notation-test@sha256:da53a44247cdffda84f979b73eb2064a75ec46378a0a53d4df1e064269842324
```

---

**Additional details**

To perform this same task by our own we should:

- Find out the correct registry
- Find out the correct authentication endpoint for that registry and request an auth token
- Request the manifest to the registry using the aforementioned token
- Parse the manifest retrieving the digest for the image compatible with our architecture

Nothing difficult per se but finding out the correct registry/auth endpoint doesn't seem to be straightforward.