### PR TITLE
feat(linux.net): Modified dhcp server selection order

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
@@ -58,12 +58,12 @@ public class DhcpServerManager {
 
     public static DhcpServerTool getTool() {
         if (dhcpServerTool == DhcpServerTool.NONE) {
-            if (LinuxNetworkUtil.toolExists(DhcpServerTool.DHCPD.getValue())) {
-                dhcpServerTool = DhcpServerTool.DHCPD;
+            if (LinuxNetworkUtil.toolExists(DhcpServerTool.DNSMASQ.getValue())) {
+                dhcpServerTool = DhcpServerTool.DNSMASQ;
             } else if (LinuxNetworkUtil.toolExists(DhcpServerTool.UDHCPD.getValue())) {
                 dhcpServerTool = DhcpServerTool.UDHCPD;
-            } else if (LinuxNetworkUtil.toolExists(DhcpServerTool.DNSMASQ.getValue())) {
-                dhcpServerTool = DhcpServerTool.DNSMASQ;
+            } else if (LinuxNetworkUtil.toolExists(DhcpServerTool.DHCPD.getValue())) {
+                dhcpServerTool = DhcpServerTool.DHCPD;
             }
         }
 


### PR DESCRIPTION
This PR changes the selection order of the DHCP servers.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** Since `isc-dhcp-server` will be deprecated, we decided to prefer `dnsmasq` and `udhcpd` instead of `dhcpd` in the automatic selection of the DHCP servers in the `DhcpServerManager` class.
