### PR TITLE
refactor: removed calls to containerConfiguration based deprecated code

### DIFF
--- a/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManager.java
+++ b/kura/org.eclipse.kura.ai.triton.server/src/main/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManager.java
@@ -33,6 +33,7 @@ import org.eclipse.kura.container.orchestration.ContainerConfiguration.Container
 import org.eclipse.kura.container.orchestration.ContainerInstanceDescriptor;
 import org.eclipse.kura.container.orchestration.ContainerNetworkConfiguration.ContainerNetworkConfigurationBuilder;
 import org.eclipse.kura.container.orchestration.ContainerOrchestrationService;
+import org.eclipse.kura.container.orchestration.ContainerPort;
 import org.eclipse.kura.container.orchestration.ContainerState;
 import org.eclipse.kura.container.orchestration.ImageConfiguration.ImageConfigurationBuilder;
 import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
@@ -233,9 +234,8 @@ public class TritonServerContainerManager implements TritonServerInstanceManager
         builder.setContainerName(TRITON_CONTAINER_NAME);
         builder.setFrameworkManaged(TRITON_FRAMEWORK_MANAGED);
         builder.setLoggingType(TRITON_LOGGING_TYPE);
-        builder.setInternalPorts(TRITON_INTERNAL_PORTS);
-        builder.setExternalPorts(
-                Arrays.asList(this.options.getHttpPort(), this.options.getGrpcPort(), this.options.getMetricsPort()));
+        builder.setContainerPorts(parseContainerPorts(TRITON_INTERNAL_PORTS,
+                Arrays.asList(this.options.getHttpPort(), this.options.getGrpcPort(), this.options.getMetricsPort())));
 
         builder.setMemory(this.options.getContainerMemory());
         builder.setCpus(this.options.getContainerCpus());
@@ -267,5 +267,15 @@ public class TritonServerContainerManager implements TritonServerInstanceManager
         builder.setEntryPoint(entrypointOverride);
 
         return builder.build();
+    }
+
+    private List<ContainerPort> parseContainerPorts(List<Integer> internalPorts, List<Integer> externalPorts) {
+        List<ContainerPort> containerPorts = new ArrayList<>();
+
+        for (int i = 0; i < externalPorts.size(); i++) {
+            containerPorts.add(new ContainerPort(internalPorts.get(i), externalPorts.get(i)));
+        }
+
+        return containerPorts;
     }
 }

--- a/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
+++ b/kura/test/org.eclipse.kura.ai.triton.server.test/src/test/java/org/eclipse/kura/ai/triton/server/TritonServerContainerManagerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.container.orchestration.ContainerConfiguration;
 import org.eclipse.kura.container.orchestration.ContainerInstanceDescriptor;
 import org.eclipse.kura.container.orchestration.ContainerOrchestrationService;
+import org.eclipse.kura.container.orchestration.ContainerPort;
 import org.eclipse.kura.container.orchestration.ContainerState;
 import org.eclipse.kura.container.orchestration.ImageInstanceDescriptor;
 import org.junit.Test;
@@ -52,6 +54,10 @@ public class TritonServerContainerManagerTest {
     private static final String TRITON_INTERNAL_BACKENDS_FOLDER = "/backends";
     private static final String TRITON_BACKENDS_PATH = "/path/to/backends";
 
+    private static final Integer[] EXTERNAL_PORTS = new Integer[] { 4000, 4001, 4002 };
+    private static final List<ContainerPort> CONTAINER_PORTS = new ArrayList<>(
+            Arrays.asList(new ContainerPort(8000, 4000), new ContainerPort(8001, 4001), new ContainerPort(8002, 4002)));
+
     private Map<String, Object> properties = new HashMap<>();
     private TritonServerServiceOptions options = new TritonServerServiceOptions(properties);
 
@@ -66,7 +72,7 @@ public class TritonServerContainerManagerTest {
     public void isServerRunningWorksWhenNotRunning() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -80,7 +86,7 @@ public class TritonServerContainerManagerTest {
     public void isServerRunningWorksWhenRunning() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -94,7 +100,7 @@ public class TritonServerContainerManagerTest {
     public void isServerRunningWorksWhenOrchestratorNotConnected() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -108,7 +114,7 @@ public class TritonServerContainerManagerTest {
     public void stopMethodShouldWork() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -125,7 +131,7 @@ public class TritonServerContainerManagerTest {
     public void stopMethodShouldWorkWhenNotRunning() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -142,7 +148,7 @@ public class TritonServerContainerManagerTest {
     public void killMethodShouldWork() {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -160,7 +166,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -177,7 +183,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -195,7 +201,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -213,7 +219,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -225,7 +231,7 @@ public class TritonServerContainerManagerTest {
 
         thenContainerOrchestrationStartContainerWasCalled();
         thenContainerConfigurationIsFrameworkManaged(true);
-        thenContainerConfigurationPortsEquals(Arrays.asList(4000, 4001, 4002));
+        thenContainerConfigurationPortsEquals(CONTAINER_PORTS);
         thenContainerConfigurationImageEquals(TRITON_IMAGE_NAME);
         thenContainerConfigurationImageTagEquals(TRITON_IMAGE_TAG);
         thenContainerConfigurationNameEquals(TRITON_CONTAINER_NAME);
@@ -245,7 +251,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -264,7 +270,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
         givenPropertyWith("local.model.repository.password", "hutini");
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -284,7 +290,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenPropertyWith("container.memory", "7g");
         givenPropertyWith("container.cpus", 1.5F);
         givenPropertyWith("container.gpus", "all");
@@ -322,7 +328,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenPropertyWith("local.backends.config", "testConfiguration");
         givenServiceOptionsBuiltWith(properties);
 
@@ -335,7 +341,7 @@ public class TritonServerContainerManagerTest {
 
         thenContainerOrchestrationStartContainerWasCalled();
         thenContainerConfigurationIsFrameworkManaged(true);
-        thenContainerConfigurationPortsEquals(Arrays.asList(4000, 4001, 4002));
+        thenContainerConfigurationPortsEquals(CONTAINER_PORTS);
         thenContainerConfigurationImageEquals(TRITON_IMAGE_NAME);
         thenContainerConfigurationEntrypointOverrideContains("--backend-config=testConfiguration");
     }
@@ -345,7 +351,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image", TRITON_IMAGE_NAME);
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -357,7 +363,7 @@ public class TritonServerContainerManagerTest {
 
         thenContainerOrchestrationStartContainerWasCalled();
         thenContainerConfigurationIsFrameworkManaged(true);
-        thenContainerConfigurationPortsEquals(Arrays.asList(4000, 4001, 4002));
+        thenContainerConfigurationPortsEquals(CONTAINER_PORTS);
         thenContainerConfigurationImageEquals(TRITON_IMAGE_NAME);
         thenContainerConfigurationImageTagEquals(TRITON_IMAGE_TAG);
         thenContainerConfigurationNameEquals(TRITON_CONTAINER_NAME);
@@ -372,7 +378,7 @@ public class TritonServerContainerManagerTest {
         givenPropertyWith("container.image.tag", TRITON_IMAGE_TAG);
         givenPropertyWith("local.model.repository.path", TRITON_REPOSITORY_PATH);
         givenPropertyWith("local.backends.path", TRITON_BACKENDS_PATH);
-        givenPropertyWith("server.ports", new Integer[] { 4000, 4001, 4002 });
+        givenPropertyWith("server.ports", EXTERNAL_PORTS);
         givenServiceOptionsBuiltWith(properties);
 
         givenMockContainerOrchestrationService();
@@ -384,16 +390,15 @@ public class TritonServerContainerManagerTest {
 
         thenContainerOrchestrationStartContainerWasCalled();
         thenContainerConfigurationIsFrameworkManaged(true);
-        thenContainerConfigurationPortsEquals(Arrays.asList(4000, 4001, 4002));
+        thenContainerConfigurationPortsEquals(CONTAINER_PORTS);
         thenContainerConfigurationImageEquals(TRITON_IMAGE_NAME);
         thenContainerConfigurationImageTagEquals(TRITON_IMAGE_TAG);
         thenContainerConfigurationNameEquals(TRITON_CONTAINER_NAME);
-        thenContainerConfigurationVolumesEquals(Stream.of(new String[][] {
-                { TRITON_REPOSITORY_PATH, TRITON_INTERNAL_MODEL_REPO },
-                { TRITON_BACKENDS_PATH, TRITON_INTERNAL_BACKENDS_FOLDER },
-        }).collect(Collectors.collectingAndThen(
-                Collectors.toMap(data -> data[0], data -> data[1]),
-                Collections::<String, String>unmodifiableMap)));
+        thenContainerConfigurationVolumesEquals(Stream
+                .of(new String[][] { { TRITON_REPOSITORY_PATH, TRITON_INTERNAL_MODEL_REPO },
+                        { TRITON_BACKENDS_PATH, TRITON_INTERNAL_BACKENDS_FOLDER }, })
+                .collect(Collectors.collectingAndThen(Collectors.toMap(data -> data[0], data -> data[1]),
+                        Collections::<String, String> unmodifiableMap)));
         thenContainerConfigurationEntrypointOverrideContains("--model-control-mode=explicit");
     }
 
@@ -554,8 +559,8 @@ public class TritonServerContainerManagerTest {
         assertEquals(expectedContainerName, this.capturedContainerConfig.getContainerName());
     }
 
-    private void thenContainerConfigurationPortsEquals(List<Integer> expectedPorts) {
-        assertEquals(expectedPorts, this.capturedContainerConfig.getContainerPortsExternal());
+    private void thenContainerConfigurationPortsEquals(List<ContainerPort> expectedPorts) {
+        assertEquals(expectedPorts, this.capturedContainerConfig.getContainerPorts());
     }
 
     private void thenContainerConfigurationVolumesEquals(Map<String, String> expectedVolumes) {

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerConfigurationTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerConfigurationTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.container.orchestration.ContainerConfiguration;
 import org.eclipse.kura.container.orchestration.ContainerConfiguration.ContainerConfigurationBuilder;
 import org.eclipse.kura.container.orchestration.ContainerNetworkConfiguration;
+import org.eclipse.kura.container.orchestration.ContainerPort;
 import org.eclipse.kura.container.orchestration.ImageConfiguration;
 import org.eclipse.kura.container.orchestration.PasswordRegistryCredentials;
 import org.junit.Test;
@@ -40,8 +42,8 @@ public class ContainerConfigurationTest {
     private static final String REGISTRY_URL = "https://test";
     private static final String REGISTRY_USERNAME = "test";
     private static final String REGISTRY_PASSWORD = "test1";
-    private static final List<Integer> CONTAINER_PORTS_EXTERNAL = Arrays.asList(1521, 81);
-    private static final List<Integer> CONTAINER_PORTS_INTERNAL = Arrays.asList(1521, 81);
+    private static final List<ContainerPort> CONTAINER_PORTS = new ArrayList<>(
+            Arrays.asList(new ContainerPort(1521, 1521), new ContainerPort(81, 81)));
     private static final Map<String, String> CONTAINER_VOLUMES = Collections.singletonMap("key1", "val1");
     private static final Map<String, String> CONTAINER_LOGGER_PARAMETERS = Collections.singletonMap("key2", "val2");
     private static final String CONTAINER_LOGGER_TYPE = "test2";
@@ -133,10 +135,9 @@ public class ContainerConfigurationTest {
                 .setImageDownloadTimeoutSeconds(0).build();
 
         this.containerConfigurationBuilder = ContainerConfiguration.builder().setContainerName(CONTAINER_NAME)
-                .setImageConfiguration(firstImageConfig).setExternalPorts(CONTAINER_PORTS_EXTERNAL)
-                .setInternalPorts(CONTAINER_PORTS_INTERNAL).setEnvVars(CONTAINER_ENV_VARS)
-                .setDeviceList(CONTAINER_DEVICE_LIST).setVolumes(CONTAINER_VOLUMES).setPrivilegedMode(false)
-                .setFrameworkManaged(false).setLoggerParameters(CONTAINER_LOGGER_PARAMETERS)
+                .setImageConfiguration(firstImageConfig).setContainerPorts(CONTAINER_PORTS)
+                .setEnvVars(CONTAINER_ENV_VARS).setDeviceList(CONTAINER_DEVICE_LIST).setVolumes(CONTAINER_VOLUMES)
+                .setPrivilegedMode(false).setFrameworkManaged(false).setLoggerParameters(CONTAINER_LOGGER_PARAMETERS)
                 .setLoggingType(CONTAINER_LOGGER_TYPE)
                 .setContainerNetowrkConfiguration(
                         new ContainerNetworkConfiguration.ContainerNetworkConfigurationBuilder()
@@ -180,8 +181,7 @@ public class ContainerConfigurationTest {
         assertEquals(CONTAINER_IMAGE, this.firstContainerConfig.getImageConfiguration().getImageName());
         assertEquals(CONTAINER_IMAGE_TAG, this.firstContainerConfig.getImageConfiguration().getImageTag());
 
-        assertEquals(CONTAINER_PORTS_EXTERNAL, this.firstContainerConfig.getContainerPortsExternal());
-        assertEquals(CONTAINER_PORTS_INTERNAL, this.firstContainerConfig.getContainerPortsInternal());
+        assertEquals(CONTAINER_PORTS, this.firstContainerConfig.getContainerPorts());
         assertEquals(CONTAINER_VOLUMES, this.firstContainerConfig.getContainerVolumes());
         assertEquals(CONTAINER_LOGGER_PARAMETERS, this.firstContainerConfig.getLoggerParameters());
         assertEquals(CONTAINER_LOGGER_TYPE, this.firstContainerConfig.getContainerLoggingType());

--- a/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerInstanceDescriptorTest.java
+++ b/kura/test/org.eclipse.kura.container.orchestration.provider.test/src/test/java/org/eclipse/kura/container/orchestration/provider/ContainerInstanceDescriptorTest.java
@@ -23,14 +23,15 @@ import java.util.List;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.eclipse.kura.container.orchestration.ContainerInstanceDescriptor;
+import org.eclipse.kura.container.orchestration.ContainerPort;
 import org.junit.Test;
 
 public class ContainerInstanceDescriptorTest {
 
     private static final String H2_DB_NAME = "Kura_H2DB";
     private static final String H2_DB_IMAGE = "joedoe/h2db";
-    private static final List<Integer> H2_DB_PORTS_EXTERNAL = new ArrayList<>(Arrays.asList(1521, 81));
-    private static final List<Integer> H2_DB_PORTS_INTERNAL = new ArrayList<>(Arrays.asList(1521, 81));
+    private static final List<ContainerPort> H2_DB_PORTS = new ArrayList<>(
+            Arrays.asList(new ContainerPort(1521, 1521), new ContainerPort(81, 81)));
     private ContainerInstanceDescriptor firstContainerConfig;
     private ContainerInstanceDescriptor seccondContainerConfig;
 
@@ -57,23 +58,21 @@ public class ContainerInstanceDescriptorTest {
     private void givenContainerOne() {
 
         this.firstContainerConfig = ContainerInstanceDescriptor.builder().setContainerImageTag(H2_DB_NAME)
-                .setContainerName(H2_DB_NAME).setContainerImage(H2_DB_IMAGE).setExternalPorts(H2_DB_PORTS_EXTERNAL)
-                .setInternalPorts(H2_DB_PORTS_INTERNAL).build();
+                .setContainerName(H2_DB_NAME).setContainerImage(H2_DB_IMAGE).setContainerPorts(H2_DB_PORTS).build();
     }
 
     private void givenContainerTwoDiffrent() {
 
         this.seccondContainerConfig = ContainerInstanceDescriptor.builder().setContainerImageTag(H2_DB_NAME)
                 .setContainerName(H2_DB_NAME).setContainerImage(H2_DB_IMAGE).setContainerImageTag("diffrent")
-                .setExternalPorts(H2_DB_PORTS_EXTERNAL).setInternalPorts(H2_DB_PORTS_INTERNAL).build();
+                .setContainerPorts(H2_DB_PORTS).build();
     }
 
     // then
     private void thenCompareContainerOneToExpectedOutput() {
         assertEquals(H2_DB_NAME, this.firstContainerConfig.getContainerName());
         assertEquals(H2_DB_IMAGE, this.firstContainerConfig.getContainerImage());
-        assertTrue(ArrayUtils.isEquals(H2_DB_PORTS_EXTERNAL, this.firstContainerConfig.getContainerPortsExternal()));
-        assertTrue(ArrayUtils.isEquals(H2_DB_PORTS_INTERNAL, this.firstContainerConfig.getContainerPortsInternal()));
+        assertTrue(ArrayUtils.isEquals(H2_DB_PORTS, this.firstContainerConfig.getContainerPorts()));
     }
 
     private void thenFirstContainerDoesntEqualSeccond() {


### PR DESCRIPTION
This PR removes the calls to deprecated methods from [ContainerConfiguration](https://github.com/eclipse/kura/blob/49f9b1aa8137486a6405e8a32b4c8f2725f87aa3/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerConfiguration.java#L41) and [ContainerInstanceDescriptor](https://github.com/eclipse/kura/blob/49f9b1aa8137486a6405e8a32b4c8f2725f87aa3/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerInstanceDescriptor.java#L33) classes, regarding the management of the Internal/External ports of containers.

The depracated methods separated internal and external ports, while now they're substituted with the newer methods which unify the two kind of ports into the [ContainerPort](https://github.com/eclipse/kura/blob/49f9b1aa8137486a6405e8a32b4c8f2725f87aa3/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/ContainerPort.java#L24) class.

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
