### PR TITLE
fix(distrib): missing uninstallation logging

### DIFF
--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/prerm
@@ -4,6 +4,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -85,9 +87,6 @@ function preRemove {
       rm -rf ${INSTALL_DIR}/kura
       rm -rf $PARENT
     fi
-
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -96,10 +95,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -108,12 +107,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/generic-aarch64-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-aarch64-nn/deb/control/prerm
@@ -16,6 +16,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -102,9 +104,6 @@ function preRemove {
       rm -rf ${INSTALL_DIR}/kura
       rm -rf $PARENT
     fi
-
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -113,10 +112,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -125,12 +124,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/prerm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -130,9 +132,6 @@ function preRemove {
     fi
 
     restore_netplan
-    
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -141,10 +140,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -153,12 +152,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/generic-arm32-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-arm32-nn/deb/control/prerm
@@ -16,6 +16,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -102,9 +104,6 @@ function preRemove {
       rm -rf ${INSTALL_DIR}/kura
       rm -rf $PARENT
     fi
-    
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -113,10 +112,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -125,12 +124,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/prerm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -130,9 +132,6 @@ function preRemove {
     fi
 
     restore_netplan
-    
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -141,10 +140,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -153,12 +152,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/generic-x86_64-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-x86_64-nn/deb/control/prerm
@@ -16,6 +16,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -102,9 +104,6 @@ function preRemove {
       rm -rf ${INSTALL_DIR}/kura
       rm -rf $PARENT
     fi
-
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -113,10 +112,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -125,12 +124,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/prerm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -130,9 +132,6 @@ function preRemove {
     fi
 
     restore_netplan
-
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -141,10 +140,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -153,12 +152,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/prerm
@@ -4,6 +4,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -85,9 +87,6 @@ function preRemove {
       rm -rf ${INSTALL_DIR}/kura
       rm -rf $PARENT
     fi
-
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -96,10 +95,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -108,12 +107,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/prerm
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/prerm
@@ -4,6 +4,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -85,9 +87,6 @@ function preRemove {
       rm -rf ${INSTALL_DIR}/kura
       rm -rf $PARENT
     fi
-
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -96,10 +95,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -108,12 +107,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/prerm
@@ -4,6 +4,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -77,9 +79,6 @@ function preRemove {
       rm -rf ${INSTALL_DIR}/kura
       rm -rf $PARENT
     fi
-
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -88,10 +87,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -100,12 +99,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/prerm
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/prerm
@@ -4,6 +4,8 @@ INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
 REFRESH_TIME=5
 TIMEOUT_TIME=300
+TIMESTAMP=$(date +%Y%m%d%H%M)
+LOG=/tmp/kura_uninstall_${TIMESTAMP}.log
 
 ##############################################
 # UTILITY FUNCTIONS
@@ -85,9 +87,6 @@ function preRemove {
       rm -rf ${INSTALL_DIR}/kura
       rm -rf $PARENT
     fi
-
-    echo ""
-    echo "Uninstalling KURA... Done!"
 }
 ##############################################
 # END UTILITY FUNCTIONS
@@ -96,10 +95,10 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
-PIDS=`pgrep java`
-
 echo ""
 echo "Uninstalling KURA..."
+
+PIDS=`pgrep java`
 
 #Kill JVM and monit for installation
 if [ -f "/var/run/kura.pid" ] ; then
@@ -108,12 +107,18 @@ if [ -f "/var/run/kura.pid" ] ; then
   for pid in "${PIDS[@]}"
   do
     if [ "$KURA_PID" == "$pid" ] ; then
-      `kill $pid` >> /tmp/kura_install.log 2>&1
+      `kill $pid` >> "$LOG" 2>&1
     fi
   done
 fi
 
-runPreRemove
+runPreRemove >> "$LOG" 2>&1
+
+mkdir -p /opt/eclipse/kura/log/
+mv "$LOG" /opt/eclipse/kura/log/
+
+echo ""
+echo "Uninstalling KURA... Done!"
 ##############################################
 # END PRE-REMOVE SCRIPT
 ##############################################


### PR DESCRIPTION
This PR fixes the missing uninstallation logs that are located in `/opt/eclipse/kura/log/kura_uninstall_${TIMESTAMP}.log`.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
