### PR TITLE
feat(container.orchestration.provider): implemented enforcement allowlist

### DIFF
--- a/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/component.xml
+++ b/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/component.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
+++ b/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
@@ -33,7 +33,7 @@
         <AD
             id="enforcement.allowlist"
             name="Container Image Allowlist "
-            description="List of values containing the image digests. Each entry must be inserted in a new line of the text box|TextArea"
+            description="List of container image digests. Each entry must be separated by a new line of the text box|TextArea"
             type="String"
             cardinality="1"
             required="false"

--- a/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
+++ b/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
@@ -27,7 +27,7 @@
             cardinality="0" required="true" default="unix:///var/run/docker.sock" />
             
         <AD id="allowlist.enabled" name="Allowlist Enforcement Enabled" type="Boolean" cardinality="0" required="true" default="false"
-            description="Enable/Disable the Allowlist enforcement. If enabled, only containers images whose digest can be found in the allowlist will be allowed to be ran/loaded/created.">
+            description="Enable/Disable the Allowlist enforcement. If enabled, only containers images whose digest can be found in the allowlist will be allowed to be run/loaded/created.">
         </AD>
         
         <AD

--- a/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
+++ b/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
@@ -26,14 +26,14 @@
             description="Host URL: tcp://localhost:2376 or unix:///var/run/docker.sock" type="String"
             cardinality="0" required="true" default="unix:///var/run/docker.sock" />
             
-        <AD id="allowlist.enabled" name="Allowlist Enforcement Enabled" type="Boolean" cardinality="0" required="true" default="false"
+        <AD id="enforcement.enabled" name="Allowlist Enforcement Enabled" type="Boolean" cardinality="0" required="true" default="false"
             description="Enable/Disable the Allowlist enforcement. If enabled, only containers images whose digest can be found in the allowlist will be allowed to be run/loaded/created.">
         </AD>
         
         <AD
-            id="allowlist.content"
-            name="Container Image Allowlist Content"
-            description="List of comma separated 'sha256' values containing the image digests.|TextArea"
+            id="enforcement.allowlist"
+            name="Container Image Allowlist "
+            description="List of values containing the image digests. Each entry must be inserted in a new line of the text box|TextArea"
             type="String"
             cardinality="1"
             required="false"

--- a/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
+++ b/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
@@ -31,13 +31,13 @@
         </AD>
         
         <AD
-			id="allowlist.content"
-			name="Container Image Allowlist Content"
-			description="List of comma separated 'sha256' values containing the image digests.|TextArea"
-			type="String"
-			cardinality="1"
-			required="false"
-			default="" />
+            id="allowlist.content"
+            name="Container Image Allowlist Content"
+            description="List of comma separated 'sha256' values containing the image digests.|TextArea"
+            type="String"
+            cardinality="1"
+            required="false"
+            default="" />
         
     </OCD>
 

--- a/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
+++ b/kura/org.eclipse.kura.container.orchestration.provider/OSGI-INF/metatype/org.eclipse.kura.container.orchestration.provider.ContainerOrchestrationService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Eurotech and/or its affiliates and others
+    Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,19 @@
         <AD id="container.engine.host" name="Container Engine Host URL"
             description="Host URL: tcp://localhost:2376 or unix:///var/run/docker.sock" type="String"
             cardinality="0" required="true" default="unix:///var/run/docker.sock" />
+            
+        <AD id="allowlist.enabled" name="Allowlist Enforcement Enabled" type="Boolean" cardinality="0" required="true" default="false"
+            description="Enable/Disable the Allowlist enforcement. If enabled, only containers images whose digest can be found in the allowlist will be allowed to be ran/loaded/created.">
+        </AD>
+        
+        <AD
+			id="allowlist.content"
+			name="Container Image Allowlist Content"
+			description="List of comma separated 'sha256' values containing the image digests.|TextArea"
+			type="String"
+			cardinality="1"
+			required="false"
+			default="" />
         
     </OCD>
 

--- a/kura/org.eclipse.kura.container.orchestration.provider/build.properties
+++ b/kura/org.eclipse.kura.container.orchestration.provider/build.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2022 Eurotech and/or its affiliates and others
+#  Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
 #
 #  This program and the accompanying materials are made
 #  available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.container.orchestration.provider/pom.xml
+++ b/kura/org.eclipse.kura.container.orchestration.provider/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -168,7 +168,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
             this.allowlistEnforcementMonitor.awaitCompletion(5, TimeUnit.SECONDS);
             this.allowlistEnforcementMonitor = null;
         } catch (InterruptedException ex) {
-            logger.error("Waited to long to close enforcement monitor, stopping it...", ex);
+            logger.error("Waited too long to close enforcement monitor, stopping it...", ex);
             Thread.currentThread().interrupt();
         } catch (IOException ex) {
             logger.error("Failed to close enforcement monitor, stopping it...", ex);

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -163,6 +163,11 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
     }
 
     private void closeEnforcementMonitor() {
+
+        if (this.allowlistEnforcementMonitor == null) {
+            return;
+        }
+
         try {
             logger.info("Enforcement monitor closing...");
             this.allowlistEnforcementMonitor.close();

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -176,7 +176,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
     }
 
     private void verifyAlreadyRunningContainer() {
-        this.allowlistEnforcementMonitor.verifyContainersDigests(listContainerDescriptors());
+        this.allowlistEnforcementMonitor.verifyAlreadyRunningContainersDigests(listContainerDescriptors());
     }
 
     @Override

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -150,7 +150,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
                     logger.error("Disconnected from docker");
                 }
 
-                verifyAlreadyRunningContainer();
+                enforceAlreadyRunningContainer();
             }
         }
 
@@ -175,8 +175,8 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
         }
     }
 
-    private void verifyAlreadyRunningContainer() {
-        this.allowlistEnforcementMonitor.verifyAlreadyRunningContainersDigests(listContainerDescriptors());
+    private void enforceAlreadyRunningContainer() {
+        this.allowlistEnforcementMonitor.enforceAllowlistFor(listContainerDescriptors());
     }
 
     @Override

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -100,7 +100,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
 
     private void startEnforcementMonitor() {
         this.enforcementEvent = this.dockerClient.eventsCmd().withEventFilter("start")
-                .exec(new AllowlistEnforcementMonitor(currentConfig, this));
+                .exec(new AllowlistEnforcementMonitor(currentConfig.getEnforcementAllowlistContent(), this));
     }
 
     public void activate(Map<String, Object> properties) {
@@ -958,9 +958,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
         List<String> imageDigests = new ArrayList<>();
         dockerClient.listImagesCmd().withImageNameFilter(containerName).exec().stream().forEach(image -> {
             List<String> digests = Arrays.asList(image.getRepoDigests());
-            digests.stream().forEach(digest -> {
-                imageDigests.add(digest.split("@")[1]);
-            });
+            digests.stream().forEach(digest -> imageDigests.add(digest.split("@")[1]));
         });
 
         return imageDigests;

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceImpl.java
@@ -143,15 +143,15 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
                 logger.error("Could not connect to docker CLI.");
                 return;
             }
+            logger.info("Connection Successful");
 
             if (currentConfig.isEnforcementEnabled()) {
                 try {
                     startEnforcementMonitor();
                 } catch (Exception ex) {
-                    logger.error("Error starting enforcement monitor", ex);
+                    logger.error("Error starting enforcement monitor, connection to docker stopped", ex);
                 }
             }
-            logger.info("Connection Successful");
         }
 
         logger.info("Bundle {} has updated with config!", APP_ID);
@@ -161,6 +161,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
         try {
             this.enforcementEvent.close();
             this.enforcementEvent.awaitCompletion(5, TimeUnit.SECONDS);
+            this.enforcementEvent = null;
         } catch (InterruptedException ex) {
             logger.error("Waited to long to close enforcement monitor, stopping it...", ex);
             Thread.currentThread().interrupt();
@@ -956,6 +957,7 @@ public class ContainerOrchestrationServiceImpl implements ConfigurableComponent,
     public List<String> getImageDigestsByContainerName(String containerName) {
 
         List<String> imageDigests = new ArrayList<>();
+
         dockerClient.listImagesCmd().withImageNameFilter(containerName).exec().stream().forEach(image -> {
             List<String> digests = Arrays.asList(image.getRepoDigests());
             digests.stream().forEach(digest -> imageDigests.add(digest.split("@")[1]));

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
@@ -24,13 +24,13 @@ public class ContainerOrchestrationServiceOptions {
     private static final Property<Boolean> IS_ENABLED = new Property<>("enabled", false);
     private static final Property<String> DOCKER_HOST_URL = new Property<>("container.engine.host",
             "unix:///var/run/docker.sock");
-    private static final Property<Boolean> ALLOWLIST_ENABLED = new Property<>("allowlist.enabled", false);
-    private static final Property<String> ALLOWLIST_CONTENT = new Property<>("allowlist.content", "");
+    private static final Property<Boolean> ENFORCEMENT_ENABLED = new Property<>("enforcement.enabled", false);
+    private static final Property<String> ENFORCEMENT_ALLOWLIST = new Property<>("enforcement.allowlist", "");
 
     private final boolean enabled;
     private final String hostUrl;
     private final boolean enforcementEnabled;
-    private final String enforcementAllowlistContent;
+    private final String enforcementAllowlist;
 
     public ContainerOrchestrationServiceOptions(final Map<String, Object> properties) {
 
@@ -40,8 +40,8 @@ public class ContainerOrchestrationServiceOptions {
 
         this.enabled = IS_ENABLED.get(properties);
         this.hostUrl = DOCKER_HOST_URL.get(properties);
-        this.enforcementEnabled = ALLOWLIST_ENABLED.get(properties);
-        this.enforcementAllowlistContent = ALLOWLIST_CONTENT.get(properties);
+        this.enforcementEnabled = ENFORCEMENT_ENABLED.get(properties);
+        this.enforcementAllowlist = ENFORCEMENT_ALLOWLIST.get(properties);
 
     }
 
@@ -57,13 +57,13 @@ public class ContainerOrchestrationServiceOptions {
         return this.enforcementEnabled;
     }
 
-    public String getEnforcementAllowlistContent() {
-        return this.enforcementAllowlistContent;
+    public String getEnforcementAllowlist() {
+        return this.enforcementAllowlist;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enforcementAllowlistContent, enforcementEnabled, enabled, hostUrl);
+        return Objects.hash(enforcementAllowlist, enforcementEnabled, enabled, hostUrl);
     }
 
     @Override
@@ -78,7 +78,7 @@ public class ContainerOrchestrationServiceOptions {
             return false;
         }
         ContainerOrchestrationServiceOptions other = (ContainerOrchestrationServiceOptions) obj;
-        return Objects.equals(enforcementAllowlistContent, other.enforcementAllowlistContent)
+        return Objects.equals(enforcementAllowlist, other.enforcementAllowlist)
                 && enforcementEnabled == other.enforcementEnabled && enabled == other.enabled
                 && Objects.equals(hostUrl, other.hostUrl);
     }

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,8 @@ package org.eclipse.kura.container.orchestration.provider.impl;
 
 import static java.util.Objects.isNull;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -24,9 +26,13 @@ public class ContainerOrchestrationServiceOptions {
     private static final Property<Boolean> IS_ENABLED = new Property<>("enabled", false);
     private static final Property<String> DOCKER_HOST_URL = new Property<>("container.engine.host",
             "unix:///var/run/docker.sock");
+    private static final Property<Boolean> ALLOWLIST_ENABLED = new Property<>("allowlist.enabled", false);
+    private static final Property<String> ALLOWLIST_CONTENT = new Property<>("allowlist.content", "");
 
     private final boolean enabled;
     private final String hostUrl;
+    private final boolean enforcementEnabled;
+    private final String enforcementAllowlistContent;
 
     public ContainerOrchestrationServiceOptions(final Map<String, Object> properties) {
 
@@ -36,6 +42,8 @@ public class ContainerOrchestrationServiceOptions {
 
         this.enabled = IS_ENABLED.get(properties);
         this.hostUrl = DOCKER_HOST_URL.get(properties);
+        this.enforcementEnabled = ALLOWLIST_ENABLED.get(properties);
+        this.enforcementAllowlistContent = ALLOWLIST_CONTENT.get(properties);
 
     }
 
@@ -47,9 +55,17 @@ public class ContainerOrchestrationServiceOptions {
         return this.hostUrl;
     }
 
+    public boolean isEnforcementEnabled() {
+        return this.enforcementEnabled;
+    }
+
+    public List<String> getEnforcementAllowlistContent() {
+        return Arrays.asList(this.enforcementAllowlistContent.trim().split(","));
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(this.enabled, this.hostUrl);
+        return Objects.hash(enforcementAllowlistContent, enforcementEnabled, enabled, hostUrl);
     }
 
     @Override
@@ -57,10 +73,15 @@ public class ContainerOrchestrationServiceOptions {
         if (this == obj) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
             return false;
         }
         ContainerOrchestrationServiceOptions other = (ContainerOrchestrationServiceOptions) obj;
-        return isEnabled() == other.isEnabled() && Objects.equals(getHostUrl(), other.getHostUrl());
+        return Objects.equals(enforcementAllowlistContent, other.enforcementAllowlistContent) && enforcementEnabled == other.enforcementEnabled
+                && enabled == other.enabled && Objects.equals(hostUrl, other.hostUrl);
     }
+
 }

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
@@ -14,8 +14,6 @@ package org.eclipse.kura.container.orchestration.provider.impl;
 
 import static java.util.Objects.isNull;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -59,9 +57,8 @@ public class ContainerOrchestrationServiceOptions {
         return this.enforcementEnabled;
     }
 
-    public List<String> getEnforcementAllowlistContent() {
-        return Arrays
-                .asList(this.enforcementAllowlistContent.replaceAll("\\s", "").replace("\n", "").trim().split(","));
+    public String getEnforcementAllowlistContent() {
+        return this.enforcementAllowlistContent;
     }
 
     @Override

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/ContainerOrchestrationServiceOptions.java
@@ -60,7 +60,8 @@ public class ContainerOrchestrationServiceOptions {
     }
 
     public List<String> getEnforcementAllowlistContent() {
-        return Arrays.asList(this.enforcementAllowlistContent.trim().split(","));
+        return Arrays
+                .asList(this.enforcementAllowlistContent.replaceAll("\\s", "").replace("\n", "").trim().split(","));
     }
 
     @Override
@@ -80,8 +81,9 @@ public class ContainerOrchestrationServiceOptions {
             return false;
         }
         ContainerOrchestrationServiceOptions other = (ContainerOrchestrationServiceOptions) obj;
-        return Objects.equals(enforcementAllowlistContent, other.enforcementAllowlistContent) && enforcementEnabled == other.enforcementEnabled
-                && enabled == other.enabled && Objects.equals(hostUrl, other.hostUrl);
+        return Objects.equals(enforcementAllowlistContent, other.enforcementAllowlistContent)
+                && enforcementEnabled == other.enforcementEnabled && enabled == other.enabled
+                && Objects.equals(hostUrl, other.hostUrl);
     }
 
 }

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcement.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcement.java
@@ -1,0 +1,70 @@
+package org.eclipse.kura.container.orchestration.provider.impl.enforcement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceImpl;
+import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.model.Event;
+
+public class AllowlistEnforcement {
+
+    private static final Logger logger = LoggerFactory.getLogger(AllowlistEnforcement.class);
+    private static final String ENFORCEMENT_SUCCESS = "Enforcement allowlist contains image digests {}...container {} is starting";
+    private static final String ENFORCEMENT_FAILURE = "Enforcement allowlist doesn't contain image digests...container {} will be stopped";
+
+    private final ContainerOrchestrationServiceImpl orchestrationServiceImpl;
+    private final ResultCallback.Adapter<Event> enforcement;
+
+    public AllowlistEnforcement(ContainerOrchestrationServiceOptions currentConfig,
+            ContainerOrchestrationServiceImpl containerOrchestrationService) {
+
+        this.orchestrationServiceImpl = containerOrchestrationService;
+        this.enforcement = new ResultCallback.Adapter<Event>() {
+
+            @Override
+            public void onNext(Event item) {
+
+                if (item.getAction().equals("start") && currentConfig.isEnforcementEnabled()) {
+                    try {
+                        implementAllowlistEnforcement(item.getId(), currentConfig);
+                    } catch (KuraException e) {
+                        logger.error("Error during container stopping process");
+                    }
+                }
+            }
+        };
+    }
+
+    private void implementAllowlistEnforcement(String id, ContainerOrchestrationServiceOptions currentConfig)
+            throws KuraException {
+        List<String> digestsList = this.orchestrationServiceImpl
+                .getImageDigestsByContainerName(getContainerNameById(id));
+
+        List<String> digestIntersection = currentConfig.getEnforcementAllowlistContent().stream().distinct()
+                .filter(digestsList::contains).collect(Collectors.toList());
+
+        if (!digestIntersection.isEmpty()) {
+            logger.info(ENFORCEMENT_SUCCESS, digestIntersection, id);
+        } else {
+            logger.error(ENFORCEMENT_FAILURE, id);
+            this.orchestrationServiceImpl.stopContainer(id);
+            this.orchestrationServiceImpl.deleteContainer(id);
+        }
+    }
+
+    private String getContainerNameById(String id) {
+        return this.orchestrationServiceImpl.listContainerDescriptors().stream()
+                .filter(container -> container.getContainerId().equals(id)).findFirst()
+                .map(container -> container.getContainerName()).orElse(null);
+    }
+
+    public ResultCallback.Adapter<Event> getEnforcementCallback() {
+        return this.enforcement;
+    }
+}

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
@@ -97,7 +97,7 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
         }
     }
 
-    public void verifyContainersDigests(List<ContainerInstanceDescriptor> containerDescriptors) {
+    public void verifyAlreadyRunningContainersDigests(List<ContainerInstanceDescriptor> containerDescriptors) {
 
         for (ContainerInstanceDescriptor descriptor : containerDescriptors) {
             implementAllowlistEnforcement(descriptor.getContainerId());

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
@@ -45,10 +45,10 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
 
     @Override
     public void onNext(Event item) {
-        implementAllowlistEnforcement(item.getId());
+        enforceAllowlistFor(item.getId());
     }
 
-    private void implementAllowlistEnforcement(String containerId) {
+    private void enforceAllowlistFor(String containerId) {
 
         List<String> digestsList = this.orchestrationServiceImpl
                 .getImageDigestsByContainerName(getContainerNameById(containerId));
@@ -62,6 +62,13 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
             logger.error(ENFORCEMENT_FAILURE, containerId);
             stopContainer(containerId);
             deleteContainer(containerId);
+        }
+    }
+
+    public void enforceAllowlistFor(List<ContainerInstanceDescriptor> containerDescriptors) {
+
+        for (ContainerInstanceDescriptor descriptor : containerDescriptors) {
+            enforceAllowlistFor(descriptor.getContainerId());
         }
     }
 
@@ -94,13 +101,6 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
             this.orchestrationServiceImpl.deleteContainer(containerId);
         } catch (KuraException ex) {
             logger.error("Error during container deleting process of {}:", containerId, ex);
-        }
-    }
-
-    public void verifyAlreadyRunningContainersDigests(List<ContainerInstanceDescriptor> containerDescriptors) {
-
-        for (ContainerInstanceDescriptor descriptor : containerDescriptors) {
-            implementAllowlistEnforcement(descriptor.getContainerId());
         }
     }
 }

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
@@ -15,6 +15,7 @@ package org.eclipse.kura.container.orchestration.provider.impl.enforcement;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.kura.KuraException;
@@ -32,14 +33,14 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
     private static final Logger logger = LoggerFactory.getLogger(AllowlistEnforcementMonitor.class);
     private static final String ENFORCEMENT_SUCCESS = "Enforcement allowlist contains image digests {}...container {} is starting";
     private static final String ENFORCEMENT_FAILURE = "Enforcement allowlist doesn't contain image digests...container {} will be stopped";
-    private final List<String> enforcementAllowlistContent;
+    private final Set<String> enforcementAllowlistContent;
     private final ContainerOrchestrationServiceImpl orchestrationServiceImpl;
 
     public AllowlistEnforcementMonitor(String allowlistContent,
             ContainerOrchestrationServiceImpl containerOrchestrationService) {
 
         this.enforcementAllowlistContent = Arrays.asList(allowlistContent.replace(" ", "").split("\\r?\\n|\\r"))
-                .stream().filter(line -> !line.isEmpty()).collect(Collectors.toList());
+                .stream().filter(line -> !line.isEmpty()).collect(Collectors.toSet());
         this.orchestrationServiceImpl = containerOrchestrationService;
     }
 
@@ -50,11 +51,10 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
 
     private void enforceAllowlistFor(String containerId) {
 
-        List<String> digestsList = this.orchestrationServiceImpl
-                .getImageDigestsByContainerName(getContainerNameById(containerId));
+        Set<String> digestsList = this.orchestrationServiceImpl.getImageDigestsByContainerId(containerId);
 
-        List<String> digestIntersection = this.enforcementAllowlistContent.stream().distinct()
-                .filter(digestsList::contains).collect(Collectors.toList());
+        Set<String> digestIntersection = this.enforcementAllowlistContent.stream().distinct()
+                .filter(digestsList::contains).collect(Collectors.toSet());
 
         if (!digestIntersection.isEmpty()) {
             logger.info(ENFORCEMENT_SUCCESS, digestIntersection, containerId);
@@ -70,12 +70,6 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
         for (ContainerInstanceDescriptor descriptor : containerDescriptors) {
             enforceAllowlistFor(descriptor.getContainerId());
         }
-    }
-
-    private String getContainerNameById(String containerId) {
-        return this.orchestrationServiceImpl.listContainerDescriptors().stream()
-                .filter(container -> container.getContainerId().equals(containerId)).findFirst()
-                .map(container -> container.getContainerName()).orElse(null);
     }
 
     private void stopContainer(String containerId) {

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.kura.container.orchestration.provider.impl.enforcement;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -32,10 +33,11 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
     private final List<String> enforcementAllowlistContent;
     private final ContainerOrchestrationServiceImpl orchestrationServiceImpl;
 
-    public AllowlistEnforcementMonitor(List<String> allowlistContent,
+    public AllowlistEnforcementMonitor(String allowlistContent,
             ContainerOrchestrationServiceImpl containerOrchestrationService) {
 
-        this.enforcementAllowlistContent = allowlistContent;
+        this.enforcementAllowlistContent = Arrays
+                .asList(allowlistContent.replaceAll("\\s", "").replace("\n", "").trim().split(","));
         this.orchestrationServiceImpl = containerOrchestrationService;
     }
 
@@ -49,6 +51,7 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
     }
 
     private void implementAllowlistEnforcement(String id) throws KuraException {
+
         List<String> digestsList = this.orchestrationServiceImpl
                 .getImageDigestsByContainerName(getContainerNameById(id));
 

--- a/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
+++ b/kura/org.eclipse.kura.container.orchestration.provider/src/main/java/org/eclipse/kura/container/orchestration/provider/impl/enforcement/AllowlistEnforcementMonitor.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
 package org.eclipse.kura.container.orchestration.provider.impl.enforcement;
 
 import java.util.List;
@@ -5,7 +18,6 @@ import java.util.stream.Collectors;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceImpl;
-import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,31 +29,30 @@ public class AllowlistEnforcementMonitor extends ResultCallbackTemplate<Allowlis
     private static final Logger logger = LoggerFactory.getLogger(AllowlistEnforcementMonitor.class);
     private static final String ENFORCEMENT_SUCCESS = "Enforcement allowlist contains image digests {}...container {} is starting";
     private static final String ENFORCEMENT_FAILURE = "Enforcement allowlist doesn't contain image digests...container {} will be stopped";
-    private final ContainerOrchestrationServiceOptions currentConfig;
+    private final List<String> enforcementAllowlistContent;
     private final ContainerOrchestrationServiceImpl orchestrationServiceImpl;
 
-    public AllowlistEnforcementMonitor(ContainerOrchestrationServiceOptions currentConfiguration,
+    public AllowlistEnforcementMonitor(List<String> allowlistContent,
             ContainerOrchestrationServiceImpl containerOrchestrationService) {
 
-        this.currentConfig = currentConfiguration;
+        this.enforcementAllowlistContent = allowlistContent;
         this.orchestrationServiceImpl = containerOrchestrationService;
     }
 
     @Override
     public void onNext(Event item) {
         try {
-            implementAllowlistEnforcement(item.getId(), currentConfig);
+            implementAllowlistEnforcement(item.getId());
         } catch (KuraException e) {
             logger.error("Error during container stopping process");
         }
     }
 
-    private void implementAllowlistEnforcement(String id, ContainerOrchestrationServiceOptions currentConfig)
-            throws KuraException {
+    private void implementAllowlistEnforcement(String id) throws KuraException {
         List<String> digestsList = this.orchestrationServiceImpl
                 .getImageDigestsByContainerName(getContainerNameById(id));
 
-        List<String> digestIntersection = currentConfig.getEnforcementAllowlistContent().stream().distinct()
+        List<String> digestIntersection = this.enforcementAllowlistContent.stream().distinct()
                 .filter(digestsList::contains).collect(Collectors.toList());
 
         if (!digestIntersection.isEmpty()) {

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/build.properties
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022 Eurotech and/or its affiliates and others
+# Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
 # 
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/pom.xml
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerInstanceDescriptorTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerInstanceDescriptorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -33,8 +33,7 @@ public class ContainerInstanceDescriptorTest {
     private static final List<Integer> H2_DB_PORTS_INTERNAL = new ArrayList<>(Arrays.asList(1521, 81));
     private ContainerInstanceDescriptor firstContainerConfig;
     private ContainerInstanceDescriptor seccondContainerConfig;
-    
-    
+
     @Test
     public void testSupportOfBasicParameters() {
         givenContainerOne();
@@ -66,10 +65,8 @@ public class ContainerInstanceDescriptorTest {
 
         this.seccondContainerConfig = ContainerInstanceDescriptor.builder().setContainerImageTag(H2_DB_NAME)
                 .setContainerName(H2_DB_NAME).setContainerImage(H2_DB_IMAGE).setContainerImageTag("diffrent")
-                .setExternalPorts(H2_DB_PORTS_EXTERNAL).setInternalPorts(H2_DB_PORTS_INTERNAL)
-                .build();
+                .setExternalPorts(H2_DB_PORTS_EXTERNAL).setInternalPorts(H2_DB_PORTS_INTERNAL).build();
     }
-
 
     // then
     private void thenCompareContainerOneToExpectedOutput() {

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
 package org.eclipse.kura.container.orchestration.provider;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -51,6 +50,10 @@ import com.github.dockerjava.api.model.Image;
 
 public class ContainerOrchestrationServiceImplTest {
 
+    private static final String[] REPO_DIGESTS_ARRAY = new String[] {
+            "ubuntu@sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107" };
+    private static final String[] EXPECTED_DIGESTS_ARRAY = new String[] {
+            "sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107" };
     private static final String IMAGE_TAG_LATEST = "latest";
     private static final String IMAGE_NAME_NGINX = "nginx";
     private static final String CONTAINER_NAME_FRANK = "frank";
@@ -310,7 +313,7 @@ public class ContainerOrchestrationServiceImplTest {
 
         whenGetImageDigestsByContainerName(IMAGE_NAME_NGINX);
 
-        thenDigestsListIsNotEmpty();
+        thenDigestsListEqualsExpectedOne(EXPECTED_DIGESTS_ARRAY);
 
     }
 
@@ -486,8 +489,7 @@ public class ContainerOrchestrationServiceImplTest {
 
         when(mockImage.getId()).thenReturn("ngnix");
         when(mockImage.getRepoTags()).thenReturn(new String[] { IMAGE_NAME_NGINX, IMAGE_TAG_LATEST, "nginx:latest" });
-        when(mockImage.getRepoDigests()).thenReturn(
-                new String[] { "ubuntu@sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107" });
+        when(mockImage.getRepoDigests()).thenReturn(REPO_DIGESTS_ARRAY);
         images.add(mockImage);
 
         when(this.localDockerClient.listImagesCmd()).thenReturn(mock(ListImagesCmd.class));
@@ -508,8 +510,7 @@ public class ContainerOrchestrationServiceImplTest {
 
         when(mockImage.getId()).thenReturn("ngnix");
         when(mockImage.getRepoTags()).thenReturn(new String[] { IMAGE_NAME_NGINX, IMAGE_TAG_LATEST, "nginx:latest" });
-        when(mockImage.getRepoDigests()).thenReturn(
-                new String[] { "ubuntu@sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107" });
+        when(mockImage.getRepoDigests()).thenReturn(REPO_DIGESTS_ARRAY);
         images.add(mockImage);
 
         when(this.localDockerClient.listImagesCmd()).thenReturn(mock(ListImagesCmd.class));
@@ -590,7 +591,7 @@ public class ContainerOrchestrationServiceImplTest {
         verify(this.localDockerClient, times(1)).inspectImageCmd(any(String.class));
     }
 
-    private void thenDigestsListIsNotEmpty() {
-        assertFalse(this.digestsList.isEmpty());
+    private void thenDigestsListEqualsExpectedOne(String[] digestsArray) {
+        assertEquals(this.digestsList, Arrays.asList(digestsArray));
     }
 }

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceImplTest.java
@@ -23,10 +23,12 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.Password;
@@ -99,7 +101,7 @@ public class ContainerOrchestrationServiceImplTest {
     private Map<String, Object> properties;
     private String containerId;
 
-    List<String> digestsList;
+    Set<String> digestsList;
 
     @Test
     public void testServiceActivateEmptyProperties() {
@@ -310,8 +312,8 @@ public class ContainerOrchestrationServiceImplTest {
         givenDockerClient();
 
         whenMockForImageDigestsListing();
-
-        whenGetImageDigestsByContainerName(IMAGE_NAME_NGINX);
+        whenDockerClientMockSomeContainers();
+        whenGetImageDigestsByContainerId(CONTAINER_ID_1);
 
         thenDigestsListEqualsExpectedOne(EXPECTED_DIGESTS_ARRAY);
 
@@ -538,8 +540,8 @@ public class ContainerOrchestrationServiceImplTest {
         this.dockerService.listImageInstanceDescriptors();
     }
 
-    private void whenGetImageDigestsByContainerName(String containerName) {
-        this.digestsList = this.dockerService.getImageDigestsByContainerName(containerName);
+    private void whenGetImageDigestsByContainerId(String containerName) {
+        this.digestsList = this.dockerService.getImageDigestsByContainerId(containerName);
     }
 
     /**
@@ -592,6 +594,6 @@ public class ContainerOrchestrationServiceImplTest {
     }
 
     private void thenDigestsListEqualsExpectedOne(String[] digestsArray) {
-        assertEquals(this.digestsList, Arrays.asList(digestsArray));
+        assertEquals(new HashSet<>(Arrays.asList(digestsArray)), this.digestsList);
     }
 }

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceOptionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -214,7 +214,7 @@ public class ContainerOrchestrationServiceOptionsTest {
     }
 
     private void whenAllowlistContentSet() {
-        this.allowlist_content = this.dso.getEnforcementAllowlistContent();
+        this.allowlist_content = this.dso.getEnforcementAllowlist();
     }
 
     private void whenIsEnforcementEnabled() {

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerOrchestrationServiceOptionsTest.java
@@ -29,9 +29,13 @@ public class ContainerOrchestrationServiceOptionsTest {
 
     private static final String DOCKER_HOST_URL = "container.engine.host";
     private static final String IS_ENABLED = "enabled";
+    private static final String ALLOWLIST_ENABLED = "allowlist.enabled";
+    private static final String ALLOWLIST_CONTENT = "allowlist.content";
 
     private static final String DEFAULT_DOCKER_HOST_URL = "unix:///var/run/docker.sock";
     private static final boolean DEFAULT_IS_ENABLED = false;
+    private static final String DEFAULT_ALLOWLIST_CONTENT = "";
+    private static final boolean DEFAULT_ALLOWLIST_ENABLED = false;
 
     private static final String REPOSITORY_ENABLED = "repository.enabled";
     private static final String REPOSITORY_URL = "repository.hostname";
@@ -45,6 +49,9 @@ public class ContainerOrchestrationServiceOptionsTest {
 
     private String host_url = "";
     private boolean is_enabled = false;
+    private String allowlist_content = "";
+    private boolean enforcement_enabled = false;
+
     private int hash;
 
     private Map<String, Object> properties = new HashMap<>();
@@ -109,6 +116,8 @@ public class ContainerOrchestrationServiceOptionsTest {
 
         whenHostStringSet();
         whenIsEnabled();
+        whenAllowlistContentSet();
+        whenIsEnforcementEnabled();
 
         whenHashIsCalculated();
 
@@ -156,6 +165,8 @@ public class ContainerOrchestrationServiceOptionsTest {
         this.properties = new HashMap<>();
         this.properties.put(DOCKER_HOST_URL, DEFAULT_DOCKER_HOST_URL);
         this.properties.put(IS_ENABLED, DEFAULT_IS_ENABLED);
+        this.properties.put(ALLOWLIST_ENABLED, DEFAULT_ALLOWLIST_ENABLED);
+        this.properties.put(ALLOWLIST_CONTENT, DEFAULT_ALLOWLIST_CONTENT);
         this.properties.put(REPOSITORY_ENABLED, DEFAULT_REPOSITORY_ENABLED);
         this.properties.put(REPOSITORY_URL, DEFAULT_REPOSITORY_URL);
         this.properties.put(REPOSITORY_USERNAME, DEFAULT_REPOSITORY_USERNAME);
@@ -166,6 +177,8 @@ public class ContainerOrchestrationServiceOptionsTest {
         this.newProperties = new HashMap<>();
         this.newProperties.put(DOCKER_HOST_URL, "http://docker.local");
         this.newProperties.put(IS_ENABLED, true);
+        this.properties.put(ALLOWLIST_ENABLED, DEFAULT_ALLOWLIST_ENABLED);
+        this.properties.put(ALLOWLIST_CONTENT, DEFAULT_ALLOWLIST_CONTENT);
         this.properties.put(REPOSITORY_ENABLED, DEFAULT_REPOSITORY_ENABLED);
         this.properties.put(REPOSITORY_URL, DEFAULT_REPOSITORY_URL);
         this.properties.put(REPOSITORY_USERNAME, DEFAULT_REPOSITORY_USERNAME);
@@ -200,8 +213,16 @@ public class ContainerOrchestrationServiceOptionsTest {
         this.host_url = this.dso.getHostUrl();
     }
 
+    private void whenAllowlistContentSet() {
+        this.allowlist_content = this.dso.getEnforcementAllowlistContent();
+    }
+
+    private void whenIsEnforcementEnabled() {
+        this.enforcement_enabled = this.dso.isEnforcementEnabled();
+    }
+
     private void whenHashIsCalculated() {
-        this.hash = Objects.hash(this.is_enabled, this.host_url);
+        this.hash = Objects.hash(this.allowlist_content, this.enforcement_enabled, this.is_enabled, this.host_url);
     }
 
     /**

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/EnforcementSecurityTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/EnforcementSecurityTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/EnforcementSecurityTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/EnforcementSecurityTest.java
@@ -1,0 +1,198 @@
+package org.eclipse.kura.container.orchestration.provider;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.configuration.Password;
+import org.eclipse.kura.container.orchestration.ContainerConfiguration;
+import org.eclipse.kura.container.orchestration.ContainerInstanceDescriptor;
+import org.eclipse.kura.container.orchestration.ContainerState;
+import org.eclipse.kura.container.orchestration.ImageConfiguration;
+import org.eclipse.kura.container.orchestration.PasswordRegistryCredentials;
+import org.eclipse.kura.container.orchestration.provider.impl.ContainerOrchestrationServiceImpl;
+import org.eclipse.kura.container.orchestration.provider.impl.enforcement.AllowlistEnforcementMonitor;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.model.Event;
+import com.github.dockerjava.api.model.Image;
+
+public class EnforcementSecurityTest {
+
+    private static final String IMAGE_NAME = "nginx";
+    private static final String CONTAINER_NAME = "frank";
+    private static final String CONTAINER_ID = "1d3dewf34r5";
+
+    private static final String REGISTRY_URL = "https://test";
+    private static final String REGISTRY_USERNAME = "test";
+    private static final String REGISTRY_PASSWORD = "test1";
+
+    private static final String EMPTY_ALLOWLIST_CONTENT = "";
+    private static final String FILLED_ALLOWLIST_CONTENT_NO_SPACE = "sha256:f9d633ff6640178c2d0525017174a688e2c1aef28f0a0130b26bd5554491f0da,sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107";
+    private static final String FILLED_ALLOWLIST_CONTENT_WITH_SPACES = " sha256:f9d633ff6640178c2d0525017174a688e2c1aef28f0a0130b26bd5554491f0da , sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107";
+
+    private static final String CORRECT_DIGEST = "ubuntu@sha256:c26ae7472d624ba1fafd296e73cecc4f93f853088e6a9c13c0d52f6ca5865107";
+    private static final String WRONG_DIGEST = "ubuntu@sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+    private AllowlistEnforcementMonitor allowlistEnforcementMonitor;
+    private ContainerOrchestrationServiceImpl mockedContainerOrchImpl;
+
+    ContainerConfiguration containerConfig;
+
+    private Map<String, Object> properties = new HashMap<>();
+
+    public EnforcementSecurityTest() {
+        this.properties.clear();
+    }
+
+    @Test
+    public void shouldAllowStartingWithCorrectAllowlistContent() throws KuraException, InterruptedException {
+
+        givenMockedContainerOrchestrationService();
+        givenMockedDockerClient(new String[] { CORRECT_DIGEST });
+        givenAllowlistEnforcement(FILLED_ALLOWLIST_CONTENT_NO_SPACE);
+
+        whenOnNext();
+
+        thenContainerDigestIsVerified();
+    }
+
+    @Test
+    public void shouldAllowStartingWithCorrectAllowlistContentWithSpaces() throws KuraException, InterruptedException {
+
+        givenMockedContainerOrchestrationService();
+        givenMockedDockerClient(new String[] { CORRECT_DIGEST });
+        givenAllowlistEnforcement(FILLED_ALLOWLIST_CONTENT_WITH_SPACES);
+
+        whenOnNext();
+
+        thenContainerDigestIsVerified();
+    }
+
+    @Test
+    public void shouldNotAllowStartingWithEmptyAllowlistContent() throws KuraException, InterruptedException {
+
+        givenMockedContainerOrchestrationService();
+        givenMockedDockerClient(new String[] { CORRECT_DIGEST });
+        givenAllowlistEnforcement(EMPTY_ALLOWLIST_CONTENT);
+
+        whenOnNext();
+
+        thenContainerDigestIsNotVerifiedAndStopped();
+    }
+
+    @Test
+    public void shouldNotAllowStartingWithWrongContainerDigest() throws KuraException, InterruptedException {
+
+        givenMockedContainerOrchestrationService();
+        givenMockedDockerClient(new String[] { WRONG_DIGEST });
+        givenAllowlistEnforcement(FILLED_ALLOWLIST_CONTENT_NO_SPACE);
+
+        whenOnNext();
+
+        thenContainerDigestIsNotVerifiedAndStopped();
+    }
+
+    /*
+     * Given
+     */
+
+    ContainerInstanceDescriptor containerInstanceDescriptor;
+
+    private void givenMockedContainerOrchestrationService() throws KuraException, InterruptedException {
+        this.mockedContainerOrchImpl = spy(new ContainerOrchestrationServiceImpl());
+
+        containerInstanceDescriptor = ContainerInstanceDescriptor.builder().setContainerID(CONTAINER_ID)
+                .setContainerName(CONTAINER_NAME).setContainerImage(IMAGE_NAME).setContainerState(ContainerState.ACTIVE)
+                .build();
+        List<ContainerInstanceDescriptor> containerDescriptors = new ArrayList<>();
+        containerDescriptors.add(containerInstanceDescriptor);
+
+        ImageConfiguration imageConfig = new ImageConfiguration.ImageConfigurationBuilder().setImageName(IMAGE_NAME)
+                .setImageTag("latest").setImageDownloadTimeoutSeconds(0)
+                .setRegistryCredentials(Optional.of(new PasswordRegistryCredentials(Optional.of(REGISTRY_URL),
+                        REGISTRY_USERNAME, new Password(REGISTRY_PASSWORD))))
+                .build();
+
+        this.containerConfig = ContainerConfiguration.builder().setContainerName(CONTAINER_NAME)
+                .setImageConfiguration(imageConfig).setVolumes(Collections.singletonMap("test", "~/test/test"))
+                .setDeviceList(Arrays.asList("/dev/gpio1", "/dev/gpio2"))
+                .setEnvVars(Arrays.asList("test=test", "test2=test2")).build();
+
+        doReturn(containerDescriptors).when(this.mockedContainerOrchImpl).listContainerDescriptors();
+
+        doNothing().when(this.mockedContainerOrchImpl).pullImage(any(ImageConfiguration.class));
+    }
+
+    private void givenMockedDockerClient(String[] digestsList) {
+        DockerClient mockedDockerClient = mock(DockerClient.class, Mockito.RETURNS_DEEP_STUBS);
+        List<Image> images = new LinkedList<>();
+        Image mockImage = mock(Image.class);
+
+        when(mockImage.getRepoTags()).thenReturn(new String[] { IMAGE_NAME, "latest", "nginx:latest" });
+        when(mockImage.getRepoDigests()).thenReturn(digestsList);
+        when(mockImage.getId()).thenReturn(IMAGE_NAME);
+        images.add(mockImage);
+
+        when(mockedDockerClient.listImagesCmd()).thenReturn(mock(ListImagesCmd.class));
+        when(mockedDockerClient.listImagesCmd().withImageNameFilter(anyString())).thenReturn(mock(ListImagesCmd.class));
+        when(mockedDockerClient.listImagesCmd().withImageNameFilter(anyString()).exec()).thenReturn(images);
+        when(mockedDockerClient.stopContainerCmd(anyString())).thenReturn(mock(StopContainerCmd.class));
+        when(mockedDockerClient.stopContainerCmd(anyString()).exec()).thenAnswer(answer -> {
+            this.containerInstanceDescriptor = ContainerInstanceDescriptor.builder().setContainerID(CONTAINER_ID)
+                    .setContainerName(CONTAINER_NAME).setContainerImage(IMAGE_NAME)
+                    .setContainerState(ContainerState.FAILED).build();
+            return null;
+        });
+
+        this.mockedContainerOrchImpl.setDockerClient(mockedDockerClient);
+    }
+
+    private void givenAllowlistEnforcement(String rawAllowlistContent) {
+        // List<String> allowlistContent = Arrays
+        // .asList(rawAllowlistContent.replaceAll("\\s", "").replace("\n", "").trim().split(","));
+        this.allowlistEnforcementMonitor = new AllowlistEnforcementMonitor(rawAllowlistContent,
+                this.mockedContainerOrchImpl);
+    }
+
+    /*
+     * When
+     */
+
+    private void whenOnNext() {
+        this.allowlistEnforcementMonitor.onNext(new Event("start", CONTAINER_ID, "nginx:latest", 1708963202L));
+    }
+
+    /*
+     * Then
+     */
+
+    private void thenContainerDigestIsVerified() {
+
+        assertEquals(ContainerState.ACTIVE, this.containerInstanceDescriptor.getContainerState());
+
+    }
+
+    private void thenContainerDigestIsNotVerifiedAndStopped() {
+        assertEquals(ContainerState.FAILED, this.containerInstanceDescriptor.getContainerState());
+    }
+}

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/EnforcementSecurityTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/EnforcementSecurityTest.java
@@ -200,9 +200,6 @@ public class EnforcementSecurityTest {
         when(mockedDockerClient.listImagesCmd().withImageNameFilter(anyString()).exec()).thenReturn(images);
         when(mockedDockerClient.stopContainerCmd(anyString())).thenReturn(mock(StopContainerCmd.class));
         when(mockedDockerClient.stopContainerCmd(anyString()).exec()).thenAnswer(answer -> {
-            // this.containerInstanceDescriptor = ContainerInstanceDescriptor.builder().setContainerID(containerId)
-            // .setContainerName(containerName).setContainerImage(imageName)
-            // .setContainerState(ContainerState.STOPPING).build();
             this.stoppingResult = ContainerState.STOPPING;
             return null;
         });
@@ -232,7 +229,7 @@ public class EnforcementSecurityTest {
     }
 
     private void whenVerifyAlreadyRunningContainersDigests(List<ContainerInstanceDescriptor> containerDescriptors) {
-        this.allowlistEnforcementMonitor.verifyAlreadyRunningContainersDigests(containerDescriptors);
+        this.allowlistEnforcementMonitor.enforceAllowlistFor(containerDescriptors);
     }
 
     /*

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ImageInstanceDescriptorTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ImageInstanceDescriptorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,14 +15,7 @@ package org.eclipse.kura.container.orchestration.provider;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import org.apache.commons.lang.ArrayUtils;
-import org.eclipse.kura.container.orchestration.ContainerInstanceDescriptor;
 import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
 import org.junit.Test;
 
@@ -34,13 +27,10 @@ public class ImageInstanceDescriptorTest {
     private static final String IMAGE_AUTHOR = "Nginx";
     private static final String IMAGE_ID = "f45f645f457uyrthjfghje4r6t";
     private static final long IMAGE_SIZE = 123123;
-    
-    
-    
+
     private ImageInstanceDescriptor firstImageConfig;
     private ImageInstanceDescriptor seccondImageConfig;
-    
-    
+
     @Test
     public void testSupportOfBasicParameters() {
         givenContainerOne();
@@ -63,14 +53,17 @@ public class ImageInstanceDescriptorTest {
     // given
     private void givenContainerOne() {
 
-    	this.firstImageConfig = ImageInstanceDescriptor.builder().setImageName(IMAGE_NAME).setImageTag(IMAGE_TAG).setImageArch(IMAGE_ARCH).setImageAuthor(IMAGE_AUTHOR).setimageSize(IMAGE_SIZE).setImageId(IMAGE_ID).build();
+        this.firstImageConfig = ImageInstanceDescriptor.builder().setImageName(IMAGE_NAME).setImageTag(IMAGE_TAG)
+                .setImageArch(IMAGE_ARCH).setImageAuthor(IMAGE_AUTHOR).setimageSize(IMAGE_SIZE).setImageId(IMAGE_ID)
+                .build();
     }
 
     private void givenContainerTwoDiffrent() {
 
-        this.seccondImageConfig = ImageInstanceDescriptor.builder().setImageName("NOT_"+IMAGE_NAME).setImageTag("NOT_"+IMAGE_TAG).setImageArch("NOT_"+IMAGE_ARCH).setImageAuthor(IMAGE_AUTHOR).setimageSize(IMAGE_SIZE).setImageId("3rhf8943hf78934hf734t7r8fw38fy234897fh8").build();
+        this.seccondImageConfig = ImageInstanceDescriptor.builder().setImageName("NOT_" + IMAGE_NAME)
+                .setImageTag("NOT_" + IMAGE_TAG).setImageArch("NOT_" + IMAGE_ARCH).setImageAuthor(IMAGE_AUTHOR)
+                .setimageSize(IMAGE_SIZE).setImageId("3rhf8943hf78934hf734t7r8fw38fy234897fh8").build();
     }
-
 
     // then
     private void thenCompareContainerOneToExpectedOutput() {


### PR DESCRIPTION
This PR introduces the Enforcement Allowlist into the Container Orchestration bundle: this adds another security level when managing containers.

The user can enable the `Enforcement` through a new component option and write the list of image digests that are allowed to be run on the device.

If a container is run, the container orchestration will retrieve the container's image digests and compare it/them to the ones in the `Enforcement Allowlist`:

- If the image digest is in the allowlist, the container will be allowed to start
- If not, the container is immediately stopped and deleted

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
