### PR TITLE
feat(web2): separation between wlan channel configuration and status

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabHardwareUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabHardwareUi.java
@@ -153,7 +153,7 @@ public class TabHardwareUi extends Composite implements NetworkTab {
         this.mtu.setText(String.valueOf(this.selectedNetIfConfig.getHwMTU()));
         this.usb.setText(this.selectedNetIfConfig.getHwUsbDevice());
         this.rssi.setText(this.selectedNetIfConfig.getHwRssi());
-        this.channel.setText(this.selectedNetIfConfig.getHwWlanChannel());
+        this.channel.setText(this.selectedNetIfConfig.getCurrentHwWifiChannel());
     }
 
     private void reset() {
@@ -187,7 +187,7 @@ public class TabHardwareUi extends Composite implements NetworkTab {
             }
             updatedNetIf.setHwUsbDevice(this.usb.getText());
             updatedNetIf.setHwRssi(this.rssi.getText());
-            updatedNetIf.setHwWlanChannel(this.channel.getText());
+            updatedNetIf.setCurrentHwWifiChannel(this.channel.getText());
         }
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabHardwareUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabHardwareUi.java
@@ -57,6 +57,8 @@ public class TabHardwareUi extends Composite implements NetworkTab {
     FormLabel labelUsb;
     @UiField
     FormLabel labelRssi;
+    @UiField
+    FormLabel labelChannel;
 
     @UiField
     FormControlStatic state;
@@ -80,6 +82,8 @@ public class TabHardwareUi extends Composite implements NetworkTab {
     FormControlStatic usb;
     @UiField
     FormControlStatic rssi;
+    @UiField
+    FormControlStatic channel;
 
     public TabHardwareUi(GwtSession currentSession) {
         initWidget(uiBinder.createAndBindUi(this));
@@ -98,6 +102,7 @@ public class TabHardwareUi extends Composite implements NetworkTab {
         this.labelMtu.setText(MSGS.netHwMTU());
         this.labelUsb.setText(MSGS.netHwUSBDevice());
         this.labelRssi.setText(MSGS.netHwSignalStrength());
+        this.labelChannel.setText(MSGS.netHwWlanChannel());
     }
 
     // Dirty flag not needed here since this tab is not modifiable
@@ -148,6 +153,7 @@ public class TabHardwareUi extends Composite implements NetworkTab {
         this.mtu.setText(String.valueOf(this.selectedNetIfConfig.getHwMTU()));
         this.usb.setText(this.selectedNetIfConfig.getHwUsbDevice());
         this.rssi.setText(this.selectedNetIfConfig.getHwRssi());
+        this.channel.setText(this.selectedNetIfConfig.getHwWlanChannel());
     }
 
     private void reset() {
@@ -162,6 +168,7 @@ public class TabHardwareUi extends Composite implements NetworkTab {
         this.mtu.setText("");
         this.usb.setText("");
         this.rssi.setText("");
+        this.channel.setText("");
     }
 
     @Override
@@ -180,6 +187,7 @@ public class TabHardwareUi extends Composite implements NetworkTab {
             }
             updatedNetIf.setHwUsbDevice(this.usb.getText());
             updatedNetIf.setHwRssi(this.rssi.getText());
+            updatedNetIf.setHwWlanChannel(this.channel.getText());
         }
     }
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabHardwareUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabHardwareUi.java
@@ -102,7 +102,7 @@ public class TabHardwareUi extends Composite implements NetworkTab {
         this.labelMtu.setText(MSGS.netHwMTU());
         this.labelUsb.setText(MSGS.netHwUSBDevice());
         this.labelRssi.setText(MSGS.netHwSignalStrength());
-        this.labelChannel.setText(MSGS.netHwWlanChannel());
+        this.labelChannel.setText(MSGS.netCurrentHwWifiChannel());
     }
 
     // Dirty flag not needed here since this tab is not modifiable

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabHardwareUi.ui.xml
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabHardwareUi.ui.xml
@@ -112,6 +112,12 @@
                                 <b:FormControlStatic
                                     b:id="state" ui:field="rssi" />
                             </b:FormGroup>
+                            <b:FormGroup>
+                                <b:FormLabel for="state"
+                                    ui:field="labelChannel" />
+                                <b:FormControlStatic
+                                    b:id="state" ui:field="channel" />
+                            </b:FormGroup>
                         </b:FieldSet>
                     </b:Form>
                 </b:Row>

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1810,8 +1810,9 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
         if (TabWirelessUi.this.channelList.getItemCount() != 0) {
             selectedChannelValue = this.channelList.getSelectedIndex();
-            this.channelList.clear();
         }
+
+        this.channelList.clear();
 
         addAutomaticChannel(freqChannels);
         freqChannels.stream().forEach(this::addItemChannelList);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -16,7 +16,6 @@ package org.eclipse.kura.web.client.ui.network;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.messages.Messages;
@@ -368,7 +367,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
             update();
         });
-        
+
         this.tcp6Tab.status.addChangeHandler(event -> {
             evalActiveConfig();
 
@@ -387,7 +386,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                     || !tcpIp6Status.equals(TabWirelessUi.this.tcp6Status);
 
             if (isStatusChanged) {
-                if (tcpIp4Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv4StatusEnabledWAN.name())) || tcpIp6Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv4StatusEnabledWAN.name()))) {
+                if (tcpIp4Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv4StatusEnabledWAN.name()))
+                        || tcpIp6Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv4StatusEnabledWAN.name()))) {
                     TabWirelessUi.this.activeConfig = TabWirelessUi.this.selectedNetIfConfig.getStationWifiConfig();
                 } else {
                     TabWirelessUi.this.activeConfig = TabWirelessUi.this.selectedNetIfConfig.getActiveWifiConfig();
@@ -460,27 +460,9 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             this.selectedNetIfConfig = (GwtWifiNetInterfaceConfig) config;
 
             this.activeConfig = this.selectedNetIfConfig.getActiveWifiConfig();
-            if (Objects.nonNull(this.activeConfig)) {
-                if (this.activeConfig.getChannels() != null
-                        && !TabWirelessUi.this.activeConfig.getChannels().isEmpty()) {
-                    updateChanneList(TabWirelessUi.this.activeConfig);
-                }
-            }
+
             loadCountryCode();
         }
-    }
-
-    private void updateChanneList(GwtWifiConfig config) {
-        int channelToSelect = 0;
-
-        List<Integer> channels = config.getChannels();
-
-        if (channels != null && !channels.isEmpty()) {
-            channelToSelect = config.getChannels().get(0);
-        }
-
-        this.channelList.setSelectedIndex(getChannelIndexFromValue(channelToSelect));
-
     }
 
     @Override
@@ -559,9 +541,6 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         // ------------
 
         setRadioModeByValue(this.activeConfig.getRadioMode());
-
-        // select proper channels
-        updateChanneList(this.activeConfig);
 
         String activeSecurity = this.activeConfig.getSecurity();
         if (activeSecurity != null) {
@@ -659,7 +638,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         String tcpip6Status = this.tcp6Tab.getStatus();
 
         // Tcp/IP disabled
-        if (tcpip4Status.equals(GwtNetIfStatus.netIPv4StatusDisabled.name()) && tcpip6Status.equals(GwtNetIfStatus.netIPv4StatusDisabled.name())) {
+        if (tcpip4Status.equals(GwtNetIfStatus.netIPv4StatusDisabled.name())
+                && tcpip6Status.equals(GwtNetIfStatus.netIPv4StatusDisabled.name())) {
             setForm(false);
         } else {
             setForm(true);
@@ -1814,27 +1794,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                                 @Override
                                 public void onSuccess(List<GwtWifiChannelFrequency> freqChannels) {
 
-                                    TabWirelessUi.this.channelList.clear();
-
-                                    addAutomaticChannel(freqChannels);
-
-                                    freqChannels.stream().forEach(TabWirelessUi.this::addItemChannelList);
-
-                                    List<Integer> currentChannels = TabWirelessUi.this.activeConfig.getChannels();
-
-                                    if (currentChannels != null && !currentChannels.isEmpty()) {
-                                        int channel = TabWirelessUi.this.activeConfig.getChannels().get(0);
-
-                                        int selectedChannelIndex = getChannelIndexFromValue(channel);
-                                        int channelIndex = selectedChannelIndex == -1 ? 0 : selectedChannelIndex;
-
-                                        TabWirelessUi.this.channelList.setSelectedIndex(channelIndex);
-
-                                    }
-
-                                    boolean hasChannels = TabWirelessUi.this.channelList.getItemCount() > 0;
-
-                                    TabWirelessUi.this.noChannels.setVisible(!hasChannels);
+                                    updateChannelListValues(freqChannels);
 
                                 }
                             });
@@ -1842,6 +1802,28 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             });
         }
 
+    }
+
+    private void updateChannelListValues(List<GwtWifiChannelFrequency> freqChannels) {
+
+        int selectedChannelValue = 0;
+
+        if (TabWirelessUi.this.channelList.getItemCount() != 0) {
+            selectedChannelValue = this.channelList.getSelectedIndex();
+            this.channelList.clear();
+        }
+
+        addAutomaticChannel(freqChannels);
+        freqChannels.stream().forEach(this::addItemChannelList);
+
+        if (this.activeConfig.getChannels() != null && !this.activeConfig.getChannels().isEmpty()) {
+            this.netTabs.hardwareTab.channel
+                    .setText(this.channelList.getItemText(this.activeConfig.getChannels().get(0)));
+
+            this.channelList.setSelectedIndex(selectedChannelValue);
+        }
+
+        this.noChannels.setVisible((this.channelList.getItemCount() <= 0));
     }
 
     private void addAutomaticChannel(List<GwtWifiChannelFrequency> freqs) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -337,6 +337,12 @@ public class NetworkStatusServiceAdapter {
             } else if (wifiInterfaceInfo.getMode() == WifiMode.INFRA) {
                 setWifiInfraStateProperties(gwtWifiNetInterfaceConfig, wifiInterfaceInfo);
             }
+
+            if (logger.isDebugEnabled()) {
+                Optional<WifiAccessPoint> activeAP = wifiInterfaceInfo.getActiveWifiAccessPoint();
+                activeAP.ifPresent(accessPoint -> logger.debug("Wifi Interface Info: {}",
+                        wifiInterfaceInfo.getActiveWifiAccessPoint().get().getChannel().getChannel()));
+            }
         }
     }
 
@@ -381,9 +387,14 @@ public class NetworkStatusServiceAdapter {
         }
 
         ChannelsBuilder channelsBuilder = new ChannelsBuilder();
-        List<Integer> activeChannel = gwtConfig.getChannels();
-        if (activeChannel != null && activeChannel.size() == 1) {
-            channelsBuilder.setActiveChannel(activeChannel.get(0));
+        Optional<WifiAccessPoint> activeAP = wifiInterfaceInfo.getActiveWifiAccessPoint();
+        if (activeAP.isPresent()) {
+            channelsBuilder.setActiveChannel(activeAP.get().getChannel().getChannel());
+        } else {
+            List<Integer> activeChannel = gwtConfig.getChannels();
+            if (activeChannel != null && activeChannel.size() == 1) {
+                channelsBuilder.setActiveChannel(activeChannel.get(0));
+            }
         }
         channelsBuilder.addChannels(wifiInterfaceInfo.getChannels());
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/status/NetworkStatusServiceAdapter.java
@@ -332,28 +332,36 @@ public class NetworkStatusServiceAdapter {
             WifiInterfaceStatus wifiInterfaceInfo = (WifiInterfaceStatus) networkInterfaceInfo;
             gwtWifiNetInterfaceConfig.setHwState(wifiInterfaceInfo.getState().toString());
 
-            if (wifiInterfaceInfo.getMode() == WifiMode.MASTER) {
-                setWifiMasterStateProperties(gwtWifiNetInterfaceConfig, wifiInterfaceInfo);
-            } else if (wifiInterfaceInfo.getMode() == WifiMode.INFRA) {
-                setWifiInfraStateProperties(gwtWifiNetInterfaceConfig, wifiInterfaceInfo);
-            }
-
-            if (logger.isDebugEnabled()) {
-                Optional<WifiAccessPoint> activeAP = wifiInterfaceInfo.getActiveWifiAccessPoint();
-                activeAP.ifPresent(accessPoint -> logger.debug("Wifi Interface Info: {}",
-                        wifiInterfaceInfo.getActiveWifiAccessPoint().get().getChannel().getChannel()));
-            }
+            setWifiSpecificStateProperties(wifiInterfaceInfo.getMode(), gwtWifiNetInterfaceConfig, wifiInterfaceInfo);
         }
     }
 
-    private void setWifiMasterStateProperties(GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig,
+    private void setWifiSpecificStateProperties(WifiMode wifiMode, GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig,
             WifiInterfaceStatus wifiInterfaceInfo) {
+
         GwtWifiConfig gwtConfig;
-        if (Objects.nonNull(gwtWifiNetInterfaceConfig.getAccessPointWifiConfig())) {
-            gwtConfig = gwtWifiNetInterfaceConfig.getAccessPointWifiConfig();
+
+        if (wifiMode.equals(WifiMode.INFRA)) {
+            AtomicReference<String> rssi = new AtomicReference<>("N/A");
+            wifiInterfaceInfo.getActiveWifiAccessPoint()
+                    .ifPresent(accessPoint -> rssi.set(String.valueOf(accessPoint.getSignalStrength())));
+            gwtWifiNetInterfaceConfig.setHwRssi(rssi.get());
+
+            if (Objects.nonNull(gwtWifiNetInterfaceConfig.getStationWifiConfig())) {
+                gwtConfig = gwtWifiNetInterfaceConfig.getStationWifiConfig();
+            } else {
+                gwtConfig = gwtWifiNetInterfaceConfig.getActiveWifiConfig();
+                gwtWifiNetInterfaceConfig.setStationWifiConfig(gwtConfig);
+            }
+
         } else {
-            gwtConfig = gwtWifiNetInterfaceConfig.getActiveWifiConfig();
-            gwtWifiNetInterfaceConfig.setAccessPointWifiConfig(gwtConfig);
+
+            if (Objects.nonNull(gwtWifiNetInterfaceConfig.getAccessPointWifiConfig())) {
+                gwtConfig = gwtWifiNetInterfaceConfig.getAccessPointWifiConfig();
+            } else {
+                gwtConfig = gwtWifiNetInterfaceConfig.getActiveWifiConfig();
+                gwtWifiNetInterfaceConfig.setAccessPointWifiConfig(gwtConfig);
+            }
         }
 
         ChannelsBuilder channelsBuilder = new ChannelsBuilder();
@@ -367,37 +375,6 @@ public class NetworkStatusServiceAdapter {
             }
         }
         channelsBuilder.addChannels(wifiInterfaceInfo.getChannels());
-        gwtConfig.setChannels(channelsBuilder.getChannelsIntegers());
-    }
-
-    private void setWifiInfraStateProperties(GwtWifiNetInterfaceConfig gwtWifiNetInterfaceConfig,
-            WifiInterfaceStatus wifiInterfaceInfo) {
-        AtomicReference<String> rssi = new AtomicReference<>("N/A");
-        wifiInterfaceInfo.getActiveWifiAccessPoint()
-                .ifPresent(accessPoint -> rssi.set(String.valueOf(accessPoint.getSignalStrength())));
-        gwtWifiNetInterfaceConfig.setHwRssi(rssi.get());
-
-        GwtWifiConfig gwtConfig;
-
-        if (Objects.nonNull(gwtWifiNetInterfaceConfig.getStationWifiConfig())) {
-            gwtConfig = gwtWifiNetInterfaceConfig.getStationWifiConfig();
-        } else {
-            gwtConfig = gwtWifiNetInterfaceConfig.getActiveWifiConfig();
-            gwtWifiNetInterfaceConfig.setStationWifiConfig(gwtConfig);
-        }
-
-        ChannelsBuilder channelsBuilder = new ChannelsBuilder();
-        Optional<WifiAccessPoint> activeAP = wifiInterfaceInfo.getActiveWifiAccessPoint();
-        if (activeAP.isPresent()) {
-            channelsBuilder.setActiveChannel(activeAP.get().getChannel().getChannel());
-        } else {
-            List<Integer> activeChannel = gwtConfig.getChannels();
-            if (activeChannel != null && activeChannel.size() == 1) {
-                channelsBuilder.setActiveChannel(activeChannel.get(0));
-            }
-        }
-        channelsBuilder.addChannels(wifiInterfaceInfo.getChannels());
-
         gwtConfig.setChannels(channelsBuilder.getChannelsIntegers());
     }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
@@ -239,12 +239,12 @@ public class GwtNetInterfaceConfig extends KuraBaseModel implements Serializable
         set("hwRssi", rssi);
     }
 
-    public String getHwWlanChannel() {
-        return get("hwWlanChannel");
+    public String getCurrentHwWifiChannel() {
+        return get("currentHwWifiChannel");
     }
 
-    public void setHwWlanChannel(String channel) {
-        set("hwWlanChannel", channel);
+    public void setCurrentHwWifiChannel(String channel) {
+        set("currentHwWifiChannel", channel);
     }
 
     public GwtNetRouterMode getRouterModeEnum() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtNetInterfaceConfig.java
@@ -239,6 +239,14 @@ public class GwtNetInterfaceConfig extends KuraBaseModel implements Serializable
         set("hwRssi", rssi);
     }
 
+    public String getHwWlanChannel() {
+        return get("hwWlanChannel");
+    }
+
+    public void setHwWlanChannel(String channel) {
+        set("hwWlanChannel", channel);
+    }
+
     public GwtNetRouterMode getRouterModeEnum() {
         return GwtNetRouterMode.valueOf(getRouterMode());
     }

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -562,6 +562,7 @@ netHwRadio=Radio
 netHwBand=Frequency Band
 netHwLAC=LAC
 netHwCI=CI
+netHwWlanChannel=WLAN Channel
 
 netStatusWarning=There is another interface configured as WAN. That interface should bet set to LAN before changing the selected interface to WAN. Multiple WAN interfaces is not recommended.
 netRouter=DHCPv4 & NAT

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -562,7 +562,7 @@ netHwRadio=Radio
 netHwBand=Frequency Band
 netHwLAC=LAC
 netHwCI=CI
-netHwWlanChannel=WLAN Channel
+netCurrentHwWifiChannel=Current WLAN Channel
 
 netStatusWarning=There is another interface configured as WAN. That interface should bet set to LAN before changing the selected interface to WAN. Multiple WAN interfaces is not recommended.
 netRouter=DHCPv4 & NAT

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages_ja.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages_ja.properties
@@ -538,6 +538,7 @@ netHwFirmware=ファームウェア
 netHwMTU=MTU
 netHwUSBDevice=USBデバイス
 netHwSignalStrength=受信したシグナル強度（dBm）
+netCurrentHwWifiChannel=現在の Wlan チャネル
 
 netStatusWarning=WANとして環境設定された他のインターフェースが存在します。洗濯されたインターフェースをWANにする前に、そちらをLANに変更することが推奨されます。複数のインターフェースをWAN設定にすることは推奨されていません。
 netRouter=DHCPv4とNAT


### PR DESCRIPTION
This PR improves the separation between the WLAN Channel configuraion and status: the Wireless tab will now always show the selected option in the WLAN channles list box, while in the Hardware tab e new entry `WLAN Channel` was added, showing which is the used channel by the interface.

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
