### PR TITLE
feat(web2): Added dynamic validator for scale and offset fields

### DIFF
--- a/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/BaseChannelDescriptor.java
+++ b/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/asset/provider/BaseChannelDescriptor.java
@@ -158,8 +158,8 @@ public class BaseChannelDescriptor implements ChannelDescriptor {
         final Tad valueScale = new Tad();
         valueScale.setName(VALUE_SCALE.value().substring(1));
         valueScale.setId(VALUE_SCALE.value());
-        valueScale.setDescription("Scale to be applied to the numeric value of the channel");
-        valueScale.setType(Tscalar.DOUBLE);
+        valueScale.setDescription("Scale to be applied to the numeric value of the channel.");
+        valueScale.setType(Tscalar.STRING);
         valueScale.setRequired(false);
 
         this.defaultElements.add(valueScale);
@@ -168,7 +168,7 @@ public class BaseChannelDescriptor implements ChannelDescriptor {
         valueOffset.setName(VALUE_OFFSET.value().substring(1));
         valueOffset.setId(VALUE_OFFSET.value());
         valueOffset.setDescription("Offset to be applied to the numeric value of the channel");
-        valueOffset.setType(Tscalar.DOUBLE);
+        valueOffset.setType(Tscalar.STRING);
         valueOffset.setRequired(false);
 
         this.defaultElements.add(valueOffset);

--- a/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/internal/asset/provider/BaseAssetConfiguration.java
+++ b/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/internal/asset/provider/BaseAssetConfiguration.java
@@ -411,8 +411,7 @@ public final class BaseAssetConfiguration {
             case DOUBLE:
                 return Double.parseDouble(value);
             case LONG:
-                // TODO replace with Long.parseLong(value) once scale and offset are turned in String in the metatype
-                return (Double.valueOf(value).longValue());
+                return Long.parseLong(value);
             default:
                 throw new IllegalArgumentException(value + " cannot be converted into a Number of type " + type);
             }

--- a/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/internal/asset/provider/BaseAssetConfiguration.java
+++ b/kura/org.eclipse.kura.asset.provider/src/main/java/org/eclipse/kura/internal/asset/provider/BaseAssetConfiguration.java
@@ -342,7 +342,7 @@ public final class BaseAssetConfiguration {
         private static Number getValueScale(final Map<String, Object> properties) {
             final String valueScale = (String) properties.get(VALUE_SCALE.value());
 
-            if (valueScale == null) {
+            if (valueScale == null || valueScale.isEmpty()) {
                 return 1.0d;
             }
             return parseScaleOffsetTypedValue(getScaleOffsetType(properties), valueScale);
@@ -351,7 +351,7 @@ public final class BaseAssetConfiguration {
         private static Number getValueOffset(final Map<String, Object> properties) {
             final String valueOffset = (String) properties.get(VALUE_OFFSET.value());
 
-            if (valueOffset == null) {
+            if (valueOffset == null || valueOffset.isEmpty()) {
                 return 0.0d;
             }
             return parseScaleOffsetTypedValue(getScaleOffsetType(properties), valueOffset);

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.eclipse.kura.web.Console;
@@ -97,8 +96,6 @@ import com.google.gwt.view.client.SingleSelectionModel;
 public class AssetConfigurationUi extends AbstractServicesUi implements HasConfiguration {
 
     private static final String COLUMN_VISIBILITY_SETTINGS_KEY = "org.eclipse.kura.settings.column.asset.";
-
-    private static final Logger logger = Logger.getLogger(AssetConfigurationUi.class.getSimpleName());
 
     private static final List<String> defaultHiddenColumns = //
             Arrays.asList(//
@@ -323,8 +320,6 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
         this.btnManageHiddenColumn.setText(MSGS.columnVisibilityModalButton(//
                 String.valueOf(totalEnabledColumns(this.columnNameVisibilityMap)),
                 String.valueOf(this.columnNameVisibilityMap.size())));
-
-        logger.info("created AssetConfigurationUi for: " + this.model.getAssetPid());
     }
 
     private void fillColumnVisibilityCheckBox() {
@@ -394,7 +389,6 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
 
     private void populateColumnVisibilityMap() {
         this.model.getChannelDescriptor().getParameters().forEach(param -> {
-            AssetConfigurationUi.logger.info("Id: " + param.getId() + ", Name: " + param.getName());
             if (!param.getId().equals(AssetConstants.ENABLED.value())
                     && !param.getId().equals(AssetConstants.NAME.value())) {
                 boolean visible = !defaultHiddenColumns.contains(param.getId());
@@ -450,7 +444,6 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
     }
 
     private void addColumn(final GwtConfigParameter param) {
-        logger.info("Adding column for: " + param.getId());
         AssetConfigurationUi.this.channelTable.addColumn(
                 getColumnFromParam(param, param.getId().equals(AssetConstants.NAME.value())), buildHeader(param));
     }
@@ -535,7 +528,6 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
                 final String paramId = channelModel.getChannelName() + '#' + param.getId();
                 Integer paramIndex = AssetConfigurationUi.this.model.getParameterIndex(param.getId());
                 channelModel.setValue(paramIndex, value);
-                AssetConfigurationUi.logger.info("Setting value for " + paramId + " to " + value);
                 if (!channelModel.isValid(paramIndex)) {
                     AssetConfigurationUi.this.invalidParameters.add(paramId);
                 } else {
@@ -583,15 +575,12 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
             }
         };
 
-        logger.info("param: " + param.getId() + "has reaonly: " + isReadOnly);
-
         if (!isReadOnly) {
             result.setFieldUpdater((index, channelModel, label) -> {
                 String paramId = param.getId();
                 AssetConfigurationUi.this.setDirty(true);
                 String newValue = labelsToValues.get(label);
                 Integer paramIndex = AssetConfigurationUi.this.model.getParameterIndex(paramId);
-                logger.info("changing param: " + paramId + " to: " + newValue + " with index" + paramIndex);
                 String oldValue = channelModel.getValue(paramIndex);
                 channelModel.setValue(paramIndex, newValue);
                 if ((param.getId().equals(AssetConstants.VALUE_TYPE.value())
@@ -603,10 +592,8 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
                         String paramIdentifier = channelModel.getChannelName() + '#' + paramEntry.getKey();
                         Integer parameterIndex = paramEntry.getValue();
                         if (!channelModel.isValid(parameterIndex)) {
-                            logger.info("Invalid parameter: " + paramIdentifier);
                             AssetConfigurationUi.this.invalidParameters.add(paramIdentifier);
                         } else {
-                            logger.info("Valid parameter: " + paramIdentifier);
                             AssetConfigurationUi.this.invalidParameters.remove(paramIdentifier);
                         }
                     }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetConfigurationUi.java
@@ -450,6 +450,7 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
     }
 
     private void addColumn(final GwtConfigParameter param) {
+        logger.info("Adding column for: " + param.getId());
         AssetConfigurationUi.this.channelTable.addColumn(
                 getColumnFromParam(param, param.getId().equals(AssetConstants.NAME.value())), buildHeader(param));
     }
@@ -530,10 +531,12 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
         final Column<ChannelModel, String> result = new ChannelColumn(cell, param);
 
         if (!isReadOnly) {
-            result.setFieldUpdater((index, object, value) -> {
-                final String paramId = object.getChannelName() + '#' + param.getId();
-                object.setValue(param.getId(), value);
-                if (!object.isValid(param.getId())) {
+            result.setFieldUpdater((index, channelModel, value) -> {
+                final String paramId = channelModel.getChannelName() + '#' + param.getId();
+                Integer paramIndex = AssetConfigurationUi.this.model.getParameterIndex(param.getId());
+                channelModel.setValue(paramIndex, value);
+                AssetConfigurationUi.logger.info("Setting value for " + paramId + " to " + value);
+                if (!channelModel.isValid(paramIndex)) {
                     AssetConfigurationUi.this.invalidParameters.add(paramId);
                 } else {
                     AssetConfigurationUi.this.invalidParameters.remove(paramId);
@@ -552,35 +555,65 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
     }
 
     private Column<ChannelModel, String> getSelectionInputColumn(final GwtConfigParameter param, boolean isReadOnly) {
-        final String id = param.getId();
         final Map<String, String> labelsToValues = param.getOptions();
         ArrayList<Entry<String, String>> sortedLabelsToValues = new ArrayList<>(labelsToValues.entrySet());
         Collections.sort(sortedLabelsToValues, DROPDOWN_LABEL_COMPARATOR);
+
         final ArrayList<String> labels = new ArrayList<>();
         final Map<String, String> valuesToLabels = new HashMap<>();
+
         for (Entry<String, String> entry : sortedLabelsToValues) {
             labels.add(entry.getKey());
             valuesToLabels.put(entry.getValue(), entry.getKey());
         }
+
         final SelectionCell cell = new SelectionCell(new ArrayList<>(labels));
         final Column<ChannelModel, String> result = new Column<ChannelModel, String>(cell) {
 
             @Override
-            public String getValue(final ChannelModel object) {
-                String result = object.getValue(id);
+            public String getValue(final ChannelModel channelModel) {
+                Integer paramIndex = AssetConfigurationUi.this.model.getParameterIndex(param.getId());
+                String result = channelModel.getValue(paramIndex);
                 if (result == null) {
                     final String defaultValue = param.getDefault();
                     result = defaultValue != null ? defaultValue : labelsToValues.get(labels.get(0));
-                    object.setValue(id, result);
+                    channelModel.setValue(paramIndex, result);
                 }
                 return valuesToLabels.get(result);
             }
         };
 
+        logger.info("param: " + param.getId() + "has reaonly: " + isReadOnly);
+
         if (!isReadOnly) {
-            result.setFieldUpdater((index, object, label) -> {
+            result.setFieldUpdater((index, channelModel, label) -> {
+                String paramId = param.getId();
                 AssetConfigurationUi.this.setDirty(true);
-                object.setValue(param.getId(), labelsToValues.get(label));
+                String newValue = labelsToValues.get(label);
+                Integer paramIndex = AssetConfigurationUi.this.model.getParameterIndex(paramId);
+                logger.info("changing param: " + paramId + " to: " + newValue + " with index" + paramIndex);
+                String oldValue = channelModel.getValue(paramIndex);
+                channelModel.setValue(paramIndex, newValue);
+                if ((param.getId().equals(AssetConstants.VALUE_TYPE.value())
+                        || param.getId().equals(AssetConstants.SCALE_OFFSET_TYPE.value())
+                                && !oldValue.equals(newValue))) {
+
+                    for (Map.Entry<String, Integer> paramEntry : AssetConfigurationUi.this.model.getParameterIndexes()
+                            .entrySet()) {
+                        String paramIdentifier = channelModel.getChannelName() + '#' + paramEntry.getKey();
+                        Integer parameterIndex = paramEntry.getValue();
+                        if (!channelModel.isValid(parameterIndex)) {
+                            logger.info("Invalid parameter: " + paramIdentifier);
+                            AssetConfigurationUi.this.invalidParameters.add(paramIdentifier);
+                        } else {
+                            logger.info("Valid parameter: " + paramIdentifier);
+                            AssetConfigurationUi.this.invalidParameters.remove(paramIdentifier);
+                        }
+                    }
+
+                    this.channelTable.redrawRow(index);
+
+                }
             });
         }
 
@@ -878,7 +911,7 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
         }
     }
 
-    private static class ChannelColumn extends Column<ChannelModel, String> {
+    private class ChannelColumn extends Column<ChannelModel, String> {
 
         private final GwtConfigParameter param;
 
@@ -888,8 +921,9 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
         }
 
         @Override
-        public String getValue(final ChannelModel object) {
-            String result = object.getValue(this.param.getId());
+        public String getValue(final ChannelModel channelModel) {
+            Integer paramIndex = AssetConfigurationUi.this.model.getParameterIndex(this.param.getId());
+            String result = channelModel.getValue(paramIndex);
             if (result != null) {
                 return result;
             }
@@ -897,8 +931,9 @@ public class AssetConfigurationUi extends AbstractServicesUi implements HasConfi
         }
 
         @Override
-        public String getCellStyleNames(Context context, ChannelModel object) {
-            if (!object.isValid(this.param.getId())) {
+        public String getCellStyleNames(Context context, ChannelModel channelModel) {
+            Integer paramIndex = AssetConfigurationUi.this.model.getParameterIndex(this.param.getId());
+            if (!channelModel.isValid(paramIndex)) {
                 return "config-cell-not-valid";
             } else {
                 return "";

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetDataUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetDataUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -124,8 +124,8 @@ public class AssetDataUi extends Composite {
             @Override
             public void onBrowserEvent(Context context, Element elem, ChannelModel object, NativeEvent event) {
                 if (getChannelStatus(object) == ChannelStatus.FAILURE) {
-                    final GwtChannelRecord record = AssetDataUi.this.channelValues.get(object.getChannelName());
-                    showFailureDetails(record);
+                    final GwtChannelRecord channelRecord = AssetDataUi.this.channelValues.get(object.getChannelName());
+                    showFailureDetails(channelRecord);
                 }
             }
 
@@ -154,9 +154,10 @@ public class AssetDataUi extends Composite {
                 this.valuesCell) {
 
             @Override
-            public void onBrowserEvent(Context context, Element elem, ChannelModel object, NativeEvent event) {
-                if (!"READ".equals(object.getValue(AssetConstants.TYPE.value()))) {
-                    super.onBrowserEvent(context, elem, object, event);
+            public void onBrowserEvent(Context context, Element elem, ChannelModel channelModel, NativeEvent event) {
+                if (!"READ".equals(
+                        channelModel.getValue(AssetDataUi.this.model.getParameterIndex(AssetConstants.TYPE.value())))) {
+                    super.onBrowserEvent(context, elem, channelModel, event);
                 }
             }
 
@@ -178,15 +179,16 @@ public class AssetDataUi extends Composite {
             }
 
             @Override
-            public void render(Context context, ChannelModel object, SafeHtmlBuilder sb) {
-                if ("READ".equals(object.getValue(AssetConstants.TYPE.value()))) {
-                    sb.appendEscaped(getValue(object));
+            public void render(Context context, ChannelModel channelModel, SafeHtmlBuilder sb) {
+                if ("READ".equals(
+                        channelModel.getValue(AssetDataUi.this.model.getParameterIndex(AssetConstants.TYPE.value())))) {
+                    sb.appendEscaped(getValue(channelModel));
                     return;
                 }
-                if (!isDirty(object.getChannelName())) {
+                if (!isDirty(channelModel.getChannelName())) {
                     AssetDataUi.this.valuesCell.clearViewData(context.getKey());
                 }
-                super.render(context, object, sb);
+                super.render(context, channelModel, sb);
             }
         };
 
@@ -205,24 +207,25 @@ public class AssetDataUi extends Composite {
         this.assetDataTable.addColumn(valueColumn, new TextHeader(MSGS.devicePropValue()));
     }
 
-    private static void showFailureDetails(final GwtChannelRecord record) {
-        record.setUnescaped(true);
-        String reason = record.getExceptionMessage();
-        record.setUnescaped(false);
+    private static void showFailureDetails(final GwtChannelRecord channelRecord) {
+        channelRecord.setUnescaped(true);
+        String reason = channelRecord.getExceptionMessage();
+        channelRecord.setUnescaped(false);
 
         if (reason == null || reason.trim().isEmpty()) {
             reason = "unknown";
         }
 
         FailureHandler.showErrorMessage("Channel failure details", "Reason: " + reason,
-                record.getExceptionStackTrace());
+                channelRecord.getExceptionStackTrace());
     }
 
     private GwtChannelRecord createWriteRecord(AssetModel.ChannelModel channel) {
         final GwtChannelRecord result = new GwtChannelRecord();
         result.setUnescaped(true);
         result.setName(channel.getChannelName());
-        result.setValueType(channel.getValue(AssetConstants.VALUE_TYPE.value()));
+        result.setValueType(
+                channel.getValue(AssetDataUi.this.model.getParameterIndex(AssetConstants.VALUE_TYPE.value())));
         return result;
     }
 
@@ -234,11 +237,11 @@ public class AssetDataUi extends Composite {
         final ArrayList<GwtChannelRecord> writeRecords = new ArrayList<>();
 
         for (final String channelName : this.modifiedWriteChannels) {
-            final GwtChannelRecord record = this.channelValues.get(channelName);
-            if (record == null) {
+            final GwtChannelRecord channelRecord = this.channelValues.get(channelName);
+            if (channelRecord == null) {
                 continue;
             }
-            writeRecords.add(record);
+            writeRecords.add(channelRecord);
         }
 
         if (writeRecords.isEmpty()) {
@@ -299,9 +302,9 @@ public class AssetDataUi extends Composite {
             final List<GwtChannelRecord> records = result.getRecords();
 
             if (records != null) {
-                for (final GwtChannelRecord record : records) {
-                    record.setUnescaped(true);
-                    this.channelValues.put(record.getName(), record);
+                for (final GwtChannelRecord channelRecord : records) {
+                    channelRecord.setUnescaped(true);
+                    this.channelValues.put(channelRecord.getName(), channelRecord);
                 }
                 AssetDataUi.this.channelsDataProvider.getList().addAll(this.model.getChannels());
                 AssetDataUi.this.channelsDataProvider.refresh();
@@ -319,22 +322,22 @@ public class AssetDataUi extends Composite {
 
     private ChannelStatus getChannelStatus(final ChannelModel model) {
         final String channelName = model.getChannelName();
-        final GwtChannelRecord record = this.channelValues.get(model.getChannelName());
+        final GwtChannelRecord channelRecord = this.channelValues.get(model.getChannelName());
 
-        if ("false".equals(model.getValue(AssetConstants.ENABLED.value()))) {
+        if ("false".equals(model.getValue(AssetDataUi.this.model.getParameterIndex(AssetConstants.ENABLED.value())))) {
             return ChannelStatus.DISABLED;
         } else if (this.modifiedWriteChannels.contains(channelName)) {
             return ChannelStatus.DIRTY;
-        } else if (record == null) {
+        } else if (channelRecord == null) {
             return ChannelStatus.UNKNOWN;
-        } else if (record.getValue() == null) {
+        } else if (channelRecord.getValue() == null) {
             return ChannelStatus.FAILURE;
         } else {
             return ChannelStatus.SUCCESS;
         }
     }
 
-    private static final class StaticColumn extends Column<AssetModel.ChannelModel, String> {
+    private final class StaticColumn extends Column<AssetModel.ChannelModel, String> {
 
         private final String key;
 
@@ -344,12 +347,12 @@ public class AssetDataUi extends Composite {
         }
 
         @Override
-        public String getValue(final AssetModel.ChannelModel object) {
-            return object.getValue(this.key);
+        public String getValue(final AssetModel.ChannelModel channelModel) {
+            return channelModel.getValue(AssetDataUi.this.model.getParameterIndex(this.key));
         }
     }
 
-    private static final class StatusCell extends TextCell {
+    private final class StatusCell extends TextCell {
 
         @Override
         public Set<String> getConsumedEvents() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetModel.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetModel.java
@@ -13,6 +13,7 @@
 package org.eclipse.kura.web.client.ui.drivers.assets;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
@@ -40,16 +41,21 @@ public interface AssetModel {
 
     public boolean isValid();
 
+    public Integer getParameterIndex(String value);
+
+    public Map<String, Integer> getParameterIndexes();
+
     public interface ChannelModel {
 
         public GwtConfigParameter getParameter(int index);
 
-        public void setValue(String id, String value);
+        public void setValue(Integer index, String value);
 
-        public boolean isValid(String id);
+        public boolean isValid(Integer index);
 
-        public String getValue(String id);
+        public String getValue(Integer index);
 
         public String getChannelName();
     }
+
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetModelImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetModelImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.eclipse.kura.web.client.ui.drivers.assets.LegacyChannelModel.LegacyChannelModelBuilder;
@@ -32,8 +31,6 @@ import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter;
 
 public class AssetModelImpl implements AssetModel {
-
-    private static final Logger logger = Logger.getLogger(AssetModelImpl.class.getSimpleName());
 
     public static final LabelComparator<LegacyChannelModel> CHANNEL_LABEL_COMPARATOR = new LabelComparator<>();
 
@@ -146,8 +143,6 @@ public class AssetModelImpl implements AssetModel {
 
         this.channelModels.clear();
         this.channelModels.addAll(sortedLegacyChannelModels);
-
-        logger.info("ChannelModels for " + getAssetPid() + ":" + " " + this.channelModels.toString());
     }
 
     @Override

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetModelImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/AssetModelImpl.java
@@ -21,7 +21,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
+import org.eclipse.kura.web.client.ui.drivers.assets.LegacyChannelModel.LegacyChannelModelBuilder;
 import org.eclipse.kura.web.client.util.LabelComparator;
 import org.eclipse.kura.web.client.util.ValidationUtil;
 import org.eclipse.kura.web.shared.AssetConstants;
@@ -30,6 +33,8 @@ import org.eclipse.kura.web.shared.model.GwtConfigParameter;
 
 public class AssetModelImpl implements AssetModel {
 
+    private static final Logger logger = Logger.getLogger(AssetModelImpl.class.getSimpleName());
+
     public static final LabelComparator<LegacyChannelModel> CHANNEL_LABEL_COMPARATOR = new LabelComparator<>();
 
     private final GwtConfigComponent assetConfiguration;
@@ -37,6 +42,7 @@ public class AssetModelImpl implements AssetModel {
 
     private Set<String> channelNames = new HashSet<>();
     private final Map<String, Integer> paramIndexes = new HashMap<>();
+
     private final List<ChannelModel> channelModels = new ArrayList<>();
     private final List<GwtConfigParameter> extraParameters = new ArrayList<>();
 
@@ -73,7 +79,7 @@ public class AssetModelImpl implements AssetModel {
         return result;
     }
 
-    private String getChannelName(String propertyName) {
+    private static String getChannelName(String propertyName) {
         int separatorIndex = propertyName.indexOf(AssetConstants.CHANNEL_PROPERTY_SEPARATOR.value());
         if (separatorIndex != -1) {
             return propertyName.substring(0, separatorIndex);
@@ -81,7 +87,7 @@ public class AssetModelImpl implements AssetModel {
         return null;
     }
 
-    private String getChannelPropertyName(String propertyName) {
+    private static String getChannelPropertyName(String propertyName) {
         int separatorIndex = propertyName.indexOf(AssetConstants.CHANNEL_PROPERTY_SEPARATOR.value());
         if (separatorIndex != -1) {
             return propertyName.substring(separatorIndex + 1);
@@ -104,16 +110,18 @@ public class AssetModelImpl implements AssetModel {
 
     private void loadChannelModels() {
 
-        final HashMap<String, Integer> channelIndexes = new HashMap<>();
+        final Map<String, Integer> channelIndexes = new HashMap<>();
         int i = 0;
+
         for (GwtConfigParameter param : this.channelDescriptor.getParameters()) {
             channelIndexes.put(param.getId(), i);
             i++;
         }
 
-        final HashMap<String, LegacyChannelModel> models = new HashMap<>();
+        final Map<String, LegacyChannelModelBuilder> modelBuilders = new HashMap<>();
 
         for (GwtConfigParameter param : this.assetConfiguration.getParameters()) {
+
             final String channelName = getChannelName(param.getId());
             final String propertyName = getChannelPropertyName(param.getId());
             if (channelName == null || propertyName == null) {
@@ -121,9 +129,13 @@ public class AssetModelImpl implements AssetModel {
             }
 
             final int index = i;
-            LegacyChannelModel model = models.computeIfAbsent(channelName, name -> new LegacyChannelModel(name, index));
-            model.parameters[channelIndexes.get(propertyName)] = param;
+            LegacyChannelModelBuilder modelBuilder = modelBuilders.computeIfAbsent(channelName,
+                    name -> LegacyChannelModel.builder(name, index));
+            modelBuilder.addParameter(channelIndexes.get(propertyName), param);
         }
+
+        Map<String, LegacyChannelModel> models = modelBuilders.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().build()));
 
         ArrayList<Entry<String, LegacyChannelModel>> sortedModels = new ArrayList<>(models.entrySet());
         Collections.sort(sortedModels, CHANNEL_LABEL_COMPARATOR);
@@ -134,6 +146,8 @@ public class AssetModelImpl implements AssetModel {
 
         this.channelModels.clear();
         this.channelModels.addAll(sortedLegacyChannelModels);
+
+        logger.info("ChannelModels for " + getAssetPid() + ":" + " " + this.channelModels.toString());
     }
 
     @Override
@@ -143,9 +157,7 @@ public class AssetModelImpl implements AssetModel {
 
     @Override
     public ChannelModel createNewChannel(String channelName) {
-        final LegacyChannelModel result = new LegacyChannelModel(channelName,
-                this.channelDescriptor.getParameters().size());
-        int i = 0;
+        List<GwtConfigParameter> params = new ArrayList<>();
         for (GwtConfigParameter param : this.channelDescriptor.getParameters()) {
             final GwtConfigParameter cloned = new GwtConfigParameter(param);
             final String paramId = channelName + AssetConstants.CHANNEL_PROPERTY_SEPARATOR.value() + param.getId();
@@ -153,10 +165,14 @@ public class AssetModelImpl implements AssetModel {
             cloned.setName(paramId);
             cloned.setValue(cloned.getDefault());
             this.assetConfiguration.getParameters().add(cloned);
-            result.parameters[i] = cloned;
-            i++;
+            params.add(cloned);
         }
-        result.setValue(AssetConstants.NAME.value(), channelName);
+
+        final LegacyChannelModel result = new LegacyChannelModel(channelName,
+                params.toArray(new GwtConfigParameter[0]));
+
+        result.setValue(AssetModelImpl.this.paramIndexes.get(AssetConstants.NAME.value()), channelName);
+
         this.channelNames.add(channelName);
         this.channelModels.add(result);
         return result;
@@ -180,71 +196,8 @@ public class AssetModelImpl implements AssetModel {
             final ChannelModel model = iter.next();
             if (model.getChannelName().equals(channelName)) {
                 iter.remove();
-                ((LegacyChannelModel) model).remove();
+                ((LegacyChannelModel) model).removeParameters(this.assetConfiguration.getParameters());
                 return;
-            }
-        }
-    }
-
-    private class LegacyChannelModel implements AssetModel.ChannelModel {
-
-        String channelName;
-        GwtConfigParameter[] parameters;
-
-        public LegacyChannelModel(String channelName, int parameterCount) {
-            this.channelName = channelName;
-            this.parameters = new GwtConfigParameter[parameterCount];
-        }
-
-        @Override
-        public String getChannelName() {
-            return this.channelName;
-        }
-
-        @Override
-        public GwtConfigParameter getParameter(int index) {
-            return this.parameters[index];
-        }
-
-        @Override
-        public void setValue(String id, String value) {
-            final Integer index = AssetModelImpl.this.paramIndexes.get(id);
-            if (index == null) {
-                return;
-            }
-            this.parameters[index].setValue(value);
-        }
-
-        @Override
-        public boolean isValid(final String id) {
-            final Integer index = AssetModelImpl.this.paramIndexes.get(id);
-            if (index == null) {
-                return false;
-            }
-            final GwtConfigParameter param = getParameter(index);
-
-            return ValidationUtil.validateParameter(param, param.getValue());
-        }
-
-        @Override
-        public String getValue(String id) {
-            final Integer index = AssetModelImpl.this.paramIndexes.get(id);
-            if (index == null) {
-                return null;
-            }
-            return this.parameters[index].getValue();
-        }
-
-        private void remove() {
-            final Iterator<GwtConfigParameter> iterator = AssetModelImpl.this.assetConfiguration.getParameters()
-                    .iterator();
-            while (iterator.hasNext()) {
-                final GwtConfigParameter param = iterator.next();
-                for (GwtConfigParameter parameter : this.parameters) {
-                    if (parameter == param) {
-                        iterator.remove();
-                    }
-                }
             }
         }
     }
@@ -262,8 +215,8 @@ public class AssetModelImpl implements AssetModel {
     @Override
     public boolean isValid() {
         for (final ChannelModel model : this.channelModels) {
-            for (final String param : this.paramIndexes.keySet()) {
-                if (!model.isValid(param)) {
+            for (final Map.Entry<String, Integer> entry : this.paramIndexes.entrySet()) {
+                if (!model.isValid(entry.getValue())) {
                     return false;
                 }
             }
@@ -285,8 +238,9 @@ public class AssetModelImpl implements AssetModel {
             final ChannelModel channel = this.channelModels.stream()
                     .filter(c -> c.getChannelName().contentEquals(model.getChannelName())).findAny()
                     .orElseGet(() -> createNewChannel(model.getChannelName()));
-            for (final String param : this.paramIndexes.keySet()) {
-                channel.setValue(param, model.getValue(param));
+            for (final Map.Entry<String, Integer> entry : this.paramIndexes.entrySet()) {
+                Integer index = entry.getValue();
+                channel.setValue(index, model.getValue(index));
             }
         }
     }
@@ -297,6 +251,16 @@ public class AssetModelImpl implements AssetModel {
             deleteChannel(this.channelNames.iterator().next());
         }
         addAllChannels(other);
+    }
+
+    @Override
+    public Integer getParameterIndex(String value) {
+        return this.paramIndexes.get(value);
+    }
+
+    @Override
+    public Map<String, Integer> getParameterIndexes() {
+        return this.paramIndexes;
     }
 
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/LegacyChannelModel.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/LegacyChannelModel.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
+package org.eclipse.kura.web.client.ui.drivers.assets;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.eclipse.kura.web.client.util.ValidationUtil;
+import org.eclipse.kura.web.shared.AssetConstants;
+import org.eclipse.kura.web.shared.DataType;
+import org.eclipse.kura.web.shared.ScaleOffsetType;
+import org.eclipse.kura.web.shared.model.GwtConfigParameter;
+import org.eclipse.kura.web.shared.model.GwtConfigParameter.GwtConfigParameterType;
+
+public class LegacyChannelModel implements AssetModel.ChannelModel {
+
+    private static final Logger logger = Logger.getLogger(LegacyChannelModel.class.getSimpleName());
+
+    private final String channelName;
+    private final GwtConfigParameter[] parameters;
+
+    private GwtConfigParameterType subtype;
+
+    public LegacyChannelModel(String channelName, GwtConfigParameter[] parameters) {
+        this.channelName = channelName;
+        this.parameters = parameters;
+
+        logger.info("Parameters for channelName " + channelName + ": " + this.parameters);
+
+        // calculate the subtype for scale and offset parameters based on the scaleoffset.type and value type
+        // properties.
+        detectSubtype();
+
+        logger.info("Subtype: " + this.subtype);
+
+        setScaleOffsetSubtype();
+    }
+
+    private void setScaleOffsetSubtype() {
+        for (GwtConfigParameter param : this.parameters) {
+            if (param.getId().equals(getId(AssetConstants.VALUE_SCALE))
+                    || param.getId().equals(getId(AssetConstants.VALUE_OFFSET))) {
+
+                param.setSubtype(this.subtype);
+
+                logger.info("Subtype for " + param.getId() + ": " + param.getSubtype());
+            }
+        }
+    }
+
+    private void updateScaleOffsetSubtypeForParameters() {
+        for (GwtConfigParameter param : this.parameters) {
+            if (param.getSubtype() != null && param.getSubtype() != this.subtype) {
+
+                param.setSubtype(this.subtype);
+
+                logger.info("Subtype for " + param.getId() + ": " + param.getSubtype() + " updated");
+            }
+        }
+    }
+
+    private void detectSubtype() {
+
+        GwtConfigParameterType subType = null;
+
+        ScaleOffsetType scaleOffsetType = null;
+        DataType valueType = null;
+
+        for (GwtConfigParameter param : this.parameters) {
+            if (param.getId().equals(getId(AssetConstants.SCALE_OFFSET_TYPE))) {
+                String paramValue = param.getValue() != null ? param.getValue() : param.getDefault();
+                scaleOffsetType = ScaleOffsetType.getScaleOffsetType(paramValue);
+            }
+            if (param.getId().equals(getId(AssetConstants.VALUE_TYPE))) {
+                String paramValue = param.getValue() != null ? param.getValue() : param.getDefault();
+                valueType = DataType.getDataType(paramValue);
+            }
+        }
+
+        if (scaleOffsetType != null && valueType != null) {
+            logger.info("ScaleOffsetType: " + scaleOffsetType + ", ValueType: " + valueType);
+
+            subType = scaleOffsetType == ScaleOffsetType.DEFINED_BY_VALUE_TYPE
+                    ? GwtConfigParameterType.valueOf(valueType.name())
+                    : GwtConfigParameterType.valueOf(scaleOffsetType.name());
+        }
+
+        this.subtype = subType;
+    }
+
+    private String getId(AssetConstants assetConstant) {
+        return this.channelName + AssetConstants.CHANNEL_PROPERTY_SEPARATOR.value() + assetConstant.value();
+    }
+
+    @Override
+    public String getChannelName() {
+        return this.channelName;
+    }
+
+    @Override
+    public GwtConfigParameter getParameter(int index) {
+        return this.parameters[index];
+    }
+
+    @Override
+    public void setValue(Integer index, String value) {
+        if (index == null) {
+            return;
+        }
+        GwtConfigParameter param = this.parameters[index];
+        param.setValue(value);
+
+        if (param.getId().equals(getId(AssetConstants.SCALE_OFFSET_TYPE))
+                || param.getId().equals(getId(AssetConstants.VALUE_TYPE))) {
+
+            detectSubtype();
+            updateScaleOffsetSubtypeForParameters();
+        }
+    }
+
+    @Override
+    public boolean isValid(final Integer index) {
+        if (index == null) {
+            return false;
+        }
+        final GwtConfigParameter param = getParameter(index);
+
+        return ValidationUtil.validateParameter(param, param.getValue());
+    }
+
+    @Override
+    public String getValue(final Integer index) {
+        if (index == null) {
+            return null;
+        }
+        return this.parameters[index].getValue();
+    }
+
+    @Override
+    public String toString() {
+        return "LegacyChannelModel [channelName=" + this.channelName + ", parameters="
+                + Arrays.toString(this.parameters) + "]";
+    }
+
+    public static LegacyChannelModelBuilder builder(String channelName, int parameterCount) {
+        return new LegacyChannelModelBuilder(channelName, parameterCount);
+    }
+
+    public void removeParameters(List<GwtConfigParameter> parametersToRemove) {
+        final Iterator<GwtConfigParameter> iterator = parametersToRemove.iterator();
+        while (iterator.hasNext()) {
+            final GwtConfigParameter param = iterator.next();
+            for (GwtConfigParameter parameter : this.parameters) {
+                if (parameter == param) {
+                    iterator.remove();
+                }
+            }
+        }
+    }
+
+    public static class LegacyChannelModelBuilder {
+
+        private String channelName;
+        private GwtConfigParameter[] parameters;
+
+        public LegacyChannelModelBuilder(String channelName, int parameterCount) {
+            this.channelName = channelName;
+            this.parameters = new GwtConfigParameter[parameterCount];
+        }
+
+        public LegacyChannelModelBuilder addParameter(int index, GwtConfigParameter param) {
+            this.parameters[index] = param;
+            return this;
+        }
+
+        public LegacyChannelModel build() {
+            return new LegacyChannelModel(this.channelName, this.parameters);
+        }
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/LegacyChannelModel.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/LegacyChannelModel.java
@@ -16,7 +16,6 @@ package org.eclipse.kura.web.client.ui.drivers.assets;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.util.ValidationUtil;
 import org.eclipse.kura.web.shared.AssetConstants;
@@ -27,8 +26,6 @@ import org.eclipse.kura.web.shared.model.GwtConfigParameter.GwtConfigParameterTy
 
 public class LegacyChannelModel implements AssetModel.ChannelModel {
 
-    private static final Logger logger = Logger.getLogger(LegacyChannelModel.class.getSimpleName());
-
     private final String channelName;
     private final GwtConfigParameter[] parameters;
 
@@ -38,13 +35,9 @@ public class LegacyChannelModel implements AssetModel.ChannelModel {
         this.channelName = channelName;
         this.parameters = parameters;
 
-        logger.info("Parameters for channelName " + channelName + ": " + this.parameters);
-
         // calculate the subtype for scale and offset parameters based on the scaleoffset.type and value type
         // properties.
         detectSubtype();
-
-        logger.info("Subtype: " + this.subtype);
 
         setScaleOffsetSubtype();
     }
@@ -55,8 +48,6 @@ public class LegacyChannelModel implements AssetModel.ChannelModel {
                     || param.getId().equals(getId(AssetConstants.VALUE_OFFSET))) {
 
                 param.setSubtype(this.subtype);
-
-                logger.info("Subtype for " + param.getId() + ": " + param.getSubtype());
             }
         }
     }
@@ -64,10 +55,7 @@ public class LegacyChannelModel implements AssetModel.ChannelModel {
     private void updateScaleOffsetSubtypeForParameters() {
         for (GwtConfigParameter param : this.parameters) {
             if (param.getSubtype() != null && param.getSubtype() != this.subtype) {
-
                 param.setSubtype(this.subtype);
-
-                logger.info("Subtype for " + param.getId() + ": " + param.getSubtype() + " updated");
             }
         }
     }
@@ -91,8 +79,6 @@ public class LegacyChannelModel implements AssetModel.ChannelModel {
         }
 
         if (scaleOffsetType != null && valueType != null) {
-            logger.info("ScaleOffsetType: " + scaleOffsetType + ", ValueType: " + valueType);
-
             subType = scaleOffsetType == ScaleOffsetType.DEFINED_BY_VALUE_TYPE
                     ? GwtConfigParameterType.valueOf(valueType.name())
                     : GwtConfigParameterType.valueOf(scaleOffsetType.name());

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/ValidationUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/ValidationUtil.java
@@ -17,13 +17,17 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.messages.Messages;
+import org.eclipse.kura.web.client.ui.drivers.assets.AssetConfigurationUi;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter;
+import org.eclipse.kura.web.shared.model.GwtConfigParameter.GwtConfigParameterType;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.TakesValue;
 
 public final class ValidationUtil {
+
+    private static final Logger logger = Logger.getLogger(AssetConfigurationUi.class.getSimpleName());
 
     private static final String CONFIG_MAX_VALUE = "configMaxValue";
     private static final String CONFIG_MIN_VALUE = "configMinValue";
@@ -45,6 +49,8 @@ public final class ValidationUtil {
     // Validates all the entered values
     public static void validateParameter(GwtConfigParameter param, String value, ValidationErrorConsumer consumer) {
 
+        logger.info("Validating parameter: " + param.toString());
+
         if (value == null || value.trim().isEmpty()) {
             if (!param.isRequired()) {
                 return;
@@ -61,8 +67,18 @@ public final class ValidationUtil {
             return;
         }
 
+        validateType(param.getType(), param, consumer, trimmedValue);
+        validateType(param.getSubtype(), param, consumer, trimmedValue);
+
+    }
+
+    private static void validateType(GwtConfigParameterType type, GwtConfigParameter param,
+            ValidationErrorConsumer consumer, String trimmedValue) {
+        if (type == null) {
+            return;
+        }
         try {
-            switch (param.getType()) {
+            switch (type) {
             case BOOLEAN:
                 validateBoolean(trimmedValue, param, consumer);
                 break;
@@ -99,7 +115,6 @@ public final class ValidationUtil {
         } catch (NumberFormatException e) {
             consumer.addError(MessageUtils.get(INVALID_VALUE, trimmedValue));
         }
-
     }
 
     public static boolean validateParameters(GwtConfigComponent component) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/ValidationUtil.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/util/ValidationUtil.java
@@ -17,7 +17,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.kura.web.client.messages.Messages;
-import org.eclipse.kura.web.client.ui.drivers.assets.AssetConfigurationUi;
 import org.eclipse.kura.web.shared.model.GwtConfigComponent;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter;
 import org.eclipse.kura.web.shared.model.GwtConfigParameter.GwtConfigParameterType;
@@ -26,8 +25,6 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.TakesValue;
 
 public final class ValidationUtil {
-
-    private static final Logger logger = Logger.getLogger(AssetConfigurationUi.class.getSimpleName());
 
     private static final String CONFIG_MAX_VALUE = "configMaxValue";
     private static final String CONFIG_MIN_VALUE = "configMinValue";
@@ -48,8 +45,6 @@ public final class ValidationUtil {
 
     // Validates all the entered values
     public static void validateParameter(GwtConfigParameter param, String value, ValidationErrorConsumer consumer) {
-
-        logger.info("Validating parameter: " + param.toString());
 
         if (value == null || value.trim().isEmpty()) {
             if (!param.isRequired()) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/DataType.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/DataType.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *  Amit Kumar Mondal
+ ******************************************************************************/
+
+/**
+ * This is a copy of {@code org.eclipse.kura.type.DataType}
+ */
+
+package org.eclipse.kura.web.shared;
+
+import org.eclipse.kura.type.TypedValue;
+
+/**
+ * This contains all the required data type constants required for representing
+ * Java data types as {@link TypedValue}
+ *
+ * @since 1.2
+ */
+public enum DataType {
+
+    BOOLEAN,
+
+    BYTE_ARRAY,
+
+    DOUBLE,
+
+    INTEGER,
+
+    LONG,
+
+    FLOAT,
+
+    STRING;
+
+    /**
+     * Converts {@code stringDataType}, if possible, to the related {@link DataType}.
+     *
+     * @param stringDataType
+     *            String that we want to use to get the respective {@link DataType}.
+     * @return a DataType that corresponds to the String passed as argument.
+     * @throws IllegalArgumentException
+     *             if the passed string does not correspond to an existing {@link DataType}.
+     */
+    public static DataType getDataType(String stringDataType) {
+        if (INTEGER.name().equalsIgnoreCase(stringDataType)) {
+            return INTEGER;
+        }
+        if (FLOAT.name().equalsIgnoreCase(stringDataType)) {
+            return FLOAT;
+        }
+        if (DOUBLE.name().equalsIgnoreCase(stringDataType)) {
+            return DOUBLE;
+        }
+        if (LONG.name().equalsIgnoreCase(stringDataType)) {
+            return LONG;
+        }
+        if (BYTE_ARRAY.name().equalsIgnoreCase(stringDataType)) {
+            return BYTE_ARRAY;
+        }
+        if (BOOLEAN.name().equalsIgnoreCase(stringDataType)) {
+            return BOOLEAN;
+        }
+        if (STRING.name().equalsIgnoreCase(stringDataType)) {
+            return STRING;
+        }
+
+        throw new IllegalArgumentException("Cannot convert to DataType");
+    }
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/ScaleOffsetType.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/ScaleOffsetType.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
+package org.eclipse.kura.web.shared;
+
+/**
+ * This contains all the required type constants for representing
+ * Scale and Offset.
+ * 
+ * This is a copy of {@code org.eclipse.kura.channel.ScaleOffsetType}
+ *
+ * @since 2.8
+ */
+
+public enum ScaleOffsetType {
+
+    DEFINED_BY_VALUE_TYPE,
+
+    DOUBLE,
+
+    LONG;
+
+    /**
+     * Converts {@code stringScaleOffsetType}, if possible, to the related {@link ScaleOffsetType}.
+     *
+     * @param stringDataType
+     *            String that we want to use to get the respective {@link ScaleOffsetType}.
+     * @return a ScaleOffsetType that corresponds to the String passed as argument.
+     * @throws IllegalArgumentException
+     *             if the passed string does not correspond to an existing {@link ScaleOffsetType}.
+     */
+    public static ScaleOffsetType getScaleOffsetType(String stringScaleOffsetType) {
+
+        if (DEFINED_BY_VALUE_TYPE.name().equalsIgnoreCase(stringScaleOffsetType)) {
+            return DEFINED_BY_VALUE_TYPE;
+        }
+
+        if (DOUBLE.name().equalsIgnoreCase(stringScaleOffsetType)) {
+            return DOUBLE;
+        }
+
+        if (LONG.name().equalsIgnoreCase(stringScaleOffsetType)) {
+            return LONG;
+        }
+
+        throw new IllegalArgumentException("Cannot convert to DataType");
+    }
+
+}

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtConfigParameter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtConfigParameter.java
@@ -1,17 +1,18 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
 package org.eclipse.kura.web.shared.model;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
@@ -19,6 +20,7 @@ import com.google.gwt.user.client.rpc.IsSerializable;
 public class GwtConfigParameter implements IsSerializable {
 
     public enum GwtConfigParameterType {
+
         STRING,
         LONG,
         DOUBLE,
@@ -34,130 +36,150 @@ public class GwtConfigParameter implements IsSerializable {
         }
     }
 
-    private String m_id;
-    private String m_name;
-    private String m_description;
-    private GwtConfigParameterType m_type;
-    private boolean m_required;
-    private String m_default;
-    private int m_cardinality;
-    private Map<String, String> m_options;
-    private String m_min;
-    private String m_max;
-    private String m_value;  // used for fields with single cardinality
-    private String[] m_values; // used for fields with multiple cardinality
+    private String id;
+    private String name;
+    private String description;
+    private GwtConfigParameterType type;
+    private GwtConfigParameterType subtype;
+
+    private boolean required;
+    private String defaultValue;
+    private int cardinality;
+    private Map<String, String> options;
+    private String min;
+    private String max;
+    private String value;  // used for fields with single cardinality
+    private String[] values; // used for fields with multiple cardinality
 
     public GwtConfigParameter() {
     }
 
     public GwtConfigParameter(GwtConfigParameter reference) {
-        this.m_id = reference.getId();
-        this.m_name = reference.getName();
-        this.m_description = reference.getDescription();
-        this.m_type = reference.getType();
-        this.m_required = reference.isRequired();
-        this.m_default = reference.getDefault();
-        this.m_cardinality = reference.getCardinality();
-        this.m_options = reference.getOptions();
-        this.m_min = reference.getMin();
-        this.m_max = reference.getMax();
-        this.m_value = reference.getValue();
-        this.m_values = reference.getValues();
+        this.id = reference.getId();
+        this.name = reference.getName();
+        this.description = reference.getDescription();
+        this.type = reference.getType();
+        this.subtype = reference.getSubtype();
+        this.required = reference.isRequired();
+        this.defaultValue = reference.getDefault();
+        this.cardinality = reference.getCardinality();
+        this.options = reference.getOptions();
+        this.min = reference.getMin();
+        this.max = reference.getMax();
+        this.value = reference.getValue();
+        this.values = reference.getValues();
     }
 
     public String getId() {
-        return this.m_id;
+        return this.id;
     }
 
     public void setId(String id) {
-        this.m_id = id;
+        this.id = id;
     }
 
     public String getName() {
-        return this.m_name;
+        return this.name;
     }
 
     public void setName(String name) {
-        this.m_name = name;
+        this.name = name;
     }
 
     public String getDescription() {
-        return this.m_description;
+        return this.description;
     }
 
     public void setDescription(String description) {
-        this.m_description = description;
+        this.description = description;
     }
 
     public GwtConfigParameterType getType() {
-        return this.m_type;
+        return this.type;
     }
 
     public void setType(GwtConfigParameterType type) {
-        this.m_type = type;
+        this.type = type;
+    }
+
+    public GwtConfigParameterType getSubtype() {
+        return this.subtype;
+    }
+
+    public void setSubtype(GwtConfigParameterType subtype) {
+        this.subtype = subtype;
     }
 
     public boolean isRequired() {
-        return this.m_required;
+        return this.required;
     }
 
     public void setRequired(boolean required) {
-        this.m_required = required;
+        this.required = required;
     }
 
     public String getDefault() {
-        return this.m_default;
+        return this.defaultValue;
     }
 
-    public void setDefault(String default1) {
-        this.m_default = default1;
+    public void setDefault(String defaultValue) {
+        this.defaultValue = defaultValue;
     }
 
     public int getCardinality() {
-        return this.m_cardinality;
+        return this.cardinality;
     }
 
     public void setCardinality(int cardinality) {
-        this.m_cardinality = cardinality;
+        this.cardinality = cardinality;
     }
 
     public Map<String, String> getOptions() {
-        return this.m_options;
+        return this.options;
     }
 
     public void setOptions(Map<String, String> options) {
-        this.m_options = options;
+        this.options = options;
     }
 
     public String getMin() {
-        return this.m_min;
+        return this.min;
     }
 
     public void setMin(String min) {
-        this.m_min = min;
+        this.min = min;
     }
 
     public String getMax() {
-        return this.m_max;
+        return this.max;
     }
 
     public void setMax(String max) {
-        this.m_max = max;
+        this.max = max;
     }
 
     public String getValue() {
-        return this.m_value;
+        return this.value;
     }
 
     public void setValue(String value) {
-        this.m_value = value;
+        this.value = value;
     }
 
     public String[] getValues() {
-        return this.m_values;
+        return this.values;
     }
 
     public void setValues(String[] values) {
-        this.m_values = values;
+        this.values = values;
+    }
+
+    @Override
+    public String toString() {
+        return "GwtConfigParameter [id=" + this.id + ", name=" + this.name + ", description=" + this.description
+                + ", type=" + this.type + ", subtype=" + this.subtype + ", required=" + this.required
+                + ", defaultValue=" + this.defaultValue + ", cardinality=" + this.cardinality + ", options="
+                + this.options + ", min=" + this.min + ", max=" + this.max + ", value=" + this.value + ", values="
+                + Arrays.toString(this.values) + "]";
     }
 }

--- a/kura/test/org.eclipse.kura.rest.wire.provider.test/src/main/java/org/eclipse/kura/rest/wire/provider/test/Snippets.java
+++ b/kura/test/org.eclipse.kura.rest.wire.provider.test/src/main/java/org/eclipse/kura/rest/wire/provider/test/Snippets.java
@@ -120,9 +120,9 @@ public class Snippets {
             + "        },\n" //
             + "        {\n" //
             + "            \"name\": \"scale\",\n" //
-            + "            \"description\": \"Scale to be applied to the numeric value of the channel\",\n" //
+            + "            \"description\": \"Scale to be applied to the numeric value of the channel.\",\n" //
             + "            \"id\": \"+scale\",\n" //
-            + "            \"type\": \"DOUBLE\",\n" //
+            + "            \"type\": \"STRING\",\n" //
             + "            \"cardinality\": 0,\n" //
             + "            \"isRequired\": false\n" //
             + "        },\n" //
@@ -130,7 +130,7 @@ public class Snippets {
             + "            \"name\": \"offset\",\n" //
             + "            \"description\": \"Offset to be applied to the numeric value of the channel\",\n" //
             + "            \"id\": \"+offset\",\n" //
-            + "            \"type\": \"DOUBLE\",\n" //
+            + "            \"type\": \"STRING\",\n" //
             + "            \"cardinality\": 0,\n" //
             + "            \"isRequired\": false\n" //
             + "        },\n" //


### PR DESCRIPTION
Now scale and offset fields in the asset's channel table are validated according to the **mode** calculated for the channel as described [here](https://eclipse-kura.github.io/kura/docs-develop/connect-field-devices/asset-implemetation/#arithmetic-with-scale-and-offset).



