### PR TITLE
fix: Fixed error on null password when AP name changed

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net/GwtNetworkServiceImpl.java
@@ -1683,8 +1683,7 @@ public class GwtNetworkServiceImpl {
         String wirelessSSID = gwtWifiConfig.getWirelessSsid();
 
         if (isPlaceholder(passKey, security)) {
-            Optional<GwtWifiConfig> oldGwtWifiConfig = wirelessSSID == null ? getOldGwtWifiConfig(interfaceName, mode)
-                    : getOldGwtWifiConfigBySSID(wirelessSSID, interfaceName, mode);
+            Optional<GwtWifiConfig> oldGwtWifiConfig = getOldGwtWifiConfig(interfaceName, mode);
 
             if (oldGwtWifiConfig.isPresent()) {
                 properties.put(wifiPassphrasePropName,
@@ -1704,30 +1703,6 @@ public class GwtNetworkServiceImpl {
     private static boolean isPlaceholder(String passKey, GwtWifiSecurity security) {
         return passKey != null && (passKey.equals(PASSWORD_PLACEHOLDER)
                 || (security != GwtWifiSecurity.netWifiSecurityNONE && passKey.isEmpty()));
-    }
-
-    private static Optional<GwtWifiConfig> getOldGwtWifiConfigBySSID(String wirelessSSID, String interfaceName,
-            String mode) throws GwtKuraException {
-        Optional<GwtWifiConfig> config = Optional.empty();
-        List<GwtNetInterfaceConfig> result = privateFindNetInterfaceConfigurations(false);
-        for (GwtNetInterfaceConfig netConfig : result) {
-            if (netConfig instanceof GwtWifiNetInterfaceConfig
-                    && interfaceName.equals(((GwtWifiNetInterfaceConfig) netConfig).getName())) {
-                GwtWifiNetInterfaceConfig oldWifiConfig = (GwtWifiNetInterfaceConfig) netConfig;
-                GwtWifiConfig oldGwtWifiConfig;
-                if (mode.equals(GwtWifiWirelessMode.netWifiWirelessModeAccessPoint.name())) {
-                    oldGwtWifiConfig = oldWifiConfig.getAccessPointWifiConfig();
-                } else {
-                    oldGwtWifiConfig = oldWifiConfig.getStationWifiConfig();
-                }
-
-                if (oldGwtWifiConfig != null && oldGwtWifiConfig.getWirelessSsid().equals(wirelessSSID)) {
-                    config = Optional.of(oldGwtWifiConfig);
-                    break;
-                }
-            }
-        }
-        return config;
     }
 
     private static Optional<GwtWifiConfig> getOldGwtWifiConfig(String interfaceName, String mode)

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net/GwtNetworkServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION

1. Create an AP with name "test-ap" with the following configuration:
    
        - range: 172.16.1.10/24 - 172.16.1.11/24, lease 300sec
        - mode: DHCP only, pass DNS
        - security WPA/WPA2, add some password
        - everything else with default values

2. Apply changes and wait for them to be applied
3. Try to change the AP name results in an error dialog, the chages are not applied
4. Try to change the AP name and also the password (to the same set before), the error does not appear

![Screenshot 2024-03-04 at 15 45 08](https://github.com/eclipse/kura/assets/10448126/f86c77d2-a154-4575-9631-15a3ecf30f60)
