### PR TITLE
style(linux.usb): updated copyright header

### DIFF
--- a/kura/org.eclipse.kura.linux.usb/src/main/c/udev/LinuxUdev.c
+++ b/kura/org.eclipse.kura.linux.usb/src/main/c/udev/LinuxUdev.c
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  *
  *  This program and the accompanying materials are made
  *  available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
This PR adds a missing copyright header update on the `linux.usb` code, modified by https://github.com/eclipse/kura/pull/5130.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
