### PR TITLE
fix(distrib): Added dhcpcd dependency to debian installer

### DIFF
--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
@@ -19,7 +19,7 @@ Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | tem
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
  ntpdate, chrony, chronyc | chrony, cron | cronie,
- network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, dhcpcd | isc-dhcp-client, iw, iptables, modemmanager,
+ network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, isc-dhcp-client | dhcpcd, iw, iptables, modemmanager,
  logrotate,
  gpsd
 Recommends: python3

--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
@@ -19,7 +19,7 @@ Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | tem
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
  ntpdate, chrony, chronyc | chrony, cron | cronie,
- network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, isc-dhcp-client, iw, iptables, modemmanager,
+ network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, dhcpcd | isc-dhcp-client, iw, iptables, modemmanager,
  logrotate,
  gpsd
 Recommends: python3

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/control
@@ -19,7 +19,7 @@ Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | tem
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
  ntpdate, chrony, chronyc | chrony, cron | cronie,
- network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server,  dhcpcd | isc-dhcp-client, iw, iptables, modemmanager,
+ network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, isc-dhcp-client | dhcpcd, iw, iptables, modemmanager,
  logrotate,
  gpsd
 Recommends: python3

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/control
@@ -19,7 +19,7 @@ Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | tem
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
  ntpdate, chrony, chronyc | chrony, cron | cronie,
- network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, isc-dhcp-client, iw, iptables, modemmanager,
+ network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server,  dhcpcd | isc-dhcp-client, iw, iptables, modemmanager,
  logrotate,
  gpsd
 Recommends: python3

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
@@ -19,7 +19,7 @@ Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | tem
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
  ntpdate, chrony, chronyc | chrony, cron | cronie,
- network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, dhcpcd | isc-dhcp-client, iw, iptables, modemmanager,
+ network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, isc-dhcp-client | dhcpcd, iw, iptables, modemmanager,
  logrotate,
  gpsd
 Recommends: python3

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
@@ -19,7 +19,7 @@ Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | tem
  polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
  ntpdate, chrony, chronyc | chrony, cron | cronie,
- network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, isc-dhcp-client, iw, iptables, modemmanager,
+ network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, dhcpcd | isc-dhcp-client, iw, iptables, modemmanager,
  logrotate,
  gpsd
 Recommends: python3


### PR DESCRIPTION
This PR adds `dhcpcd` as dependency to the Debian installer. This is needed for devices/OS that doesn't provide `isc-dhcp-client` anymore.

