### PR TITLE
fix: Linux.Pid equals override

### DIFF
--- a/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/LinuxPid.java
+++ b/kura/org.eclipse.kura.core/src/main/java/org/eclipse/kura/core/linux/executor/LinuxPid.java
@@ -52,7 +52,7 @@ public class LinuxPid implements Pid {
             return false;
         }
         LinuxPid other = (LinuxPid) obj;
-        return this.pid != other.pid;
+        return this.pid == other.pid;
     }
 
 }


### PR DESCRIPTION
Brief description of the PR: `equals` override fix for Linux.Pid

**Related Issue:** #5506
