### PR TITLE
ci: disable flaky tests

### DIFF
--- a/kura/test/org.eclipse.kura.core.cloud.test/src/main/java/org/eclipse/kura/core/cloud/CloudServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.cloud.test/src/main/java/org/eclipse/kura/core/cloud/CloudServiceTest.java
@@ -58,6 +58,7 @@ import org.eclipse.kura.system.ExtendedPropertyGroup;
 import org.eclipse.kura.system.SystemService;
 import org.eclipse.kura.test.annotation.TestTarget;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.osgi.framework.FrameworkUtil;
@@ -70,6 +71,7 @@ import org.slf4j.LoggerFactory;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 
+@Ignore
 public class CloudServiceTest {
 
     private static final String MODEM_RSSI = "modem_rssi";

--- a/kura/test/org.eclipse.kura.rest.configuration.provider.test/src/main/java/org/eclipse/kura/rest/configuration/provider/test/ConfigurationRestServiceTest.java
+++ b/kura/test/org.eclipse.kura.rest.configuration.provider.test/src/main/java/org/eclipse/kura/rest/configuration/provider/test/ConfigurationRestServiceTest.java
@@ -63,6 +63,7 @@ import org.eclipse.kura.core.testutil.requesthandler.Transport.MethodSpec;
 import org.eclipse.kura.crypto.CryptoService;
 import org.eclipse.kura.util.wire.test.WireTestUtil;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -77,6 +78,7 @@ import org.osgi.service.cm.ConfigurationAdmin;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonValue;
 
+@Ignore
 @RunWith(Parameterized.class)
 public class ConfigurationRestServiceTest extends AbstractRequestHandlerTest {
 

--- a/kura/test/org.eclipse.kura.rest.network.configuration.provider.test/src/main/java/org/eclipse/kura/rest/network/configuration/provider/test/NetworkConfigurationRestServiceTest.java
+++ b/kura/test/org.eclipse.kura.rest.network.configuration.provider.test/src/main/java/org/eclipse/kura/rest/network/configuration/provider/test/NetworkConfigurationRestServiceTest.java
@@ -50,6 +50,7 @@ import org.osgi.service.useradmin.Role;
 import org.osgi.service.useradmin.User;
 import org.osgi.service.useradmin.UserAdmin;
 
+@Ignore
 public class NetworkConfigurationRestServiceTest extends AbstractRequestHandlerTest {
 
     private static final String METHOD_SPEC_GET = "GET";

--- a/kura/test/org.eclipse.kura.rest.network.configuration.provider.test/src/main/java/org/eclipse/kura/rest/network/configuration/provider/test/NetworkConfigurationRestServiceTest.java
+++ b/kura/test/org.eclipse.kura.rest.network.configuration.provider.test/src/main/java/org/eclipse/kura/rest/network/configuration/provider/test/NetworkConfigurationRestServiceTest.java
@@ -38,6 +38,7 @@ import org.eclipse.kura.rest.network.configuration.provider.test.responses.MockC
 import org.eclipse.kura.rest.network.configuration.provider.test.responses.RestNetworkConfigurationJson;
 import org.eclipse.kura.util.wire.test.WireTestUtil;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;


### PR DESCRIPTION
We're currently experiencing high instability with our CI. The Eclipse Foundation issued a statement regarding this and it's probably related to the recent Jenkins update.

Since our builds are affected and they're blocking us we decided to disable the tests that are affecting us the most at the moment.

**Note**: this is a **temporary** measure. We plan to refactor these unit tests and restore them ASAP.