### PR TITLE
ci: use newly introduced bot personal access token for github workflows (#5397)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,6 +27,6 @@ jobs:
     steps:
       - uses: tibdex/backport@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
           title_template: "<%= title %> [backport <%= base %>]"
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -102,3 +102,4 @@ jobs:
         commit-message: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
         body: "Automated changes by _Release Notes automation_ action: add Kura ${{ steps.get-version.outputs.resolved-version }} version release notes since commit `${{ github.event.inputs.starting_commit }}`"
         branch-suffix: short-commit-hash
+        token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -68,3 +68,4 @@ jobs:
         commit-message: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
         body: "Automated changes by _Version uptick automation_ action: automated uptick to ${{ steps.get-version.outputs.version }} version"
         branch-suffix: timestamp
+        token: ${{ secrets.BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Backport of #5397
