### PR TITLE
refactor(container.provider): changed metatype option id in container instance

### DIFF
--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -38,7 +38,7 @@
             cardinality="1" required="false" default="true" />
         
         <AD
-            id="enforcement.digest"
+            id="container.signature.enforcement.digest"
             name="Container Image Enforcement Digest "
             description="Digest of the container image allowed to run on the device if the Container Enforcement Monitor is enabled. If not given, it will be computed by the Container Signature Verification service."
             type="String" cardinality="1" required="false"

--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/metatype/org.eclipse.kura.container.provider.ContainerInstance.xml
@@ -39,7 +39,7 @@
         
         <AD
             id="container.signature.enforcement.digest"
-            name="Container Image Enforcement Digest "
+            name="Container Image Enforcement Digest"
             description="Digest of the container image allowed to run on the device if the Container Enforcement Monitor is enabled. If not given, it will be computed by the Container Signature Verification service."
             type="String" cardinality="1" required="false"
             default="" />

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
@@ -465,7 +465,7 @@ public class ContainerInstance implements ConfigurableComponent, ContainerOrches
             String enforcementDigest) {
 
         Map<String, Object> updatedProperties = new HashMap<>(oldProperties);
-        updatedProperties.put("enforcement.digest", enforcementDigest);
+        updatedProperties.put("container.signature.enforcement.digest", enforcementDigest);
         return updatedProperties;
 
     }

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
@@ -72,7 +72,8 @@ public class ContainerInstanceOptions {
             "");
     private static final Property<Boolean> SIGNATURE_VERIFY_TLOG = new Property<>(
             "container.signature.verify.transparency.log", true);
-    private static final Property<String> ENFORCEMENT_DIGEST = new Property<>("enforcement.digest", "");
+    private static final Property<String> ENFORCEMENT_DIGEST = new Property<>("container.signature.enforcement.digest",
+            "");
 
     private boolean enabled;
     private final String image;

--- a/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceOptionsTest.java
+++ b/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceOptionsTest.java
@@ -82,7 +82,7 @@ public class ContainerInstanceOptionsTest {
     private static final String CONTAINER_CPUS = "container.cpus";
     private static final String CONTAINER_GPUS = "container.gpus";
     private static final String CONTAINER_RUNTIME = "container.runtime";
-    private static final String ENFORCEMENT_DIGEST = "enforcement.digest";
+    private static final String ENFORCEMENT_DIGEST = "container.signature.enforcement.digest";
 
     private Map<String, Object> properties;
 

--- a/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceTest.java
+++ b/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceTest.java
@@ -62,7 +62,7 @@ public class ContainerInstanceTest {
     private static final String CONTAINER_VERIFY_TLOG = "container.signature.verify.transparency.log";
     private static final String CONTAINER_REGISTRY_USERNAME = "registry.username";
     private static final String CONTAINER_REGISTRY_PASSWORD = "registry.password";
-    private static final String CONTAINER_ENFORCEMENT_DIGEST = "enforcement.digest";
+    private static final String CONTAINER_ENFORCEMENT_DIGEST = "container.signature.enforcement.digest";
 
     private static final ValidationResult FAILED_VALIDATION = new ValidationResult();
 


### PR DESCRIPTION
This PR changes the metatype id of the **Container Image Enforcement Digest** option of the Container Instance class to be aligned to the others option regarding container signature.

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
