### PR TITLE
chore: Update release notes known issue

### DIFF
--- a/kura/distrib/RELEASE_NOTES.txt
+++ b/kura/distrib/RELEASE_NOTES.txt
@@ -28,6 +28,8 @@ Target Platform Updates:
   * cca825718d - update org.eclipse.kura.linux.usb.version from 1.4.0 to 1.4.1-SNAPSHOT (#5145) (Marcello Rinaldo Martina)
 
 Known Issues:
+  * The firewall rule applied by the network threat manager that block uncommon TCP MSS values is not applied in the Nvidia Jetson Nano.
+  * When the IPv6 network threat manager is disabled, the filtering on TCP fragments is disabled only after a reboot.
   * The republish.mqtt.birth.cert.on.modem.detect property in the CloudService configuration is not supported for devices that use NetworkManager. The property value is ignored.
   * When dnsmasq is used as DHCP server, only one file is used to store the leases.
   * When dnsmasq is used as DHCP server, the DHCP List field in the DHCP and NAT tab shows the leases for all the interfaces.


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds the following known issues:
  * The firewall rule applied by the network threat manager that block uncommon TCP MSS values is not applied in the Nvidia Jetson Nano.
  * When the IPv6 network threat manager is disabled, the filtering on TCP fragments is disabled only after a reboot.
