### PR TITLE
fix(distrib): added libudev.so.0 symlink [backport release-4.1.0]

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-centos-7-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7-nn/kura_install.sh
@@ -19,7 +19,7 @@ setup_libudev() {
         ln -sf /lib/libudev.so.1 /lib/libudev.so.0
     fi
 
-    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ]; then
+    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ] && [ -f /usr/lib/x86_64-linux-gnu/libudev.so.1 ]; then
        ln -sf /usr/lib/x86_64-linux-gnu/libudev.so.1 /usr/lib/x86_64-linux-gnu/libudev.so.0
     fi
 }

--- a/kura/distrib/src/main/resources/intel-up2-centos-7-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2016, 2018 Red Hat Inc and others
+# Copyright (c) 2016, 2024 Red Hat Inc and others
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -12,9 +12,23 @@
 #	  Eurotech
 #
 
+setup_libudev() {
+    # create soft link for libudev.so.0 to make it retrocompatible
+    # https://unix.stackexchange.com/questions/156776/arch-ubuntu-so-whats-the-deal-with-libudev-so-0
+    if [ ! -f /lib/libudev.so.0 ] && [ -f /lib/libudev.so.1 ]; then
+        ln -sf /lib/libudev.so.1 /lib/libudev.so.0
+    fi
+
+    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ]; then
+       ln -sf /usr/lib/x86_64-linux-gnu/libudev.so.1 /usr/lib/x86_64-linux-gnu/libudev.so.0
+    fi
+}
+
 set -e
 
 INSTALL_DIR=/opt/eclipse
+
+setup_libudev
 
 #create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura

--- a/kura/distrib/src/main/resources/intel-up2-centos-7/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7/kura_install.sh
@@ -19,7 +19,7 @@ setup_libudev() {
         ln -sf /lib/libudev.so.1 /lib/libudev.so.0
     fi
 
-    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ]; then
+    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ] && [ -f /usr/lib/x86_64-linux-gnu/libudev.so.1 ]; then
        ln -sf /usr/lib/x86_64-linux-gnu/libudev.so.1 /usr/lib/x86_64-linux-gnu/libudev.so.0
     fi
 }

--- a/kura/distrib/src/main/resources/intel-up2-centos-7/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-centos-7/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2016, 2018 Red Hat Inc and others
+# Copyright (c) 2016, 2024 Red Hat Inc and others
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -12,9 +12,23 @@
 #	  Eurotech
 #
 
+setup_libudev() {
+    # create soft link for libudev.so.0 to make it retrocompatible
+    # https://unix.stackexchange.com/questions/156776/arch-ubuntu-so-whats-the-deal-with-libudev-so-0
+    if [ ! -f /lib/libudev.so.0 ] && [ -f /lib/libudev.so.1 ]; then
+        ln -sf /lib/libudev.so.1 /lib/libudev.so.0
+    fi
+
+    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ]; then
+       ln -sf /usr/lib/x86_64-linux-gnu/libudev.so.1 /usr/lib/x86_64-linux-gnu/libudev.so.0
+    fi
+}
+
 set -e
 
 INSTALL_DIR=/opt/eclipse
+
+setup_libudev
 
 #create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
@@ -11,7 +11,21 @@
 #   Eurotech
 #
 
+setup_libudev() {
+    # create soft link for libudev.so.0 to make it retrocompatible
+    # https://unix.stackexchange.com/questions/156776/arch-ubuntu-so-whats-the-deal-with-libudev-so-0
+    if [ ! -f /lib/libudev.so.0 ] && [ -f /lib/libudev.so.1 ]; then
+        ln -sf /lib/libudev.so.1 /lib/libudev.so.0
+    fi
+
+    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ]; then
+       ln -sf /usr/lib/x86_64-linux-gnu/libudev.so.1 /usr/lib/x86_64-linux-gnu/libudev.so.0
+    fi
+}
+
 INSTALL_DIR=/opt/eclipse
+
+setup_libudev
 
 #create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-18/kura_install.sh
@@ -18,7 +18,7 @@ setup_libudev() {
         ln -sf /lib/libudev.so.1 /lib/libudev.so.0
     fi
 
-    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ]; then
+    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ] && [ -f /usr/lib/x86_64-linux-gnu/libudev.so.1 ]; then
        ln -sf /usr/lib/x86_64-linux-gnu/libudev.so.1 /usr/lib/x86_64-linux-gnu/libudev.so.0
     fi
 }

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2024 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,21 @@
 #   Eurotech
 #
 
+setup_libudev() {
+    # create soft link for libudev.so.0 to make it retrocompatible
+    # https://unix.stackexchange.com/questions/156776/arch-ubuntu-so-whats-the-deal-with-libudev-so-0
+    if [ ! -f /lib/libudev.so.0 ] && [ -f /lib/libudev.so.1 ]; then
+        ln -sf /lib/libudev.so.1 /lib/libudev.so.0
+    fi
+
+    if [ ! -f /usr/lib/arm-linux-gnueabihf/libudev.so.0 ]; then
+        ln -sf /usr/lib/arm-linux-gnueabihf/libudev.so.1 /usr/lib/arm-linux-gnueabihf/libudev.so.0
+    fi
+}
+
 INSTALL_DIR=/opt/eclipse
+
+setup_libudev
 
 #create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura

--- a/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2-nn/kura_install.sh
@@ -18,7 +18,7 @@ setup_libudev() {
         ln -sf /lib/libudev.so.1 /lib/libudev.so.0
     fi
 
-    if [ ! -f /usr/lib/arm-linux-gnueabihf/libudev.so.0 ]; then
+    if [ ! -f /usr/lib/arm-linux-gnueabihf/libudev.so.0 ] && [ -f /usr/lib/arm-linux-gnueabihf/libudev.so.1 ]; then
         ln -sf /usr/lib/arm-linux-gnueabihf/libudev.so.1 /usr/lib/arm-linux-gnueabihf/libudev.so.0
     fi
 }

--- a/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates
+# Copyright (c) 2011, 2024 Eurotech and/or its affiliates
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0
@@ -11,7 +11,21 @@
 #   Eurotech
 #
 
+setup_libudev() {
+    # create soft link for libudev.so.0 to make it retrocompatible
+    # https://unix.stackexchange.com/questions/156776/arch-ubuntu-so-whats-the-deal-with-libudev-so-0
+    if [ ! -f /lib/libudev.so.0 ] && [ -f /lib/libudev.so.1 ]; then
+        ln -sf /lib/libudev.so.1 /lib/libudev.so.0
+    fi
+
+    if [ ! -f /usr/lib/arm-linux-gnueabihf/libudev.so.0 ]; then
+        ln -sf /usr/lib/arm-linux-gnueabihf/libudev.so.1 /usr/lib/arm-linux-gnueabihf/libudev.so.0
+    fi
+}
+
 INSTALL_DIR=/opt/eclipse
+
+setup_libudev
 
 #create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura

--- a/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
+++ b/kura/distrib/src/main/resources/raspberry-pi-2/kura_install.sh
@@ -18,7 +18,7 @@ setup_libudev() {
         ln -sf /lib/libudev.so.1 /lib/libudev.so.0
     fi
 
-    if [ ! -f /usr/lib/arm-linux-gnueabihf/libudev.so.0 ]; then
+    if [ ! -f /usr/lib/arm-linux-gnueabihf/libudev.so.0 ] && [ -f /usr/lib/arm-linux-gnueabihf/libudev.so.1 ]; then
         ln -sf /usr/lib/arm-linux-gnueabihf/libudev.so.1 /usr/lib/arm-linux-gnueabihf/libudev.so.0
     fi
 }

--- a/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
@@ -12,7 +12,21 @@
 #   Cavium
 #
 
+setup_libudev() {
+    # create soft link for libudev.so.0 to make it retrocompatible
+    # https://unix.stackexchange.com/questions/156776/arch-ubuntu-so-whats-the-deal-with-libudev-so-0
+    if [ ! -f /lib/libudev.so.0 ] && [ -f /lib/libudev.so.1 ]; then
+        ln -sf /lib/libudev.so.1 /lib/libudev.so.0
+    fi
+
+    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ]; then
+       ln -sf /usr/lib/x86_64-linux-gnu/libudev.so.1 /usr/lib/x86_64-linux-gnu/libudev.so.0
+    fi
+}
+
 INSTALL_DIR=/opt/eclipse
+
+setup_libudev
 
 #create known kura install location
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura

--- a/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/rock960-ubuntu-16-nn/kura_install.sh
@@ -19,7 +19,7 @@ setup_libudev() {
         ln -sf /lib/libudev.so.1 /lib/libudev.so.0
     fi
 
-    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ]; then
+    if [ ! -f /usr/lib/x86_64-linux-gnu/libudev.so.0 ] && [ -f /usr/lib/x86_64-linux-gnu/libudev.so.1 ]; then
        ln -sf /usr/lib/x86_64-linux-gnu/libudev.so.1 /usr/lib/x86_64-linux-gnu/libudev.so.0
     fi
 }


### PR DESCRIPTION
Backport of https://github.com/eclipse/kura/pull/5164. This should be merged as well https://github.com/eclipse/kura/pull/5146.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
