### PR TITLE
test: add print on H2DB test failure

### DIFF
--- a/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/H2DbServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/H2DbServiceImplTest.java
@@ -247,7 +247,7 @@ public class H2DbServiceImplTest {
 
         // test a method and clean the files
         File[] files = f.getParentFile().listFiles();
-        assertEquals(1, files.length);
+        assertTrue(files.length >= 1);
 
         H2DbServiceOptions cfg = (H2DbServiceOptions) TestUtil.getFieldValue(svc, "configuration");
         TestUtil.invokePrivate(svc, "deleteDbFiles", cfg);

--- a/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/H2DbServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.db.h2db.provider.test/src/test/java/org/eclipse/kura/internal/db/h2db/provider/H2DbServiceImplTest.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -247,7 +248,7 @@ public class H2DbServiceImplTest {
 
         // test a method and clean the files
         File[] files = f.getParentFile().listFiles();
-        assertTrue(files.length >= 1);
+        assertEquals(String.format("Found: %s", Arrays.toString(files)), 1, files.length);
 
         H2DbServiceOptions cfg = (H2DbServiceOptions) TestUtil.getFieldValue(svc, "configuration");
         TestUtil.invokePrivate(svc, "deleteDbFiles", cfg);


### PR DESCRIPTION
#5343 introduced some unit tests stability issues for H2Db. This PR adds a print on test failure to further debug the issue