### PR TITLE
fix(rest.identity): fixed status codes and error messages for malformed requests

### DIFF
--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
@@ -111,6 +111,9 @@ public class IdentityRestServiceV2 {
         logger.debug(DEBUG_MESSAGE, "createIdentity");
 
         try {
+
+            StringUtils.validateField("name", identity.getName());
+
             boolean created = this.identityService.createIdentity(identity.getName());
             if (!created) {
                 throw DefaultExceptionHandler.buildWebApplicationException(Status.CONFLICT, "Identity already exists");
@@ -130,6 +133,8 @@ public class IdentityRestServiceV2 {
         logger.debug(DEBUG_MESSAGE, "updateIdentity");
         try {
 
+            StringUtils.validateField("name", identityConfigurationDTO.getIdentity().getName());
+
             this.identityService
                     .updateIdentityConfiguration(IdentityDTOUtils.toIdentityConfiguration(identityConfigurationDTO));
         } catch (Exception e) {
@@ -148,6 +153,9 @@ public class IdentityRestServiceV2 {
             final IdentityConfigurationRequestDTO identityConfigurationRequestDTO) {
         logger.debug(DEBUG_MESSAGE, "getIdentityByName");
         try {
+
+            StringUtils.validateField("name", identityConfigurationRequestDTO.getIdentity().getName());
+
             String identityName = identityConfigurationRequestDTO.getIdentity().getName();
 
             Optional<IdentityConfiguration> identityConfiguration = this.identityService.getIdentityConfiguration(
@@ -177,6 +185,9 @@ public class IdentityRestServiceV2 {
         String identityName = identityConfigurationRequestDTO.getIdentity().getName();
 
         try {
+
+            StringUtils.validateField("name", identityName);
+
             IdentityConfiguration identityConfiguration = this.identityService.getIdentityDefaultConfiguration(
                     identityName, //
                     IdentityDTOUtils.toIdentityConfigurationComponents(
@@ -197,7 +208,7 @@ public class IdentityRestServiceV2 {
         logger.debug(DEBUG_MESSAGE, "deleteIdentity");
         try {
 
-            StringUtils.validateInputField("name", identity.getName());
+            StringUtils.validateField("name", identity.getName());
 
             boolean deleted = this.identityService.deleteIdentity(identity.getName());
             if (!deleted) {
@@ -259,6 +270,9 @@ public class IdentityRestServiceV2 {
         logger.debug(DEBUG_MESSAGE, "createPermission");
 
         try {
+
+            StringUtils.validateField("name", permissionDTO.getName());
+
             boolean created = this.identityService.createPermission(IdentityDTOUtils.toPermission(permissionDTO));
             if (!created) {
                 throw DefaultExceptionHandler.buildWebApplicationException(Status.CONFLICT,
@@ -278,7 +292,7 @@ public class IdentityRestServiceV2 {
     public Response deletePermission(final PermissionDTO permissionDTO) {
         logger.debug(DEBUG_MESSAGE, "deletePermission");
 
-        StringUtils.validateInputField("name", permissionDTO.getName());
+        StringUtils.validateField("name", permissionDTO.getName());
 
         boolean deleted = false;
         try {

--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kura.internal.rest.identity.provider;
 
+import static java.util.Objects.isNull;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -196,7 +198,7 @@ public class IdentityRestServiceV2 {
         logger.debug(DEBUG_MESSAGE, "deleteIdentity");
         try {
 
-            if (identity.getName() == null) {
+            if (isNull(identity.getName())) {
                 throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST,
                         "Missing 'name' property");
             }
@@ -280,7 +282,7 @@ public class IdentityRestServiceV2 {
     public Response deletePermission(final PermissionDTO permissionDTO) {
         logger.debug(DEBUG_MESSAGE, "deletePermission");
 
-        if (permissionDTO.getName() == null) {
+        if (isNull(permissionDTO.getName())) {
             throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST, "Missing 'name' property");
         }
 

--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kura.internal.rest.identity.provider;
 
-import static java.util.Objects.isNull;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -46,6 +44,7 @@ import org.eclipse.kura.identity.IdentityService;
 import org.eclipse.kura.identity.PasswordConfiguration;
 import org.eclipse.kura.identity.PasswordStrengthVerificationService;
 import org.eclipse.kura.internal.rest.identity.provider.util.IdentityDTOUtils;
+import org.eclipse.kura.internal.rest.identity.provider.util.StringUtils;
 import org.eclipse.kura.internal.rest.identity.provider.v2.dto.IdentityConfigurationDTO;
 import org.eclipse.kura.internal.rest.identity.provider.v2.dto.IdentityConfigurationRequestDTO;
 import org.eclipse.kura.internal.rest.identity.provider.v2.dto.IdentityDTO;
@@ -198,10 +197,7 @@ public class IdentityRestServiceV2 {
         logger.debug(DEBUG_MESSAGE, "deleteIdentity");
         try {
 
-            if (isNull(identity.getName())) {
-                throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST,
-                        "Missing 'name' property");
-            }
+            StringUtils.validateInputField("name", identity.getName());
 
             boolean deleted = this.identityService.deleteIdentity(identity.getName());
             if (!deleted) {
@@ -282,9 +278,7 @@ public class IdentityRestServiceV2 {
     public Response deletePermission(final PermissionDTO permissionDTO) {
         logger.debug(DEBUG_MESSAGE, "deletePermission");
 
-        if (isNull(permissionDTO.getName())) {
-            throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST, "Missing 'name' property");
-        }
+        StringUtils.validateInputField("name", permissionDTO.getName());
 
         boolean deleted = false;
         try {

--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
@@ -314,6 +314,9 @@ public class IdentityRestServiceV2 {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response validateIdentityConfiguration(final IdentityConfigurationDTO identityConfigurationDTO) {
         try {
+
+            StringUtils.validateField("name", identityConfigurationDTO.getIdentity().getName());
+
             this.identityService
                     .validateIdentityConfiguration(IdentityDTOUtils.toIdentityConfiguration(identityConfigurationDTO));
         } catch (KuraException e) {

--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
@@ -60,6 +60,8 @@ import org.slf4j.LoggerFactory;
 @Path("identity/v2")
 public class IdentityRestServiceV2 {
 
+    private static final String NAME_REQUEST_FIELD = "name";
+
     private static final Logger logger = LoggerFactory.getLogger(IdentityRestServiceV2.class);
 
     private static final String MQTT_APP_ID = "IDN-V2";
@@ -112,7 +114,7 @@ public class IdentityRestServiceV2 {
 
         try {
 
-            StringUtils.validateField("name", identity.getName());
+            StringUtils.validateField(NAME_REQUEST_FIELD, identity.getName());
 
             boolean created = this.identityService.createIdentity(identity.getName());
             if (!created) {
@@ -133,7 +135,7 @@ public class IdentityRestServiceV2 {
         logger.debug(DEBUG_MESSAGE, "updateIdentity");
         try {
 
-            StringUtils.validateField("name", identityConfigurationDTO.getIdentity().getName());
+            StringUtils.validateField(NAME_REQUEST_FIELD, identityConfigurationDTO.getIdentity().getName());
 
             this.identityService
                     .updateIdentityConfiguration(IdentityDTOUtils.toIdentityConfiguration(identityConfigurationDTO));
@@ -154,7 +156,7 @@ public class IdentityRestServiceV2 {
         logger.debug(DEBUG_MESSAGE, "getIdentityByName");
         try {
 
-            StringUtils.validateField("name", identityConfigurationRequestDTO.getIdentity().getName());
+            StringUtils.validateField(NAME_REQUEST_FIELD, identityConfigurationRequestDTO.getIdentity().getName());
 
             String identityName = identityConfigurationRequestDTO.getIdentity().getName();
 
@@ -186,7 +188,7 @@ public class IdentityRestServiceV2 {
 
         try {
 
-            StringUtils.validateField("name", identityName);
+            StringUtils.validateField(NAME_REQUEST_FIELD, identityName);
 
             IdentityConfiguration identityConfiguration = this.identityService.getIdentityDefaultConfiguration(
                     identityName, //
@@ -208,7 +210,7 @@ public class IdentityRestServiceV2 {
         logger.debug(DEBUG_MESSAGE, "deleteIdentity");
         try {
 
-            StringUtils.validateField("name", identity.getName());
+            StringUtils.validateField(NAME_REQUEST_FIELD, identity.getName());
 
             boolean deleted = this.identityService.deleteIdentity(identity.getName());
             if (!deleted) {
@@ -271,7 +273,7 @@ public class IdentityRestServiceV2 {
 
         try {
 
-            StringUtils.validateField("name", permissionDTO.getName());
+            StringUtils.validateField(NAME_REQUEST_FIELD, permissionDTO.getName());
 
             boolean created = this.identityService.createPermission(IdentityDTOUtils.toPermission(permissionDTO));
             if (!created) {
@@ -292,7 +294,7 @@ public class IdentityRestServiceV2 {
     public Response deletePermission(final PermissionDTO permissionDTO) {
         logger.debug(DEBUG_MESSAGE, "deletePermission");
 
-        StringUtils.validateField("name", permissionDTO.getName());
+        StringUtils.validateField(NAME_REQUEST_FIELD, permissionDTO.getName());
 
         boolean deleted = false;
         try {
@@ -315,7 +317,7 @@ public class IdentityRestServiceV2 {
     public Response validateIdentityConfiguration(final IdentityConfigurationDTO identityConfigurationDTO) {
         try {
 
-            StringUtils.validateField("name", identityConfigurationDTO.getIdentity().getName());
+            StringUtils.validateField(NAME_REQUEST_FIELD, identityConfigurationDTO.getIdentity().getName());
 
             this.identityService
                     .validateIdentityConfiguration(IdentityDTOUtils.toIdentityConfiguration(identityConfigurationDTO));

--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
@@ -279,6 +279,11 @@ public class IdentityRestServiceV2 {
     @Consumes(MediaType.APPLICATION_JSON)
     public Response deletePermission(final PermissionDTO permissionDTO) {
         logger.debug(DEBUG_MESSAGE, "deletePermission");
+
+        if (permissionDTO.getName() == null) {
+            throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST, "Missing 'name' property");
+        }
+
         boolean deleted = false;
         try {
             deleted = this.identityService.deletePermission(IdentityDTOUtils.toPermission(permissionDTO));

--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/IdentityRestServiceV2.java
@@ -195,6 +195,12 @@ public class IdentityRestServiceV2 {
     public Response deleteIdentity(final IdentityDTO identity) {
         logger.debug(DEBUG_MESSAGE, "deleteIdentity");
         try {
+
+            if (identity.getName() == null) {
+                throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST,
+                        "Missing 'name' property");
+            }
+
             boolean deleted = this.identityService.deleteIdentity(identity.getName());
             if (!deleted) {
                 throw DefaultExceptionHandler.buildWebApplicationException(Status.NOT_FOUND, "Identity not found");

--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/util/StringUtils.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/util/StringUtils.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kura.internal.rest.identity.provider.util;
 
+import static java.util.Objects.isNull;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.kura.request.handler.jaxrs.DefaultExceptionHandler;
+
 public class StringUtils {
 
     private StringUtils() {
@@ -21,6 +27,19 @@ public class StringUtils {
     public static void requireNotEmpty(String value, String message) {
         if (value == null || value.trim().isEmpty()) {
             throw new IllegalArgumentException(message);
+        }
+    }
+
+    public static void validateInputField(String propertyName, String inputToValidate) {
+
+        if (isNull(inputToValidate)) {
+            throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST,
+                    "Missing '" + propertyName + "' property");
+        }
+
+        if (inputToValidate.isEmpty()) {
+            throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST,
+                    "`" + propertyName + "` value can't be empty");
         }
     }
 }

--- a/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/util/StringUtils.java
+++ b/kura/org.eclipse.kura.rest.identity.provider/src/main/java/org/eclipse/kura/internal/rest/identity/provider/util/StringUtils.java
@@ -30,14 +30,14 @@ public class StringUtils {
         }
     }
 
-    public static void validateInputField(String propertyName, String inputToValidate) {
+    public static void validateField(String propertyName, String inputToValidate) {
 
         if (isNull(inputToValidate)) {
             throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST,
                     "Missing '" + propertyName + "' property");
         }
 
-        if (inputToValidate.isEmpty()) {
+        if (inputToValidate.trim().isEmpty()) {
             throw DefaultExceptionHandler.buildWebApplicationException(Status.BAD_REQUEST,
                     "`" + propertyName + "` value can't be empty");
         }

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityV2EndpointsTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityV2EndpointsTest.java
@@ -212,10 +212,10 @@ public class IdentityV2EndpointsTest extends AbstractRequestHandlerTest {
     }
 
     @Test
-    public void shouldReturnErrorDeletingWithMalformedRequest() {
+    public void shouldReturnErrorDeletingWithMalformedIdentityRequest() {
 
         whenRequestIsPerformed(new MethodSpec(METHOD_SPEC_DELETE, MQTT_METHOD_SPEC_DEL), "/identities",
-                "{\"nm\":\"test\"}");
+                "{\"nm\":\"identity\"}");
 
         thenResponseCodeIs(400);
         thenResponseBodyEqualsJson("{\"message\":\"Missing 'name' property\"}");
@@ -282,6 +282,17 @@ public class IdentityV2EndpointsTest extends AbstractRequestHandlerTest {
 
         thenResponseCodeIs(404);
         thenResponseBodyEqualsJson("{\"message\":\"Permission not found\"}");
+
+    }
+
+    @Test
+    public void shouldReturnErrorDeletingWithMalformedPermissionRequest() {
+
+        whenRequestIsPerformed(new MethodSpec(METHOD_SPEC_DELETE, MQTT_METHOD_SPEC_DEL), "/permissions",
+                "{\"nm\":\"permission\"}");
+
+        thenResponseCodeIs(400);
+        thenResponseBodyEqualsJson("{\"message\":\"Missing 'name' property\"}");
 
     }
 

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityV2EndpointsTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityV2EndpointsTest.java
@@ -212,6 +212,17 @@ public class IdentityV2EndpointsTest extends AbstractRequestHandlerTest {
     }
 
     @Test
+    public void shouldReturnErrorDeletingWithMalformedRequest() {
+
+        whenRequestIsPerformed(new MethodSpec(METHOD_SPEC_DELETE, MQTT_METHOD_SPEC_DEL), "/identities",
+                "{\"nm\":\"test\"}");
+
+        thenResponseCodeIs(400);
+        thenResponseBodyEqualsJson("{\"message\":\"Missing 'name' property\"}");
+
+    }
+
+    @Test
     public void shouldGetDefinedPermissions() {
         whenRequestIsPerformed(new MethodSpec(METHOD_SPEC_GET), "/definedPermissions");
 


### PR DESCRIPTION
This PR modifies the response status code and error message in case of malformed request body for Identity/Permission REST APIs of IdentityV2.

When the request doesn't contain the `name` key or it's wrong (eg: `nam`), the corresponding DTO (Identity or Permission DTO) will have a null value as name. On Kura side, null/empty checks were missing, so the IdentityService was trying to remove something that it could not found, responding with a 404 status code with message `Identity not found`.

After this change, the null/empty checks are added: if the `name` value is null (missing or wrong `name` field) or empty, a 400 status code is returned with an appropriate message.

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
