### PR TITLE
fix: Added a check to not display the automatic option for the old networking

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1817,7 +1817,10 @@ public class TabWirelessUi extends Composite implements NetworkTab {
 
         this.channelList.clear();
 
-        addAutomaticChannel(freqChannels);
+        if (isNet2) {
+            addAutomaticChannel(freqChannels);
+        }
+        
         freqChannels.stream().forEach(this::addItemChannelList);
 
         if (this.activeConfig != null && this.activeConfig.getChannels() != null


### PR DESCRIPTION
This PR solves an issue where the automatic channel proper of Network Manager is also displayed for the old Kura networking.
The user, unaware of it will keep the default selection that is not known to the old Kura networking determining the fact that the AP was not visible.