### PR TITLE
fix(web2): Workaround for fix GWT strange behavior when deleting a certificate entry after DNs have been added as column in the table.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/security/CertificateListTabUi.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.eclipse.kura.web.client.messages.Messages;
 import org.eclipse.kura.web.client.ui.AlertDialog;
@@ -181,7 +180,7 @@ public class CertificateListTabUi extends Composite implements Tab, CertificateM
 
             @Override
             public String getValue(GwtKeystoreEntry object) {
-                return String.join(" ", object.getDistinguishedNames());
+                return object.getDistinguishedNames();
             }
         };
         this.certificatesGrid.addColumn(col1bis, MSGS.certificateDNs());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
@@ -155,7 +155,7 @@ public class GwtCertificatesServiceImpl extends OsgiRemoteServiceServlet impleme
                     Date validityEndDate = null;
 
                     List<String> distinguishedNames = new ArrayList<>();
-                    
+
                     if (e.getValue() instanceof PrivateKeyEntry) {
                         kind = Kind.KEY_PAIR;
 
@@ -200,8 +200,8 @@ public class GwtCertificatesServiceImpl extends OsgiRemoteServiceServlet impleme
                         continue;
                     }
 
-                    result.add(new GwtKeystoreEntry(e.getKey(), distinguishedNames, (String) kuraServicePid, kind, validityStartDate,
-                            validityEndDate));
+                    result.add(new GwtKeystoreEntry(e.getKey(), String.join(" ", distinguishedNames),
+                            (String) kuraServicePid, kind, validityStartDate, validityEndDate));
                 }
             } catch (KuraException keystoreException) {
                 logger.error("Error while accessing keystore file of Keystore Service {}: {}", kuraServicePid,

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtKeystoreEntry.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtKeystoreEntry.java
@@ -14,7 +14,6 @@ package org.eclipse.kura.web.shared.model;
 
 import java.io.Serializable;
 import java.util.Date;
-import java.util.List;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
 
@@ -31,8 +30,8 @@ public class GwtKeystoreEntry extends GwtBaseModel implements IsSerializable, Se
     public GwtKeystoreEntry() {
     }
 
-    public GwtKeystoreEntry(final String alias, final List<String> distinguishedNames, String keystoreName,
-            final Kind kind, final Date validityStart, final Date validityEnd) {
+    public GwtKeystoreEntry(final String alias, final String distinguishedNames, String keystoreName, final Kind kind,
+            final Date validityStart, final Date validityEnd) {
         set("alias", alias);
         set("DNs", distinguishedNames);
         set("keystoreName", keystoreName);
@@ -45,7 +44,7 @@ public class GwtKeystoreEntry extends GwtBaseModel implements IsSerializable, Se
         return get("alias");
     }
 
-    public List<String> getDistinguishedNames() {
+    public String getDistinguishedNames() {
         return get("DNs");
     }
 


### PR DESCRIPTION
For some unknown reason GWT raise en error if the DNs name is rappresented as an array of String.

Now the DNs is generated by backend and the DNs is modeled as a String.
This fix the impossibility to delete an entry after the merge of #5079 