### PR TITLE
fix(container.instance): refactored code to remove unreachable code

### DIFF
--- a/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceTest.java
+++ b/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceTest.java
@@ -294,7 +294,6 @@ public class ContainerInstanceTest {
             throws KuraException, InterruptedException {
 
         givenContainerOrchestratorWithRunningContainer("test-instance", "test-id");
-        givenContainerOrchestratorReturningOnStart("1234");
 
         givenContainerInstanceWith(this.mockContainerOrchestrationService);
 

--- a/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceTest.java
+++ b/kura/test/org.eclipse.kura.container.provider.test/src/test/java/org/eclipse/kura/container/provider/ContainerInstanceTest.java
@@ -290,6 +290,29 @@ public class ContainerInstanceTest {
     }
 
     @Test
+    public void disabledInstanceDeletesAlreadyRunningContainerWithSameName()
+            throws KuraException, InterruptedException {
+
+        givenContainerOrchestratorWithRunningContainer("test-instance", "test-id");
+        givenContainerOrchestratorReturningOnStart("1234");
+
+        givenContainerInstanceWith(this.mockContainerOrchestrationService);
+
+        givenPropertiesWith(CONTAINER_ENABLED, false);
+        givenPropertiesWith(CONTAINER_IMAGE, "nginx");
+        givenPropertiesWith(CONTAINER_IMAGE_TAG, "latest");
+        givenPropertiesWith(CONTAINER_NAME, "test-instance");
+        givenPropertiesWith("kura.service.pid", "test-instance");
+        givenContainerInstanceActivatedWith(this.properties);
+
+        thenNoExceptionOccurred();
+        thenWaitForContainerInstanceToBecome(CONTAINER_STATE_DISABLED);
+        thenStopContainerWasCalledFor("test-id");
+        thenDeleteContainerWasCalledFor("test-id");
+
+    }
+
+    @Test
     public void signatureValidationDoesntGetCalledWithMissingTrustAnchor() throws KuraException, InterruptedException {
         givenContainerOrchestratorWithNoRunningContainers();
         givenContainerOrchestratorReturningOnStart("1234");


### PR DESCRIPTION
This PR fixes a problem in the Container Instance code that led to an unreachable code branch.

When a Container Instance in `Disabled` state started (startup of Kura or Instance creation) while an other container with same name was already running on the system, the latter was not stopped and deleted: this happened due to an incorrect exit condition of the update method that prevent the correct actions.

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
