### PR TITLE
refactor(network.threat.manager): Updated flooding protection metatype

### DIFF
--- a/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
+++ b/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
@@ -83,7 +83,8 @@ public class FloodingProtectionOptions {
     private static final String FP_ENABLED_DESCRIPTION_IPV4 = "Enable the flooding protection feature for IPv4.";
     private static final String FP_ENABLED_PROP_NAME_IPV6 = "flooding.protection.enabled.ipv6";
     private static final String FP_ENABLED_DESCRIPTION_IPV6 = "Enable the flooding protection feature for IPv6. "
-            + "If the device does not support IPv6, this property will be ignored.";
+            + "If the device does not support IPv6, this property will be ignored. "
+            + "When the feature is disabled, a reboot is required to recover the device state.";
     private static final boolean FP_ENABLED_DEFAULT_IPV4 = false;
     private static final boolean FP_ENABLED_DEFAULT_IPV6 = false;
 

--- a/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
+++ b/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
@@ -84,7 +84,8 @@ public class FloodingProtectionOptions {
     private static final String FP_ENABLED_PROP_NAME_IPV6 = "flooding.protection.enabled.ipv6";
     private static final String FP_ENABLED_DESCRIPTION_IPV6 = "Enable the flooding protection feature for IPv6. "
             + "If the device does not support IPv6, this property will be ignored. "
-            + "In kernel versions less than 6.x, after disabling the feature in this field, a reboot may be needed to completely disable the filtering.";
+            + "In kernel versions less than 6.x, after disabling the feature by setting this field to false, "
+            + "a reboot may be needed to completely disable the filtering.";
     private static final boolean FP_ENABLED_DEFAULT_IPV4 = false;
     private static final boolean FP_ENABLED_DEFAULT_IPV6 = false;
 

--- a/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
+++ b/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
@@ -84,7 +84,7 @@ public class FloodingProtectionOptions {
     private static final String FP_ENABLED_PROP_NAME_IPV6 = "flooding.protection.enabled.ipv6";
     private static final String FP_ENABLED_DESCRIPTION_IPV6 = "Enable the flooding protection feature for IPv6. "
             + "If the device does not support IPv6, this property will be ignored. "
-            + "When the feature is disabled, a reboot is required to recover the device state.";
+            + "In kernel versions less than 6.x, after disabling the feature in this field, a reboot may be needed to completely disable the filtering.";
     private static final boolean FP_ENABLED_DEFAULT_IPV4 = false;
     private static final boolean FP_ENABLED_DEFAULT_IPV6 = false;
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

The IPv6 flooding protection rules applied by the `network.threat.manager` are not recovered when the feature is disabled. In particular, the TCP fragments filtering stay active even if the property is set to false due to a [bug](https://patchwork.kernel.org/project/netdevbpf/patch/20220823233848.2759487-1-eric.dumazet@gmail.com/) in the Linux kernel.

Since the configuration can be recovered after a reboot, this PR adds a note in the description of the property in the metatype.
