### PR TITLE
feat(nm): Modem APN as an optional parameter

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -425,7 +425,8 @@ public class NMSettingsConverter {
         settings.put("address-data", new Variant<>(addressData, "aa{sv}"));
     }
 
-    private static void configureIp6MethodAuto(NetworkProperties props, String deviceId, Map<String, Variant<?>> settings) {
+    private static void configureIp6MethodAuto(NetworkProperties props, String deviceId,
+            Map<String, Variant<?>> settings) {
         settings.put(NM_SETTINGS_IPV6_METHOD, new Variant<>("auto"));
 
         Optional<String> addressGenerationMode = props.getOpt(String.class,
@@ -568,8 +569,8 @@ public class NMSettingsConverter {
     public static Map<String, Variant<?>> buildGsmSettings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
-        String apn = props.get(String.class, "net.interface.%s.config.apn", deviceId);
-        settings.put("apn", new Variant<>(apn));
+        Optional<String> apn = props.getOpt(String.class, "net.interface.%s.config.apn", deviceId);
+        apn.ifPresent(apnString -> settings.put("apn", new Variant<>(apnString)));
 
         Optional<String> username = props.getOpt(String.class, "net.interface.%s.config.username", deviceId);
         username.ifPresent(usernameString -> settings.put("username", new Variant<>(usernameString)));

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabModemUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabModemUi.java
@@ -306,11 +306,6 @@ public class TabModemUi extends Composite implements NetworkTab {
         if (this.dial.getText() == null || "".equals(this.dial.getText().trim())) {
             this.groupDial.setValidationState(ValidationState.ERROR);
         }
-        if (this.apn.getText() == null || "".equals(this.apn.getText().trim())) {
-            if (this.apn.isEnabled()) {
-                this.groupApn.setValidationState(ValidationState.ERROR);
-            }
-        }
         if (this.maxfail.getText() == null || "".equals(this.maxfail.getText().trim())) {
             this.groupMaxfail.setValidationState(ValidationState.ERROR);
         }
@@ -547,7 +542,7 @@ public class TabModemUi extends Composite implements NetworkTab {
         });
 
         // APN
-        this.labelApn.setText(MSGS.netModemAPN() + "*");
+        this.labelApn.setText(MSGS.netModemAPN());
         this.apn.addMouseOverHandler(event -> {
             if (TabModemUi.this.apn.isEnabled()) {
                 TabModemUi.this.helpText.clear();
@@ -555,18 +550,7 @@ public class TabModemUi extends Composite implements NetworkTab {
             }
         });
         this.apn.addMouseOutHandler(event -> resetHelp());
-        this.apn.addValueChangeHandler(event -> {
-            setDirty(true);
-            if (TabModemUi.this.apn.getText() == null || "".equals(TabModemUi.this.apn.getText().trim())) {
-                if (TabModemUi.this.apn.isEnabled()) {
-                    TabModemUi.this.groupApn.setValidationState(ValidationState.ERROR);
-                } else {
-                    TabModemUi.this.groupApn.setValidationState(ValidationState.NONE);
-                }
-            } else {
-                TabModemUi.this.groupApn.setValidationState(ValidationState.NONE);
-            }
-        });
+        this.apn.addValueChangeHandler(event -> setDirty(true));
 
         // AUTH TYPE
         this.labelAuth.setText(MSGS.netModemAuthType());
@@ -672,7 +656,7 @@ public class TabModemUi extends Composite implements NetworkTab {
                 TabModemUi.this.groupMaxfail.setValidationState(ValidationState.NONE);
             }
         });
-        
+
         this.labelHoldoff.setText(MSGS.netModemHoldoff() + "*");
         this.holdoff.addMouseOverHandler(event -> {
             if (TabModemUi.this.holdoff.isEnabled()) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -1129,12 +1129,12 @@ public class NMSettingsConverterTest {
     }
 
     @Test
-    public void buildGsmSettingsShouldThrowWithMissingRequiredArgument() {
+    public void buildGsmSettingsShouldNotThrowWithNoArgument() {
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildGsmSettingsIsRunWith(this.networkProperties, "ttyACM0");
 
-        thenExceptionOccurred(NoSuchElementException.class);
+        thenNoExceptionOccurred();
     }
 
     @Test


### PR DESCRIPTION
This PR converts the APN parameter in the `Cellular` tab an optional property. In this way, `ModemManager` will manage automatically this value. If an APN is set, this will be passed to `ModemManager`.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** In the `nm` bundle the property is optional. The `web2` bundle is updated accordingly.

**Manual Tests**: Setup a device with cellular connection. In the `Cellular` tab leave empty the APN field and check that the connection succeed.

**Any side note on the changes made:** I noticed the following behavior:

1. Setup a connection without an APN value
2. The connection succeed
3. Set the APN property to a wrong one and connect
4. The connection succeed, since ModemManager uses the previous value as fallback.

This behavior is not present if the interface is disabled before setting the wrong APN. This has to be documented.

This PR has to be backported to Kura 5.6.0
