### PR TITLE
feat(nm): Added SIM operator ID to Network Status

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/Sim.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ public class Sim {
     private final String imsi;
     private final String eid;
     private final String operatorName;
+    private final String operatorIdentifier;
     private final SimType simType;
     private final ESimStatus eSimStatus;
 
@@ -40,6 +41,7 @@ public class Sim {
         this.imsi = builder.imsi;
         this.eid = builder.eid;
         this.operatorName = builder.operatorName;
+        this.operatorIdentifier = builder.operatorIdentifier;
         this.simType = builder.simType;
         this.eSimStatus = builder.eSimStatus;
     }
@@ -68,6 +70,14 @@ public class Sim {
         return this.operatorName;
     }
 
+    /**
+     * 
+     * @since 2.8
+     */
+    public String getOperatorIdentifier() {
+        return this.operatorIdentifier;
+    }
+
     public SimType getSimType() {
         return this.simType;
     }
@@ -88,6 +98,7 @@ public class Sim {
         private String imsi = "NA";
         private String eid = "NA";
         private String operatorName = "NA";
+        private String operatorIdentifier = "NA";
         private SimType simType = SimType.UNKNOWN;
         private ESimStatus eSimStatus = ESimStatus.UNKNOWN;
 
@@ -124,6 +135,15 @@ public class Sim {
             return this;
         }
 
+        /**
+         * 
+         * @since 2.8
+         */
+        public SimBuilder withOperatorIdentifier(String operatorIdentifier) {
+            this.operatorIdentifier = operatorIdentifier;
+            return this;
+        }
+
         public SimBuilder withSimType(SimType simType) {
             this.simType = simType;
             return this;
@@ -143,7 +163,7 @@ public class Sim {
     @Override
     public int hashCode() {
         return Objects.hash(this.active, this.primary, this.eSimStatus, this.eid, this.iccid, this.imsi,
-                this.operatorName, this.simType);
+                this.operatorName, this.operatorIdentifier, this.simType);
     }
 
     @Override
@@ -158,7 +178,7 @@ public class Sim {
         return this.active == other.active && this.primary == other.primary && this.eSimStatus == other.eSimStatus
                 && Objects.equals(this.eid, other.eid) && Objects.equals(this.iccid, other.iccid)
                 && Objects.equals(this.imsi, other.imsi) && Objects.equals(this.operatorName, other.operatorName)
-                && this.simType == other.simType;
+                && Objects.equals(this.operatorIdentifier, other.operatorIdentifier) && this.simType == other.simType;
     }
 
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/NMStatusConverter.java
@@ -759,6 +759,7 @@ public class NMStatusConverter {
             logger.warn("Eid property not found.");
         }
         String operatorName = simProperties.Get(MM_SIM_BUS_NAME, "OperatorName");
+        String operatorIdentifier = simProperties.Get(MM_SIM_BUS_NAME, "OperatorIdentifier");
         SimType simType = SimType.PHYSICAL;
         ESimStatus eSimStatus = ESimStatus.UNKNOWN;
         try {
@@ -771,7 +772,8 @@ public class NMStatusConverter {
         }
 
         return Sim.builder().withActive(isActive).withPrimary(isPrimary).withIccid(iccid).withImsi(imsi).withEid(eid)
-                .withOperatorName(operatorName).withSimType(simType).withESimStatus(eSimStatus).build();
+                .withOperatorName(operatorName).withOperatorIdentifier(operatorIdentifier).withSimType(simType)
+                .withESimStatus(eSimStatus).build();
     }
 
     private static List<Bearer> getBearers(List<Properties> properties) {

--- a/kura/org.eclipse.kura.rest.network.status.provider/src/main/java/org/eclipse/kura/network/status/provider/api/SimDTO.java
+++ b/kura/org.eclipse.kura.rest.network.status.provider/src/main/java/org/eclipse/kura/network/status/provider/api/SimDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,7 @@ public class SimDTO {
     private final String imsi;
     private final String eid;
     private final String operatorName;
+    private final String operatorIdentifier;
     private final SimType simType;
     private final ESimStatus eSimStatus;
 
@@ -35,6 +36,7 @@ public class SimDTO {
         this.imsi = sim.getImsi();
         this.eid = sim.getEid();
         this.operatorName = sim.getOperatorName();
+        this.operatorIdentifier = sim.getOperatorIdentifier();
         this.simType = sim.getSimType();
         this.eSimStatus = sim.geteSimStatus();
     }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/status/NMStatusConverterTest.java
@@ -26,11 +26,15 @@ import java.io.StringWriter;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import org.eclipse.kura.net.IP4Address;
 import org.eclipse.kura.net.IP6Address;
@@ -40,11 +44,30 @@ import org.eclipse.kura.net.status.NetworkInterfaceIpAddressStatus;
 import org.eclipse.kura.net.status.NetworkInterfaceState;
 import org.eclipse.kura.net.status.NetworkInterfaceStatus;
 import org.eclipse.kura.net.status.ethernet.EthernetInterfaceStatus;
+import org.eclipse.kura.net.status.modem.AccessTechnology;
+import org.eclipse.kura.net.status.modem.BearerIpType;
+import org.eclipse.kura.net.status.modem.ModemBand;
+import org.eclipse.kura.net.status.modem.ModemCapability;
+import org.eclipse.kura.net.status.modem.ModemConnectionStatus;
+import org.eclipse.kura.net.status.modem.ModemGpsMode;
+import org.eclipse.kura.net.status.modem.ModemInterfaceStatus;
+import org.eclipse.kura.net.status.modem.ModemMode;
+import org.eclipse.kura.net.status.modem.ModemModePair;
+import org.eclipse.kura.net.status.modem.ModemPortType;
+import org.eclipse.kura.net.status.modem.ModemPowerState;
+import org.eclipse.kura.net.status.modem.RegistrationStatus;
+import org.eclipse.kura.net.status.modem.SimType;
 import org.eclipse.kura.net.status.vlan.VlanInterfaceStatus;
+import org.eclipse.kura.nm.enums.MMBearerIpFamily;
+import org.eclipse.kura.nm.enums.MMModem3gppRegistrationState;
+import org.eclipse.kura.nm.enums.MMModemLocationSource;
+import org.eclipse.kura.nm.enums.MMModemPowerState;
+import org.eclipse.kura.nm.enums.MMSimType;
 import org.eclipse.kura.nm.enums.NMDeviceState;
 import org.eclipse.kura.nm.enums.NMDeviceType;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.UInt64;
 import org.freedesktop.dbus.types.Variant;
 import org.junit.Test;
 
@@ -54,18 +77,30 @@ public class NMStatusConverterTest {
     private static final String NM_IP4CONFIG_BUS_NAME = "org.freedesktop.NetworkManager.IP4Config";
     private static final String NM_IP6CONFIG_BUS_NAME = "org.freedesktop.NetworkManager.IP6Config";
     private static final String NM_VLAN_BUS_NAME = "org.freedesktop.NetworkManager.Device.Vlan";
+    private static final String MM_MODEM_BUS_NAME = "org.freedesktop.ModemManager1.Modem";
+    private static final String MM_SIM_BUS_NAME = "org.freedesktop.ModemManager1.Sim";
+    private static final String MM_BEARER_BUS_NAME = "org.freedesktop.ModemManager1.Bearer";
+    private static final String MM_MODEM_LOCATION_BUS_NAME = "org.freedesktop.ModemManager1.Modem.Location";
+    private static final String MM_MODEM_3GPP_BUS_NAME = "org.freedesktop.ModemManager1.Modem.Modem3gpp";
 
     private Properties mockDeviceProperties = mock(Properties.class);
     private Properties mockParentDeviceProperties = mock(Properties.class);
     private Properties mockIp4ConfigProperties = mock(Properties.class);
     private Properties mockIp6ConfigProperties = mock(Properties.class);
     private Properties mockVlanConfigProperties = mock(Properties.class);
+    private Properties mockModemProperties = mock(Properties.class);
+    private SimProperties mockSimProperties = mock(SimProperties.class);
+    private Properties mockAvailableSimProperties = mock(Properties.class);
+    private Properties mockBearerProperties = mock(Properties.class);
+    private Map<String, Object> bearerSettings = new HashMap<>();
+    private Map<String, Object> bearerStats = new HashMap<>();
 
     private DevicePropertiesWrapper mockDevicePropertiesWrapper;
 
     private NetworkInterfaceStatus resultingStatus;
     private EthernetInterfaceStatus resultingEthernetStatus;
     private VlanInterfaceStatus resultingVlanStatus;
+    private ModemInterfaceStatus resultingModemStatus;
 
     private Exception occurredException;
 
@@ -524,7 +559,7 @@ public class NMStatusConverterTest {
                 new NetworkInterfaceIpAddress<IP6Address>(
                         (IP6Address) IP6Address.parseHostAddress("fe80::dea6:32ff:fee0:54f6"), (short) 64)));
     }
-    
+
     @Test
     public void buildVlanStatusWorksWithIPV4Info() throws UnknownHostException {
         givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
@@ -534,7 +569,7 @@ public class NMStatusConverterTest {
         givenDevicePropertiesWith("DriverVersion", "frightening");
         givenDevicePropertiesWith("Mtu", new UInt32(420));
         givenDevicePropertiesWith("HwAddress", "F5:5B:66:7C:40:EA");
-        
+
         givenVlanConfigPropertiesWith("VlanId", new UInt32(101));
         givenParentDevicePropertiesWith("Interface", "eth0");
 
@@ -559,7 +594,7 @@ public class NMStatusConverterTest {
         thenResultingNetworkInterfaceMtuIs(420);
         thenResultingNetworkInterfaceHardwareAddressIs(
                 new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x66, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
-        
+
         thenResultingVlanIdIs(101);
         thenResultingVlanParentInterfaceIs("eth0");
 
@@ -571,23 +606,133 @@ public class NMStatusConverterTest {
         thenResultingIp6InterfaceAddressIsMissing();
     }
 
+    @Test
+    public void buildModemStatusWorksWithDeviceInfo() {
+        givenModemConfiguration();
+
+        whenBuildModemStatusIsCalledWith("1-4", this.mockDevicePropertiesWrapper,
+                Optional.of(this.mockIp4ConfigProperties), Optional.empty(), Arrays.asList(this.mockSimProperties),
+                Arrays.asList(this.mockBearerProperties));
+
+        thenNoExceptionOccurred();
+
+        thenResultingNetworkInterfaceIsVirtual(false);
+        thenResultingNetworkInterfaceAutoConnectIs(false);
+        thenResultingNetworkInterfaceStateIs(NetworkInterfaceState.ACTIVATED);
+        thenResultingNetworkInterfaceFirmwareVersionIs("isThisRealLife");
+        thenResultingNetworkInterfaceDriverIs("isThisJustFantasy");
+        thenResultingNetworkInterfaceDriverVersionIs("caughtInALandslide");
+        thenResultingNetworkInterfaceMtuIs(69);
+        thenResultingNetworkInterfaceHardwareAddressIs(
+                new byte[] { (byte) 0xF5, (byte) 0x5B, (byte) 0x32, (byte) 0x7C, (byte) 0x40, (byte) 0xEA });
+        thenResultingNetworkInterfaceIpInterfaceIs("cdc-acm0");
+    }
+
+    @Test
+    public void buildModemStatusWorksWithIPInfo() throws UnknownHostException {
+        givenModemConfiguration();
+
+        whenBuildModemStatusIsCalledWith("1-4", this.mockDevicePropertiesWrapper,
+                Optional.of(this.mockIp4ConfigProperties), Optional.empty(), Arrays.asList(this.mockSimProperties),
+                Arrays.asList(this.mockBearerProperties));
+
+        thenNoExceptionOccurred();
+
+        thenResultingIp4InterfaceGatewayIs(IPAddress.parseHostAddress("192.168.1.1"));
+        thenResultingIp4InterfaceDNSIs(Arrays.asList(IPAddress.parseHostAddress("192.168.1.10")));
+        thenResultingIp4InterfaceAddressIs(Arrays.asList(new NetworkInterfaceIpAddress<IP4Address>(
+                (IP4Address) IP4Address.parseHostAddress("192.168.1.82"), (short) 24)));
+
+        thenResultingIp6InterfaceAddressIsMissing();
+
+    }
+
+    @Test
+    public void buildModemStatusWorksWithModemInfo() {
+        givenModemConfiguration();
+
+        whenBuildModemStatusIsCalledWith("1-4", this.mockDevicePropertiesWrapper,
+                Optional.of(this.mockIp4ConfigProperties), Optional.empty(), Arrays.asList(this.mockSimProperties),
+                Arrays.asList(this.mockBearerProperties));
+
+        thenNoExceptionOccurred();
+
+        thenResultingModemModelIs("EC25");
+        thenResultingModemManufacturerIs("Quectel");
+        thenResultingModemEquipmentIdentifierIs("CoolQuectel");
+        thenResultingModemRevisionIs("Experimental");
+        thenResultingModemHWRevisionIs("TopSecret");
+        thenResultingModemPrimaryPortIs("NaN");
+        thenResultingModemPortsAre(new HashMap<String, ModemPortType>());
+        thenResultingModemSupportedCapabilitiesAre(EnumSet.noneOf(ModemCapability.class));
+        thenResultingModemCurrentCapabilitiesAre(EnumSet.of(ModemCapability.POTS, ModemCapability.GSM_UMTS));
+        thenResultingModemPowerStateIs(ModemPowerState.ON);
+        thenResultingModemSupportedModesAre(new HashSet<>());
+        thenResultingModemCurrentModesAre(new ModemModePair(Collections.emptySet(), ModemMode.NONE));
+        thenResultingModemSupportedBandsAre(new HashSet<>(Arrays.asList(ModemBand.EGSM, ModemBand.EUTRAN_2)));
+        thenResultingModemCurrentBandsAre(new HashSet<>(Arrays.asList(ModemBand.EUTRAN_6, ModemBand.UNKNOWN)));
+        thenResultingModemUnlockRequiredIs(false);
+        thenResultingModemStateIs(ModemConnectionStatus.CONNECTED);
+        thenResultingModemAccessTechnologiesAre(new HashSet<>(Arrays.asList(AccessTechnology.FIVEGNR)));
+        thenResultingModemSignalQualityIs(23);
+        thenResultingModemSignalStrengthIs(-99);
+        thenResultingModemRegistrationStateIs(RegistrationStatus.HOME);
+        thenResultingModemOperatorNameIs("VodaTim");
+        thenResultingModemLocationCapabilitiesAre(new HashSet<>(Arrays.asList(ModemGpsMode.UNMANAGED)));
+        thenResultingModemIsGpsSupported(true);
+
+    }
+
+    @Test
+    public void buildModemStatusWorksWithModemSimInfo() {
+        givenModemConfiguration();
+
+        whenBuildModemStatusIsCalledWith("1-4", this.mockDevicePropertiesWrapper,
+                Optional.of(this.mockIp4ConfigProperties), Optional.empty(), Arrays.asList(this.mockSimProperties),
+                Arrays.asList(this.mockBearerProperties));
+
+        thenNoExceptionOccurred();
+        thenResultingModemSimIsActive(true);
+        thenResultingModemSimIsPrimary(true);
+        thenResultingModemSimIdentifierIs("1234567890123456789");
+        thenResultingModemSimImsiIs("098765432109876");
+        thenResultingModemSimEidIs("AAA");
+        thenResultingModemSimOperatorNameIs("VODA");
+        thenResultingModemSimOperatorIdIs("22210");
+        thenResultingModemSimTypeIs(SimType.PHYSICAL);
+    }
+
+    @Test
+    public void buildModemStatusWorksWithModemBearerInfo() {
+        givenModemConfiguration();
+
+        whenBuildModemStatusIsCalledWith("1-4", this.mockDevicePropertiesWrapper,
+                Optional.of(this.mockIp4ConfigProperties), Optional.empty(), Arrays.asList(this.mockSimProperties),
+                Arrays.asList(this.mockBearerProperties));
+
+        thenNoExceptionOccurred();
+        thenResultingModemBearerInterfaceIs("TheModemInterface");
+        thenResultingModemBearerIsConnected(true);
+        thenResultingModemBearerApnIs("web.omnitel.it");
+        thenResultingModemBearerIpTypeIs(EnumSet.of(BearerIpType.IPV4V6));
+        thenResultingModemBearerTxBytesAre(123456789L);
+        thenResultingModemBearerRxBytesAre(987654321L);
+    }
+
     /*
      * Given
      */
 
     private void givenDevicePropertiesWith(String propertyName, Object propertyValue) {
-        when(this.mockDeviceProperties.Get(NM_DEVICE_BUS_NAME, propertyName))
-                .thenReturn(propertyValue);
+        when(this.mockDeviceProperties.Get(NM_DEVICE_BUS_NAME, propertyName)).thenReturn(propertyValue);
     }
-    
+
     private void givenParentDevicePropertiesWith(String propertyName, Object propertyValue) {
-    	when(this.mockParentDeviceProperties.Get(NM_DEVICE_BUS_NAME, propertyName))
-                .thenReturn(propertyValue);
+        when(this.mockParentDeviceProperties.Get(NM_DEVICE_BUS_NAME, propertyName)).thenReturn(propertyValue);
     }
 
     private void givenIpv4ConfigPropertiesWith(String propertyName, Object propertyValue) {
-        when(this.mockIp4ConfigProperties.Get(NM_IP4CONFIG_BUS_NAME, propertyName))
-                .thenReturn(propertyValue);
+        when(this.mockIp4ConfigProperties.Get(NM_IP4CONFIG_BUS_NAME, propertyName)).thenReturn(propertyValue);
     }
 
     private void givenIpv4ConfigPropertiesWithDNS(List<String> addresses) {
@@ -621,8 +766,7 @@ public class NMStatusConverterTest {
     }
 
     private void givenIpv6ConfigPropertiesWith(String propertyName, String propertyValue) {
-        when(this.mockIp6ConfigProperties.Get(NM_IP6CONFIG_BUS_NAME, propertyName))
-                .thenReturn(propertyValue);
+        when(this.mockIp6ConfigProperties.Get(NM_IP6CONFIG_BUS_NAME, propertyName)).thenReturn(propertyValue);
     }
 
     private void givenIpv6ConfigPropertiesWithDNS(List<String> dnsAddresses) {
@@ -657,15 +801,127 @@ public class NMStatusConverterTest {
 
         when(this.mockIp6ConfigProperties.Get(NM_IP6CONFIG_BUS_NAME, "AddressData")).thenReturn(structureList);
     }
-    
+
     private void givenVlanConfigPropertiesWith(String propertyName, Object propertyValue) {
-    	when(this.mockVlanConfigProperties.Get(NM_VLAN_BUS_NAME, propertyName)).thenReturn(propertyValue);
+        when(this.mockVlanConfigProperties.Get(NM_VLAN_BUS_NAME, propertyName)).thenReturn(propertyValue);
     }
 
     private void givenDevicePropertiesWrapperBuiltWith(Properties deviceProperties,
             Optional<Properties> deviceSpecificProperties, NMDeviceType nmDeviceType) {
         this.mockDevicePropertiesWrapper = new DevicePropertiesWrapper(deviceProperties, deviceSpecificProperties,
                 nmDeviceType);
+    }
+
+    private void givenModemPropertiesWith(String propertyName, Object propertyValue) {
+        when(this.mockModemProperties.Get(MM_MODEM_BUS_NAME, propertyName)).thenReturn(propertyValue);
+    }
+
+    private void givenModemLocationPropertiesWith(String propertyName, Object propertyValue) {
+        when(this.mockModemProperties.Get(MM_MODEM_LOCATION_BUS_NAME, propertyName)).thenReturn(propertyValue);
+    }
+
+    private void givenModem3gppPropertiesWith(String propertyName, Object propertyValue) {
+        when(mockModemProperties.Get(MM_MODEM_3GPP_BUS_NAME, propertyName)).thenReturn(propertyValue);
+    }
+
+    private void givenAvailableSimPropertiesWith(String propertyName, Object propertyValue) {
+        when(this.mockAvailableSimProperties.Get(MM_SIM_BUS_NAME, propertyName)).thenReturn(propertyValue);
+    }
+
+    private void givenSimPropertiesBuiltWith(Properties properties) {
+        when(this.mockSimProperties.getProperties()).thenReturn(properties);
+    }
+
+    private void givenSimIsActive(boolean isActive) {
+        when(this.mockSimProperties.isActive()).thenReturn(isActive);
+    }
+
+    private void givenSimIsPrimary(boolean isPrimary) {
+        when(this.mockSimProperties.isPrimary()).thenReturn(isPrimary);
+    }
+
+    private void givenBearerPropertiesWith(String propertyName, Object propertyValue) {
+        when(this.mockBearerProperties.Get(MM_BEARER_BUS_NAME, propertyName)).thenReturn(propertyValue);
+    }
+
+    private void givenBearerSettingsWith(String propertyName, Object propertyValue) {
+        this.bearerSettings.put(propertyName, propertyValue);
+    }
+
+    private void givenBearerStatsWith(String propertyName, Object propertyValue) {
+        this.bearerStats.put(propertyName, propertyValue);
+    }
+
+    private void givenBearerPropertiesBuiltWithSettings(Map<String, Object> bearerSettings) {
+        when(this.mockBearerProperties.Get(MM_BEARER_BUS_NAME, "Properties")).thenReturn(bearerSettings);
+    }
+
+    private void givenBearerPropertiesBuiltWithStats(Map<String, Object> bearerSettings) {
+        when(this.mockBearerProperties.Get(MM_BEARER_BUS_NAME, "Stats")).thenReturn(bearerStats);
+    }
+
+    private void givenModemConfiguration() {
+        givenDevicePropertiesWith("State", NMDeviceState.toUInt32(NMDeviceState.NM_DEVICE_STATE_ACTIVATED));
+        givenDevicePropertiesWith("Autoconnect", false);
+        givenDevicePropertiesWith("FirmwareVersion", "isThisRealLife");
+        givenDevicePropertiesWith("Driver", "isThisJustFantasy");
+        givenDevicePropertiesWith("DriverVersion", "caughtInALandslide");
+        givenDevicePropertiesWith("Mtu", new UInt32(69));
+        givenDevicePropertiesWith("HwAddress", "F5:5B:32:7C:40:EA");
+        givenDevicePropertiesWith("IpInterface", "cdc-acm0");
+
+        givenIpv4ConfigPropertiesWith("Gateway", "192.168.1.1");
+        givenIpv4ConfigPropertiesWithDNS(Arrays.asList("192.168.1.10"));
+        givenIpv4ConfigPropertiesWithAddress(Arrays.asList("192.168.1.82/24"));
+
+        givenModemPropertiesWith("Model", "EC25");
+        givenModemPropertiesWith("Manufacturer", "Quectel");
+        givenModemPropertiesWith("EquipmentIdentifier", "CoolQuectel");
+        givenModemPropertiesWith("Revision", "Experimental");
+        givenModemPropertiesWith("HardwareRevision", "TopSecret");
+        givenModemPropertiesWith("PrimaryPort", "NaN");
+        givenModemPropertiesWith("Ports", Arrays.asList(new Object[] {}));
+        givenModemPropertiesWith("SupportedCapabilities", Arrays.asList(new UInt32[] {}));
+        givenModemPropertiesWith("CurrentCapabilities", new UInt32(5));
+        givenModemPropertiesWith("PowerState", MMModemPowerState.MM_MODEM_POWER_STATE_ON.toUInt32());
+        givenModemPropertiesWith("SupportedModes", Arrays.asList(new Object[] {}));
+        givenModemPropertiesWith("CurrentModes", new Object[] {});
+        givenModemPropertiesWith("SupportedBands", Arrays.asList(new UInt32[] { new UInt32(1), new UInt32(32) }));
+        givenModemPropertiesWith("CurrentBands", Arrays.asList(new UInt32[] { new UInt32(36), new UInt32(102) }));
+        givenModemPropertiesWith("UnlockRequired", new UInt32(1));
+        givenModemPropertiesWith("State", 11);
+        givenModemPropertiesWith("AccessTechnologies", new UInt32(32768));
+        givenModemPropertiesWith("SignalQuality", new Object[] { new UInt32(23), new UInt32(0) });
+
+        givenModemLocationPropertiesWith("Capabilities",
+                MMModemLocationSource.MM_MODEM_LOCATION_SOURCE_GPS_UNMANAGED.toUInt32());
+
+        givenModem3gppPropertiesWith("RegistrationState",
+                MMModem3gppRegistrationState.MM_MODEM_3GPP_REGISTRATION_STATE_HOME.toUInt32());
+        givenModem3gppPropertiesWith("OperatorName", "VodaTim");
+
+        givenSimIsActive(true);
+        givenSimIsPrimary(true);
+        givenAvailableSimPropertiesWith("SimIdentifier", "1234567890123456789");
+        givenAvailableSimPropertiesWith("Imsi", "098765432109876");
+        givenAvailableSimPropertiesWith("Eid", "AAA");
+        givenAvailableSimPropertiesWith("OperatorName", "VODA");
+        givenAvailableSimPropertiesWith("OperatorIdentifier", "22210");
+        givenAvailableSimPropertiesWith("SimType", MMSimType.MM_SIM_TYPE_PHYSICAL.toUInt32());
+
+        givenBearerPropertiesWith("Interface", "TheModemInterface");
+        givenBearerPropertiesWith("Connected", true);
+        givenBearerSettingsWith("apn", "web.omnitel.it");
+        givenBearerSettingsWith("ip-type", MMBearerIpFamily.MM_BEARER_IP_FAMILY_IPV4V6.toUInt32());
+        givenBearerStatsWith("tx-bytes", new UInt64(Long.toUnsignedString(123456789L)));
+        givenBearerStatsWith("rx-bytes", new UInt64(Long.toUnsignedString(987654321L)));
+        givenBearerPropertiesBuiltWithSettings(this.bearerSettings);
+        givenBearerPropertiesBuiltWithStats(this.bearerStats);
+
+        givenDevicePropertiesWrapperBuiltWith(this.mockDeviceProperties, Optional.of(this.mockModemProperties),
+                NMDeviceType.NM_DEVICE_TYPE_MODEM);
+
+        givenSimPropertiesBuiltWith(this.mockAvailableSimProperties);
     }
 
     /*
@@ -692,13 +948,25 @@ public class NMStatusConverterTest {
             this.occurredException = e;
         }
     }
-    
+
     private void whenBuildVlanStatusIsCalledWith(String ifaceName, DevicePropertiesWrapper deviceProps,
             Optional<Properties> ip4Properties, Optional<Properties> ip6Properties) {
         try {
             this.resultingStatus = NMStatusConverter.buildVlanStatus(ifaceName, deviceProps, ip4Properties,
                     ip6Properties, this.mockParentDeviceProperties);
             this.resultingVlanStatus = (VlanInterfaceStatus) this.resultingStatus;
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
+    private void whenBuildModemStatusIsCalledWith(String ifaceName, DevicePropertiesWrapper deviceProps,
+            Optional<Properties> ip4Properties, Optional<Properties> ip6Properties, List<SimProperties> simProperties,
+            List<Properties> bearerProperties) {
+        try {
+            this.resultingStatus = NMStatusConverter.buildModemStatus(ifaceName, deviceProps, ip4Properties,
+                    ip6Properties, simProperties, bearerProperties);
+            this.resultingModemStatus = (ModemInterfaceStatus) this.resultingStatus;
         } catch (Exception e) {
             this.occurredException = e;
         }
@@ -756,6 +1024,10 @@ public class NMStatusConverterTest {
 
     private void thenResultingNetworkInterfaceHardwareAddressIs(byte[] expectedResult) {
         assertArrayEquals(expectedResult, this.resultingStatus.getHardwareAddress());
+    }
+
+    private void thenResultingNetworkInterfaceIpInterfaceIs(String ipInterface) {
+        assertEquals(ipInterface, this.resultingStatus.getInterfaceName());
     }
 
     private void thenResultingIp4InterfaceAddressIsMissing() {
@@ -863,12 +1135,160 @@ public class NMStatusConverterTest {
         assertTrue(address.getGateway().isPresent());
         assertEquals(expectedResult, address.getGateway().get());
     }
-    
+
     private void thenResultingVlanIdIs(int expectedVlanId) {
-    	assertEquals(expectedVlanId, resultingVlanStatus.getVlanId());
+        assertEquals(expectedVlanId, resultingVlanStatus.getVlanId());
     }
-    
+
     private void thenResultingVlanParentInterfaceIs(String expectedParentInterface) {
-    	assertEquals(expectedParentInterface, resultingVlanStatus.getParentInterface());
+        assertEquals(expectedParentInterface, resultingVlanStatus.getParentInterface());
+    }
+
+    private void thenResultingModemModelIs(String model) {
+        assertEquals(model, this.resultingModemStatus.getModel());
+    }
+
+    private void thenResultingModemManufacturerIs(String manufacturer) {
+        assertEquals(manufacturer, this.resultingModemStatus.getManufacturer());
+    }
+
+    private void thenResultingModemEquipmentIdentifierIs(String EquipmentIdentifier) {
+        assertEquals(EquipmentIdentifier, this.resultingModemStatus.getSerialNumber());
+    }
+
+    private void thenResultingModemRevisionIs(String Revision) {
+        assertEquals(Revision, this.resultingModemStatus.getSoftwareRevision());
+    }
+
+    private void thenResultingModemHWRevisionIs(String hwRevision) {
+        assertEquals(hwRevision, this.resultingModemStatus.getHardwareRevision());
+    }
+
+    private void thenResultingModemPrimaryPortIs(String port) {
+        assertEquals(port, this.resultingModemStatus.getPrimaryPort());
+    }
+
+    private void thenResultingModemPortsAre(Map<String, ModemPortType> ports) {
+        assertEquals(ports, this.resultingModemStatus.getPorts());
+    }
+
+    private void thenResultingModemSupportedCapabilitiesAre(EnumSet<ModemCapability> modemCapability) {
+        assertEquals(modemCapability, this.resultingModemStatus.getSupportedModemCapabilities());
+    }
+
+    private void thenResultingModemCurrentCapabilitiesAre(EnumSet<ModemCapability> modemCapability) {
+        assertEquals(modemCapability, this.resultingModemStatus.getCurrentModemCapabilities());
+    }
+
+    private void thenResultingModemPowerStateIs(ModemPowerState modemState) {
+        assertEquals(modemState, this.resultingModemStatus.getPowerState());
+    }
+
+    private void thenResultingModemSupportedModesAre(Set<ModemModePair> modemModePair) {
+        assertEquals(modemModePair, this.resultingModemStatus.getSupportedModes());
+    }
+
+    private void thenResultingModemCurrentModesAre(ModemModePair modemModePair) {
+        assertEquals(modemModePair, this.resultingModemStatus.getCurrentModes());
+    }
+
+    private void thenResultingModemSupportedBandsAre(Set<ModemBand> modemBands) {
+        assertEquals(modemBands, this.resultingModemStatus.getSupportedBands());
+    }
+
+    private void thenResultingModemCurrentBandsAre(Set<ModemBand> modemBands) {
+        assertEquals(modemBands, this.resultingModemStatus.getCurrentBands());
+    }
+
+    private void thenResultingModemUnlockRequiredIs(boolean unlockRequired) {
+        assertEquals(unlockRequired, this.resultingModemStatus.isSimLocked());
+    }
+
+    private void thenResultingModemStateIs(ModemConnectionStatus modemStatus) {
+        assertEquals(modemStatus, this.resultingModemStatus.getConnectionStatus());
+    }
+
+    private void thenResultingModemAccessTechnologiesAre(Set<AccessTechnology> accessTechnologies) {
+        assertEquals(accessTechnologies, this.resultingModemStatus.getAccessTechnologies());
+    }
+
+    private void thenResultingModemSignalQualityIs(int signalQuality) {
+        assertEquals(signalQuality, this.resultingModemStatus.getSignalQuality());
+    }
+
+    private void thenResultingModemSignalStrengthIs(int signalStrength) {
+        assertEquals(signalStrength, this.resultingModemStatus.getSignalStrength());
+    }
+
+    private void thenResultingModemRegistrationStateIs(RegistrationStatus status) {
+        assertEquals(status, this.resultingModemStatus.getRegistrationStatus());
+    }
+
+    private void thenResultingModemOperatorNameIs(String operatorName) {
+        assertEquals(operatorName, this.resultingModemStatus.getOperatorName());
+    }
+
+    private void thenResultingModemLocationCapabilitiesAre(Set<ModemGpsMode> gpsModes) {
+        assertEquals(gpsModes, this.resultingModemStatus.getSupporteGpsModes());
+    }
+
+    private void thenResultingModemIsGpsSupported(boolean isGpsSupported) {
+        assertEquals(isGpsSupported, this.resultingModemStatus.isGpsSupported());
+    }
+
+    private void thenResultingModemSimIsActive(boolean isActive) {
+        assertEquals(isActive, this.resultingModemStatus.getAvailableSims().get(0).isActive());
+    }
+
+    private void thenResultingModemSimIsPrimary(boolean isPrimary) {
+        assertEquals(isPrimary, this.resultingModemStatus.getAvailableSims().get(0).isPrimary());
+    }
+
+    private void thenResultingModemSimIdentifierIs(String iccid) {
+        assertEquals(iccid, this.resultingModemStatus.getAvailableSims().get(0).getIccid());
+    }
+
+    private void thenResultingModemSimImsiIs(String imsi) {
+        assertEquals(imsi, this.resultingModemStatus.getAvailableSims().get(0).getImsi());
+    }
+
+    private void thenResultingModemSimEidIs(String eid) {
+        assertEquals(eid, this.resultingModemStatus.getAvailableSims().get(0).getEid());
+    }
+
+    private void thenResultingModemSimOperatorNameIs(String operatorName) {
+        assertEquals(operatorName, this.resultingModemStatus.getAvailableSims().get(0).getOperatorName());
+    }
+
+    private void thenResultingModemSimOperatorIdIs(String operatorId) {
+        assertEquals(operatorId, this.resultingModemStatus.getAvailableSims().get(0).getOperatorIdentifier());
+    }
+
+    private void thenResultingModemSimTypeIs(SimType simType) {
+        assertEquals(simType, this.resultingModemStatus.getAvailableSims().get(0).getSimType());
+    }
+
+    private void thenResultingModemBearerInterfaceIs(String interfaceName) {
+        assertEquals(interfaceName, this.resultingModemStatus.getBearers().get(0).getName());
+    }
+
+    private void thenResultingModemBearerIsConnected(boolean isConnected) {
+        assertEquals(isConnected, this.resultingModemStatus.getBearers().get(0).isConnected());
+    }
+
+    private void thenResultingModemBearerApnIs(String apn) {
+        assertEquals(apn, this.resultingModemStatus.getBearers().get(0).getApn());
+    }
+
+    private void thenResultingModemBearerIpTypeIs(Set<BearerIpType> ipTypes) {
+        assertEquals(ipTypes, this.resultingModemStatus.getBearers().get(0).getIpTypes());
+    }
+
+    private void thenResultingModemBearerTxBytesAre(long txBytes) {
+        assertEquals(txBytes, this.resultingModemStatus.getBearers().get(0).getBytesTransmitted());
+    }
+
+    private void thenResultingModemBearerRxBytesAre(long rxBytes) {
+        assertEquals(rxBytes, this.resultingModemStatus.getBearers().get(0).getBytesReceived());
     }
 }

--- a/kura/test/org.eclipse.kura.rest.network.status.provider.test/src/main/java/org/eclipse/kura/rest/network/status/provider/test/NetworkStatusRestServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.rest.network.status.provider.test/src/main/java/org/eclipse/kura/rest/network/status/provider/test/NetworkStatusRestServiceImplTest.java
@@ -929,6 +929,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
                         .withImsi("imsi") //
                         .withEid("sed") //
                         .withOperatorName("op") //
+                        .withOperatorIdentifier("id") //
                         .withSimType(SimType.PHYSICAL) //
                         .withESimStatus(ESimStatus.UNKNOWN).build(), //
                 Sim.builder() //
@@ -938,6 +939,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
                         .withImsi("isi") //
                         .withEid("se") //
                         .withOperatorName("opp") //
+                        .withOperatorIdentifier("idd") //
                         .withSimType(SimType.ESIM) //
                         .withESimStatus(ESimStatus.WITH_PROFILES) //
                         .build())));
@@ -968,6 +970,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
                 + "\"imsi\":\"imsi\"," //
                 + "\"eid\":\"sed\"," //
                 + "\"operatorName\":\"op\"," //
+                + "\"operatorIdentifier\":\"id\"," //
                 + "\"simType\":\"PHYSICAL\"," //
                 + "\"eSimStatus\":\"UNKNOWN\"}," //
                 + "{\"active\":false," //
@@ -976,6 +979,7 @@ public class NetworkStatusRestServiceImplTest extends AbstractRequestHandlerTest
                 + "\"imsi\":\"isi\"," //
                 + "\"eid\":\"se\"," //
                 + "\"operatorName\":\"opp\"," //
+                + "\"operatorIdentifier\":\"idd\"," //
                 + "\"simType\":\"ESIM\"," //
                 + "\"eSimStatus\":\"WITH_PROFILES\"}]," //
                 + "\"simLocked\":false," //


### PR DESCRIPTION
This PR adds the SIM `operatorIdentifier` to the `NetworkStatusService`.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** The new field `operatorIdentifier` has been added to the SIM properties. This value can be obtained using Rest calls.
