### PR TITLE
fix: Container page refresh performed at completed operation

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/DockerContainersTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/DockerContainersTabUi.java
@@ -296,6 +296,7 @@ public class DockerContainersTabUi extends Composite implements Tab {
                             @Override
                             public void onSuccess(Void result) {
                                 EntryClassUi.hideWaitModal();
+                                refresh();
                             }
                         });
 
@@ -307,7 +308,6 @@ public class DockerContainersTabUi extends Composite implements Tab {
                 FailureHandler.handle(caught);
             }
         });
-        refresh();
     }
 
     private void stopSelectedContainer() {
@@ -337,11 +337,11 @@ public class DockerContainersTabUi extends Composite implements Tab {
                             public void onSuccess(Void result) {
                                 EntryClassUi.hideWaitModal();
                                 DockerContainersTabUi.this.containersStop.setEnabled(false);
+                                refresh();
                             }
                         });
             }
         });
-        refresh();
     }
 
     private void loadContainersTable(CellTable<GwtGroupedNVPair> bundlesGrid2,


### PR DESCRIPTION
Right now the refreshing of the container and images section is not performed in the proper time.
Result is that the refresh happens too early while a concurrent start/stop is performed forcing the user to manually refresh to get the state
