### PR TITLE
docs: added note on Command Service for Docker installations

### DIFF
--- a/docs/core-services/command-service.md
+++ b/docs/core-services/command-service.md
@@ -28,4 +28,7 @@ The Command Service provides the following configuration parameters:
 
 - **Privileged/Unprivileged Command Service Selection**: sets the modality of the command service. When set to privileged, the commands are run using the (privileged) user that started Kura, tipically *kurad* or *root*. When set to unprivileged, a standard user will run the commands.
 
+    !!! info
+        On Docker installations, only the Privileged mode is supported.
+
 When a command execution is requested in the cloud platform, it sends an MQTT control message to the device requesting that the command be executed. On the device, the Command Service opens a temporary shell in the _command.working.directory,_ sets the _command.environment_ variables (if any), and waits  _command.timeout_ seconds to get command response.


### PR DESCRIPTION
This PR adds a note for the Command Service options on Docker installation.

**Related Issue:** Documentation for PR https://github.com/eclipse/kura/pull/5249.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
