### PR TITLE
feat: Disable HTTP trace

### DIFF
--- a/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraJettyCustomizer.java
+++ b/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraJettyCustomizer.java
@@ -35,6 +35,8 @@ import javax.servlet.SessionCookieConfig;
 
 import org.eclipse.equinox.http.jetty.JettyConstants;
 import org.eclipse.equinox.http.jetty.JettyCustomizer;
+import org.eclipse.jetty.security.ConstraintMapping;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -46,6 +48,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 public class KuraJettyCustomizer extends JettyCustomizer {
@@ -66,6 +69,18 @@ public class KuraJettyCustomizer extends JettyCustomizer {
         servletContextHandler.setGzipHandler(gzipHandler);
 
         servletContextHandler.setErrorHandler(new KuraErrorHandler());
+
+        Constraint authConstraint = new Constraint();
+        authConstraint.setAuthenticate(true);
+        ConstraintMapping traceConstraintMapping = new ConstraintMapping();
+        traceConstraintMapping.setPathSpec("/");
+        traceConstraintMapping.setMethod("TRACE");
+        traceConstraintMapping.setConstraint(authConstraint);
+        
+        ConstraintSecurityHandler constraintSecurityHandler = new ConstraintSecurityHandler();
+        constraintSecurityHandler.addConstraintMapping(traceConstraintMapping);
+        
+        servletContextHandler.setSecurityHandler(constraintSecurityHandler);
 
         final SessionCookieConfig cookieConfig = servletContextHandler.getSessionHandler().getSessionCookieConfig();
 

--- a/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraJettyCustomizer.java
+++ b/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraJettyCustomizer.java
@@ -35,20 +35,21 @@ import javax.servlet.SessionCookieConfig;
 
 import org.eclipse.equinox.http.jetty.JettyConstants;
 import org.eclipse.equinox.http.jetty.JettyCustomizer;
-import org.eclipse.jetty.security.ConstraintMapping;
-import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.ForwardedRequestCustomizer;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConfiguration.Customizer;
 import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 public class KuraJettyCustomizer extends JettyCustomizer {
@@ -69,18 +70,6 @@ public class KuraJettyCustomizer extends JettyCustomizer {
         servletContextHandler.setGzipHandler(gzipHandler);
 
         servletContextHandler.setErrorHandler(new KuraErrorHandler());
-
-        Constraint authConstraint = new Constraint();
-        authConstraint.setAuthenticate(true);
-        ConstraintMapping traceConstraintMapping = new ConstraintMapping();
-        traceConstraintMapping.setPathSpec("/");
-        traceConstraintMapping.setMethod("TRACE");
-        traceConstraintMapping.setConstraint(authConstraint);
-        
-        ConstraintSecurityHandler constraintSecurityHandler = new ConstraintSecurityHandler();
-        constraintSecurityHandler.addConstraintMapping(traceConstraintMapping);
-        
-        servletContextHandler.setSecurityHandler(constraintSecurityHandler);
 
         final SessionCookieConfig cookieConfig = servletContextHandler.getSessionHandler().getSessionCookieConfig();
 
@@ -104,9 +93,12 @@ public class KuraJettyCustomizer extends JettyCustomizer {
             return null;
         }
 
+        HttpConfiguration httpConfiguration = new HttpConfiguration();
+        httpConfiguration.addCustomizer(new BlockHttpMethods(EnumSet.of(HttpMethod.TRACE)));
+
         for (final int port : ports) {
             final ServerConnector newConnector = new ServerConnector(serverConnector.getServer(),
-                    new HttpConnectionFactory(new HttpConfiguration()));
+                    new HttpConnectionFactory(httpConfiguration));
 
             customizeConnector(newConnector, port);
             serverConnector.getServer().addConnector(newConnector);
@@ -200,6 +192,7 @@ public class KuraJettyCustomizer extends JettyCustomizer {
 
         final HttpConfiguration httpsConfig = new HttpConfiguration();
         httpsConfig.addCustomizer(new SecureRequestCustomizer());
+        httpsConfig.addCustomizer(new BlockHttpMethods(EnumSet.of(HttpMethod.TRACE)));
 
         final ServerConnector connector = new ServerConnector(server,
                 new SslConnectionFactory(sslContextFactory, "http/1.1"), new HttpConnectionFactory(httpsConfig));
@@ -273,7 +266,7 @@ public class KuraJettyCustomizer extends JettyCustomizer {
         }
 
         public Optional<CertStore> getCRLStore() {
-            return crlStore;
+            return this.crlStore;
         }
 
         public void setKeyManagersProvider(Function<String, List<KeyManager>> keyManagersProvider) {
@@ -282,13 +275,31 @@ public class KuraJettyCustomizer extends JettyCustomizer {
 
         @Override
         protected KeyManager[] getKeyManagers(KeyStore keyStore) throws Exception {
-            if (keyManagersProvider.isPresent()) {
-                return keyManagersProvider.get().apply(getKeyManagerFactoryAlgorithm()).toArray(new KeyManager[0]);
+            if (this.keyManagersProvider.isPresent()) {
+                return this.keyManagersProvider.get().apply(getKeyManagerFactoryAlgorithm()).toArray(new KeyManager[0]);
             }
 
             return super.getKeyManagers(keyStore);
         }
 
+    }
+
+    private static class BlockHttpMethods implements HttpConfiguration.Customizer {
+
+        private final Set<HttpMethod> blockedMethods;
+
+        public BlockHttpMethods(Set<HttpMethod> methods) {
+            this.blockedMethods = methods;
+        }
+
+        @Override
+        public void customize(Connector connector, HttpConfiguration channelConfig, Request request) {
+            HttpMethod httpMethod = HttpMethod.fromString(request.getMethod());
+            if (this.blockedMethods.contains(httpMethod)) {
+                request.setHandled(true);
+                request.getResponse().setStatus(HttpStatus.METHOD_NOT_ALLOWED_405);
+            }
+        }
     }
 
     private static final class ClientAuthSslContextFactoryImpl extends BaseSslContextFactory {
@@ -309,7 +320,7 @@ public class KuraJettyCustomizer extends JettyCustomizer {
                 Collection<? extends java.security.cert.CRL> crls) throws Exception {
             PKIXBuilderParameters pbParams = new PKIXBuilderParameters(trustStore, new X509CertSelector());
 
-            final boolean isRevocationEnabled = getOrDefault(settings, "org.eclipse.kura.revocation.check.enabled",
+            final boolean isRevocationEnabled = getOrDefault(this.settings, "org.eclipse.kura.revocation.check.enabled",
                     true);
 
             pbParams.setMaxPathLength(getMaxCertPathLength());
@@ -318,7 +329,7 @@ public class KuraJettyCustomizer extends JettyCustomizer {
             final PKIXRevocationChecker revocationChecker = (PKIXRevocationChecker) CertPathValidator
                     .getInstance("PKIX").getRevocationChecker();
 
-            final EnumSet<PKIXRevocationChecker.Option> revocationOptions = getOrDefault(settings,
+            final EnumSet<PKIXRevocationChecker.Option> revocationOptions = getOrDefault(this.settings,
                     "org.eclipse.kura.revocation.checker.options", EnumSet.noneOf(PKIXRevocationChecker.Option.class));
 
             revocationChecker.setOptions(revocationOptions);

--- a/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraJettyCustomizer.java
+++ b/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraJettyCustomizer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Red Hat Inc and others
+ * Copyright (c) 2018, 2024 Red Hat Inc and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
Previous to this change:

```
Issue reported by a user and verified with the following call:

➜  ~ curl -v -X TRACE <https://192.168.1.219>
*   Trying 192.168.1.219:443...
* Connected to 192.168.1.219 (192.168.1.219) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* SSL certificate problem: self signed certificate
* Closing connection
curl: (60) SSL certificate problem: self signed certificate
More details here: <https://curl.se/docs/sslcerts.html>

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
➜  ~ curl -k -v -X TRACE <https://192.168.1.219>
*   Trying 192.168.1.219:443...
* Connected to 192.168.1.219 (192.168.1.219) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=CA; ST=Ontario; L=Ottawa; O=Eclipse Foundation; OU=Kura; CN=Kura
*  start date: Feb 22 11:16:16 2024 GMT
*  expire date: Nov 18 11:16:16 2026 GMT
*  issuer: C=CA; ST=Ontario; L=Ottawa; O=Eclipse Foundation; OU=Kura; CN=Kura
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/1.x
> TRACE / HTTP/1.1
> Host: 192.168.1.219
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Thu, 22 Feb 2024 13:42:28 GMT
< X-FRAME-OPTIONS: SAMEORIGIN
< X-XSS-protection: 1; mode=block
< X-Content-Type-Options: nosniff
< Cache-Control: no-cache,no-store,must-revalidate
< Pragma: no-cache
< Content-Type: message/http
< Content-Length: 76
<
TRACE / HTTP/1.1
Accept: */*
User-Agent: curl/8.4.0
Host: 192.168.1.219
* Connection #0 to host 192.168.1.219 left intact
```

After the change:

```
➜  ~ curl -k -v -X TRACE https://192.168.1.219
*   Trying 192.168.1.219:443...
* Connected to 192.168.1.219 (192.168.1.219) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=CA; ST=Ontario; L=Ottawa; O=Eclipse Foundation; OU=Kura; CN=Kura
*  start date: Apr  8 13:18:56 2024 GMT
*  expire date: Jan  3 13:18:56 2027 GMT
*  issuer: C=CA; ST=Ontario; L=Ottawa; O=Eclipse Foundation; OU=Kura; CN=Kura
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/1.x
> TRACE / HTTP/1.1
> Host: 192.168.1.219
> User-Agent: curl/8.4.0
> Accept: */*
>
< HTTP/1.1 403 Forbidden
< Content-Length: 0
<
* Connection #0 to host 192.168.1.219 left intact

```