### PR TITLE
fix: Corrected default container max-size for logging

### DIFF
--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -161,7 +161,7 @@
          </AD>
             
        <AD id="container.loggerParameters" name="Logger Parameters"
-            description="Used to pass logger parameters to a container's logging driver. Example: max-size=5m, max-file=2." type="String" cardinality="1"
+            description="Used to pass logger parameters to a container's logging driver. Example: max-size=10m, max-file=2." type="String" cardinality="1"
             required="false" default="max-size=10m" />
 
         <AD id="container.restart.onfailure" name="Restart Container On Failure" type="Boolean" cardinality="1" required="true" default="false"

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -161,8 +161,8 @@
          </AD>
             
        <AD id="container.loggerParameters" name="Logger Parameters"
-            description="Used to pass logger parameters to a container's logging driver. Example: max-buffer-size=5m, max-file=2." type="String" cardinality="1"
-            required="false" default="max-buffer-size=5m, max-file=2" />
+            description="Used to pass logger parameters to a container's logging driver. Example: max-size=5m, max-file=2." type="String" cardinality="1"
+            required="false" default="max-size=10m" />
 
         <AD id="container.restart.onfailure" name="Restart Container On Failure" type="Boolean" cardinality="1" required="true" default="false"
             description="Automatically restart the container when it has failed.">


### PR DESCRIPTION
Updated the default value with the correct property as stated in the docker documentation. https://docs.docker.com/config/containers/logging/local/

It sets a new default of 10 MB instead of the default of 20MB per container log
Unchanged the number of rotations that default to 5.

![image](https://github.com/eclipse/kura/assets/10448126/4322aaef-c55f-426e-9a4d-58527c58575e)

