### PR TITLE
build: Reduce number of job history to 5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 node {
     properties([
         disableConcurrentBuilds(abortPrevious: true),
-        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2', daysToKeepStr: '', numToKeepStr: '10')),
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2', daysToKeepStr: '', numToKeepStr: '5')),
         gitLabConnection('gitlab.eclipse.org'),
         [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
         [$class: 'JobLocalConfiguration', changeReasonComment: '']


### PR DESCRIPTION
Setting build history size to 5 for CI jobs as suggested in https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/2660#note_2839525