### PR TITLE
fix(nm): Fixed dnsmasq behavior on configuration change

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMConfigurationServiceImpl.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
@@ -505,11 +506,11 @@ public class NMConfigurationServiceImpl implements SelfConfiguringComponent {
                 DhcpServerConfigWriter dhcpServerConfigWriter = buildDhcpServerConfigWriter(interfaceName,
                         this.networkProperties);
                 try {
-                    dhcpServerConfigWriter.writeConfiguration();
-                    this.dhcpServerMonitor.putDhcpServerInterfaceConfiguration(interfaceName, true);
                     this.dhcpServerMonitor.disable(interfaceName); // Side effect: we rely on the monitor bringing the
                                                                    // server back up so that the configuration change
                                                                    // takes effect
+                    dhcpServerConfigWriter.writeConfiguration();
+                    this.dhcpServerMonitor.putDhcpServerInterfaceConfiguration(interfaceName, true);
 
                 } catch (UnknownHostException | KuraException e) {
                     logger.error("Failed to write DHCP Server configuration", e);


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR fixes a weird behaviour when `dnsmasq` is used as DHCP server with generic profiles and NM.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** During testing we found that the `dnsmasq` used as DHCP server doesn't listen on port 67 after a re-configuration. If the configuration was submitted again, the service starts working as aspected.
After further investigations, we found that when the problem occours, the dnsmasq configuration file is not present in the filesystem. So, the service is running, but without any configuration of the given interface. As a consequence, the port 67 UDP is not used.

This is due to a wrong operation sequence during the DHCP server startup performed by Kura. The configuration file is written, but when the DHCP server activation is triggered, the code disable the service and then re-enable it. During the disable, the configuration file is removed. If a new configuration is submitted again, all works since the bundle doesn’t recognize the service as running and doesn’t disable it.

This PR fixes the issue changing the order of the operation when the DHCP server is configured. Now, the `dnsmasq` service is disable before that the configuration file is written.

**Manual Tests**: Using a generic profile, configure an AP with DHCP server enabled. Try to connect to the configured AP with another device (i.e. a laptop) and try to get an IP address. Change the AP configuration and apply it. Then try to connect again with the laptop. The laptop should be able to connect and get the address. 

