### PR TITLE
chore(poms): uptick version of properties maven plugin

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -43,6 +43,8 @@
         <kura.skip.web>false</kura.skip.web>
         <kura.skip.examples>true</kura.skip.examples>
 
+        <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
+
         <!-- used for RPM uninstallation -->
         <kura.install.link>/opt/eclipse/kura</kura.install.link>
     </properties>
@@ -93,7 +95,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0-alpha-1</version>
+                <version>${properties-maven-plugin.version}/version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>
@@ -1022,7 +1024,7 @@
                                             properties-maven-plugin
                                         </artifactId>
                                         <versionRange>
-                                            [1.0-alpha-1,)
+                                            [1.2.1,)
                                         </versionRange>
                                         <goals>
                                             <goal>

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>${properties-maven-plugin.version}/version>
+                <version>${properties-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>

--- a/kura/org.eclipse.kura.container.orchestration.provider/pom.xml
+++ b/kura/org.eclipse.kura.container.orchestration.provider/pom.xml
@@ -183,7 +183,7 @@
                                             properties-maven-plugin
                                         </artifactId>
 										<versionRange>
-                                            [1.0-alpha-1,)
+                                            [1.2.1,)
                                         </versionRange>
 										<goals>
 											<goal>read-project-properties</goal>

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -800,7 +800,7 @@
                                     <pluginExecutionFilter>
                                         <groupId>org.codehaus.mojo</groupId>
                                         <artifactId>properties-maven-plugin</artifactId>
-                                        <versionRange>[1.0-alpha-1,)</versionRange>
+                                        <versionRange>[1.2.1,)</versionRange>
                                         <goals>
                                             <goal>read-project-properties</goal>
                                         </goals>

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -168,7 +168,7 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <slf4j.version>1.7.36</slf4j.version>
         <wagon-ssh.version>1.0-beta-6</wagon-ssh.version>
-        <properties-maven-plugin.version>1.0-alpha-2</properties-maven-plugin.version>
+        <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
     </properties>
 
     <distributionManagement>

--- a/target-platform/p2-repo-common/pom.xml
+++ b/target-platform/p2-repo-common/pom.xml
@@ -22,6 +22,7 @@
     <packaging>pom</packaging>
     <properties>
         <skip.libsocket-can>true</skip.libsocket-can>
+        <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
     </properties>
     <profiles>
         <profile>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -43,7 +43,7 @@
         <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
         <maven-site-plugin.version>3.3</maven-site-plugin.version>
         <maven-surefire-plugin.version>2.7.2</maven-surefire-plugin.version>
-        <properties-maven-plugin.version>1.0-alpha-2</properties-maven-plugin.version>
+        <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
I noticed we are using an old alpha version of this plugin, so this is an uptick.

The properties maven plugin is used to read the file from target-platform/config/kura.target-platform.build.properties. It should be harmless to uptick.
On the other side, it is wise to move away from the alpha version.

References:
https://mvnrepository.com/artifact/org.codehaus.mojo/properties-maven-plugin/1.2.1

https://www.mojohaus.org/properties-maven-plugin/  (see top right for the version)




