### PR TITLE
fix: Return the selfconfig component configuration even if there is a type error

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -1296,7 +1296,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                                                                 logger.error(
                                                                         "Type: {} for property named: {} does not match the AD type: {} for returned Configuration of SelfConfiguringComponent with pid: {}",
                                                                         new Object[] { propType, adId, adType, pid });
-                                                                return null;
                                                             }
                                                         } catch (IllegalArgumentException e) {
                                                             logger.error(


### PR DESCRIPTION
This PR will fix cases where a Kura 5.2 configuration with PPP enabled is used in a more recent version of Kura.
After 5.2.0 we adjusted the network configuration meta type correctly specifying the type for the self configuring component.
But if an old configuration is used or an existing instance is upgraded to the latest release, the Configuration service will refuse to load the configuration of such component due to the inconsistency of types between the currently managed configuration and the type specified in the OCD.
This will prevent any type of configuration change that could fix the issue.

The PR removes the return null, keeping the error warning but do allow to retrieve such erroneous configuration to allow later replacement. 