### PR TITLE
refactor(container.signature): use RegistryCredentials in verify methods

### DIFF
--- a/kura/examples/org.eclipse.kura.example.container.signature.validation/src/org/eclipse/kura/example/container/signature/validation/DummyContainerSignatureValidationService.java
+++ b/kura/examples/org.eclipse.kura.example.container.signature.validation/src/org/eclipse/kura/example/container/signature/validation/DummyContainerSignatureValidationService.java
@@ -18,8 +18,8 @@ import java.util.Objects;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ConfigurableComponent;
-import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
+import org.eclipse.kura.container.orchestration.RegistryCredentials;
 import org.eclipse.kura.container.signature.ContainerSignatureValidationService;
 import org.eclipse.kura.container.signature.ValidationResult;
 import org.slf4j.Logger;
@@ -62,7 +62,7 @@ public class DummyContainerSignatureValidationService
 
     @Override
     public ValidationResult verify(String imageName, String imageReference, String trustAnchor,
-            boolean verifyInTransparencyLog, String registryUsername, Password registryPassword) throws KuraException {
+            boolean verifyInTransparencyLog, RegistryCredentials credentials) throws KuraException {
         logger.info("Validating signature for {}:{} using authenticated registry", imageName, imageReference);
         return verify(imageName, imageReference);
     }
@@ -76,7 +76,7 @@ public class DummyContainerSignatureValidationService
 
     @Override
     public ValidationResult verify(ImageInstanceDescriptor imageDescriptor, String trustAnchor,
-            boolean verifyInTransparencyLog, String registryUsername, Password registryPassword) throws KuraException {
+            boolean verifyInTransparencyLog, RegistryCredentials credentials) throws KuraException {
         logger.info("Validating signature for {}:{} using authenticated registry", imageDescriptor.getImageName(),
                 imageDescriptor.getImageTag());
         return verify(imageDescriptor.getImageName(), imageDescriptor.getImageTag());

--- a/kura/examples/test/org.eclipse.kura.example.container.signature.validation.test/src/test/java/org/eclipse/kura/example/container/signature/validation/DummyContainerSignatureValidationServiceTest.java
+++ b/kura/examples/test/org.eclipse.kura.example.container.signature.validation.test/src/test/java/org/eclipse/kura/example/container/signature/validation/DummyContainerSignatureValidationServiceTest.java
@@ -22,10 +22,12 @@ import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
+import org.eclipse.kura.container.orchestration.PasswordRegistryCredentials;
 import org.eclipse.kura.container.signature.ValidationResult;
 import org.junit.Test;
 
@@ -241,7 +243,7 @@ public class DummyContainerSignatureValidationServiceTest {
             String user, String pass) {
         try {
             this.validationResult = this.containerSignatureValidationService.verify(imageName, imageTag, trustAnchor,
-                    isVerify, user, new Password(pass));
+                    isVerify, new PasswordRegistryCredentials(Optional.empty(), user, new Password(pass)));
         } catch (KuraException e) {
             this.occurredException = e;
         }
@@ -260,7 +262,7 @@ public class DummyContainerSignatureValidationServiceTest {
             String trustAnchor, boolean isVerify, String user, String pass) {
         try {
             this.validationResult = this.containerSignatureValidationService.verify(descriptor, trustAnchor, isVerify,
-                    user, new Password(pass));
+                    new PasswordRegistryCredentials(Optional.empty(), user, new Password(pass)));
         } catch (KuraException e) {
             this.occurredException = e;
         }

--- a/kura/examples/test/org.eclipse.kura.example.container.signature.validation.test/src/test/java/org/eclipse/kura/example/container/signature/validation/DummyContainerSignatureValidationServiceTest.java
+++ b/kura/examples/test/org.eclipse.kura.example.container.signature.validation.test/src/test/java/org/eclipse/kura/example/container/signature/validation/DummyContainerSignatureValidationServiceTest.java
@@ -28,6 +28,7 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
 import org.eclipse.kura.container.orchestration.PasswordRegistryCredentials;
+import org.eclipse.kura.container.orchestration.RegistryCredentials;
 import org.eclipse.kura.container.signature.ValidationResult;
 import org.junit.Test;
 
@@ -136,7 +137,8 @@ public class DummyContainerSignatureValidationServiceTest {
         givenPropertyWith(PROPERTY_NAME, "alpine:latest@sha256:1234567890");
         givenContainerSignatureValidationServiceWith(this.properties);
 
-        whenVerifyWithAuthIsCalledWith("alpine", "develop", TRUST_ANCHOR, false, USERNAME, PASSWORD);
+        whenVerifyWithAuthIsCalledWith("alpine", "develop", TRUST_ANCHOR, false,
+            new PasswordRegistryCredentials(Optional.empty(), USERNAME, new Password(PASSWORD)));
 
         thenNoExceptionOccurred();
         thenVerificationResultIs(FAILED_VALIDATION);
@@ -147,7 +149,8 @@ public class DummyContainerSignatureValidationServiceTest {
         givenPropertyWith(PROPERTY_NAME, "alpine:latest@sha256:1234567890");
         givenContainerSignatureValidationServiceWith(this.properties);
 
-        whenVerifyWithAuthIsCalledWith("alpine", "latest", TRUST_ANCHOR, false, USERNAME, PASSWORD);
+        whenVerifyWithAuthIsCalledWith("alpine", "latest", TRUST_ANCHOR, false,
+            new PasswordRegistryCredentials(Optional.empty(), USERNAME, new Password(PASSWORD)));
 
         thenNoExceptionOccurred();
         thenVerificationResultIs(new ValidationResult(true, "sha256:1234567890"));
@@ -183,8 +186,8 @@ public class DummyContainerSignatureValidationServiceTest {
         givenImageInstanceDescriptorWith("alpine", "develop", IMAGE_ID);
         givenContainerSignatureValidationServiceWith(this.properties);
 
-        whenVerifyImageInstanceDescriptorWithAuthIsCalledWith(this.imageDescriptor, TRUST_ANCHOR, false, USERNAME,
-                PASSWORD);
+        whenVerifyImageInstanceDescriptorWithAuthIsCalledWith(this.imageDescriptor, TRUST_ANCHOR, false,
+            new PasswordRegistryCredentials(Optional.empty(), USERNAME, new Password(PASSWORD)));
 
         thenNoExceptionOccurred();
         thenVerificationResultIs(FAILED_VALIDATION);
@@ -196,8 +199,8 @@ public class DummyContainerSignatureValidationServiceTest {
         givenImageInstanceDescriptorWith("alpine", "latest", IMAGE_ID);
         givenContainerSignatureValidationServiceWith(this.properties);
 
-        whenVerifyImageInstanceDescriptorWithAuthIsCalledWith(this.imageDescriptor, TRUST_ANCHOR, false, USERNAME,
-                PASSWORD);
+        whenVerifyImageInstanceDescriptorWithAuthIsCalledWith(this.imageDescriptor, TRUST_ANCHOR, false,
+            new PasswordRegistryCredentials(Optional.empty(), USERNAME, new Password(PASSWORD)));
 
         thenNoExceptionOccurred();
         thenVerificationResultIs(new ValidationResult(true, "sha256:1234567890"));
@@ -240,10 +243,10 @@ public class DummyContainerSignatureValidationServiceTest {
     }
 
     private void whenVerifyWithAuthIsCalledWith(String imageName, String imageTag, String trustAnchor, boolean isVerify,
-            String user, String pass) {
+            RegistryCredentials credentials) {
         try {
             this.validationResult = this.containerSignatureValidationService.verify(imageName, imageTag, trustAnchor,
-                    isVerify, new PasswordRegistryCredentials(Optional.empty(), user, new Password(pass)));
+                    isVerify, credentials);
         } catch (KuraException e) {
             this.occurredException = e;
         }
@@ -259,10 +262,9 @@ public class DummyContainerSignatureValidationServiceTest {
     }
 
     private void whenVerifyImageInstanceDescriptorWithAuthIsCalledWith(ImageInstanceDescriptor descriptor,
-            String trustAnchor, boolean isVerify, String user, String pass) {
+            String trustAnchor, boolean isVerify, RegistryCredentials credentials) {
         try {
-            this.validationResult = this.containerSignatureValidationService.verify(descriptor, trustAnchor, isVerify,
-                    new PasswordRegistryCredentials(Optional.empty(), user, new Password(pass)));
+            this.validationResult = this.containerSignatureValidationService.verify(descriptor, trustAnchor, isVerify, credentials);
         } catch (KuraException e) {
             this.occurredException = e;
         }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ContainerSignatureValidationService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/signature/ContainerSignatureValidationService.java
@@ -13,8 +13,8 @@
 package org.eclipse.kura.container.signature;
 
 import org.eclipse.kura.KuraException;
-import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
+import org.eclipse.kura.container.orchestration.RegistryCredentials;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -84,16 +84,13 @@ public interface ContainerSignatureValidationService {
      * @param verifyInTransparencyLog
      *            Sets the transparency log verification, to be used when an artifact signature has been uploaded to the
      *            transparency log. Artifacts cannot be publicly verified when not included in a log.
-     * @param registryUsername
-     *            Optional username for registry authentication. If the registry requires authentication,
-     *            both username and password must be provided.
-     * @param registryPassword
-     *            Optional password for registry authentication. If the registry requires authentication,
-     *            both username and password must be provided.
+     * @param credentials
+     *            Credentials for registry authentication. If the registry requires authentication,
+     *            this needs to be provided to verify the signature. See {@link RegistryCredentials}.
      * @return {@link:ValidationResult}
      */
     public ValidationResult verify(String imageName, String imageReference, String trustAnchor,
-            boolean verifyInTransparencyLog, String registryUsername, Password registryPassword) throws KuraException;
+            boolean verifyInTransparencyLog, RegistryCredentials credentials) throws KuraException;
 
     /**
      * Verifies the signature of a container image using the provided trust anchor. The trust anchor format depends on
@@ -145,14 +142,11 @@ public interface ContainerSignatureValidationService {
      * @param verifyInTransparencyLog
      *            Sets the transparency log verification, to be used when an artifact signature has been uploaded to the
      *            transparency log. Artifacts cannot be publicly verified when not included in a log.
-     * @param registryUsername
-     *            Optional username for registry authentication. If the registry requires authentication,
-     *            both username and password must be provided.
-     * @param registryPassword
-     *            Optional password for registry authentication. If the registry requires authentication,
-     *            both username and password must be provided.
+     * @param credentials
+     *            Credentials for registry authentication. If the registry requires authentication,
+     *            this needs to be provided to verify the signature. See {@link RegistryCredentials}.
      * @return {@link:ValidationResult}
      */
     public ValidationResult verify(ImageInstanceDescriptor imageDescriptor, String trustAnchor,
-            boolean verifyInTransparencyLog, String registryUsername, Password registryPassword) throws KuraException;
+            boolean verifyInTransparencyLog, RegistryCredentials credentials) throws KuraException;
 }


### PR DESCRIPTION
Instead of passing raw `String username, Password password` to the `verify` method we should use [the already defined `RegistryCredentials` from the Orchestrator APIs](https://github.com/eclipse/kura/blob/develop/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/RegistryCredentials.java).

For now the only implementation we have is the [`PasswordRegistryCredentials`](https://github.com/eclipse/kura/blob/develop/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/PasswordRegistryCredentials.java) which is exactly what we need.

This allows us to have a more flexible API (if one day we'll support [the `token` auth method for example](https://github.com/sigstore/cosign/blob/main/doc/cosign_verify.md)) and be more consistent with the rest of the codebase.
