### PR TITLE
build(examples): fix jacoco report path

### DIFF
--- a/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.dbus.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.dbus.test/pom.xml
@@ -28,6 +28,8 @@
 
     <properties>
         <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.ble.tisensortag.test/pom.xml
@@ -28,6 +28,8 @@
 
     <properties>
         <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/org.eclipse.kura.example.wire.logic.multiport.provider.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.wire.logic.multiport.provider.test/pom.xml
@@ -24,6 +24,8 @@
 
     <properties>
 	    <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/org.eclipse.kura.example.wire.math.singleport.provider.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.wire.math.singleport.provider.test/pom.xml
@@ -28,6 +28,8 @@
 
     <properties>
 	    <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/org.eclipse.kura.example.wire.math.trig.test/pom.xml
+++ b/kura/examples/test/org.eclipse.kura.example.wire.math.trig.test/pom.xml
@@ -28,6 +28,8 @@
 
     <properties>
 	    <kura.basedir>${project.basedir}/../../..</kura.basedir>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.build.directory}/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>

--- a/kura/examples/test/pom.xml
+++ b/kura/examples/test/pom.xml
@@ -256,7 +256,6 @@
                             <goal>prepare-agent</goal>
                         </goals>
                         <configuration>
-                            <destFile>${sonar.jacoco.reportPath}</destFile>
                             <propertyName>jacocoArgs</propertyName>
                         </configuration>
                     </execution>
@@ -267,9 +266,9 @@
 
     <properties>
         <kura.basedir>${project.basedir}/../..</kura.basedir>
-        <tycho.argline>${jacocoArgs} -Dlog4j.configurationFile=file:${kura.basedir}/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml</tycho.argline>
-        <jacoco.reportDir>target/jacoco/</jacoco.reportDir>
-        <sonar.jacoco.reportPath>target/jacoco.exec</sonar.jacoco.reportPath>
+        <tycho.argline>
+            ${jacocoArgs}
+            -Dlog4j.configurationFile=file:${kura.basedir}/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml</tycho.argline>
     </properties>
 
     <modules>


### PR DESCRIPTION
This PR fixes the failing builds due to the wrong jacoco reporting path.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
