### PR TITLE
feat(linux.gpio): Added support to gpio symlinks

### DIFF
--- a/kura/org.eclipse.kura.linux.gpio/src/main/java/org/eclipse/kura/linux/gpio/GPIOServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.gpio/src/main/java/org/eclipse/kura/linux/gpio/GPIOServiceImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *  Red Hat Inc
@@ -38,7 +38,7 @@ public class GPIOServiceImpl implements GPIOService {
     private static final Logger logger = LoggerFactory.getLogger(GPIOServiceImpl.class);
 
     @SuppressWarnings("checkstyle:constantName")
-    private static final HashSet<JdkDioPin> pins = new HashSet<JdkDioPin>();
+    private static final HashSet<JdkDioPin> pins = new HashSet<>();
 
     private SystemService systemService;
 
@@ -54,9 +54,9 @@ public class GPIOServiceImpl implements GPIOService {
      * Test if a file is available for loading
      *
      * @param path
-     *            the path to test
-     * @return the path from input which can be used for loading, {@code null}
-     *         if the file is not present or should not be used for loading
+     *         the path to test
+     * @return the path from input which can be used for loading, {@code null} if the file is not present or should not
+     *         be used for loading
      */
     private static String whenAvailable(String path) {
         if (path == null) {

--- a/kura/org.eclipse.kura.linux.gpio/src/main/java/org/eclipse/kura/linux/gpio/GPIOServiceImpl.java
+++ b/kura/org.eclipse.kura.linux.gpio/src/main/java/org/eclipse/kura/linux/gpio/GPIOServiceImpl.java
@@ -13,16 +13,6 @@
  *******************************************************************************/
 package org.eclipse.kura.linux.gpio;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Properties;
-
 import org.eclipse.kura.gpio.GPIOService;
 import org.eclipse.kura.gpio.KuraGPIODirection;
 import org.eclipse.kura.gpio.KuraGPIOMode;
@@ -33,12 +23,23 @@ import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+
 public class GPIOServiceImpl implements GPIOService {
 
     private static final Logger logger = LoggerFactory.getLogger(GPIOServiceImpl.class);
 
     @SuppressWarnings("checkstyle:constantName")
     private static final HashSet<JdkDioPin> pins = new HashSet<>();
+    public static final String FILE = "file:";
 
     private SystemService systemService;
 
@@ -47,7 +48,9 @@ public class GPIOServiceImpl implements GPIOService {
     }
 
     public void unsetSystemService(SystemService systemService) {
-        this.systemService = null;
+        if (this.systemService == systemService) {
+            this.systemService = null;
+        }
     }
 
     /**
@@ -63,8 +66,8 @@ public class GPIOServiceImpl implements GPIOService {
             return null;
         }
 
-        if (!path.startsWith("file:")) {
-            path = "file:" + path;
+        if (!path.startsWith(FILE)) {
+            path = FILE + path;
         }
 
         try {
@@ -88,8 +91,8 @@ public class GPIOServiceImpl implements GPIOService {
         FileReader fr = null;
         try {
             String configFile = System.getProperty("jdk.dio.registry");
-            if (configFile != null && !configFile.startsWith("file:")) {
-                configFile = "file:" + configFile;
+            if (configFile != null && !configFile.startsWith(FILE)) {
+                configFile = FILE + configFile;
             }
             logger.debug("System property location: {}", configFile);
 
@@ -135,9 +138,7 @@ public class GPIOServiceImpl implements GPIOService {
             } else {
                 logger.warn("File does not exist: {}", dioPropsFile);
             }
-        } catch (IOException e) {
-            logger.error("Exception while accessing resource!", e);
-        } catch (URISyntaxException e) {
+        } catch (IOException | URISyntaxException e) {
             logger.error("Exception while accessing resource!", e);
         } finally {
             if (fr != null) {
@@ -234,7 +235,7 @@ public class GPIOServiceImpl implements GPIOService {
 
     @Override
     public Map<Integer, String> getAvailablePins() {
-        HashMap<Integer, String> result = new HashMap<Integer, String>();
+        HashMap<Integer, String> result = new HashMap<>();
         for (JdkDioPin p : pins) {
             result.put(p.getIndex(), p.getName());
         }

--- a/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/GPIOServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/GPIOServiceImplTest.java
@@ -20,7 +20,6 @@ import org.eclipse.kura.gpio.KuraGPIOTrigger;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/GPIOServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/GPIOServiceImplTest.java
@@ -37,11 +37,11 @@ import static org.junit.Assert.assertTrue;
 
 public class GPIOServiceImplTest {
 
-    Path jdkProperties;
-    Path digitalInSymlink;
-    Path digitalOutSymlink;
-    Path digitalIn;
-    Path digitalOut;
+    private Path jdkProperties;
+    private Path digitalInSymlink;
+    private Path digitalOutSymlink;
+    private Path digitalIn;
+    private Path digitalOut;
 
     @Test
     public void testActivateDeactivatePinSearch() throws IOException, NoSuchFieldException {

--- a/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/GPIOServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/GPIOServiceImplTest.java
@@ -12,18 +12,6 @@
  ******************************************************************************/
 package org.eclipse.kura.linux.gpio;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
-
 import org.eclipse.kura.core.testutil.TestUtil;
 import org.eclipse.kura.gpio.KuraGPIODirection;
 import org.eclipse.kura.gpio.KuraGPIOMode;
@@ -31,29 +19,44 @@ import org.eclipse.kura.gpio.KuraGPIOPin;
 import org.eclipse.kura.gpio.KuraGPIOTrigger;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 
 public class GPIOServiceImplTest {
+
+    Path jdkProperties;
+    Path digitalInSymlink;
+    Path digitalOutSymlink;
+    Path digitalIn;
+    Path digitalOut;
 
     @Test
     public void testActivateDeactivatePinSearch() throws IOException, NoSuchFieldException {
         GPIOServiceImpl svc = new GPIOServiceImpl();
 
-        File f = new File("target/jdk.dio.properties");
-        String dioConfigFileName = f.getAbsolutePath();
-        System.setProperty("jdk.dio.registry", "file:///" + dioConfigFileName);
-
-        f.createNewFile();
-
         String led1 = "user led 1";
         String testpin1 = "testpin1";
-        FileWriter fw = new FileWriter(f);
-        fw.write("1=name:" + led1 + ",deviceType:gpio.GPIOPin,direction:1,mode:8,trigger:0\n");
-        fw.write("2=name:" + testpin1 + ",deviceType:gpio.GPIOPin,direction:1,mode:8,trigger:0");
-        fw.close();
+        String content = "1=name:" + led1 + ",deviceType:gpio.GPIOPin,direction:1,mode:8,trigger:0\n" +
+                "2=name:" + testpin1 + ",deviceType:gpio.GPIOPin,direction:1,mode:8,trigger:0";
+
+        createJdkDioPropertiesFile(content);
 
         svc.activate(null);
 
-        f.delete();
+        deleteJdkDioPropertiesFile();
 
         Set<JdkDioPin> pins = (Set) TestUtil.getFieldValue(svc, "pins");
         assertEquals(2, pins.size());
@@ -158,4 +161,78 @@ public class GPIOServiceImplTest {
         f.delete();
     }
 
+    @Test
+    public void shouldParsePinSymlinks() throws IOException, NoSuchFieldException {
+        GPIOServiceImpl svc = new GPIOServiceImpl();
+
+        String content = "target/digital_in_symlink=name:IN1,deviceType:gpio.GPIOPin,direction:0,mode:1,trigger:0\n"
+                + "target/digital_out_symlink=name:OUT1,deviceType:gpio.GPIOPin,direction:1,mode:4,trigger:0";
+
+        createJdkDioPropertiesFile(content);
+        createGpioFiles();
+        createGpioSymlinks();
+
+        svc.activate(null);
+
+        deleteGpioSymlinks();
+        deleteGpioFiles();
+        deleteJdkDioPropertiesFile();
+
+        Set<JdkDioPin> pins = (Set) TestUtil.getFieldValue(svc, "pins");
+        assertEquals(2, pins.size());
+
+        pins.iterator().forEachRemaining(pin -> {
+            assertTrue(111 == pin.getIndex() || 123 == pin.getIndex());
+            if (pin.getIndex() == 111) {
+                assertEquals("IN1", pin.getName());
+                assertEquals(KuraGPIODirection.INPUT, pin.getDirection());
+                assertEquals(KuraGPIOMode.INPUT_PULL_UP, pin.getMode());
+                assertEquals(KuraGPIOTrigger.NONE, pin.getTrigger());
+            } else if (pin.getIndex() == 123) {
+                assertEquals("OUT1", pin.getName());
+                assertEquals(KuraGPIODirection.OUTPUT, pin.getDirection());
+                assertEquals(KuraGPIOMode.OUTPUT_PUSH_PULL, pin.getMode());
+                assertEquals(KuraGPIOTrigger.NONE, pin.getTrigger());
+            }
+        });
+        svc.deactivate(null);
+    }
+
+    private void createJdkDioPropertiesFile(String content) throws IOException {
+        this.jdkProperties = Paths.get("target/jdk.dio.properties");
+        String dioConfigFileName = this.jdkProperties.toAbsolutePath().toString();
+        System.setProperty("jdk.dio.registry", "file:///" + dioConfigFileName);
+
+        Files.write(this.jdkProperties, content.getBytes());
+    }
+
+    private void deleteJdkDioPropertiesFile() throws IOException {
+        Files.delete(this.jdkProperties);
+    }
+
+    private void createGpioFiles() throws IOException {
+        this.digitalIn = Paths.get("target/gpio111");
+        this.digitalOut = Paths.get("target/gpio123");
+
+        Files.createFile(this.digitalIn);
+        Files.createFile(this.digitalOut);
+    }
+
+    private void deleteGpioFiles() throws IOException {
+       Files.delete(this.digitalIn);
+       Files.delete(this.digitalOut);
+    }
+
+    private void createGpioSymlinks() throws IOException {
+        this.digitalInSymlink = Paths.get("target/digital_in_symlink");
+        this.digitalOutSymlink = Paths.get("target/digital_out_symlink");
+
+        Files.createSymbolicLink(this.digitalInSymlink, this.digitalIn.toRealPath());
+        Files.createSymbolicLink(this.digitalOutSymlink, this.digitalOut.toRealPath());
+    }
+
+    private void deleteGpioSymlinks() throws IOException {
+        Files.delete(this.digitalInSymlink);
+        Files.delete(this.digitalOutSymlink);
+    }
 }

--- a/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/GPIOServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.linux.gpio.test/src/test/java/org/eclipse/kura/linux/gpio/GPIOServiceImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR adds the support to symlinks in the `jdk.dio.properties` file.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** The current implementation of the `GPIOService` parses the `jdk.dio.properties` and reads the GPIO indexes/numbers. The entry looks like:

```
123 = deviceType: gpio.GPIOPin, pinNumber:123, name:GPIO123
```

This PR allows to set a symlink instead of a pin number in the configuration file:

```
/dev/dio1 = deviceType: gpio.GPIOPin, name:DIGITAL_INPUT1
```

where the `/dev/dio1` points to `/sys/class/gpio/gpioXYZ`. The `GPIOService` implementation will follow the symlink and read the pin number (XYZ) from the path.

