### PR TITLE
ci: use newly introduced bot personal access token for github workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,6 +27,6 @@ jobs:
     steps:
       - uses: tibdex/backport@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
           title_template: "<%= title %> [backport <%= base %>]"
 


### PR DESCRIPTION
Port of #5397 for the documentation branch