### PR TITLE
docs: Added rest security api v1 and v2 pages

### DIFF
--- a/docs/references/rest-apis/rest-security-api-v1.md
+++ b/docs/references/rest-apis/rest-security-api-v1.md
@@ -1,0 +1,59 @@
+# Rest Security V1 API
+!!! warning
+
+    This API id deprecated and superseded by the [Security V2 REST APIs](./rest-security-api-v2.md).
+
+!!! note
+
+    This API can also be accessed via the RequestHandler with app-id: `SEC-V1`.
+
+    This REST API requires a [SecurityService](https://download.eclipse.org/kura/docs/api/5.4.0/apidocs/org/eclipse/kura/security/SecurityService.html) implementation to be registered on the framework, which is not provided by the standard Kura distribution.
+
+
+The `SecurityRestService` APIs provides methods to manage the system security.
+Identities with `rest.security` permissions can access these APIs.
+
+## POST methods
+
+#### Security policy fingerprint reload
+
+- Description: This method allows the reload of the security policy's fingerprint
+- Method: POST
+- API PATH: `services/security/v1/security-policy-fingerprint/reload`
+
+##### Responses
+
+- 200 OK status
+- 500 Internal Server Error (also returned when no `SecurityService` implementation is available)
+
+#### Reload command line fingerprint
+
+- Description: This method allows the reload of the command line fingerprint
+- Method: POST
+- API PATH: `services/security/v1/command-line-fingerprint/reload`
+
+##### Responses
+
+- 200 OK status
+- 500 Internal Server Error (also returned when no `SecurityService` implementation is available)
+
+## GET methods
+
+#### Debug enabled 
+!!! note
+
+    Access to this resource doesn't require the `rest.security` permission.
+
+- Description: This method allows you to check whether debug mode is enabled in the system.
+- Method: GET
+- API PATH: `services/security/v1/debug-enabled`
+
+##### Responses
+
+- 200 OK status
+```JSON
+{
+    "enabled":true
+}
+```
+- 500 Internal Server Error (also returned when no `SecurityService` implementation is available)

--- a/docs/references/rest-apis/rest-security-api-v2.md
+++ b/docs/references/rest-apis/rest-security-api-v2.md
@@ -1,7 +1,7 @@
-# Rest Security v1 API
+# Rest Security V2 API
 !!! note
 
-    This API can also be accessed via the RequestHandler with app-id: `SEC-V1`.
+    This API can also be accessed via the RequestHandler with app-id: `SEC-V2`.
 
     This REST API requires a [SecurityService](https://download.eclipse.org/kura/docs/api/5.4.0/apidocs/org/eclipse/kura/security/SecurityService.html) implementation to be registered on the framework, which is not provided by the standard Kura distribution.
 
@@ -15,7 +15,7 @@ Identities with `rest.security` permissions can access these APIs.
 
 - Description: This method allows the reload of the security policy's fingerprint
 - Method: POST
-- API PATH: `services/security/v1/security-policy-fingerprint/reload`
+- API PATH: `services/security/v2/security-policy-fingerprint/reload`
 
 ##### Responses
 
@@ -26,7 +26,35 @@ Identities with `rest.security` permissions can access these APIs.
 
 - Description: This method allows the reload of the command line fingerprint
 - Method: POST
-- API PATH: `services/security/v1/command-line-fingerprint/reload`
+- API PATH: `services/security/v2/command-line-fingerprint/reload`
+
+##### Responses
+
+- 200 OK status
+- 500 Internal Server Error (also returned when no `SecurityService` implementation is available)
+
+#### Apply default production security policy
+
+- Description: This method allows to apply the default production security policy available in the system
+- Method: POST
+- API PATH: `services/security/v2/security-policy/apply-default-production`
+
+##### Responses
+
+- 200 OK status
+- 500 Internal Server Error (also returned when no `SecurityService` implementation is available)
+
+#### Apply security policy
+
+- Description: This method allows to apply the user provided security policy
+- Method: POST
+- API PATH: `services/security/v2/security-policy/apply`
+
+##### Request
+
+```
+<plain text security policy>
+```
 
 ##### Responses
 
@@ -42,7 +70,7 @@ Identities with `rest.security` permissions can access these APIs.
 
 - Description: This method allows you to check whether debug mode is enabled in the system.
 - Method: GET
-- API PATH: `services/security/v1/debug-enabled`
+- API PATH: `services/security/v2/debug-enabled`
 
 ##### Responses
 

--- a/docs/references/rest-apis/rest-security-api-v2.md
+++ b/docs/references/rest-apis/rest-security-api-v2.md
@@ -46,7 +46,7 @@ Identities with `rest.security` permissions can access these APIs.
 
 #### Apply security policy
 
-- Description: This method allows to apply the user provided security policy
+- Description: This method allows to apply the user provided security policy. The maximum allowed security policy size is 1MB.
 - Method: POST
 - API PATH: `services/security/v2/security-policy/apply`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,7 +164,8 @@ nav:
         - Inventory: references/rest-apis/rest-inventory-api.md
         - Network Configuration: references/rest-apis/rest-network-configuration-api.md
         - Position: references/rest-apis/rest-position-api.md
-        - Security: references/rest-apis/rest-security-api.md
+        - Security V1: references/rest-apis/rest-security-api-v1.md
+        - Security V2: references/rest-apis/rest-security-api-v2.md
         - Service Listing: references/rest-apis/rest-service-listing-api.md
         - Session: references/rest-apis/rest-session-api.md
         - System: references/rest-apis/rest-system-api.md


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds the new `Security REST API V2` page.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** 
The new `Security REST API V2` page is added. The old one is renamed `V1` and a note about its deprecation is added.
