### PR TITLE
fix(web): Fixed firewall service pid in GwtNetworkService

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -59,7 +59,8 @@ import org.slf4j.LoggerFactory;
 public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements GwtNetworkService {
 
     private static final long serialVersionUID = -4188750359099902616L;
-    private static final String FIREWALL_CONFIGURATION_SERVICE_PID = "org.eclipse.kura.net.admin.ipv6.FirewallConfigurationServiceIPv6";
+    private static final String FIREWALL_IPV4_CONFIGURATION_SERVICE_PID = "org.eclipse.kura.net.admin.FirewallConfigurationService";
+    private static final String FIREWALL_IPV6_CONFIGURATION_SERVICE_PID = "org.eclipse.kura.net.admin.ipv6.FirewallConfigurationServiceIPv6";
     private static final String UNKNOWN_NETWORK_IP6_SHORT = "::/0";
     private static final String UNKNOWN_NETWORK_IP6_LONG = "0:0:0:0:0:0:0:0/0";
     private static final String UNKNOWN_NETWORK_IP4 = "0.0.0.0/0";
@@ -411,7 +412,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             }
 
             properties.put(openPortsPropName, openPorts.toString());
-            configurationService.updateConfiguration(FIREWALL_CONFIGURATION_SERVICE_PID, properties, true);
+            configurationService.updateConfiguration(FIREWALL_IPV4_CONFIGURATION_SERVICE_PID, properties, true);
         } catch (KuraException | UnknownHostException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
@@ -457,7 +458,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             }
 
             properties.put(openPortsPropName, openPorts.toString());
-            configurationService.updateConfiguration(FIREWALL_CONFIGURATION_SERVICE_PID, properties, true);
+            configurationService.updateConfiguration(FIREWALL_IPV6_CONFIGURATION_SERVICE_PID, properties, true);
         } catch (KuraException | UnknownHostException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
@@ -505,7 +506,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             }
 
             properties.put(portForwardingPropName, portForwarding.toString());
-            configurationService.updateConfiguration(FIREWALL_CONFIGURATION_SERVICE_PID, properties, true);
+            configurationService.updateConfiguration(FIREWALL_IPV4_CONFIGURATION_SERVICE_PID, properties, true);
         } catch (KuraException | UnknownHostException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
@@ -554,7 +555,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             }
 
             properties.put(portForwardingPropName, portForwarding.toString());
-            configurationService.updateConfiguration(FIREWALL_CONFIGURATION_SERVICE_PID, properties, true);
+            configurationService.updateConfiguration(FIREWALL_IPV6_CONFIGURATION_SERVICE_PID, properties, true);
         } catch (KuraException | UnknownHostException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
@@ -596,7 +597,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             }
 
             properties.put(natPropName, nat.toString());
-            configurationService.updateConfiguration(FIREWALL_CONFIGURATION_SERVICE_PID, properties, true);
+            configurationService.updateConfiguration(FIREWALL_IPV4_CONFIGURATION_SERVICE_PID, properties, true);
         } catch (KuraException | UnknownHostException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
@@ -638,7 +639,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             }
 
             properties.put(natPropName, nat.toString());
-            configurationService.updateConfiguration(FIREWALL_CONFIGURATION_SERVICE_PID, properties, true);
+            configurationService.updateConfiguration(FIREWALL_IPV6_CONFIGURATION_SERVICE_PID, properties, true);
         } catch (KuraException | UnknownHostException e) {
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR fixes the `GwtNetworkService` in the web bundle that prevents the correct application of the firewall IPv4 rules.

