### PR TITLE
fix: Network failover configuration fixes

### DIFF
--- a/kura/distrib/src/main/resources/common/99-kura-nm.conf
+++ b/kura/distrib/src/main/resources/common/99-kura-nm.conf
@@ -1,5 +1,5 @@
 [main]
-ignore-carrier=*
+ignore-carrier=no
 no-auto-default=*
 plugins=ifupdown,keyfile
 dhcp=dhclient

--- a/kura/distrib/src/main/resources/common/99-kura-nm.conf
+++ b/kura/distrib/src/main/resources/common/99-kura-nm.conf
@@ -1,5 +1,4 @@
 [main]
-ignore-carrier=no
 no-auto-default=*
 plugins=ifupdown,keyfile
 dhcp=dhclient
@@ -10,7 +9,7 @@ managed=true
 [connectivity]
 uri=http://network-test.debian.org/nm
 interval=60
-response="NetworkManager is online"
+response=NetworkManager is online
 
 [keyfile]
 unmanaged-devices=*,except:type:wifi,except:type:gsm,except:type:wwan,except:type:ethernet,except:type:vlan


### PR DESCRIPTION
This PR does the following:

- removes the `ignore-carrier` property from the `99-kura-nn.conf` file
- fix the expected message in the connectivity section of the `99-kura-nn.conf` file.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** The network failover feature of NM fails since the expected message in the configuration file is wrong: `"NetworkManager is online"` instead of `NetworkManager is online`. 
Moreover, the `ignore-carrier` property is removed, since the default configuration is to detect the missing carrier.
According to [this](https://access.redhat.com/solutions/894763) and [this](https://man.archlinux.org/man/NetworkManager.conf.5.en) resource, the `ignore-carrier` property for NM specifies if NM will ignore the carrier state. If it is not ignored, when a cable is unplugged, the IP address and IP routes are removed. In this way, NM will fallback to another interface if the priority is set.

**Manual Tests**: Configure two ethernet interfaces as WAN (i.e. eno1 and enp5s0). Assign to them a priority. Check that the property is correctly configured in NetworkManager (use `nmcli`) and the route priorities are set in the system (use `ip route` or `route -n`). Check that the priorities are not increased by 20000. Check with `traceroute` the device path followed to reach google and check that the interface with higher priority is used. Unplug the cable from the high priority interface and check that it is possible to reach Internet via the other interface.

Moreover, using `nmcli` check that the unplugged interface has not an IP address and with `route -n` the route has been removed.
