### PR TITLE
ci: fix Github actions permissions for documentation branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,6 +6,7 @@ on:
       - labeled
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,9 @@ on:
       - closed
       - labeled
 
+permissions:
+  pull-requests: write
+
 jobs:
   backport:
     name: Backport

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - 'docs-develop'
       - 'docs-release-*.*'
+
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Following https://github.com/eclipse-kura/.eclipsefdn/pull/1, this PR attempts to fix the current issues we're experiencing with the Github actions permissions.

See:
![image](https://github.com/user-attachments/assets/937d3564-3b6e-417c-b08a-b336f864bedd)
