### PR TITLE
fix(distrib): Updated installer script to write all interface names to snapshot file

### DIFF
--- a/kura/distrib/src/main/resources/common/customize_snapshot.py
+++ b/kura/distrib/src/main/resources/common/customize_snapshot.py
@@ -90,12 +90,12 @@ def main():
         
         interfaces_list = "lo"
     
-        for i, eth_name in enumerate(eth_names[:2]):
+        for i, eth_name in enumerate(eth_names):
             snapshot_content = snapshot_content.replace('ETH_INTERFACE_' + str(i), eth_name)
             interfaces_list += "," + eth_name
             logging.info("%s : replaced ETH_INTERFACE_%s with %s", SNAPSHOT_FILENAME, str(i), eth_name)
     
-        for i, wlan_name in enumerate(wlan_names[:1]):
+        for i, wlan_name in enumerate(wlan_names):
             snapshot_content = snapshot_content.replace('WIFI_INTERFACE_' + str(i), wlan_name)
             interfaces_list += "," + wlan_name
             logging.info("%s : replaced WIFI_INTERFACE_%s with %s", SNAPSHOT_FILENAME, str(i), wlan_name)


### PR DESCRIPTION
This PR updates the installer script to add all the interface names detected on the system during installation to the `net.interfaces` property of the snapshot_0 file.
