### PR TITLE
ci: update `mkdocs` versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ mkdocs-material==8.3.9
 mkdocs-markdownextradata-plugin==0.2.5
 mkdocs-minify-plugin==0.5.0
 mkdocs-jupyter==0.22.0
+lxml==5.2.1
+lxml_html_clean==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,4 @@ mkdocs==1.3.0
 mkdocs-material==8.3.9
 mkdocs-markdownextradata-plugin==0.2.5
 mkdocs-minify-plugin==0.5.0
-mkdocs-jupyter==0.22.0
-lxml==5.2.1
-lxml_html_clean==0.1.1
+mkdocs-jupyter==0.24.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mike==1.1.2
-mkdocs==1.3.0
-mkdocs-material==8.3.9
+mkdocs==1.5.3
+mkdocs-material==9.5.17
 mkdocs-markdownextradata-plugin==0.2.5
-mkdocs-minify-plugin==0.5.0
+mkdocs-minify-plugin==0.8.0
 mkdocs-jupyter==0.24.7


### PR DESCRIPTION
Fix the documentation build automation by updating the `mkdocs` versions.

The documentation build automation started acting up recently due to a change in `mike` dependencies.

![image](https://github.com/eclipse/kura/assets/22748355/3025c363-d258-4248-9987-45ce201f2999)

See: https://github.com/eclipse/kura/actions/runs/8551781748/job/23571664614

I was able to reproduce the issue locally:

```
mike deploy docs-develop
error: lxml.html.clean module is now a separate project lxml_html_clean.
Install lxml[html_clean] or lxml_html_clean directly.
```

The fix just updates the `mkdocs-jupyter`-related plugins

```
pip3 install --upgrade mkdocs-jupyter
Requirement already satisfied: mkdocs-jupyter in ./newtest/lib/python3.11/site-packages (0.22.0)
Collecting mkdocs-jupyter
  Downloading mkdocs_jupyter-0.24.7-py3-none-any.whl.metadata (9.4 kB)
```

```
mike deploy docs-develop
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: /Users/mattia.dalben/Desktop/kura_docs/site
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
              - index.md
```

To do so and avoid version conflicts I had to update all the `mkdocs`-related plugins.