### PR TITLE
feat(container.orchestration.provider): implemented enforcement allowlist

### DIFF
--- a/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
+++ b/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,19 @@
         <AD id="container.engine.host" name="Container Engine Host URL"
             description="Host URL: tcp://localhost:2376 or unix:///var/run/docker.sock" type="String"
             cardinality="0" required="true" default="unix:///var/run/docker.sock" />
+            
+        <AD id="allowlist.enabled" name="Allowlist Enforcement Enabled" type="Boolean" cardinality="0" required="true" default="false"
+            description="Enable/Disable the Allowlist enforcement. If enabled, only containers images whose digest can be found in the allowlist will be allowed to be ran/loaded/created.">
+        </AD>
+        
+        <AD
+			id="allowlist.content"
+			name="Container Image Allowlist Content"
+			description="List of comma separated 'sha256' values containing the image digests.|TextArea"
+			type="String"
+			cardinality="1"
+			required="false"
+			default="" />
         
     </OCD>
 

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -100,7 +100,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
 
     private void startEnforcementMonitor() {
         this.enforcementEvent = this.dockerClient.eventsCmd().withEventFilter("start")
-                .exec(new AllowlistEnforcementMonitor(currentConfig, this));
+                .exec(new AllowlistEnforcementMonitor(currentConfig.getEnforcementAllowlistContent(), this));
     }
 
     public void activate(Map<String, Object> properties) {
@@ -958,9 +958,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
         List<String> imageDigests = new ArrayList<>();
         dockerClient.listImagesCmd().withImageNameFilter(containerName).exec().stream().forEach(image -> {
             List<String> digests = Arrays.asList(image.getRepoDigests());
-            digests.stream().forEach(digest -> {
-                imageDigests.add(digest.split("@")[1]);
-            });
+            digests.stream().forEach(digest -> imageDigests.add(digest.split("@")[1]));
         });
 
         return imageDigests;

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -143,15 +143,15 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
                 logger.error("Could not connect to docker CLI.");
                 return;
             }
+            logger.info("Connection Successful");
 
             if (currentConfig.isEnforcementEnabled()) {
                 try {
                     startEnforcementMonitor();
                 } catch (Exception ex) {
-                    logger.error("Error starting enforcement monitor", ex);
+                    logger.error("Error starting enforcement monitor, connection to docker stopped", ex);
                 }
             }
-            logger.info("Connection Successful");
         }
 
         logger.info("Bundle {} has updated with config!", APP_ID);
@@ -161,6 +161,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
         try {
             this.enforcementEvent.close();
             this.enforcementEvent.awaitCompletion(5, TimeUnit.SECONDS);
+            this.enforcementEvent = null;
         } catch (InterruptedException ex) {
             logger.error("Waited to long to close enforcement monitor, stopping it...", ex);
             Thread.currentThread().interrupt();
@@ -956,6 +957,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
     public List<String> getImageDigestsByContainerName(String containerName) {
 
         List<String> imageDigests = new ArrayList<>();
+
         dockerClient.listImagesCmd().withImageNameFilter(containerName).exec().stream().forEach(image -> {
             List<String> digests = Arrays.asList(image.getRepoDigests());
             digests.stream().forEach(digest -> imageDigests.add(digest.split("@")[1]));

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,8 @@ package org.eclipse.kura.container.orchestration.provider.impl;
 
 import static java.util.Objects.isNull;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -24,9 +26,13 @@ public class ContainerOrchestrationServiceOptions {
     private static final Property<Boolean> IS_ENABLED = new Property<>("enabled", false);
     private static final Property<String> DOCKER_HOST_URL = new Property<>("container.engine.host",
             "unix:///var/run/docker.sock");
+    private static final Property<Boolean> ALLOWLIST_ENABLED = new Property<>("allowlist.enabled", false);
+    private static final Property<String> ALLOWLIST_CONTENT = new Property<>("allowlist.content", "");
 
     private final boolean enabled;
     private final String hostUrl;
+    private final boolean enforcementEnabled;
+    private final String enforcementAllowlistContent;
 
     public ContainerOrchestrationServiceOptions(final Map<String, Object> properties) {
 
@@ -36,6 +42,8 @@ public class ContainerOrchestrationServiceOptions {
 
         this.enabled = IS_ENABLED.get(properties);
         this.hostUrl = DOCKER_HOST_URL.get(properties);
+        this.enforcementEnabled = ALLOWLIST_ENABLED.get(properties);
+        this.enforcementAllowlistContent = ALLOWLIST_CONTENT.get(properties);
 
     }
 
@@ -47,9 +55,17 @@ public class ContainerOrchestrationServiceOptions {
         return this.hostUrl;
     }
 
+    public boolean isEnforcementEnabled() {
+        return this.enforcementEnabled;
+    }
+
+    public List<String> getEnforcementAllowlistContent() {
+        return Arrays.asList(this.enforcementAllowlistContent.trim().split(","));
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(this.enabled, this.hostUrl);
+        return Objects.hash(enforcementAllowlistContent, enforcementEnabled, enabled, hostUrl);
     }
 
     @Override
@@ -57,10 +73,15 @@ public class ContainerOrchestrationServiceOptions {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
             return false;
         }
         ContainerOrchestrationServiceOptions other = (ContainerOrchestrationServiceOptions) obj;
-        return isEnabled() == other.isEnabled() && Objects.equals(getHostUrl(), other.getHostUrl());
+        return Objects.equals(enforcementAllowlistContent, other.enforcementAllowlistContent) && enforcementEnabled == other.enforcementEnabled
+                && enabled == other.enabled && Objects.equals(hostUrl, other.hostUrl);
     }
+
 }

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
@@ -14,8 +14,6 @@ package org.eclipse.kura.container.orchestration.provider.impl;
 
 import static java.util.Objects.isNull;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -59,9 +57,8 @@ public class ContainerOrchestrationServiceOptions {
         return this.enforcementEnabled;
     }
 
-    public List<String> getEnforcementAllowlistContent() {
-        return Arrays
-                .asList(this.enforcementAllowlistContent.replaceAll("\\s", "").replace("\n", "").trim().split(","));
+    public String getEnforcementAllowlistContent() {
+        return this.enforcementAllowlistContent;
     }
 
     @Override

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
@@ -60,7 +60,8 @@ public class ContainerOrchestrationServiceOptions {
     }
 
     public List<String> getEnforcementAllowlistContent() {
-        return Arrays.asList(this.enforcementAllowlistContent.trim().split(","));
+        return Arrays
+                .asList(this.enforcementAllowlistContent.replaceAll("\\s", "").replace("\n", "").trim().split(","));
     }
 
     @Override
@@ -80,8 +81,9 @@ public class ContainerOrchestrationServiceOptions {
             return false;
         }
         ContainerOrchestrationServiceOptions other = (ContainerOrchestrationServiceOptions) obj;
-        return Objects.equals(enforcementAllowlistContent, other.enforcementAllowlistContent) && enforcementEnabled == other.enforcementEnabled
-                && enabled == other.enabled && Objects.equals(hostUrl, other.hostUrl);
+        return Objects.equals(enforcementAllowlistContent, other.enforcementAllowlistContent)
+                && enforcementEnabled == other.enforcementEnabled && enabled == other.enabled
+                && Objects.equals(hostUrl, other.hostUrl);
     }
 
 }

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcement.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcement.java
@@ -1,0 +1,70 @@
+package org.eclipse.kura.container.orchestration.provider.impl.enforcement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceImpl;
+import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.model.Event;
+
+public class AllowlistEnforcement {
+
+    private static final Logger logger = LoggerFactory.getLogger(AllowlistEnforcement.class);
+    private static final String ENFORCEMENT_SUCCESS = "Enforcement allowlist contains image digests {}...container {} is starting";
+    private static final String ENFORCEMENT_FAILURE = "Enforcement allowlist doesn't contain image digests...container {} will be stopped";
+
+    private final ContainerOrchestrationServiceImpl orchestrationServiceImpl;
+    private final ResultCallback.Adapter<Event> enforcement;
+
+    public AllowlistEnforcement(ContainerOrchestrationServiceOptions currentConfig,
+            ContainerOrchestrationServiceImpl containerOrchestrationService) {
+
+        this.orchestrationServiceImpl = containerOrchestrationService;
+        this.enforcement = new ResultCallback.Adapter<Event>() {
+
+            @Override
+            public void onNext(Event item) {
+
+                if (item.getAction().equals("start") && currentConfig.isEnforcementEnabled()) {
+                    try {
+                        implementAllowlistEnforcement(item.getId(), currentConfig);
+                    } catch (KuraException e) {
+                        logger.error("Error during container stopping process");
+                    }
+                }
+            }
+        };
+    }
+
+    private void implementAllowlistEnforcement(String id, ContainerOrchestrationServiceOptions currentConfig)
+            throws KuraException {
+        List<String> digestsList = this.orchestrationServiceImpl
+                .getImageDigestsByContainerName(getContainerNameById(id));
+
+        List<String> digestIntersection = currentConfig.getEnforcementAllowlistContent().stream().distinct()
+                .filter(digestsList::contains).collect(Collectors.toList());
+
+        if (!digestIntersection.isEmpty()) {
+            logger.info(ENFORCEMENT_SUCCESS, digestIntersection, id);
+        } else {
+            logger.error(ENFORCEMENT_FAILURE, id);
+            this.orchestrationServiceImpl.stopContainer(id);
+            this.orchestrationServiceImpl.deleteContainer(id);
+        }
+    }
+
+    private String getContainerNameById(String id) {
+        return this.orchestrationServiceImpl.listContainerDescriptors().stream()
+                .filter(container -> container.getContainerId().equals(id)).findFirst()
+                .map(container -> container.getContainerName()).orElse(null);
+    }
+
+    public ResultCallback.Adapter<Event> getEnforcementCallback() {
+        return this.enforcement;
+    }
+}

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.kura.container.orchestration.provider.impl.enforcement;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -32,10 +33,11 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
     private final List<String> enforcementAllowlistContent;
     private final ContainerOrchestrationServiceImpl orchestrationServiceImpl;
 
-    public AllowlistEnforcementMonitor(List<String> allowlistContent,
+    public AllowlistEnforcementMonitor(String allowlistContent,
             ContainerOrchestrationServiceImpl containerOrchestrationService) {
 
-        this.enforcementAllowlistContent = allowlistContent;
+        this.enforcementAllowlistContent = Arrays
+                .asList(allowlistContent.replaceAll("\\s", "").replace("\n", "").trim().split(","));
         this.orchestrationServiceImpl = containerOrchestrationService;
     }
 
@@ -49,6 +51,7 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
     }
 
     private void implementAllowlistEnforcement(String id) throws KuraException {
+
         List<String> digestsList = this.orchestrationServiceImpl
                 .getImageDigestsByContainerName(getContainerNameById(id));
 

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
 package org.eclipse.kura.container.orchestration.provider.impl.enforcement;
 
 import java.util.List;
@@ -5,7 +18,6 @@ import java.util.stream.Collectors;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceImpl;
-import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,31 +29,30 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
     private static final Logger logger = LoggerFactory.getLogger(AllowlistEnforcementMonitor.class);
     private static final String ENFORCEMENT_SUCCESS = "Enforcement allowlist contains image digests {}...container {} is starting";
     private static final String ENFORCEMENT_FAILURE = "Enforcement allowlist doesn't contain image digests...container {} will be stopped";
-    private final ContainerOrchestrationServiceOptions currentConfig;
+    private final List<String> enforcementAllowlistContent;
     private final ContainerOrchestrationServiceImpl orchestrationServiceImpl;
 
-    public AllowlistEnforcementMonitor(ContainerOrchestrationServiceOptions currentConfiguration,
+    public AllowlistEnforcementMonitor(List<String> allowlistContent,
             ContainerOrchestrationServiceImpl containerOrchestrationService) {
 
-        this.currentConfig = currentConfiguration;
+        this.enforcementAllowlistContent = allowlistContent;
         this.orchestrationServiceImpl = containerOrchestrationService;
     }
 
     @Override
     public void onNext(Event item) {
         try {
-            implementAllowlistEnforcement(item.getId(), currentConfig);
+            implementAllowlistEnforcement(item.getId());
         } catch (KuraException e) {
             logger.error("Error during container stopping process");
         }
     }
 
-    private void implementAllowlistEnforcement(String id, ContainerOrchestrationServiceOptions currentConfig)
-            throws KuraException {
+    private void implementAllowlistEnforcement(String id) throws KuraException {
         List<String> digestsList = this.orchestrationServiceImpl
                 .getImageDigestsByContainerName(getContainerNameById(id));
 
-        List<String> digestIntersection = currentConfig.getEnforcementAllowlistContent().stream().distinct()
+        List<String> digestIntersection = this.enforcementAllowlistContent.stream().distinct()
                 .filter(digestsList::contains).collect(Collectors.toList());
 
         if (!digestIntersection.isEmpty()) {

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceOptionsTest.java
@@ -29,9 +29,13 @@ public class ContainerOrchestrationServiceOptionsTest {
 
     private static final String DOCKER_HOST_URL = "container.engine.host";
     private static final String IS_ENABLED = "enabled";
+    private static final String ALLOWLIST_ENABLED = "allowlist.enabled";
+    private static final String ALLOWLIST_CONTENT = "allowlist.content";
 
     private static final String DEFAULT_DOCKER_HOST_URL = "unix:///var/run/docker.sock";
     private static final boolean DEFAULT_IS_ENABLED = false;
+    private static final String DEFAULT_ALLOWLIST_CONTENT = "";
+    private static final boolean DEFAULT_ALLOWLIST_ENABLED = false;
 
     private static final String REPOSITORY_ENABLED = "repository.enabled";
     private static final String REPOSITORY_URL = "repository.hostname";
@@ -45,6 +49,9 @@ public class ContainerOrchestrationServiceOptionsTest {
 
     private String host_url = "";
     private boolean is_enabled = false;
+    private String allowlist_content = "";
+    private boolean enforcement_enabled = false;
+
     private int hash;
 
     private Map<String, Object> properties = new HashMap<>();
@@ -109,6 +116,8 @@ public class ContainerOrchestrationServiceOptionsTest {
 
         whenHostStringSet();
         whenIsEnabled();
+        whenAllowlistContentSet();
+        whenIsEnforcementEnabled();
 
         whenHashIsCalculated();
 
@@ -156,6 +165,8 @@ public class ContainerOrchestrationServiceOptionsTest {
         this.properties = new HashMap<>();
         this.properties.put(DOCKER_HOST_URL, DEFAULT_DOCKER_HOST_URL);
         this.properties.put(IS_ENABLED, DEFAULT_IS_ENABLED);
+        this.properties.put(ALLOWLIST_ENABLED, DEFAULT_ALLOWLIST_ENABLED);
+        this.properties.put(ALLOWLIST_CONTENT, DEFAULT_ALLOWLIST_CONTENT);
         this.properties.put(REPOSITORY_ENABLED, DEFAULT_REPOSITORY_ENABLED);
         this.properties.put(REPOSITORY_URL, DEFAULT_REPOSITORY_URL);
         this.properties.put(REPOSITORY_USERNAME, DEFAULT_REPOSITORY_USERNAME);
@@ -166,6 +177,8 @@ public class ContainerOrchestrationServiceOptionsTest {
         this.newProperties = new HashMap<>();
         this.newProperties.put(DOCKER_HOST_URL, "http://docker.local");
         this.newProperties.put(IS_ENABLED, true);
+        this.properties.put(ALLOWLIST_ENABLED, DEFAULT_ALLOWLIST_ENABLED);
+        this.properties.put(ALLOWLIST_CONTENT, DEFAULT_ALLOWLIST_CONTENT);
         this.properties.put(REPOSITORY_ENABLED, DEFAULT_REPOSITORY_ENABLED);
         this.properties.put(REPOSITORY_URL, DEFAULT_REPOSITORY_URL);
         this.properties.put(REPOSITORY_USERNAME, DEFAULT_REPOSITORY_USERNAME);
@@ -200,8 +213,16 @@ public class ContainerOrchestrationServiceOptionsTest {
         this.host_url = this.dso.getHostUrl();
     }
 
+    private void whenAllowlistContentSet() {
+        this.allowlist_content = this.dso.getEnforcementAllowlistContent();
+    }
+
+    private void whenIsEnforcementEnabled() {
+        this.enforcement_enabled = this.dso.isEnforcementEnabled();
+    }
+
     private void whenHashIsCalculated() {
-        this.hash = Objects.hash(this.is_enabled, this.host_url);
+        this.hash = Objects.hash(this.allowlist_content, this.enforcement_enabled, this.is_enabled, this.host_url);
     }
 
     /**

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/EnforcementSecurityTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/EnforcementSecurityTest.java
@@ -1,0 +1,198 @@
+package org.eclipse.kura.container.orchestration.provider;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.configuration.Password;
+import org.eclipse.kura.container.orchestration.ContainerConfiguration;
+import org.eclipse.kura.container.orchestration.ContainerInstanceDescriptor;
+import org.eclipse.kura.container.orchestration.ContainerState;
+import org.eclipse.kura.container.orchestration.ImageConfiguration;
+import org.eclipse.kura.container.orchestration.PasswordRegistryCredentials;
+import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceImpl;
+import org.eclipse.kura.container.orchestration.provider.impl.enforcement.AllowlistEnforcementMonitor;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.model.Event;
+import com.github.dockerjava.api.model.Image;
+
+public class EnforcementSecurityTest {
+
+    private static final String IMAGE_NAME = "nginx";
+    private static final String CONTAINER_NAME = "frank";
+    private static final String CONTAINER_ID = "1d3dewf34r5";
+
+    private static final String REGISTRY_URL = "https://test";
+    private static final String REGISTRY_USERNAME = "test";
+    private static final String REGISTRY_PASSWORD = "test1";
+
+    private static final String EMPTY_ALLOWLIST_CONTENT = "";
+    private static final String FILLED_ALLOWLIST_CONTENT_NO_SPACE = "sha256:f9d633ff6640178c2d0525017174a688e2c1aef28f0a0130b26bd5554491f0da,sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107";
+    private static final String FILLED_ALLOWLIST_CONTENT_WITH_SPACES = " sha256:f9d633ff6640178c2d0525017174a688e2c1aef28f0a0130b26bd5554491f0da , sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107";
+
+    private static final String CORRECT_DIGEST = "ubuntu@sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107";
+    private static final String WRONG_DIGEST = "ubuntu@sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+    private AllowlistEnforcementMonitor allowlistEnforcementMonitor;
+    private ContainerOrchestrationServiceImpl mockedContainerOrchImpl;
+
+    ContainerConfiguration containerConfig;
+
+    private Map<String, Object> properties = new HashMap<>();
+
+    public EnforcementSecurityTest() {
+        this.properties.clear();
+    }
+
+    @Test
+    public void shouldAllowStartingWithCorrectAllowlistContent() throws KuraException, InterruptedException {
+
+        givenMockedContainerOrchestrationService();
+        givenMockedDockerClient(new String[] { CORRECT_DIGEST });
+        givenAllowlistEnforcement(FILLED_ALLOWLIST_CONTENT_NO_SPACE);
+
+        whenOnNext();
+
+        thenContainerDigestIsVerified();
+    }
+
+    @Test
+    public void shouldAllowStartingWithCorrectAllowlistContentWithSpaces() throws KuraException, InterruptedException {
+
+        givenMockedContainerOrchestrationService();
+        givenMockedDockerClient(new String[] { CORRECT_DIGEST });
+        givenAllowlistEnforcement(FILLED_ALLOWLIST_CONTENT_WITH_SPACES);
+
+        whenOnNext();
+
+        thenContainerDigestIsVerified();
+    }
+
+    @Test
+    public void shouldNotAllowStartingWithEmptyAllowlistContent() throws KuraException, InterruptedException {
+
+        givenMockedContainerOrchestrationService();
+        givenMockedDockerClient(new String[] { CORRECT_DIGEST });
+        givenAllowlistEnforcement(EMPTY_ALLOWLIST_CONTENT);
+
+        whenOnNext();
+
+        thenContainerDigestIsNotVerifiedAndStopped();
+    }
+
+    @Test
+    public void shouldNotAllowStartingWithWrongContainerDigest() throws KuraException, InterruptedException {
+
+        givenMockedContainerOrchestrationService();
+        givenMockedDockerClient(new String[] { WRONG_DIGEST });
+        givenAllowlistEnforcement(FILLED_ALLOWLIST_CONTENT_NO_SPACE);
+
+        whenOnNext();
+
+        thenContainerDigestIsNotVerifiedAndStopped();
+    }
+
+    /*
+     * Given
+     */
+
+    ContainerInstanceDescriptor containerInstanceDescriptor;
+
+    private void givenMockedContainerOrchestrationService() throws KuraException, InterruptedException {
+        this.mockedContainerOrchImpl = spy(new ContainerOrchestrationServiceImpl());
+
+        containerInstanceDescriptor = ContainerInstanceDescriptor.builder().setContainerID(CONTAINER_ID)
+                .setContainerName(CONTAINER_NAME).setContainerImage(IMAGE_NAME).setContainerState(ContainerState.ACTIVE)
+                .build();
+        List<ContainerInstanceDescriptor> containerDescriptors = new ArrayList<>();
+        containerDescriptors.add(containerInstanceDescriptor);
+
+        ImageConfiguration imageConfig = new ImageConfiguration.ImageConfigurationBuilder().setImageName(IMAGE_NAME)
+                .setImageTag("latest").setImageDownloadTimeoutSeconds(0)
+                .setRegistryCredentials(Optional.of(new PasswordRegistryCredentials(Optional.of(REGISTRY_URL),
+                        REGISTRY_USERNAME, new Password(REGISTRY_PASSWORD))))
+                .build();
+
+        this.containerConfig = ContainerConfiguration.builder().setContainerName(CONTAINER_NAME)
+                .setImageConfiguration(imageConfig).setVolumes(Collections.singletonMap("test", "~/test/test"))
+                .setDeviceList(Arrays.asList("/dev/gpio1", "/dev/gpio2"))
+                .setEnvVars(Arrays.asList("test=test", "test2=test2")).build();
+
+        doReturn(containerDescriptors).when(this.mockedContainerOrchImpl).listContainerDescriptors();
+
+        doNothing().when(this.mockedContainerOrchImpl).pullImage(any(ImageConfiguration.class));
+    }
+
+    private void givenMockedDockerClient(String[] digestsList) {
+        DockerClient mockedDockerClient = mock(DockerClient.class, Mockito.RETURNS_DEEP_STUBS);
+        List<Image> images = new LinkedList<>();
+        Image mockImage = mock(Image.class);
+
+        when(mockImage.getRepoTags()).thenReturn(new String[] { IMAGE_NAME, "latest", "nginx:latest" });
+        when(mockImage.getRepoDigests()).thenReturn(digestsList);
+        when(mockImage.getId()).thenReturn(IMAGE_NAME);
+        images.add(mockImage);
+
+        when(mockedDockerClient.listImagesCmd()).thenReturn(mock(ListImagesCmd.class));
+        when(mockedDockerClient.listImagesCmd().withImageNameFilter(anyString())).thenReturn(mock(ListImagesCmd.class));
+        when(mockedDockerClient.listImagesCmd().withImageNameFilter(anyString()).exec()).thenReturn(images);
+        when(mockedDockerClient.stopContainerCmd(anyString())).thenReturn(mock(StopContainerCmd.class));
+        when(mockedDockerClient.stopContainerCmd(anyString()).exec()).thenAnswer(answer -> {
+            this.containerInstanceDescriptor = ContainerInstanceDescriptor.builder().setContainerID(CONTAINER_ID)
+                    .setContainerName(CONTAINER_NAME).setContainerImage(IMAGE_NAME)
+                    .setContainerState(ContainerState.FAILED).build();
+            return null;
+        });
+
+        this.mockedContainerOrchImpl.setDockerClient(mockedDockerClient);
+    }
+
+    private void givenAllowlistEnforcement(String rawAllowlistContent) {
+        // List<String> allowlistContent = Arrays
+        // .asList(rawAllowlistContent.replaceAll("\\s", "").replace("\n", "").trim().split(","));
+        this.allowlistEnforcementMonitor = new AllowlistEnforcementMonitor(rawAllowlistContent,
+                this.mockedContainerOrchImpl);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenOnNext() {
+        this.allowlistEnforcementMonitor.onNext(new Event("start", CONTAINER_ID, "nginx:latest", 1708963202L));
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenContainerDigestIsVerified() {
+
+        assertEquals(ContainerState.ACTIVE, this.containerInstanceDescriptor.getContainerState());
+
+    }
+
+    private void thenContainerDigestIsNotVerifiedAndStopped() {
+        assertEquals(ContainerState.FAILED, this.containerInstanceDescriptor.getContainerState());
+    }
+}


### PR DESCRIPTION
This PR introduces the Enforcement Allowlist into the Container Orchestration bundle: this adds another security level when managing containers.

The user can enable the `Enforcement` through a new component option and write the list of image digests that are allowed to be run on the device.

If a container is run, the container orchestration will retrieve the container's image digests and compare it/them to the ones in the `Enforcement Allowlist`:

- If the image digest is in the allowlist, the container will be allowed to start
- If not, the container is immediately stopped and deleted

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
