### PR TITLE
feat: Added identity configuration extension example

### DIFF
--- a/kura/examples/org.eclipse.kura.example.identity.configuration.extension/META-INF/MANIFEST.MF
+++ b/kura/examples/org.eclipse.kura.example.identity.configuration.extension/META-INF/MANIFEST.MF
@@ -1,0 +1,17 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.example.identity.configuration.extension
+Bundle-SymbolicName: org.eclipse.kura.example.identity.configuration.extension;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+Service-Component: OSGI-INF/*.xml
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
+Import-Package: org.eclipse.kura;version="[1.7,2.0)",
+ org.eclipse.kura.configuration;version="[1.2,2.0)",
+ org.eclipse.kura.configuration.metatype;version="[1.1,2.0)",
+ org.eclipse.kura.core.configuration.metatype;version="[1.0,2.0)",
+ org.eclipse.kura.identity.configuration.extension;version="[1.0,1.1)",
+ org.osgi.framework;version="1.10.0",
+ org.osgi.service.component;version="1.4.0",
+ org.slf4j;version="1.7.36"

--- a/kura/examples/org.eclipse.kura.example.identity.configuration.extension/OSGI-INF/metatype/org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension.xml
+++ b/kura/examples/org.eclipse.kura.example.identity.configuration.extension/OSGI-INF/metatype/org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    
+    Copyright (c) 2024 Eurotech and/or its affiliates and others
+  
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+    
+    SPDX-License-Identifier: EPL-2.0
+    
+    Contributors:
+     Eurotech
+     
+-->
+<MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0"
+	localization="en_us">
+	<OCD id="org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension"
+		name="Example Identity Configuration Extension"
+		description="An example identity configuration extension" />
+
+	<Designate
+		factoryPid="org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension">
+		<Object ocdref="org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension"/>
+	</Designate>
+</MetaData>

--- a/kura/examples/org.eclipse.kura.example.identity.configuration.extension/OSGI-INF/org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension.xml
+++ b/kura/examples/org.eclipse.kura.example.identity.configuration.extension/OSGI-INF/org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Eurotech and/or its affiliates and others
+  
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+ 
+	SPDX-License-Identifier: EPL-2.0
+	
+	Contributors:
+	 Eurotech
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension">
+	<implementation class="org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension"/>
+ <service>
+    <provide interface="org.eclipse.kura.configuration.ConfigurableComponent"/>
+    <provide interface="org.eclipse.kura.identity.configuration.extension.IdentityConfigurationExtension"/>
+ </service>
+
+</scr:component>

--- a/kura/examples/org.eclipse.kura.example.identity.configuration.extension/about.html
+++ b/kura/examples/org.eclipse.kura.example.identity.configuration.extension/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>November 30, 2017</p>
+<h3>License</h3>
+
+<p>
+    The Eclipse Foundation makes available all content in this plug-in
+    (&quot;Content&quot;). Unless otherwise indicated below, the Content
+    is provided to you under the terms and conditions of the Eclipse
+    Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+    available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.
+</p>
+
+<p>
+    If you did not receive this Content directly from the Eclipse
+    Foundation, the Content is being redistributed by another party
+    (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the
+    Redistributor's license that was provided with the Content. If no such
+    license exists, contact the Redistributor. Unless otherwise indicated
+    below, the terms and conditions of the EPL still apply to any source
+    code in the Content and such source code may be obtained at <a
+        href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/kura/examples/org.eclipse.kura.example.identity.configuration.extension/about_files/epl-v20.html
+++ b/kura/examples/org.eclipse.kura.example.identity.configuration.extension/about_files/epl-v20.html
@@ -1,0 +1,301 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>Eclipse Public License - Version 2.0</title>
+  <style type="text/css">
+    body {
+      margin: 1.5em 3em;
+    }
+    h1{
+      font-size:1.5em;
+    }
+    h2{
+      font-size:1em;
+      margin-bottom:0.5em;
+      margin-top:1em;
+    }
+    p {
+      margin-top:  0.5em;
+      margin-bottom: 0.5em;
+    }
+    ul, ol{
+      list-style-type:none;
+    }
+  </style>
+</head>
+<body>
+<h1>Eclipse Public License - v 2.0</h1>
+<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+  PUBLIC LICENSE (&ldquo;AGREEMENT&rdquo;). ANY USE, REPRODUCTION OR DISTRIBUTION
+  OF THE PROGRAM CONSTITUTES RECIPIENT&#039;S ACCEPTANCE OF THIS AGREEMENT.
+</p>
+<h2 id="definitions">1. DEFINITIONS</h2>
+<p>&ldquo;Contribution&rdquo; means:</p>
+<ul>
+  <li>a) in the case of the initial Contributor, the initial content
+    Distributed under this Agreement, and
+  </li>
+  <li>
+    b) in the case of each subsequent Contributor:
+    <ul>
+      <li>i) changes to the Program, and</li>
+      <li>ii) additions to the Program;</li>
+    </ul>
+    where such changes and/or additions to the Program originate from
+    and are Distributed by that particular Contributor. A Contribution
+    &ldquo;originates&rdquo; from a Contributor if it was added to the Program by such
+    Contributor itself or anyone acting on such Contributor&#039;s behalf.
+    Contributions do not include changes or additions to the Program that
+    are not Modified Works.
+  </li>
+</ul>
+<p>&ldquo;Contributor&rdquo; means any person or entity that Distributes the Program.</p>
+<p>&ldquo;Licensed Patents&rdquo; mean patent claims licensable by a Contributor which
+  are necessarily infringed by the use or sale of its Contribution alone
+  or when combined with the Program.
+</p>
+<p>&ldquo;Program&rdquo; means the Contributions Distributed in accordance with this
+  Agreement.
+</p>
+<p>&ldquo;Recipient&rdquo; means anyone who receives the Program under this Agreement
+  or any Secondary License (as applicable), including Contributors.
+</p>
+<p>&ldquo;Derivative Works&rdquo; shall mean any work, whether in Source Code or other
+  form, that is based on (or derived from) the Program and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship.
+</p>
+<p>&ldquo;Modified Works&rdquo; shall mean any work in Source Code or other form that
+  results from an addition to, deletion from, or modification of the
+  contents of the Program, including, for purposes of clarity any new file
+  in Source Code form that contains any contents of the Program. Modified
+  Works shall not include works that contain only declarations, interfaces,
+  types, classes, structures, or files of the Program solely in each case
+  in order to link to, bind by name, or subclass the Program or Modified
+  Works thereof.
+</p>
+<p>&ldquo;Distribute&rdquo; means the acts of a) distributing or b) making available
+  in any manner that enables the transfer of a copy.
+</p>
+<p>&ldquo;Source Code&rdquo; means the form of a Program preferred for making
+  modifications, including but not limited to software source code,
+  documentation source, and configuration files.
+</p>
+<p>&ldquo;Secondary License&rdquo; means either the GNU General Public License,
+  Version 2.0, or any later versions of that license, including any
+  exceptions or additional permissions as identified by the initial
+  Contributor.
+</p>
+<h2 id="grant-of-rights">2. GRANT OF RIGHTS</h2>
+<ul>
+  <li>a) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free copyright
+    license to reproduce, prepare Derivative Works of, publicly display,
+    publicly perform, Distribute and sublicense the Contribution of such
+    Contributor, if any, and such Derivative Works.
+  </li>
+  <li>b) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free patent
+    license under Licensed Patents to make, use, sell, offer to sell,
+    import and otherwise transfer the Contribution of such Contributor,
+    if any, in Source Code or other form. This patent license shall
+    apply to the combination of the Contribution and the Program if,
+    at the time the Contribution is added by the Contributor, such
+    addition of the Contribution causes such combination to be covered
+    by the Licensed Patents. The patent license shall not apply to any
+    other combinations which include the Contribution. No hardware per
+    se is licensed hereunder.
+  </li>
+  <li>c) Recipient understands that although each Contributor grants the
+    licenses to its Contributions set forth herein, no assurances are
+    provided by any Contributor that the Program does not infringe the
+    patent or other intellectual property rights of any other entity.
+    Each Contributor disclaims any liability to Recipient for claims
+    brought by any other entity based on infringement of intellectual
+    property rights or otherwise. As a condition to exercising the rights
+    and licenses granted hereunder, each Recipient hereby assumes sole
+    responsibility to secure any other intellectual property rights needed,
+    if any. For example, if a third party patent license is required to
+    allow Recipient to Distribute the Program, it is Recipient&#039;s
+    responsibility to acquire that license before distributing the Program.
+  </li>
+  <li>d) Each Contributor represents that to its knowledge it has sufficient
+    copyright rights in its Contribution, if any, to grant the copyright
+    license set forth in this Agreement.
+  </li>
+  <li>e) Notwithstanding the terms of any Secondary License, no Contributor
+    makes additional grants to any Recipient (other than those set forth
+    in this Agreement) as a result of such Recipient&#039;s receipt of the
+    Program under the terms of a Secondary License (if permitted under
+    the terms of Section 3).
+  </li>
+</ul>
+<h2 id="requirements">3. REQUIREMENTS</h2>
+<p>3.1 If a Contributor Distributes the Program in any form, then:</p>
+<ul>
+  <li>a) the Program must also be made available as Source Code, in
+    accordance with section 3.2, and the Contributor must accompany
+    the Program with a statement that the Source Code for the Program
+    is available under this Agreement, and informs Recipients how to
+    obtain it in a reasonable manner on or through a medium customarily
+    used for software exchange; and
+  </li>
+  <li>
+    b) the Contributor may Distribute the Program under a license
+    different than this Agreement, provided that such license:
+    <ul>
+      <li>i) effectively disclaims on behalf of all other Contributors all
+        warranties and conditions, express and implied, including warranties
+        or conditions of title and non-infringement, and implied warranties
+        or conditions of merchantability and fitness for a particular purpose;
+      </li>
+      <li>ii) effectively excludes on behalf of all other Contributors all
+        liability for damages, including direct, indirect, special, incidental
+        and consequential damages, such as lost profits;
+      </li>
+      <li>iii) does not attempt to limit or alter the recipients&#039; rights in the
+        Source Code under section 3.2; and
+      </li>
+      <li>iv) requires any subsequent distribution of the Program by any party
+        to be under a license that satisfies the requirements of this section 3.
+      </li>
+    </ul>
+  </li>
+</ul>
+<p>3.2 When the Program is Distributed as Source Code:</p>
+<ul>
+  <li>a) it must be made available under this Agreement, or if the Program (i)
+    is combined with other material in a separate file or files made available
+    under a Secondary License, and (ii) the initial Contributor attached to
+    the Source Code the notice described in Exhibit A of this Agreement,
+    then the Program may be made available under the terms of such
+    Secondary Licenses, and
+  </li>
+  <li>b) a copy of this Agreement must be included with each copy of the Program.</li>
+</ul>
+<p>3.3 Contributors may not remove or alter any copyright, patent, trademark,
+  attribution notices, disclaimers of warranty, or limitations of liability
+  (&lsquo;notices&rsquo;) contained within the Program from any copy of the Program which
+  they Distribute, provided that Contributors may add their own appropriate
+  notices.
+</p>
+<h2 id="commercial-distribution">4. COMMERCIAL DISTRIBUTION</h2>
+<p>Commercial distributors of software may accept certain responsibilities
+  with respect to end users, business partners and the like. While this
+  license is intended to facilitate the commercial use of the Program, the
+  Contributor who includes the Program in a commercial product offering should
+  do so in a manner which does not create potential liability for other
+  Contributors. Therefore, if a Contributor includes the Program in a
+  commercial product offering, such Contributor (&ldquo;Commercial Contributor&rdquo;)
+  hereby agrees to defend and indemnify every other Contributor
+  (&ldquo;Indemnified Contributor&rdquo;) against any losses, damages and costs
+  (collectively &ldquo;Losses&rdquo;) arising from claims, lawsuits and other legal actions
+  brought by a third party against the Indemnified Contributor to the extent
+  caused by the acts or omissions of such Commercial Contributor in connection
+  with its distribution of the Program in a commercial product offering.
+  The obligations in this section do not apply to any claims or Losses relating
+  to any actual or alleged intellectual property infringement. In order to
+  qualify, an Indemnified Contributor must: a) promptly notify the
+  Commercial Contributor in writing of such claim, and b) allow the Commercial
+  Contributor to control, and cooperate with the Commercial Contributor in,
+  the defense and any related settlement negotiations. The Indemnified
+  Contributor may participate in any such claim at its own expense.
+</p>
+<p>For example, a Contributor might include the Program
+  in a commercial product offering, Product X. That Contributor is then a
+  Commercial Contributor. If that Commercial Contributor then makes performance
+  claims, or offers warranties related to Product X, those performance claims
+  and warranties are such Commercial Contributor&#039;s responsibility alone.
+  Under this section, the Commercial Contributor would have to defend claims
+  against the other Contributors related to those performance claims and
+  warranties, and if a court requires any other Contributor to pay any damages
+  as a result, the Commercial Contributor must pay those damages.
+</p>
+<h2 id="warranty">5. NO WARRANTY</h2>
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED
+  BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN &ldquo;AS IS&rdquo; BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
+  WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
+  MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is
+  solely responsible for determining the appropriateness of using and
+  distributing the Program and assumes all risks associated with its
+  exercise of rights under this Agreement, including but not limited to the
+  risks and costs of program errors, compliance with applicable laws, damage
+  to or loss of data, programs or equipment, and unavailability or
+  interruption of operations.
+</p>
+<h2 id="disclaimer">6. DISCLAIMER OF LIABILITY</h2>
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED
+  BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY
+  LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+  OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS),
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS
+  GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+</p>
+<h2 id="general">7. GENERAL</h2>
+<p>If any provision of this Agreement is invalid or unenforceable under
+  applicable law, it shall not affect the validity or enforceability of the
+  remainder of the terms of this Agreement, and without further action by the
+  parties hereto, such provision shall be reformed to the minimum extent
+  necessary to make such provision valid and enforceable.
+</p>
+<p>If Recipient institutes patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+  (excluding combinations of the Program with other software or hardware)
+  infringes such Recipient&#039;s patent(s), then such Recipient&#039;s rights granted
+  under Section 2(b) shall terminate as of the date such litigation is filed.
+</p>
+<p>All Recipient&#039;s rights under this Agreement shall terminate if it fails to
+  comply with any of the material terms or conditions of this Agreement and
+  does not cure such failure in a reasonable period of time after becoming
+  aware of such noncompliance. If all Recipient&#039;s rights under this Agreement
+  terminate, Recipient agrees to cease use and distribution of the Program
+  as soon as reasonably practicable. However, Recipient&#039;s obligations under
+  this Agreement and any licenses granted by Recipient relating to the
+  Program shall continue and survive.
+</p>
+<p>Everyone is permitted to copy and distribute copies of this Agreement,
+  but in order to avoid inconsistency the Agreement is copyrighted and may
+  only be modified in the following manner. The Agreement Steward reserves
+  the right to publish new versions (including revisions) of this Agreement
+  from time to time. No one other than the Agreement Steward has the right
+  to modify this Agreement. The Eclipse Foundation is the initial Agreement
+  Steward. The Eclipse Foundation may assign the responsibility to serve as
+  the Agreement Steward to a suitable separate entity. Each new version of
+  the Agreement will be given a distinguishing version number. The Program
+  (including Contributions) may always be Distributed subject to the version
+  of the Agreement under which it was received. In addition, after a new
+  version of the Agreement is published, Contributor may elect to Distribute
+  the Program (including its Contributions) under the new version.
+</p>
+<p>Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+  receives no rights or licenses to the intellectual property of any
+  Contributor under this Agreement, whether expressly, by implication,
+  estoppel or otherwise. All rights in the Program not expressly granted
+  under this Agreement are reserved. Nothing in this Agreement is intended
+  to be enforceable by any entity that is not a Contributor or Recipient.
+  No third-party beneficiary rights are created under this Agreement.
+</p>
+<h2 id="exhibit-a">Exhibit A &ndash; Form of Secondary Licenses Notice</h2>
+<p>&ldquo;This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set forth
+  in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+  version(s), and exceptions or additional permissions here}.&rdquo;
+</p>
+<blockquote>
+  <p>Simply including a copy of this Agreement, including this Exhibit A
+    is not sufficient to license the Source Code under Secondary Licenses.
+  </p>
+  <p>If it is not possible or desirable to put the notice in a particular file,
+    then You may include the notice in a location (such as a LICENSE file in a
+    relevant directory) where a recipient would be likely to look for
+    such a notice.
+  </p>
+  <p>You may add additional accurate notices of copyright ownership.</p>
+</blockquote>
+</body>
+</html>

--- a/kura/examples/org.eclipse.kura.example.identity.configuration.extension/build.properties
+++ b/kura/examples/org.eclipse.kura.example.identity.configuration.extension/build.properties
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2024 Eurotech and/or its affiliates and others
+# 
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#  Eurotech
+#
+
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               about_files/,\
+               about.html
+source.. = src/main/java/

--- a/kura/examples/org.eclipse.kura.example.identity.configuration.extension/pom.xml
+++ b/kura/examples/org.eclipse.kura.example.identity.configuration.extension/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Eurotech and/or its affiliates and others
+  
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+ 
+	SPDX-License-Identifier: EPL-2.0
+	
+	Contributors:
+	 Eurotech
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.kura</groupId>
+		<artifactId>examples</artifactId>
+		<version>5.5.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.kura.example.identity.configuration.extension</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+
+	<properties>
+		<kura.basedir>${project.basedir}/../..</kura.basedir>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-eclipse-plugin</artifactId>
+				<version>${maven-eclipse-plugin.version}</version>
+				<configuration>
+					<skip>false</skip>
+				</configuration>
+			</plugin>
+        </plugins>
+	</build>
+</project>

--- a/kura/examples/org.eclipse.kura.example.identity.configuration.extension/src/main/java/org/eclipse/kura/example/identity/configuration/extension/ExampleIdentityConfigurationExtension.java
+++ b/kura/examples/org.eclipse.kura.example.identity.configuration.extension/src/main/java/org/eclipse/kura/example/identity/configuration/extension/ExampleIdentityConfigurationExtension.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.example.identity.configuration.extension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.configuration.ComponentConfiguration;
+import org.eclipse.kura.configuration.ConfigurableComponent;
+import org.eclipse.kura.configuration.ConfigurationService;
+import org.eclipse.kura.configuration.metatype.OCD;
+import org.eclipse.kura.core.configuration.metatype.Tad;
+import org.eclipse.kura.core.configuration.metatype.Tocd;
+import org.eclipse.kura.core.configuration.metatype.Tscalar;
+import org.eclipse.kura.identity.configuration.extension.IdentityConfigurationExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExampleIdentityConfigurationExtension implements IdentityConfigurationExtension, ConfigurableComponent {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExampleIdentityConfigurationExtension.class);
+
+    private final Map<String, IdentityConfiguration> configurations = new HashMap<>();
+
+    private String kuraServicePid;
+
+    public void activate(final Map<String, Object> properties) {
+        logger.info("activating...");
+
+        updated(properties);
+
+        logger.info("activating...done");
+    }
+
+    public void updated(final Map<String, Object> properties) {
+        logger.info("updating...");
+
+        try {
+            this.kuraServicePid = (String) properties.get(ConfigurationService.KURA_SERVICE_PID);
+        } catch (final Exception e) {
+            logger.warn("failed to get own " + ConfigurationService.KURA_SERVICE_PID, e);
+        }
+
+        logger.info("updating...done");
+    }
+
+    @Override
+    public synchronized Optional<ComponentConfiguration> getConfiguration(final String identityName)
+            throws KuraException {
+
+        final IdentityConfiguration result = Optional.ofNullable(this.configurations.get(identityName))
+                .orElseGet(IdentityConfiguration::new);
+
+        return Optional.of(new ComponentConfiguration() {
+
+            @Override
+            public String getPid() {
+                return ExampleIdentityConfigurationExtension.this.kuraServicePid;
+            }
+
+            @Override
+            public OCD getDefinition() {
+                return IdentityConfiguration.buildOCD(ExampleIdentityConfigurationExtension.this.kuraServicePid);
+            }
+
+            @Override
+            public Map<String, Object> getConfigurationProperties() {
+                return result.toProperties();
+            }
+        });
+    }
+
+    @Override
+    public synchronized void updateConfiguration(String identityName, ComponentConfiguration configuration)
+            throws KuraException {
+
+        final IdentityConfiguration config = new IdentityConfiguration(configuration.getConfigurationProperties());
+
+        logger.info("received configuration for identity {}: {}", identityName, config);
+
+        this.configurations.put(identityName, config);
+
+    }
+
+    private static class IdentityConfiguration {
+
+        private static final String TEST_STRING_PROPERTY_KEY = "test.string";
+        private static final String TEST_INTEGER_PROPERTY_KEY = "test.integer";
+
+        private static final String TEST_STRING_PROPERTY_DEFAULT = "foobar";
+        private static final int TEST_INTEGER_PROPERTY_DEFAULT = 0;
+
+        private final String testStringProperty;
+        private final int testIntProperty;
+
+        IdentityConfiguration() {
+            this.testStringProperty = TEST_STRING_PROPERTY_DEFAULT;
+            this.testIntProperty = TEST_INTEGER_PROPERTY_DEFAULT;
+        }
+
+        IdentityConfiguration(final Map<String, Object> properties) {
+            this.testStringProperty = Optional.ofNullable(properties.get(TEST_STRING_PROPERTY_KEY))
+                    .filter(String.class::isInstance).map(String.class::cast).orElse(TEST_STRING_PROPERTY_DEFAULT);
+            this.testIntProperty = Optional.ofNullable(properties.get(TEST_INTEGER_PROPERTY_KEY))
+                    .filter(Integer.class::isInstance).map(Integer.class::cast).orElse(TEST_INTEGER_PROPERTY_DEFAULT);
+        }
+
+        Map<String, Object> toProperties() {
+            final Map<String, Object> result = new HashMap<>();
+
+            result.put(TEST_STRING_PROPERTY_KEY, this.testStringProperty);
+            result.put(TEST_INTEGER_PROPERTY_KEY, this.testIntProperty);
+
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "IdentityConfiguration [testStringProperty=" + this.testStringProperty + ", testIntProperty="
+                    + this.testIntProperty + "]";
+        }
+
+        static OCD buildOCD(final String kuraServicePid) {
+            final Tocd ocd = new Tocd();
+
+            ocd.setId(kuraServicePid);
+            ocd.setName("Example Configuration Extension " + kuraServicePid);
+            ocd.setDescription("Configuration provided by example configuration extension " + kuraServicePid);
+
+            final Tad testStringProp = new Tad();
+            testStringProp.setId(TEST_STRING_PROPERTY_KEY);
+            testStringProp.setName("Test String Property");
+            testStringProp.setDescription("A test string property");
+            testStringProp.setDefault(TEST_STRING_PROPERTY_DEFAULT);
+            testStringProp.setRequired(true);
+            testStringProp.setType(Tscalar.STRING);
+            ocd.addAD(testStringProp);
+
+            final Tad testIntProp = new Tad();
+            testIntProp.setId(TEST_INTEGER_PROPERTY_KEY);
+            testIntProp.setName("Test Integer Property");
+            testIntProp.setDescription("A test integer property");
+            testIntProp.setDefault(Integer.toString(TEST_INTEGER_PROPERTY_DEFAULT));
+            testIntProp.setRequired(true);
+            testIntProp.setType(Tscalar.INTEGER);
+            ocd.addAD(testIntProp);
+
+            return ocd;
+        }
+
+    }
+}

--- a/kura/examples/pom.xml
+++ b/kura/examples/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -99,6 +99,7 @@
         <module>org.eclipse.kura.example.gpio.led</module>
         <module>org.eclipse.kura.example.tamper.detection</module>
         <module>org.eclipse.kura.example.rest.authentication.provider</module>
+        <module>org.eclipse.kura.example.identity.configuration.extension</module>
         <module>test</module>
     </modules>
 
@@ -116,7 +117,6 @@
                     -Dosgi.console=5002
                     -DbuildingWithTycho=true -Dosgi.locking=none
                     -Dds.showtrace=true -Djava.io.tmpdir=/tmp
-                    -Dorg.osgi.framework.storage=/tmp/osgi/framework_storage
                     -Dosgi.clean=true
                     -Dorg.eclipse.kura.mode=emulator
                     -Dkura.snapshots=${project.basedir}/target/
@@ -139,7 +139,6 @@
                     -Dosgi.console=5002
                     -DbuildingWithTycho=true -Dosgi.locking=none
                     -Dds.showtrace=true -Djava.io.tmpdir=/tmp
-                    -Dorg.osgi.framework.storage=/tmp/osgi/framework_storage
                     -Dosgi.clean=true
                     -Dorg.eclipse.kura.mode=emulator
                     -Dkura.snapshots=${project.basedir}/target/

--- a/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/META-INF/MANIFEST.MF
+++ b/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: org.eclipse.kura.example.identity.configuration.extension.test
+Bundle-SymbolicName: org.eclipse.kura.example.identity.configuration.extension.test;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Import-Package: org.eclipse.kura.configuration;version="[1.2,2.0)",
+ org.eclipse.kura.configuration.metatype;version="1.1.0",
+ org.eclipse.kura.identity.configuration.extension;version="[1.0,2.0)",
+ org.eclipse.kura.util.wire.test;version="[1.1,2.0)",
+ org.junit;version="4.12.0",
+ org.osgi.framework;version="1.10.0"
+Require-Bundle: org.eclipse.kura.example.identity.configuration.extension;bundle-version="1.0.0"
+Bundle-Vendor: Eclipse Kura
+Bundle-License: Eclipse Public License v2.0
+Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+Bundle-ActivationPolicy: lazy

--- a/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/OSGI-INF/example.xml
+++ b/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/OSGI-INF/example.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   
+   Copyright (c) 2024 Eurotech and/or its affiliates and others
+
+   This program and the accompanying materials are made
+   available under the terms of the Eclipse Public License 2.0
+   which is available at https://www.eclipse.org/legal/epl-2.0/
+ 
+	SPDX-License-Identifier: EPL-2.0
+	
+	Contributors:
+	 Eurotech
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" enabled="true" immediate="true" name="org.eclipse.kura.example.web.extension.server.ExampleExtensionComponent">
+   <implementation class="org.eclipse.kura.example.web.extension.server.ExampleExtensionComponent"/>
+   <reference bind="setHttpService" cardinality="1..1" interface="org.osgi.service.http.HttpService" name="HttpService" policy="static"/>
+   <reference bind="setConsole" cardinality="1..1" interface="org.eclipse.kura.web.api.Console" name="Console" policy="static"/>
+</scr:component>

--- a/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/about.html
+++ b/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>November 30, 2017</p>
+<h3>License</h3>
+
+<p>
+    The Eclipse Foundation makes available all content in this plug-in
+    (&quot;Content&quot;). Unless otherwise indicated below, the Content
+    is provided to you under the terms and conditions of the Eclipse
+    Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+    available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.
+</p>
+
+<p>
+    If you did not receive this Content directly from the Eclipse
+    Foundation, the Content is being redistributed by another party
+    (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the
+    Redistributor's license that was provided with the Content. If no such
+    license exists, contact the Redistributor. Unless otherwise indicated
+    below, the terms and conditions of the EPL still apply to any source
+    code in the Content and such source code may be obtained at <a
+        href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/about_files/epl-v20.html
+++ b/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/about_files/epl-v20.html
@@ -1,0 +1,301 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>Eclipse Public License - Version 2.0</title>
+  <style type="text/css">
+    body {
+      margin: 1.5em 3em;
+    }
+    h1{
+      font-size:1.5em;
+    }
+    h2{
+      font-size:1em;
+      margin-bottom:0.5em;
+      margin-top:1em;
+    }
+    p {
+      margin-top:  0.5em;
+      margin-bottom: 0.5em;
+    }
+    ul, ol{
+      list-style-type:none;
+    }
+  </style>
+</head>
+<body>
+<h1>Eclipse Public License - v 2.0</h1>
+<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+  PUBLIC LICENSE (&ldquo;AGREEMENT&rdquo;). ANY USE, REPRODUCTION OR DISTRIBUTION
+  OF THE PROGRAM CONSTITUTES RECIPIENT&#039;S ACCEPTANCE OF THIS AGREEMENT.
+</p>
+<h2 id="definitions">1. DEFINITIONS</h2>
+<p>&ldquo;Contribution&rdquo; means:</p>
+<ul>
+  <li>a) in the case of the initial Contributor, the initial content
+    Distributed under this Agreement, and
+  </li>
+  <li>
+    b) in the case of each subsequent Contributor:
+    <ul>
+      <li>i) changes to the Program, and</li>
+      <li>ii) additions to the Program;</li>
+    </ul>
+    where such changes and/or additions to the Program originate from
+    and are Distributed by that particular Contributor. A Contribution
+    &ldquo;originates&rdquo; from a Contributor if it was added to the Program by such
+    Contributor itself or anyone acting on such Contributor&#039;s behalf.
+    Contributions do not include changes or additions to the Program that
+    are not Modified Works.
+  </li>
+</ul>
+<p>&ldquo;Contributor&rdquo; means any person or entity that Distributes the Program.</p>
+<p>&ldquo;Licensed Patents&rdquo; mean patent claims licensable by a Contributor which
+  are necessarily infringed by the use or sale of its Contribution alone
+  or when combined with the Program.
+</p>
+<p>&ldquo;Program&rdquo; means the Contributions Distributed in accordance with this
+  Agreement.
+</p>
+<p>&ldquo;Recipient&rdquo; means anyone who receives the Program under this Agreement
+  or any Secondary License (as applicable), including Contributors.
+</p>
+<p>&ldquo;Derivative Works&rdquo; shall mean any work, whether in Source Code or other
+  form, that is based on (or derived from) the Program and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship.
+</p>
+<p>&ldquo;Modified Works&rdquo; shall mean any work in Source Code or other form that
+  results from an addition to, deletion from, or modification of the
+  contents of the Program, including, for purposes of clarity any new file
+  in Source Code form that contains any contents of the Program. Modified
+  Works shall not include works that contain only declarations, interfaces,
+  types, classes, structures, or files of the Program solely in each case
+  in order to link to, bind by name, or subclass the Program or Modified
+  Works thereof.
+</p>
+<p>&ldquo;Distribute&rdquo; means the acts of a) distributing or b) making available
+  in any manner that enables the transfer of a copy.
+</p>
+<p>&ldquo;Source Code&rdquo; means the form of a Program preferred for making
+  modifications, including but not limited to software source code,
+  documentation source, and configuration files.
+</p>
+<p>&ldquo;Secondary License&rdquo; means either the GNU General Public License,
+  Version 2.0, or any later versions of that license, including any
+  exceptions or additional permissions as identified by the initial
+  Contributor.
+</p>
+<h2 id="grant-of-rights">2. GRANT OF RIGHTS</h2>
+<ul>
+  <li>a) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free copyright
+    license to reproduce, prepare Derivative Works of, publicly display,
+    publicly perform, Distribute and sublicense the Contribution of such
+    Contributor, if any, and such Derivative Works.
+  </li>
+  <li>b) Subject to the terms of this Agreement, each Contributor hereby
+    grants Recipient a non-exclusive, worldwide, royalty-free patent
+    license under Licensed Patents to make, use, sell, offer to sell,
+    import and otherwise transfer the Contribution of such Contributor,
+    if any, in Source Code or other form. This patent license shall
+    apply to the combination of the Contribution and the Program if,
+    at the time the Contribution is added by the Contributor, such
+    addition of the Contribution causes such combination to be covered
+    by the Licensed Patents. The patent license shall not apply to any
+    other combinations which include the Contribution. No hardware per
+    se is licensed hereunder.
+  </li>
+  <li>c) Recipient understands that although each Contributor grants the
+    licenses to its Contributions set forth herein, no assurances are
+    provided by any Contributor that the Program does not infringe the
+    patent or other intellectual property rights of any other entity.
+    Each Contributor disclaims any liability to Recipient for claims
+    brought by any other entity based on infringement of intellectual
+    property rights or otherwise. As a condition to exercising the rights
+    and licenses granted hereunder, each Recipient hereby assumes sole
+    responsibility to secure any other intellectual property rights needed,
+    if any. For example, if a third party patent license is required to
+    allow Recipient to Distribute the Program, it is Recipient&#039;s
+    responsibility to acquire that license before distributing the Program.
+  </li>
+  <li>d) Each Contributor represents that to its knowledge it has sufficient
+    copyright rights in its Contribution, if any, to grant the copyright
+    license set forth in this Agreement.
+  </li>
+  <li>e) Notwithstanding the terms of any Secondary License, no Contributor
+    makes additional grants to any Recipient (other than those set forth
+    in this Agreement) as a result of such Recipient&#039;s receipt of the
+    Program under the terms of a Secondary License (if permitted under
+    the terms of Section 3).
+  </li>
+</ul>
+<h2 id="requirements">3. REQUIREMENTS</h2>
+<p>3.1 If a Contributor Distributes the Program in any form, then:</p>
+<ul>
+  <li>a) the Program must also be made available as Source Code, in
+    accordance with section 3.2, and the Contributor must accompany
+    the Program with a statement that the Source Code for the Program
+    is available under this Agreement, and informs Recipients how to
+    obtain it in a reasonable manner on or through a medium customarily
+    used for software exchange; and
+  </li>
+  <li>
+    b) the Contributor may Distribute the Program under a license
+    different than this Agreement, provided that such license:
+    <ul>
+      <li>i) effectively disclaims on behalf of all other Contributors all
+        warranties and conditions, express and implied, including warranties
+        or conditions of title and non-infringement, and implied warranties
+        or conditions of merchantability and fitness for a particular purpose;
+      </li>
+      <li>ii) effectively excludes on behalf of all other Contributors all
+        liability for damages, including direct, indirect, special, incidental
+        and consequential damages, such as lost profits;
+      </li>
+      <li>iii) does not attempt to limit or alter the recipients&#039; rights in the
+        Source Code under section 3.2; and
+      </li>
+      <li>iv) requires any subsequent distribution of the Program by any party
+        to be under a license that satisfies the requirements of this section 3.
+      </li>
+    </ul>
+  </li>
+</ul>
+<p>3.2 When the Program is Distributed as Source Code:</p>
+<ul>
+  <li>a) it must be made available under this Agreement, or if the Program (i)
+    is combined with other material in a separate file or files made available
+    under a Secondary License, and (ii) the initial Contributor attached to
+    the Source Code the notice described in Exhibit A of this Agreement,
+    then the Program may be made available under the terms of such
+    Secondary Licenses, and
+  </li>
+  <li>b) a copy of this Agreement must be included with each copy of the Program.</li>
+</ul>
+<p>3.3 Contributors may not remove or alter any copyright, patent, trademark,
+  attribution notices, disclaimers of warranty, or limitations of liability
+  (&lsquo;notices&rsquo;) contained within the Program from any copy of the Program which
+  they Distribute, provided that Contributors may add their own appropriate
+  notices.
+</p>
+<h2 id="commercial-distribution">4. COMMERCIAL DISTRIBUTION</h2>
+<p>Commercial distributors of software may accept certain responsibilities
+  with respect to end users, business partners and the like. While this
+  license is intended to facilitate the commercial use of the Program, the
+  Contributor who includes the Program in a commercial product offering should
+  do so in a manner which does not create potential liability for other
+  Contributors. Therefore, if a Contributor includes the Program in a
+  commercial product offering, such Contributor (&ldquo;Commercial Contributor&rdquo;)
+  hereby agrees to defend and indemnify every other Contributor
+  (&ldquo;Indemnified Contributor&rdquo;) against any losses, damages and costs
+  (collectively &ldquo;Losses&rdquo;) arising from claims, lawsuits and other legal actions
+  brought by a third party against the Indemnified Contributor to the extent
+  caused by the acts or omissions of such Commercial Contributor in connection
+  with its distribution of the Program in a commercial product offering.
+  The obligations in this section do not apply to any claims or Losses relating
+  to any actual or alleged intellectual property infringement. In order to
+  qualify, an Indemnified Contributor must: a) promptly notify the
+  Commercial Contributor in writing of such claim, and b) allow the Commercial
+  Contributor to control, and cooperate with the Commercial Contributor in,
+  the defense and any related settlement negotiations. The Indemnified
+  Contributor may participate in any such claim at its own expense.
+</p>
+<p>For example, a Contributor might include the Program
+  in a commercial product offering, Product X. That Contributor is then a
+  Commercial Contributor. If that Commercial Contributor then makes performance
+  claims, or offers warranties related to Product X, those performance claims
+  and warranties are such Commercial Contributor&#039;s responsibility alone.
+  Under this section, the Commercial Contributor would have to defend claims
+  against the other Contributors related to those performance claims and
+  warranties, and if a court requires any other Contributor to pay any damages
+  as a result, the Commercial Contributor must pay those damages.
+</p>
+<h2 id="warranty">5. NO WARRANTY</h2>
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED
+  BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN &ldquo;AS IS&rdquo; BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
+  WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
+  MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is
+  solely responsible for determining the appropriateness of using and
+  distributing the Program and assumes all risks associated with its
+  exercise of rights under this Agreement, including but not limited to the
+  risks and costs of program errors, compliance with applicable laws, damage
+  to or loss of data, programs or equipment, and unavailability or
+  interruption of operations.
+</p>
+<h2 id="disclaimer">6. DISCLAIMER OF LIABILITY</h2>
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED
+  BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY
+  LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+  OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS),
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS
+  GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+</p>
+<h2 id="general">7. GENERAL</h2>
+<p>If any provision of this Agreement is invalid or unenforceable under
+  applicable law, it shall not affect the validity or enforceability of the
+  remainder of the terms of this Agreement, and without further action by the
+  parties hereto, such provision shall be reformed to the minimum extent
+  necessary to make such provision valid and enforceable.
+</p>
+<p>If Recipient institutes patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+  (excluding combinations of the Program with other software or hardware)
+  infringes such Recipient&#039;s patent(s), then such Recipient&#039;s rights granted
+  under Section 2(b) shall terminate as of the date such litigation is filed.
+</p>
+<p>All Recipient&#039;s rights under this Agreement shall terminate if it fails to
+  comply with any of the material terms or conditions of this Agreement and
+  does not cure such failure in a reasonable period of time after becoming
+  aware of such noncompliance. If all Recipient&#039;s rights under this Agreement
+  terminate, Recipient agrees to cease use and distribution of the Program
+  as soon as reasonably practicable. However, Recipient&#039;s obligations under
+  this Agreement and any licenses granted by Recipient relating to the
+  Program shall continue and survive.
+</p>
+<p>Everyone is permitted to copy and distribute copies of this Agreement,
+  but in order to avoid inconsistency the Agreement is copyrighted and may
+  only be modified in the following manner. The Agreement Steward reserves
+  the right to publish new versions (including revisions) of this Agreement
+  from time to time. No one other than the Agreement Steward has the right
+  to modify this Agreement. The Eclipse Foundation is the initial Agreement
+  Steward. The Eclipse Foundation may assign the responsibility to serve as
+  the Agreement Steward to a suitable separate entity. Each new version of
+  the Agreement will be given a distinguishing version number. The Program
+  (including Contributions) may always be Distributed subject to the version
+  of the Agreement under which it was received. In addition, after a new
+  version of the Agreement is published, Contributor may elect to Distribute
+  the Program (including its Contributions) under the new version.
+</p>
+<p>Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+  receives no rights or licenses to the intellectual property of any
+  Contributor under this Agreement, whether expressly, by implication,
+  estoppel or otherwise. All rights in the Program not expressly granted
+  under this Agreement are reserved. Nothing in this Agreement is intended
+  to be enforceable by any entity that is not a Contributor or Recipient.
+  No third-party beneficiary rights are created under this Agreement.
+</p>
+<h2 id="exhibit-a">Exhibit A &ndash; Form of Secondary Licenses Notice</h2>
+<p>&ldquo;This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set forth
+  in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+  version(s), and exceptions or additional permissions here}.&rdquo;
+</p>
+<blockquote>
+  <p>Simply including a copy of this Agreement, including this Exhibit A
+    is not sufficient to license the Source Code under Secondary Licenses.
+  </p>
+  <p>If it is not possible or desirable to put the notice in a particular file,
+    then You may include the notice in a location (such as a LICENSE file in a
+    relevant directory) where a recipient would be likely to look for
+    such a notice.
+  </p>
+  <p>You may add additional accurate notices of copyright ownership.</p>
+</blockquote>
+</body>
+</html>

--- a/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/build.properties
+++ b/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/build.properties
@@ -1,0 +1,6 @@
+bin.includes = .,\
+               OSGI-INF/,\
+               META-INF/,\
+               about_files/,\
+               about.html
+source.. = src/main/java/

--- a/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Eurotech and/or its affiliates and others
+  
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+ 
+	SPDX-License-Identifier: EPL-2.0
+	
+	Contributors:
+	 Eurotech
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+        <groupId>org.eclipse.kura.example</groupId>
+        <artifactId>test</artifactId>
+        <version>5.5.0-SNAPSHOT</version>
+    </parent>
+
+	<artifactId>org.eclipse.kura.example.identity.configuration.extension.test</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+    <packaging>eclipse-test-plugin</packaging>
+
+    <properties>
+        <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/src/main/java/org/eclipse/kura/example/identity/configuration/extension/test/ExampleIdentityConfigurationExtensionTest.java
+++ b/kura/examples/test/org.eclipse.kura.example.identity.configuration.extension.test/src/main/java/org/eclipse/kura/example/identity/configuration/extension/test/ExampleIdentityConfigurationExtensionTest.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.example.identity.configuration.extension.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.eclipse.kura.configuration.ComponentConfiguration;
+import org.eclipse.kura.configuration.ConfigurationService;
+import org.eclipse.kura.configuration.metatype.AD;
+import org.eclipse.kura.configuration.metatype.OCD;
+import org.eclipse.kura.configuration.metatype.Scalar;
+import org.eclipse.kura.identity.configuration.extension.IdentityConfigurationExtension;
+import org.eclipse.kura.util.wire.test.WireTestUtil;
+import org.junit.After;
+import org.junit.Test;
+
+public class ExampleIdentityConfigurationExtensionTest {
+
+    private static final String FACTORY_PID = "org.eclipse.kura.example.identity.configuration.extension.ExampleIdentityConfigurationExtension";
+    private static final String TEST_EXTENSION_PID = "testExtension";
+
+    private final ConfigurationService configurationService;
+    private IdentityConfigurationExtension extension;
+
+    private Optional<ComponentConfiguration> receivedConfiguration = Optional.empty();
+    private Optional<ComponentConfiguration> configurationToUpdate = Optional.empty();
+    private Optional<Exception> exception = Optional.empty();
+
+    @Test
+    public void shouldReturnDefaultIdentityConfigurationProperties() {
+        givenExampleIdentityConfigurationExtension();
+
+        whenConfigurationForIdentityIsRetrieved("foo");
+
+        thenNoExceptionIsThrown();
+        thenReceivedConfigurationPropertyIs("test.string", "foobar");
+        thenReceivedConfigurationPropertyIs("test.integer", 0);
+    }
+
+    @Test
+    public void shouldReturnOCD() {
+        givenExampleIdentityConfigurationExtension();
+
+        whenConfigurationForIdentityIsRetrieved("foo");
+
+        thenNoExceptionIsThrown();
+
+        thenAttributeDefinitionComponentIs("test.string", AD::getName, "Test String Property");
+        thenAttributeDefinitionComponentIs("test.string", AD::getDescription, "A test string property");
+        thenAttributeDefinitionComponentIs("test.string", AD::getDefault, "foobar");
+        thenAttributeDefinitionComponentIs("test.string", AD::isRequired, true);
+        thenAttributeDefinitionComponentIs("test.string", AD::getType, Scalar.STRING);
+
+        thenAttributeDefinitionComponentIs("test.integer", AD::getName, "Test Integer Property");
+        thenAttributeDefinitionComponentIs("test.integer", AD::getDescription, "A test integer property");
+        thenAttributeDefinitionComponentIs("test.integer", AD::getDefault, "0");
+        thenAttributeDefinitionComponentIs("test.integer", AD::isRequired, true);
+        thenAttributeDefinitionComponentIs("test.integer", AD::getType, Scalar.INTEGER);
+
+    }
+
+    @Test
+    public void shouldRememberUpdatedValues() {
+        givenExampleIdentityConfigurationExtension();
+        givenUpdateProperty("foo", "test.string", "baz");
+        givenUpdateProperty("foo", "test.integer", 5);
+        givenSuccessfulConfigurationUpdate("foo");
+
+        whenConfigurationForIdentityIsRetrieved("foo");
+
+        thenNoExceptionIsThrown();
+        thenReceivedConfigurationPropertyIs("test.string", "baz");
+        thenReceivedConfigurationPropertyIs("test.integer", 5);
+
+    }
+
+    public ExampleIdentityConfigurationExtensionTest() {
+        try {
+            this.configurationService = WireTestUtil.trackService(ConfigurationService.class, Optional.empty()).get(30,
+                    TimeUnit.SECONDS);
+        } catch (final Exception e) {
+            fail("failed to track ConfigurationService");
+            throw new IllegalStateException("unreachable");
+        }
+    }
+
+    private void givenUpdateProperty(final String identityName, final String key, final Object value) {
+        final ComponentConfiguration config;
+
+        final Optional<ComponentConfiguration> currentConfigToUpdate = this.configurationToUpdate;
+
+        if (currentConfigToUpdate.isPresent()) {
+            config = currentConfigToUpdate.get();
+        } else {
+            final Map<String, Object> properties = new HashMap<>();
+            config = new ComponentConfiguration() {
+
+                @Override
+                public String getPid() {
+                    return TEST_EXTENSION_PID;
+                }
+
+                @Override
+                public OCD getDefinition() {
+                    return null;
+                }
+
+                @Override
+                public Map<String, Object> getConfigurationProperties() {
+
+                    return properties;
+                }
+            };
+
+            this.configurationToUpdate = Optional.of(config);
+        }
+
+        config.getConfigurationProperties().put(key, value);
+    }
+
+    private void givenExampleIdentityConfigurationExtension() {
+        try {
+            this.extension = WireTestUtil.createFactoryConfiguration(this.configurationService,
+                    IdentityConfigurationExtension.class, TEST_EXTENSION_PID, FACTORY_PID, Collections.emptyMap())
+                    .get(30, TimeUnit.SECONDS);
+        } catch (final Exception e) {
+            fail("failed to create example identiy configuration extension");
+        }
+    }
+
+    private void givenSuccessfulConfigurationUpdate(final String name) {
+        whenConfigurationIsUpdated(name);
+        thenNoExceptionIsThrown();
+    }
+
+    private void whenConfigurationIsUpdated(final String name) {
+        try {
+            this.extension.updateConfiguration(name, this.configurationToUpdate
+                    .orElseThrow(() -> new IllegalStateException("configuration to update is not initialized")));
+            this.exception = Optional.empty();
+        } catch (Exception e) {
+            this.exception = Optional.of(e);
+        }
+    }
+
+    private void whenConfigurationForIdentityIsRetrieved(final String name) {
+        try {
+            this.receivedConfiguration = this.extension.getConfiguration(name);
+            this.exception = Optional.empty();
+        } catch (Exception e) {
+            this.exception = Optional.of(e);
+        }
+    }
+
+    private void thenNoExceptionIsThrown() {
+        assertEquals(Optional.empty(), this.exception);
+    }
+
+    private void thenReceivedConfigurationPropertyIs(final String key, final Object value) {
+        assertEquals(Optional.of(value), this.receivedConfiguration.map(c -> c.getConfigurationProperties().get(key)));
+    }
+
+    private <T> void thenAttributeDefinitionComponentIs(final String adId, final Function<AD, T> component,
+            final T value) {
+        assertEquals(Optional.of(value), this.receivedConfiguration.flatMap(c -> c.getDefinition().getAD().stream()
+                .filter(a -> Objects.equals(adId, a.getId())).map(component).findAny()));
+    }
+
+    @After
+    public void cleanUp() {
+        try {
+            if (this.extension != null) {
+                WireTestUtil.deleteFactoryConfiguration(this.configurationService, TEST_EXTENSION_PID).get(30,
+                        TimeUnit.SECONDS);
+            }
+        } catch (Exception e) {
+            fail("failed to delete configuration");
+        }
+
+    }
+}

--- a/kura/examples/test/pom.xml
+++ b/kura/examples/test/pom.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml  version="1.0"  encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2024 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -11,10 +11,12 @@
 
 	Contributors:
 	 Eurotech
+     Red Hat Inc
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project  xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0  http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -84,7 +86,8 @@
                         <id>checkstyle-validation</id>
                         <phase>process-sources</phase>
                         <configuration>
-                            <configLocation>${kura.basedir}/../checkstyle_checks.xml</configLocation>
+                            <configLocation>
+                                ${kura.basedir}/../checkstyle_checks.xml</configLocation>
                         </configuration>
                         <goals>
                             <goal>check</goal>
@@ -97,18 +100,183 @@
                 <artifactId>tycho-surefire-plugin</artifactId>
                 <version>${tycho-version}</version>
                 <configuration>
-                    <argLine>${tycho.argline}</argLine>
                     <failIfNoTests>false</failIfNoTests>
                     <providerHint>junit4</providerHint>
                     <useUnlimitedThreads>false</useUnlimitedThreads>
+                    <argLine>
+                        ${tycho.argline}
+                        ${tycho.surefire.testenv.args}
+                    </argLine>
+                    <appArgLine>-consoleLog  -console  5002</appArgLine>
+                    <dependencies>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>moquette-broker</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.ds</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.apache.felix.scr</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.console</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.core.runtime</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.io</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.app</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.cm</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.common</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.event</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.metatype</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.preferences</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.registry</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.util</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.osgi</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.osgi.services</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.osgi.util</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.hamcrest.core</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.launcher</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>slf4j.api</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.junit</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.apache.commons.commons-io</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.apache.logging.log4j.api</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.kura.core</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.kura.core.system</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>com.h2database</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.equinox.wireadmin</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>
+                                org.apache.activemq.artemis-mqtt-protocol</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.kura.core.keystore</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.apache.felix.dependencymanager</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.apache.felix.deploymentadmin</artifactId>
+                        </dependency>
+                        <dependency>
+                            <type>p2-installable-unit</type>
+                            <artifactId>org.eclipse.kura.emulator.position</artifactId>
+                        </dependency>
+                    </dependencies>
                     <bundleStartLevel>
+                        <bundle>
+                            <id>moquette-broker</id>
+                            <level>3</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.equinox.ds</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
                         <bundle>
                             <id>org.apache.felix.scr</id>
                             <level>4</level>
                             <autoStart>true</autoStart>
                         </bundle>
                         <bundle>
+                            <id>org.eclipse.core.runtime</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.equinox.io</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.equinox.app</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
                             <id>org.eclipse.equinox.cm</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.equinox.common</id>
                             <level>4</level>
                             <autoStart>true</autoStart>
                         </bundle>
@@ -123,12 +291,52 @@
                             <autoStart>true</autoStart>
                         </bundle>
                         <bundle>
+                            <id>org.eclipse.equinox.preferences</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
                             <id>org.eclipse.equinox.registry</id>
                             <level>4</level>
                             <autoStart>true</autoStart>
                         </bundle>
                         <bundle>
                             <id>org.eclipse.equinox.console</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.equinox.util</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.equinox.wireadmin</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.osgi.services</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.osgi.util</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.hamcrest.core</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.equinox.launcher</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>slf4j.api</id>
                             <level>4</level>
                             <autoStart>true</autoStart>
                         </bundle>
@@ -153,12 +361,74 @@
                             <autoStart>true</autoStart>
                         </bundle>
                         <bundle>
+                            <id>mqtt-client</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>com.h2database</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.junit</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.apache.commons.io</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.api</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
                             <id>org.eclipse.kura.core.configuration</id>
                             <level>4</level>
                             <autoStart>true</autoStart>
                         </bundle>
                         <bundle>
                             <id>org.eclipse.kura.core.crypto</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>
+                                org.eclipse.kura.json.marshaller.unmarshaller.provider</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>
+                                org.eclipse.kura.xml.marshaller.unmarshaller.provider</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>com.sun.xml.bind.jaxb-osgi</id>
+                            <level>1</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.glassfish.hk2.osgi-resource-locator</id>
+                            <level>1</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundleStartLevel>
+                            <id>org.apache.camel.camel-core</id>
+                            <autoStart>true</autoStart>
+                            <level>2</level>
+                        </bundleStartLevel>
+                        <bundleStartLevel>
+                            <id>org.eclipse.kura.camel</id>
+                            <autoStart>true</autoStart>
+                            <level>3</level>
+                        </bundleStartLevel>
+                        <bundle>
+                            <id>org.eclipse.kura.core.status</id>
                             <level>4</level>
                             <autoStart>true</autoStart>
                         </bundle>
@@ -173,13 +443,123 @@
                             <autoStart>true</autoStart>
                         </bundle>
                         <bundle>
-                            <id>org.eclipse.kura.json.marshaller.unmarshaller.provider</id>
-                            <level>3</level>
+                            <id>org.eclipse.kura.emulator.gpio</id>
+                            <level>4</level>
                             <autoStart>true</autoStart>
                         </bundle>
                         <bundle>
-                            <id>org.eclipse.kura.xml.marshaller.unmarshaller.provider</id>
+                            <id>org.eclipse.kura.emulator.watchdog</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.emulator.usb</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.wire.provider</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.wire.helper.provider</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.wire.component.provider</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.protocol.can</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.broker.artemis.core</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.broker.artemis.simple.mqtt</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.broker.artemis.xml</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.apache.activemq.artemis-mqtt-protocol</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.jetty.customizer</id>
+                            <level>2</level>
+                            <autoStart>false</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.equinox.http.jetty</id>
                             <level>3</level>
+                            <autoStart>false</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.http.server.manager</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>com.eclipsesource.jaxrs.jersey-min</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>com.eclipsesource.jaxrs.provider.gson</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>com.eclipsesource.jaxrs.provider.security</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>com.eclipsesource.jaxrs.publisher</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.apache.felix.useradmin</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.useradmin.store</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.rest.provider</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.apache.felix.dependencymanager</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.apache.felix.deploymentadmin</id>
+                            <level>4</level>
+                            <autoStart>true</autoStart>
+                        </bundle>
+                        <bundle>
+                            <id>org.eclipse.kura.emulator.position</id>
+                            <level>4</level>
                             <autoStart>true</autoStart>
                         </bundle>
                     </bundleStartLevel>
@@ -189,7 +569,6 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>target-platform-configuration</artifactId>
                 <configuration>
-                    <argLine>-consoleLog</argLine>
                     <resolver>p2</resolver>
                     <dependency-resolution>
                         <extraRequirements>
@@ -219,18 +598,205 @@
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
                             <requirement>
-                                <type>eclipse-plugin</type>
-                                <id>org.eclipse.kura.api</id>
-                                <versionRange>0.0.0</versionRange>
-                            </requirement>
-                            <requirement>
                                 <type>p2-installable-unit</type>
                                 <id>com.eclipsesource.jaxrs.jersey-min</id>
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
                             <requirement>
+                                <type>p2-installable-unit</type>
+                                <id>jakarta.xml.bind-api</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>p2-installable-unit</type>
+                                <id>jakarta.activation-api</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>p2-installable-unit</type>
+                                <id>com.sun.xml.bind.jaxb-osgi</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>p2-installable-unit</type>
+                                <id>org.glassfish.hk2.osgi-resource-locator</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.equinox.cm</id>
+                                <versionRange>1</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.api</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.emulator</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.emulator.net</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.emulator.watchdog</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.emulator.gpio</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core.cloud</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core.cloud.factory</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core.comm</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.wire.provider</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.wire.helper.provider</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.wire.component.provider</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>
+                                    org.eclipse.kura.xml.marshaller.unmarshaller.provider</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>
+                                    org.eclipse.kura.json.marshaller.unmarshaller.provider</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
                                 <type>eclipse-plugin</type>
                                 <id>org.eclipse.kura.core.system</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core.configuration</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core.crypto</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core.status</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core.deployment</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core.net</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.deployment.agent</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.jetty.customizer</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.equinox.http.jetty</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>com.eclipsesource.jaxrs.jersey-min</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>com.eclipsesource.jaxrs.provider.gson</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>com.eclipsesource.jaxrs.provider.security</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>com.eclipsesource.jaxrs.publisher</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.rest.provider</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.apache.felix.useradmin</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.useradmin.store</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.rest.provider</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.apache.felix.useradmin</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.core.keystore</id>
+                                <versionRange>0.0.0</versionRange>
+                            </requirement>
+                            <requirement>
+                                <type>eclipse-plugin</type>
+                                <id>org.eclipse.kura.emulator.position</id>
                                 <versionRange>0.0.0</versionRange>
                             </requirement>
                         </extraRequirements>
@@ -272,7 +838,9 @@
 
     <properties>
         <kura.basedir>${project.basedir}/../..</kura.basedir>
-        <tycho.argline>${jacocoArgs} -Dlog4j.configurationFile=file:${kura.basedir}/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml</tycho.argline>
+        <tycho.argline>
+            ${jacocoArgs}
+            -Dlog4j.configurationFile=file:${kura.basedir}/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml</tycho.argline>
     </properties>
 
     <modules>
@@ -282,6 +850,7 @@
         <module>org.eclipse.kura.example.testutil</module>
         <module>org.eclipse.kura.example.wire.logic.multiport.provider.test</module>
         <module>org.eclipse.kura.example.wire.math.trig.test</module>
+        <module>org.eclipse.kura.example.identity.configuration.extension.test</module>
     </modules>
 
     <repositories>
@@ -307,20 +876,20 @@
             </modules>
         </profile>
         <profile>
-          <id>test-debug</id>
-          <build>
-            <pluginManagement>
-              <plugins>
-                <plugin>
-                  <groupId>org.eclipse.tycho</groupId>
-                  <artifactId>tycho-surefire-plugin</artifactId>
-                  <configuration>
-                    <debugPort>8000</debugPort>
-                  </configuration>
-                </plugin>
-              </plugins>
-            </pluginManagement>
-          </build>
+            <id>test-debug</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.eclipse.tycho</groupId>
+                            <artifactId>tycho-surefire-plugin</artifactId>
+                            <configuration>
+                                <debugPort>8000</debugPort>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Adds an example bundle that implements an identity configuration extension. The extension returns a configuration that contains two example properties and stores the updated values in a local map.
