### PR TITLE
fix: fixed null in wi-fi frontend and missing wi-fi update on IPv6

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1322,16 +1322,16 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             configUserOptions.allowAnyPassword();
         }
 
-        if (this.security.getSelectedItemText().equals(WIFI_SECURITY_WPA_MESSAGE)
+        if (this.security != null && (this.security.getSelectedItemText().equals(WIFI_SECURITY_WPA_MESSAGE)
                 || this.security.getSelectedItemText().equals(WIFI_SECURITY_WPA2_MESSAGE)
-                || this.security.getSelectedItemText().contentEquals(WIFI_SECURITY_WPA_WPA2_MESSAGE)) {
+                || this.security.getSelectedItemText().contentEquals(WIFI_SECURITY_WPA_WPA2_MESSAGE))) {
 
             this.password.setValidatorsFrom(configUserOptions);
             configUserOptions.setPasswordMinimumLength(Math.min(configUserOptions.getPasswordMinimumLength(), 63));
 
             this.password.addValidator(GwtValidators.regex(REGEX_PASS_WPA, MSGS.netWifiWirelessInvalidWPAPassword()));
 
-        } else if (this.security.getSelectedItemText().equals(WIFI_SECURITY_WEP_MESSAGE)) {
+        } else if (this.security != null && this.security.getSelectedItemText().equals(WIFI_SECURITY_WEP_MESSAGE)) {
 
             configUserOptions.setPasswordRequireSpecialChars(false);
             configUserOptions.setPasswordMinimumLength(Math.min(configUserOptions.getPasswordMinimumLength(), 26));
@@ -1741,14 +1741,14 @@ public class TabWirelessUi extends Composite implements NetworkTab {
     private boolean checkPassword() {
         boolean result = true;
 
-        if (!this.password.validate() && this.password.isEnabled()) {
+        if (this.password != null && !this.password.validate() && this.password.isEnabled()) {
             this.groupPassword.setValidationState(ValidationState.ERROR);
             result = false;
         } else {
             this.groupPassword.setValidationState(ValidationState.NONE);
         }
 
-        if (this.verify.isEnabled() && TabWirelessUi.this.password != null
+        if (this.verify != null && this.verify.isEnabled() && TabWirelessUi.this.password != null
                 && !TabWirelessUi.this.verify.getText().equals(TabWirelessUi.this.password.getText())) {
             TabWirelessUi.this.helpVerify.setText(MSGS.netWifiWirelessPasswordDoesNotMatch());
             TabWirelessUi.this.groupVerify.setValidationState(ValidationState.ERROR);
@@ -1820,7 +1820,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         addAutomaticChannel(freqChannels);
         freqChannels.stream().forEach(this::addItemChannelList);
 
-        if (this.activeConfig.getChannels() != null && !this.activeConfig.getChannels().isEmpty()) {
+        if (this.activeConfig != null && this.activeConfig.getChannels() != null
+                && !this.activeConfig.getChannels().isEmpty()) {
             this.netTabs.hardwareTab.channel
                     .setText(this.channelList.getItemText(this.activeConfig.getChannels().get(0)));
 
@@ -1880,7 +1881,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
                                 if (selectedRadioMode != null) {
                                     setRadioModeByValue(selectedRadioMode);
-                                } else {
+                                } else if (TabWirelessUi.this.activeConfig != null) {
                                     setRadioModeByValue(TabWirelessUi.this.activeConfig.getRadioMode());
                                 }
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -64,15 +64,10 @@ public class NetworkConfigurationServicePropertiesBuilder {
         setIpv4DhcpServerProperties();
         set8021xConfig();
 
-        switch (this.gwtConfig.getStatusEnum()) {
-        case netIPv4StatusDisabled:
-            break;
-        case netIPv4StatusUnmanaged:
-            break;
-        default:
+        if (isIPv4StatusEnabledManaged(this.gwtConfig.getStatus())
+                || isIPv6StatusEnabledManaged(this.gwtConfig.getIpv6Status())) {
             setWifiProperties();
             setModemProperties();
-            break;
         }
 
         // Manage GPS independently of device ip status
@@ -81,6 +76,15 @@ public class NetworkConfigurationServicePropertiesBuilder {
         setAdvancedProperties();
 
         return this.properties.getProperties();
+    }
+
+    private boolean isIPv4StatusEnabledManaged(String ipv4Status) {
+        return !(ipv4Status.equals(GwtNetIfStatus.netIPv4StatusDisabled.name())
+                || ipv4Status.equals(GwtNetIfStatus.netIPv4StatusUnmanaged.name()));
+    }
+
+    private boolean isIPv6StatusEnabledManaged(String ipv6Status) {
+        return !ipv6Status.equals(GwtNetIfStatus.netIPv6StatusDisabled.name());
     }
 
     private void setCommonProperties() {
@@ -427,7 +431,7 @@ public class NetworkConfigurationServicePropertiesBuilder {
         this.properties.setIp6Mtu(this.ifname,
                 Objects.nonNull(this.gwtConfig.getIpv6Mtu()) ? this.gwtConfig.getIpv6Mtu() : DEFAULT_MTU);
         this.properties.setPromisc(this.ifname,
-        		Objects.nonNull(this.gwtConfig.getPromisc()) ? this.gwtConfig.getPromisc() : DEFAULT_PROMISC);
+                Objects.nonNull(this.gwtConfig.getPromisc()) ? this.gwtConfig.getPromisc() : DEFAULT_PROMISC);
     }
 
     private static GwtNetInterfaceConfig getConfigsAndStatuses(String ifName) throws GwtKuraException, KuraException {


### PR DESCRIPTION
Prevented null pointers in frontend especially when 2 wi-fi interfaces and the configured one is completely new.
Fixed a missed wi-fi update when only IPv6 enabled.