### PR TITLE
chore: Remove unnecessary osgi.bundles entry from config.ini

### DIFF
--- a/kura/distrib/src/main/osgi/equinox_3.16.0/configuration/config.ini
+++ b/kura/distrib/src/main/osgi/equinox_3.16.0/configuration/config.ini
@@ -1,7 +1,6 @@
 #Configuration File
 osgi.framework=file\:plugins/org.eclipse.osgi_3.16.0.v20200828-0759.jar
 equinox.use.ds=true
-osgi.bundles=
 osgi.nl=en_us
 osgi.clean=true
 osgi.noShutdown=true


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Removes the empty `osgi.bundles` entry from config.ini template, which is no longer necessary since it is now generated during Kura startup
