### PR TITLE
fix: Fixed Keypair validity display to link only the leaf

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
@@ -163,7 +163,7 @@ public class GwtCertificatesServiceImpl extends OsgiRemoteServiceServlet impleme
                         Certificate[] chain = pke.getCertificateChain();
 
                         if (chain.length > 0) {
-                            Certificate leaf = chain[chain.length - 1];
+                            Certificate leaf = chain[0];
 
                             if (leaf instanceof X509Certificate) {
                                 validityStartDate = ((X509Certificate) leaf).getNotBefore();
@@ -178,7 +178,7 @@ public class GwtCertificatesServiceImpl extends OsgiRemoteServiceServlet impleme
                                 Certificate cert = chain[i];
                                 if (cert instanceof X509Certificate) {
                                     X509Certificate x509Cert = CertificateUtil.toJavaX509Certificate(cert);
-                                    distinguishedNames.add(index + x509Cert.getSubjectX500Principal().getName());
+                                    distinguishedNames.add(index + x509Cert.getSubjectX500Principal().toString());
                                 }
                             }
                         }
@@ -192,7 +192,7 @@ public class GwtCertificatesServiceImpl extends OsgiRemoteServiceServlet impleme
                             validityEndDate = ((X509Certificate) cert).getNotAfter();
 
                             X509Certificate x509Cert = CertificateUtil.toJavaX509Certificate(cert);
-                            distinguishedNames.add(x509Cert.getSubjectX500Principal().getName());
+                            distinguishedNames.add(x509Cert.getSubjectX500Principal().toString());
                         }
                     } else if (e.getValue() instanceof SecretKeyEntry) {
                         kind = Kind.SECRET_KEY;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtCertificatesServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
In the current implementation the validity range for key-airs was linked to the CA validity.
Updated also the DN visualisation.
