### PR TITLE
fix: Connection Scheduler metatype improvement.

### DIFF
--- a/kura/org.eclipse.kura.cloud.base.provider/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
+++ b/kura/org.eclipse.kura.cloud.base.provider/OSGI-INF/metatype/org.eclipse.kura.data.DataService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -203,7 +203,7 @@
             required="true" 
             default="60"
             min="1"
-            description="Specifies an inactivity timeout in seconds. If the timeout expires, the cloud connection will be automatically closed. This parameter is only used if Enable Connection Schedule is set to true." />
+            description="Specifies an inactivity timeout in seconds. If the timeout expires, the cloud connection will be automatically closed. This timeout is delayed for the specified amount of seconds every time a new message is published. This parameter is only used if Enable Connection Schedule is set to true." />
 
           <AD id="maximum.payload.size"
             name="Maximum Payload Size"


### PR DESCRIPTION
Made clear the fact that the timeout resets at every message published


