### PR TITLE
ci: fix Github actions permissions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,6 +6,7 @@ on:
       - labeled
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,9 @@ on:
       - closed
       - labeled
 
+permissions:
+  pull-requests: write
+
 jobs:
   backport:
     name: Backport

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,6 +12,10 @@ on:
           description: Overwrite the content of TODO fields in generated release notes (typically needed for RC1 notes)
           required: true
           default: false
+
+permissions:
+  pull-requests: write
+
 jobs:
   main:
     name: Generate Release Notes
@@ -34,7 +38,7 @@ jobs:
           -Pjava8
         )\" >> \"${GITHUB_OUTPUT}\""
       shell: bash
-    
+
     - name: Check file existence
       id: check_files
       continue-on-error: true
@@ -70,7 +74,7 @@ jobs:
         -t .github/release_notes_template/template.hbs \
         -hhf .github/release_notes_template/helper.hbs \
         -of ./kura/distrib/RELEASE_NOTES.txt
-    
+
     - name: Files exist write description
       id: get-description
       if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == 'false'
@@ -80,7 +84,7 @@ jobs:
           awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' target-env.txt done=0 ./kura/distrib/RELEASE_NOTES.txt > tmpfile && mv tmpfile ./kura/distrib/RELEASE_NOTES.txt
           awk 'NR==FNR { desc = (desc == "" ? $0 : desc "\n" $0); next } /\[TODO\]/ && !done { sub(/\[TODO\]/, desc); done=1 } 1' known-issues.txt done=0 ./kura/distrib/RELEASE_NOTES.txt > tmpfile && mv tmpfile ./kura/distrib/RELEASE_NOTES.txt
       shell: bash
-        
+
     - name: Files exist clean up
       id: clean-up-files
       if: steps.check_files.outputs.exists == 'true' && github.event.inputs.overwrite == 'false'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -14,6 +14,7 @@ on:
           default: false
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -18,6 +18,9 @@ on:
             - uptick_snapshot_to_release.yml
           required: true
 
+permissions:
+  pull-requests: write
+
 jobs:
   uptick:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -19,6 +19,7 @@ on:
           required: true
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Following https://github.com/eclipse-kura/.eclipsefdn/pull/1, this PR attempts to fix the current issues we're experiencing with the Github actions permissions.

See:

![image](https://github.com/user-attachments/assets/7caaba55-73b7-49b7-93dd-6d8431f7a8a3)
