### PR TITLE
docs: remove obsolete links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -223,8 +223,6 @@ extra:
     provider: mike
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/eclipse/kura
-    - icon: fontawesome/brands/gitter
-      link: https://gitter.im/eclipse/kura
+      link: https://github.com/eclipse-kura/kura
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com/r/eclipse/kura


### PR DESCRIPTION
This PR removes a couple of leftover-obsolete links from the documentation page.