### PR TITLE
feat(nm): add managed GPS mode

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraModemGPSMode.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraModemGPSMode.java
@@ -1,0 +1,51 @@
+package org.eclipse.kura.nm;
+
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.eclipse.kura.nm.enums.MMModemLocationSource;
+
+public enum KuraModemGPSMode {
+
+    UNMANAGED,
+    MANAGED_GPS;
+
+    public static KuraModemGPSMode fromString(String mode) {
+        switch (mode) {
+        case "unmanaged":
+            return KuraModemGPSMode.UNMANAGED;
+        case "managed-gps":
+            return KuraModemGPSMode.MANAGED_GPS;
+        default:
+            throw new IllegalArgumentException(String.format("Unsupported modem GPS mode value: \"%s\"", mode));
+        }
+    }
+
+    public static Optional<KuraModemGPSMode> fromString(Optional<String> mode) {
+        if (mode.isPresent()) {
+            switch (mode.get()) {
+            case "unmanaged":
+                return Optional.of(KuraModemGPSMode.UNMANAGED);
+            case "managed-gps":
+                return Optional.of(KuraModemGPSMode.MANAGED_GPS);
+            default:
+                return Optional.empty();
+            }
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public static Set<MMModemLocationSource> toMMModemLocationSources(KuraModemGPSMode mode) {
+        switch (mode) {
+        case UNMANAGED:
+            return EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED);
+        case MANAGED_GPS:
+            return EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW,
+                    MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA);
+        default:
+            throw new IllegalArgumentException(String.format("Unsupported modem GPS mode value: \"%s\"", mode));
+        }
+    }
+}

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraModemGPSMode.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraModemGPSMode.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.nm;
 
 import java.util.EnumSet;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraModemGPSMode.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraModemGPSMode.java
@@ -1,51 +1,59 @@
 package org.eclipse.kura.nm;
 
 import java.util.EnumSet;
-import java.util.Optional;
 import java.util.Set;
 
 import org.eclipse.kura.nm.enums.MMModemLocationSource;
 
 public enum KuraModemGPSMode {
 
-    UNMANAGED,
-    MANAGED_GPS;
+    KURA_MODEM_GPS_MODE_UNMANAGED("kuraModemGpsModeUnmanaged"),
+    KURA_MODEM_GPS_MODE_MANAGED_GPS("kuraModemGpsModeManagedGps");
 
-    public static KuraModemGPSMode fromString(String mode) {
-        switch (mode) {
-        case "unmanaged":
-            return KuraModemGPSMode.UNMANAGED;
-        case "managed-gps":
-            return KuraModemGPSMode.MANAGED_GPS;
-        default:
-            throw new IllegalArgumentException(String.format("Unsupported modem GPS mode value: \"%s\"", mode));
-        }
+    private final String value;
+
+    private KuraModemGPSMode(String value) {
+        this.value = value;
     }
 
-    public static Optional<KuraModemGPSMode> fromString(Optional<String> mode) {
-        if (mode.isPresent()) {
-            switch (mode.get()) {
-            case "unmanaged":
-                return Optional.of(KuraModemGPSMode.UNMANAGED);
-            case "managed-gps":
-                return Optional.of(KuraModemGPSMode.MANAGED_GPS);
-            default:
-                return Optional.empty();
+    public String getValue() {
+        return this.value;
+    }
+
+    public static KuraModemGPSMode fromString(String name) {
+        for (KuraModemGPSMode auth : KuraModemGPSMode.values()) {
+            if (auth.getValue().equals(name)) {
+                return auth;
             }
-        } else {
-            return Optional.empty();
         }
+
+        throw new IllegalArgumentException("Invalid modem GPS mode in snapshot: " + name);
     }
 
     public static Set<MMModemLocationSource> toMMModemLocationSources(KuraModemGPSMode mode) {
         switch (mode) {
-        case UNMANAGED:
+        case KURA_MODEM_GPS_MODE_UNMANAGED:
             return EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED);
-        case MANAGED_GPS:
+        case KURA_MODEM_GPS_MODE_MANAGED_GPS:
             return EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW,
                     MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA);
         default:
             throw new IllegalArgumentException(String.format("Unsupported modem GPS mode value: \"%s\"", mode));
         }
+    }
+
+    public static Set<KuraModemGPSMode> fromMMModemLocationSources(Set<MMModemLocationSource> sources) {
+        Set<KuraModemGPSMode> modes = EnumSet.noneOf(KuraModemGPSMode.class);
+
+        if (sources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED)) {
+            modes.add(KuraModemGPSMode.KURA_MODEM_GPS_MODE_UNMANAGED);
+        }
+
+        if (sources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW)
+                && sources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA)) {
+            modes.add(KuraModemGPSMode.KURA_MODEM_GPS_MODE_MANAGED_GPS);
+        }
+
+        return modes;
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraModemGPSMode.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraModemGPSMode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 Eurotech and/or its affiliates and others
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -53,7 +53,7 @@ public class ModemManagerDbusWrapper {
 
         boolean isGPSSourceEnabled = enableGPS.isPresent() && enableGPS.get();
         KuraModemGPSMode desiredGPSMode = gpsModeString.isPresent() ? KuraModemGPSMode.fromString(gpsModeString.get())
-                : KuraModemGPSMode.UNMANAGED;
+                : KuraModemGPSMode.KURA_MODEM_GPS_MODE_UNMANAGED;
 
         Location modemLocation = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemDevicePath.get(),
                 Location.class);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.eclipse.kura.nm;
 
 import java.util.ArrayList;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -470,8 +470,10 @@ public class NMDbusConnector {
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM && device.isPresent()) {
             Optional<Boolean> enableGPS = properties.getOpt(Boolean.class, "net.interface.%s.config.gpsEnabled",
                     deviceId);
+            Optional<String> gpsModeString = properties.getOpt(String.class, "net.interface.%s.config.gpsMode",
+                    deviceId);
             Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.get().getObjectPath());
-            this.modemManager.setGPS(mmDbusPath, enableGPS);
+            this.modemManager.setGPS(mmDbusPath, enableGPS, gpsModeString);
         }
 
     }
@@ -587,7 +589,7 @@ public class NMDbusConnector {
 
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {
             Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-            this.modemManager.setGPS(mmDbusPath, Optional.of(false));
+            this.modemManager.setGPS(mmDbusPath, Optional.of(false), Optional.empty());
         }
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -690,18 +690,18 @@ public class NMStatusConverter {
     }
 
     private static boolean isGpsSupported(Properties properties) {
-        boolean isSupported = false;
         try {
             UInt32 locationSources = properties.Get(MM_MODEM_LOCATION_BUS_NAME, "Capabilities");
             Set<MMModemLocationSource> modemLocationSources = MMModemLocationSource
                     .toMMModemLocationSourceFromBitMask(locationSources);
-            if (modemLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED)) {
-                isSupported = true;
-            }
+
+            return modemLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED)
+                    || (modemLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW)
+                            && modemLocationSources.contains(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA));
         } catch (DBusExecutionException e) {
             logger.debug("Cannot retrieve location object", e);
+            return false;
         }
-        return isSupported;
     }
 
     private static boolean isSimLocked(Properties properties) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -645,6 +645,53 @@ public class NMDbusConnectorTest {
     }
 
     @Test
+    public void applyShouldWorkWithModemWithEnabledGPSAndUnmanagedMode() throws DBusException, IOException {
+        givenBasicMockedDbusConnector();
+        givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
+                true, false, false);
+        givenMockedDeviceList();
+
+        givenNetworkConfigMapWith("net.interfaces", "1-5,");
+        givenNetworkConfigMapWith("net.interface.1-5.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
+        givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
+        givenNetworkConfigMapWith("net.interface.1-5.config.gpsEnabled", true);
+        givenNetworkConfigMapWith("net.interface.1-5.config.gpsMode", "unmanaged");
+        givenNetworkConfigMapWith("net.interface.1-5.config.resetTimeout", 0);
+
+        whenApplyIsCalledWith(this.netConfig);
+
+        thenNoExceptionIsThrown();
+        thenConnectionUpdateIsCalledFor("ttyACM17");
+        thenActivateConnectionIsCalledFor("ttyACM17");
+        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED), false);
+    }
+
+    @Test
+    public void applyShouldWorkWithModemWithEnabledGPSAndManagedMode() throws DBusException, IOException {
+        givenBasicMockedDbusConnector();
+        givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
+                true, false, false);
+        givenMockedDeviceList();
+
+        givenNetworkConfigMapWith("net.interfaces", "1-5,");
+        givenNetworkConfigMapWith("net.interface.1-5.config.ip4.status", "netIPv4StatusEnabledWAN");
+        givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
+        givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
+        givenNetworkConfigMapWith("net.interface.1-5.config.gpsEnabled", true);
+        givenNetworkConfigMapWith("net.interface.1-5.config.gpsMode", "managed-gps");
+        givenNetworkConfigMapWith("net.interface.1-5.config.resetTimeout", 0);
+
+        whenApplyIsCalledWith(this.netConfig);
+
+        thenNoExceptionIsThrown();
+        thenConnectionUpdateIsCalledFor("ttyACM17");
+        thenActivateConnectionIsCalledFor("ttyACM17");
+        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW,
+                MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA), false);
+    }
+
+    @Test
     public void applyShouldDisableGPSWithMissingGPSConfiguration() throws DBusException, IOException {
         givenBasicMockedDbusConnector();
         givenMockedDevice("1-5", "ttyACM17", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -656,7 +656,7 @@ public class NMDbusConnectorTest {
         givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
         givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
         givenNetworkConfigMapWith("net.interface.1-5.config.gpsEnabled", true);
-        givenNetworkConfigMapWith("net.interface.1-5.config.gpsMode", "unmanaged");
+        givenNetworkConfigMapWith("net.interface.1-5.config.gpsMode", "kuraModemGpsModeUnmanaged");
         givenNetworkConfigMapWith("net.interface.1-5.config.resetTimeout", 0);
 
         whenApplyIsCalledWith(this.netConfig);
@@ -679,7 +679,7 @@ public class NMDbusConnectorTest {
         givenNetworkConfigMapWith("net.interface.1-5.config.dhcpClient4.enabled", true);
         givenNetworkConfigMapWith("net.interface.1-5.config.apn", "myAwesomeAPN");
         givenNetworkConfigMapWith("net.interface.1-5.config.gpsEnabled", true);
-        givenNetworkConfigMapWith("net.interface.1-5.config.gpsMode", "managed-gps");
+        givenNetworkConfigMapWith("net.interface.1-5.config.gpsMode", "kuraModemGpsModeManagedGps");
         givenNetworkConfigMapWith("net.interface.1-5.config.resetTimeout", 0);
 
         whenApplyIsCalledWith(this.netConfig);


### PR DESCRIPTION
This PR adds a new mode for handling the modem's GPS, allowing ModemManager to take control of the serial port and thus open the way for us to create a new PositionProvider that retrieves the position information from ModemManager.

This new mode leverages the following two ModemManager location sources:
- [MM_MODEM_LOCATION_SOURCE_GPS_RAW](https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/ModemManager-Flags-and-Enumerations.html#MM-MODEM-LOCATION-SOURCE-GPS-RAW:CAPS)
- [MM_MODEM_LOCATION_SOURCE_GPS_NMEA](https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/ModemManager-Flags-and-Enumerations.html#MM-MODEM-LOCATION-SOURCE-GPS-NMEA:CAPS)

Once these two are enabled ModemManager will take control of the GPS communication and start parsing the data, allowing clients to retrieve the informations via the "[GetLocation](https://www.freedesktop.org/software/ModemManager/doc/latest/ModemManager/gdbus-org.freedesktop.ModemManager1.Modem.Location.html#gdbus-method-org-freedesktop-ModemManager1-Modem-Location.GetLocation)" DBus method.

Before this PR (see #4633) we were only using the `MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED` mode, which took care of setting up the GPS for the modem but left the serial connection free for other services to connect to (eg `gpsd`).

**Note**: to avoid breaking changes in the snapshot, instead of substituting the `net.interface.[deviceId].config.gpsEnabled` parameter with an enum, I left it untouched and added the `net.interface.[deviceId].config.gpsMode` parameter. It's a little bit more clunky to use but doesn't break snapshot compatibility with older versions. The `gpsMode` parameter is *optional*, when not specified it defaults to the `UNMANAGED` mode, preserving the current behaviour.

Since we added this new parameter, the [`isGpsSupported()` method](https://github.com/eclipse-kura/kura/blob/51fcd57437af67f22809b24ccc116b52c347c336/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/modem/CellularModem.java#L208) in Kura's API **doesn't contain all the required informations anymore**. We'll need to add to the APIs a new `getSupportedGPSModes()` method to know what mode we can set for the modem at hand. This new API will be introduced in a future separate PR.