### PR TITLE
refactor(distrib): removed republish.mqtt.birth.cert.on.modem.detect option from snapshot_0.xml

### DIFF
--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-generic-device
@@ -393,9 +393,6 @@
             <esf:property array="false" encrypted="false" name="payload.encoding" type="String">
                 <esf:value>kura-protobuf</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="republish.mqtt.birth.cert.on.modem.detect" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
                 <esf:value>org.eclipse.kura.cloud.CloudService</esf:value>
             </esf:property>

--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml-raspberry
@@ -393,9 +393,6 @@
             <esf:property array="false" encrypted="false" name="payload.encoding" type="String">
                 <esf:value>kura-protobuf</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="republish.mqtt.birth.cert.on.modem.detect" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
                 <esf:value>org.eclipse.kura.cloud.CloudService</esf:value>
             </esf:property>


### PR DESCRIPTION
This PR removed the `republish.mqtt.birth.cert.on.modem.detect` option from the snapshots in distrib.

**Related Issue:** https://github.com/eclipse/kura/pull/5331.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
