### PR TITLE
fix(nm): Reset gps mode selection before applying configuration

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -103,6 +103,10 @@ public class ModemManagerDbusWrapper {
         logger.debug("Modem location setup {} for modem {}", currentLocationSources, modemDevicePath.get());
 
         if (!currentLocationSources.equals(desiredLocationSources)) {
+            if (!EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE).equals(desiredLocationSources)) {
+                modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(
+                        EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE)), false);
+            }
             modemLocation.Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(desiredLocationSources),
                     false);
         }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -579,7 +579,7 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenDisconnectIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
 
     @Test
@@ -598,7 +598,8 @@ public class NMDbusConnectorTest {
 
         thenNoExceptionIsThrown();
         thenDisconnectIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED), false);
     }
 
     @Test
@@ -620,7 +621,7 @@ public class NMDbusConnectorTest {
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
 
     @Test
@@ -642,7 +643,8 @@ public class NMDbusConnectorTest {
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED), false);
     }
 
     @Test
@@ -665,7 +667,8 @@ public class NMDbusConnectorTest {
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED), false);
     }
 
     @Test
@@ -688,7 +691,8 @@ public class NMDbusConnectorTest {
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW,
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_RAW,
                 MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_NMEA), false);
     }
 
@@ -710,7 +714,7 @@ public class NMDbusConnectorTest {
         thenNoExceptionIsThrown();
         thenConnectionUpdateIsCalledFor("ttyACM17");
         thenActivateConnectionIsCalledFor("ttyACM17");
-        thenLocationSetupWasCalledWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
+        thenLocationSetupWasCalledOnceWith(EnumSet.of(MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_NONE), false);
     }
 
     @Test
@@ -1661,7 +1665,7 @@ public class NMDbusConnectorTest {
         verify(this.mockedConnections.get(path), times(0)).Delete();
     }
 
-    private void thenLocationSetupWasCalledWith(EnumSet<MMModemLocationSource> expectedLocationSources,
+    private void thenLocationSetupWasCalledOnceWith(EnumSet<MMModemLocationSource> expectedLocationSources,
             boolean expectedFlag) {
         verify(this.mockModemLocation, times(1))
                 .Setup(MMModemLocationSource.toBitMaskFromMMModemLocationSource(expectedLocationSources), expectedFlag);


### PR DESCRIPTION
This PR sets the modem location source to `NONE` before applying the desidered configuration.