### PR TITLE
fix(web2): Added additional configuration also on configuration change

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/users/UserConfigUi.java
@@ -183,15 +183,19 @@ public class UserConfigUi extends Composite {
 
                 @Override
                 public void onConfigurationChanged(HasConfiguration hasConfiguration) {
-                    // nothing to do
+                    addAdditionalConfiguration(hasConfiguration);
                 }
 
                 @Override
                 public void onDirtyStateChanged(HasConfiguration hasConfiguration) {
+                    addAdditionalConfiguration(hasConfiguration);
+                }
+
+                private void addAdditionalConfiguration(HasConfiguration hasConfiguration) {
                     if (!hasConfiguration.isDirty()) {
                         return;
                     }
-
+                    
                     if (hasConfiguration.isValid()) {
                         final GwtConfigComponent updatedConfiguration = hasConfiguration.getConfiguration();
 
@@ -200,7 +204,7 @@ public class UserConfigUi extends Composite {
                         listener.onUserDataChanged(userData);
                     }
                 }
-
+                
             });
 
             final PanelHeader header = new PanelHeader();


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR fixes the indentity webUI page when additional configurations are used.
