### PR TITLE
fix(distrib): add wpa_supplicant dbus permissions only on NN profiles

### DIFF
--- a/kura/distrib/src/main/resources/common/manage_kura_users.sh
+++ b/kura/distrib/src/main/resources/common/manage_kura_users.sh
@@ -151,18 +151,17 @@ if ((action.id == \"org.freedesktop.login1.reboot-multiple-sessions\" ||
             done = 1
         } 1' /etc/dbus-1/system.d/bluetooth.conf >tempfile && mv tempfile /etc/dbus-1/system.d/bluetooth.conf
     fi
-    
+
     # grant kurad user the privileges to manage wpa supplicant via dbus
-    grep -lR kurad /etc/dbus-1/system.d/wpa_supplicant.conf
-    if [ $? != 0 ]; then
+    if ! grep -lR kurad /etc/dbus-1/system.d/wpa_supplicant.conf && [ $NN == "NO" ]; then
         cp /etc/dbus-1/system.d/wpa_supplicant.conf /etc/dbus-1/system.d/wpa_supplicant.conf.save
         awk 'done != 1 && /^<\/busconfig>/ {
-            print "  <policy user=\"kurad\">"
-            print "    <allow own=\"fi.w1.wpa_supplicant1\"/>"
-            print "    <allow send_destination=\"fi.w1.wpa_supplicant1\"/>"
-            print "    <allow send_interface=\"fi.w1.wpa_supplicant1\"/>"
-            print "    <allow receive_sender=\"fi.w1.wpa_supplicant1\" receive_type=\"signal\"/>"
-            print "  </policy>\n"
+            print "    <policy user=\"kurad\">"
+            print "        <allow own=\"fi.w1.wpa_supplicant1\"/>"
+            print "        <allow send_destination=\"fi.w1.wpa_supplicant1\"/>"
+            print "        <allow send_interface=\"fi.w1.wpa_supplicant1\"/>"
+            print "        <allow receive_sender=\"fi.w1.wpa_supplicant1\" receive_type=\"signal\"/>"
+            print "    </policy>\n"
             done = 1
         } 1' /etc/dbus-1/system.d/wpa_supplicant.conf >tempfile && mv tempfile /etc/dbus-1/system.d/wpa_supplicant.conf
     fi
@@ -207,7 +206,7 @@ function delete_users {
         sed -i '/^auth       sufficient pam_rootok.so/ {n;d}' /etc/pam.d/su
     fi
 
-    # recover old dbus config
+    # recover old configs
     mv /etc/dbus-1/system.d/bluetooth.conf.save /etc/dbus-1/system.d/bluetooth.conf
     mv /etc/dbus-1/system.d/wpa_supplicant.conf.save /etc/dbus-1/system.d/wpa_supplicant.conf
 }

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/kura_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-#  Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
 #
 #  This program and the accompanying materials are made
 #  available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,7 @@ fi
 #set up users and grant permissions to them
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
 chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
-${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i -nn
 
 systemctl stop apparmor
 systemctl disable apparmor

--- a/kura/distrib/src/main/resources/generic-x86_64-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/generic-x86_64-nn/kura_install.sh
@@ -54,7 +54,7 @@ systemctl disable chrony
 # set up users and grant permissions
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
 chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
-${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i -nn
 
 bash "${INSTALL_DIR}/kura/install/customize-installation.sh"
 

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/kura_install.sh
@@ -52,7 +52,7 @@ fi
 #set up users and grant permissions to them
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
 chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
-${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i -nn
 
 systemctl stop apparmor
 systemctl disable apparmor

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/kura_install.sh
@@ -60,7 +60,7 @@ fi
 #set up users and grant permissions to them
 cp ${INSTALL_DIR}/kura/install/manage_kura_users.sh ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
 chmod 700 ${INSTALL_DIR}/kura/.data/manage_kura_users.sh
-${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i 
+${INSTALL_DIR}/kura/.data/manage_kura_users.sh -i -nn
 
 #copy snapshot_0.xml
 cp ${INSTALL_DIR}/kura/user/snapshots/snapshot_0.xml ${INSTALL_DIR}/kura/.data/snapshot_0.xml


### PR DESCRIPTION
This PR adds a check for adding DBUS permissions to `kurad` user for managing WPA supplicant only on networking profiles. Furthermore, it fixes the missing `-nn` flags in no-network installations.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**:

1. `/etc/dbus-1/system.d/wpa_supplicant.conf` exists and contains a policy for `kurad` on networking profiles.
2. `/etc/dbus-1/system.d/wpa_supplicant.conf` is not modified on NN profiles.
3. `/etc/dbus-1/system.d/wpa_supplicant.conf` is restored at uninstallation on networking profiles.
4. Can connect to an access point as client.
5. Can serve as AP.

**Any side note on the changes made:** N/A.
