### PR TITLE
fix(nm): Removed check of net.interfaces property

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -406,20 +406,15 @@ public class NMDbusConnector {
     private synchronized void doApply(String deviceIdToBeConfigured, Map<String, Object> networkConfiguration)
             throws DBusException {
         NetworkProperties properties = new NetworkProperties(networkConfiguration);
-        List<String> configuredInterfaceIds = properties.getStringList("net.interfaces");
 
         Optional<Device> device = getNetworkManagerDeviceByInterfaceId(deviceIdToBeConfigured);
         if (device.isPresent()) {
-            if (configuredInterfaceIds.contains(deviceIdToBeConfigured)) {
-                manageConfiguredInterface(device, deviceIdToBeConfigured, properties);
-            } else {
-                manageNonConfiguredInterface(device, deviceIdToBeConfigured);
-            }
+            manageInterface(device, deviceIdToBeConfigured, properties);
         } else {
             NMDeviceType propertyDeviceType = NMDeviceType.fromPropertiesString(
                     properties.get(String.class, "net.interface.%s.type", deviceIdToBeConfigured));
             if (CONFIGURATION_SUPPORTED_VIRTUAL_DEVICE_TYPES.contains(propertyDeviceType)) {
-                manageConfiguredInterface(Optional.empty(), deviceIdToBeConfigured, properties);
+                manageInterface(Optional.empty(), deviceIdToBeConfigured, properties);
             } else {
                 logger.warn("Can't apply configuration to disconnected or unsupported virtual device "
                         + "\"{}\" of type \"{}\"", deviceIdToBeConfigured, propertyDeviceType);
@@ -427,23 +422,21 @@ public class NMDbusConnector {
         }
     }
 
-    private synchronized void manageConfiguredInterface(Optional<Device> device, String deviceId,
-            NetworkProperties properties) throws DBusException {
-        NMDeviceType deviceType;
-        if (device.isPresent()) {
-            deviceType = this.networkManager.getDeviceType(device.get().getObjectPath());
-        } else {
-            deviceType = NMDeviceType
-                    .fromPropertiesString(properties.get(String.class, "net.interface.%s.type", deviceId));
-        }
+    private synchronized void manageInterface(Optional<Device> device, String deviceId, NetworkProperties properties)
+            throws DBusException {
+        NMDeviceType deviceType = getDeviceType(device, deviceId, properties);
 
-        KuraIpStatus ip4Status = KuraIpStatus
-                .fromString(properties.get(String.class, "net.interface.%s.config.ip4.status", deviceId));
+        Optional<KuraIpStatus> ip4OptStatus = KuraIpStatus
+                .fromString(properties.getOpt(String.class, "net.interface.%s.config.ip4.status", deviceId));
+        KuraIpStatus ip4Status = KuraIpStatus.DISABLED;
+        if (ip4OptStatus.isPresent()) {
+            ip4Status = ip4OptStatus.get();
+        }
 
         Optional<KuraIpStatus> ip6OptStatus = KuraIpStatus
                 .fromString(properties.getOpt(String.class, "net.interface.%s.config.ip6.status", deviceId));
-        KuraIpStatus ip6Status;
 
+        KuraIpStatus ip6Status;
         if (!ip6OptStatus.isPresent()) {
             ip6Status = ip4Status == KuraIpStatus.UNMANAGED ? KuraIpStatus.UNMANAGED : KuraIpStatus.DISABLED;
         } else {
@@ -480,6 +473,15 @@ public class NMDbusConnector {
             this.modemManager.setGPS(mmDbusPath, enableGPS, gpsModeString);
         }
 
+    }
+
+    private NMDeviceType getDeviceType(Optional<Device> device, String deviceId, NetworkProperties properties)
+            throws DBusException {
+        if (device.isPresent()) {
+            return this.networkManager.getDeviceType(device.get().getObjectPath());
+        } else {
+            return NMDeviceType.fromPropertiesString(properties.get(String.class, "net.interface.%s.type", deviceId));
+        }
     }
 
     private void enableInterface(String deviceId, NetworkProperties properties, Optional<Device> device,
@@ -566,34 +568,6 @@ public class NMDbusConnector {
             dsLock.waitForSignal();
         } catch (DBusExecutionException | DBusException | TimeoutException e) {
             logger.warn("Couldn't complete creation of device {}, caused by:", deviceId, e);
-        }
-    }
-
-    private void manageNonConfiguredInterface(Optional<Device> optDevice, String deviceId) throws DBusException {
-        if (!optDevice.isPresent()) {
-            logger.warn("Ignoring missing, non configured device \"{}\"", deviceId);
-            return;
-        }
-        Device device = optDevice.get();
-
-        NMDeviceType deviceType = this.networkManager.getDeviceType(device.getObjectPath());
-
-        if (!CONFIGURATION_SUPPORTED_DEVICE_TYPES.contains(deviceType)) {
-            logger.warn("Device \"{}\" of type \"{}\" currently not supported", deviceId, deviceType);
-            return;
-        }
-
-        if (Boolean.FALSE.equals(this.networkManager.isDeviceManaged(device))) {
-            this.networkManager.setDeviceManaged(device, true);
-        }
-
-        logger.warn("Device \"{}\" of type \"{}\" not configured. Disabling...", deviceId, deviceType);
-
-        disable(optDevice, deviceId);
-
-        if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {
-            Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-            this.modemManager.setGPS(mmDbusPath, Optional.of(false), Optional.empty());
         }
     }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -148,18 +148,17 @@ public class NMSettingsConverter {
         Map<String, Variant<?>> settings = new HashMap<>();
 
         switch (Kura8021xEAP.fromString(eap)) {
-            case KURA_8021X_EAP_TTLS:
-                create8021xTunneledTls(props, deviceId, settings);
-                break;
-            case KURA_8021X_EAP_PEAP:
-                create8021xProtectedEap(props, deviceId, settings);
-                break;
-            case KURA_8021X_EAP_TLS:
-                create8021xTls(props, deviceId, settings);
-                break;
-            default:
-                throw new IllegalArgumentException(
-                        String.format("Security type 802-1x EAP \"%s\" is not supported.", eap));
+        case KURA_8021X_EAP_TTLS:
+            create8021xTunneledTls(props, deviceId, settings);
+            break;
+        case KURA_8021X_EAP_PEAP:
+            create8021xProtectedEap(props, deviceId, settings);
+            break;
+        case KURA_8021X_EAP_TLS:
+            create8021xTls(props, deviceId, settings);
+            break;
+        default:
+            throw new IllegalArgumentException(String.format("Security type 802-1x EAP \"%s\" is not supported.", eap));
         }
 
         if (!phase2.isPresent()) {
@@ -167,14 +166,14 @@ public class NMSettingsConverter {
         }
 
         switch (Kura8021xInnerAuth.fromString(phase2.get())) {
-            case KURA_8021X_INNER_AUTH_NONE:
-                break;
-            case KURA_8021X_INNER_AUTH_MSCHAPV2:
-                create8021xMschapV2(props, deviceId, settings);
-                break;
-            default:
-                throw new IllegalArgumentException(
-                        String.format("Security type 802-1x InnerAuth (Phase2) \"%s\" is not supported.", phase2));
+        case KURA_8021X_INNER_AUTH_NONE:
+            break;
+        case KURA_8021X_INNER_AUTH_MSCHAPV2:
+            create8021xMschapV2(props, deviceId, settings);
+            break;
+        default:
+            throw new IllegalArgumentException(
+                    String.format("Security type 802-1x InnerAuth (Phase2) \"%s\" is not supported.", phase2));
         }
 
         return settings;
@@ -386,8 +385,7 @@ public class NMSettingsConverter {
     }
 
     private static void configureIp6Wan(NetworkProperties props, String deviceId, Map<String, Variant<?>> settings) {
-        Optional<List<String>> dnsServers = props.getOptStringList("net.interface.%s.config.ip6.dnsServers",
-                deviceId);
+        Optional<List<String>> dnsServers = props.getOptStringList("net.interface.%s.config.ip6.dnsServers", deviceId);
 
         dnsServers.ifPresent(value -> {
             settings.put("dns", new Variant<>(convertIp6(value), "aay"));
@@ -429,14 +427,14 @@ public class NMSettingsConverter {
             Map<String, Variant<?>> settings) {
         settings.put(NM_SETTINGS_IPV6_METHOD, new Variant<>("auto"));
 
-        Optional<String> addressGenerationMode = props.getOpt(String.class,
-                "net.interface.%s.config.ip6.addr.gen.mode", deviceId);
+        Optional<String> addressGenerationMode = props.getOpt(String.class, "net.interface.%s.config.ip6.addr.gen.mode",
+                deviceId);
 
         addressGenerationMode.ifPresent(value -> {
             KuraIp6AddressGenerationMode ipv6AddressGenerationMode = KuraIp6AddressGenerationMode
                     .fromString(addressGenerationMode.get());
-            settings.put("addr-gen-mode", new Variant<>(KuraIp6AddressGenerationMode
-                    .toNMSettingIP6ConfigAddrGenMode(ipv6AddressGenerationMode).toInt32()));
+            settings.put("addr-gen-mode", new Variant<>(
+                    KuraIp6AddressGenerationMode.toNMSettingIP6ConfigAddrGenMode(ipv6AddressGenerationMode).toInt32()));
         });
 
         Optional<String> privacy = props.getOpt(String.class, "net.interface.%s.config.ip6.privacy", deviceId);
@@ -454,8 +452,7 @@ public class NMSettingsConverter {
             ip6ConfigMethod = KuraIp6ConfigurationMethod
                     .fromString(props.get(String.class, "net.interface.%s.config.ip6.address.method", deviceId));
         } catch (NoSuchElementException e) {
-            logger.warn("IPv6 address method property not found. Using default value: {}",
-                    ip6ConfigMethod);
+            logger.warn("IPv6 address method property not found. Using default value: {}", ip6ConfigMethod);
         }
         return ip6ConfigMethod;
     }
@@ -471,8 +468,12 @@ public class NMSettingsConverter {
         String ssid = props.get(String.class, "net.interface.%s.config.wifi.%s.ssid", deviceId, propMode.toLowerCase());
         settings.put("ssid", new Variant<>(ssid.getBytes(StandardCharsets.UTF_8)));
 
-        short channel = Short.parseShort(
-                props.get(String.class, "net.interface.%s.config.wifi.%s.channel", deviceId, propMode.toLowerCase()));
+        short channel = 0;
+        Optional<String> optionalChannel = props.getOpt(String.class, "net.interface.%s.config.wifi.%s.channel",
+                deviceId, propMode.toLowerCase());
+        if (optionalChannel.isPresent()) {
+            channel = Short.parseShort(optionalChannel.get());
+        }
         settings.put("channel", new Variant<>(new UInt32(channel)));
 
         Optional<String> band = wifiBandConvert(
@@ -496,17 +497,16 @@ public class NMSettingsConverter {
                 props.get(String.class, KURA_PROPS_KEY_WIFI_SECURITY_TYPE, deviceId, propMode.toLowerCase()));
 
         switch (securityType) {
-            case SECURITY_WEP:
-                return createWEPSettings(props, deviceId, propMode);
-            case SECURITY_WPA:
-            case SECURITY_WPA2:
-            case SECURITY_WPA_WPA2:
-                return createWPAWPA2Settings(props, deviceId, propMode);
-            case SECURITY_WPA2_WPA3_ENTERPRISE:
-                return createWPA2WPA3EnterpriseSettings();
-            default:
-                throw new IllegalArgumentException(
-                        String.format("Security type \"%s\" is not supported.", securityType));
+        case SECURITY_WEP:
+            return createWEPSettings(props, deviceId, propMode);
+        case SECURITY_WPA:
+        case SECURITY_WPA2:
+        case SECURITY_WPA_WPA2:
+            return createWPAWPA2Settings(props, deviceId, propMode);
+        case SECURITY_WPA2_WPA3_ENTERPRISE:
+            return createWPA2WPA3EnterpriseSettings();
+        default:
+            throw new IllegalArgumentException(String.format("Security type \"%s\" is not supported.", securityType));
         }
     }
 
@@ -753,12 +753,12 @@ public class NMSettingsConverter {
 
     private static String wifiModeConvert(String kuraMode) {
         switch (kuraMode) {
-            case "INFRA":
-                return "infrastructure";
-            case "MASTER":
-                return "ap";
-            default:
-                throw new IllegalArgumentException(String.format("Unsupported WiFi mode \"%s\"", kuraMode));
+        case "INFRA":
+            return "infrastructure";
+        case "MASTER":
+            return "ap";
+        default:
+            throw new IllegalArgumentException(String.format("Unsupported WiFi mode \"%s\"", kuraMode));
         }
     }
 
@@ -779,58 +779,57 @@ public class NMSettingsConverter {
         }
 
         switch (kuraBand) {
-            case "RADIO_MODE_80211a":
-            case "RADIO_MODE_80211_AC":
-                return Optional.of("a");
-            case "RADIO_MODE_80211b":
-            case "RADIO_MODE_80211g":
-                return Optional.of("bg");
-            default:
-                throw new IllegalArgumentException(String.format("Unsupported WiFi band \"%s\"", kuraBand));
+        case "RADIO_MODE_80211a":
+        case "RADIO_MODE_80211_AC":
+            return Optional.of("a");
+        case "RADIO_MODE_80211b":
+        case "RADIO_MODE_80211g":
+            return Optional.of("bg");
+        default:
+            throw new IllegalArgumentException(String.format("Unsupported WiFi band \"%s\"", kuraBand));
         }
     }
 
     private static List<String> wifiCipherConvert(String kuraCipher) {
         switch (kuraCipher) {
-            case "CCMP":
-                return Arrays.asList("ccmp");
-            case "TKIP":
-                return Arrays.asList("tkip");
-            case "CCMP_TKIP":
-                return Arrays.asList("tkip", "ccmp");
-            default:
-                throw new IllegalArgumentException(String.format("Unsupported WiFi cipher \"%s\"", kuraCipher));
+        case "CCMP":
+            return Arrays.asList("ccmp");
+        case "TKIP":
+            return Arrays.asList("tkip");
+        case "CCMP_TKIP":
+            return Arrays.asList("tkip", "ccmp");
+        default:
+            throw new IllegalArgumentException(String.format("Unsupported WiFi cipher \"%s\"", kuraCipher));
         }
     }
 
     private static List<String> wifiProtoConvert(KuraWifiSecurityType securityType) {
         switch (securityType) {
-            case SECURITY_WPA:
-                return Arrays.asList("wpa");
-            case SECURITY_WPA2:
-                return Arrays.asList("rsn");
-            case SECURITY_WPA_WPA2:
-                return Arrays.asList();
-            default:
-                throw new IllegalArgumentException(String.format("Unsupported WiFi proto \"%s\"", securityType));
+        case SECURITY_WPA:
+            return Arrays.asList("wpa");
+        case SECURITY_WPA2:
+            return Arrays.asList("rsn");
+        case SECURITY_WPA_WPA2:
+            return Arrays.asList();
+        default:
+            throw new IllegalArgumentException(String.format("Unsupported WiFi proto \"%s\"", securityType));
         }
     }
 
     private static String connectionTypeConvert(NMDeviceType deviceType) {
         switch (deviceType) {
-            case NM_DEVICE_TYPE_ETHERNET:
-                return "802-3-ethernet";
-            case NM_DEVICE_TYPE_WIFI:
-                return "802-11-wireless";
-            case NM_DEVICE_TYPE_MODEM:
-                return "gsm";
-            case NM_DEVICE_TYPE_VLAN:
-                return "vlan";
-            // ... WIP
-            default:
-                throw new IllegalArgumentException(String
-                        .format("Unsupported connection type conversion from NMDeviceType \"%s\"",
-                                deviceType.toString()));
+        case NM_DEVICE_TYPE_ETHERNET:
+            return "802-3-ethernet";
+        case NM_DEVICE_TYPE_WIFI:
+            return "802-11-wireless";
+        case NM_DEVICE_TYPE_MODEM:
+            return "gsm";
+        case NM_DEVICE_TYPE_VLAN:
+            return "vlan";
+        // ... WIP
+        default:
+            throw new IllegalArgumentException(String
+                    .format("Unsupported connection type conversion from NMDeviceType \"%s\"", deviceType.toString()));
         }
     }
 

--- a/kura/org.eclipse.kura.rest.network.configuration.provider/src/main/java/org/eclipse/kura/internal/rest/network/configuration/NetworkConfigurationRestService.java
+++ b/kura/org.eclipse.kura.rest.network.configuration.provider/src/main/java/org/eclipse/kura/internal/rest/network/configuration/NetworkConfigurationRestService.java
@@ -273,4 +273,5 @@ public class NetworkConfigurationRestService {
         }
         return result;
     }
+
 }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtNetworkServiceImpl.java
@@ -105,7 +105,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             throw new GwtKuraException(GwtKuraErrorCode.INTERNAL_ERROR, e);
         }
     }
-    
+
     @Override
     public boolean verifyWifiCredentials(GwtXSRFToken xsrfToken, String interfaceName, GwtWifiConfig gwtWifiConfig)
             throws GwtKuraException {
@@ -247,11 +247,11 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
         }
         return new ArrayList<>(gwtOpenPortEntries);
 
-//        if (isNet2()) {
-//            return org.eclipse.kura.web.server.net2.GwtNetworkServiceImpl.findDeviceFirewallOpenPortsIPv6();
-//        } else {
-//            throw new GwtKuraException(GwtKuraErrorCode.OPERATION_NOT_SUPPORTED);
-//        }
+        // if (isNet2()) {
+        // return org.eclipse.kura.web.server.net2.GwtNetworkServiceImpl.findDeviceFirewallOpenPortsIPv6();
+        // } else {
+        // throw new GwtKuraException(GwtKuraErrorCode.OPERATION_NOT_SUPPORTED);
+        // }
     }
 
     @Override
@@ -651,8 +651,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             } else {
                 Optional<NetworkInterfaceType> ifType = status.getNetInterfaceType(ifName);
                 if (ifType.isPresent()) {
-                    GwtNetInterfaceConfig gwtConfig = configuration.getDefaultGwtNetInterfaceConfig(ifName,
-                            ifType.get());
+                    GwtNetInterfaceConfig gwtConfig = configuration.getGwtNetInterfaceConfig(ifName, ifType.get());
                     status.fillWithStatusProperties(ifName, gwtConfig);
                     result.add(gwtConfig);
                 } else {
@@ -673,13 +672,10 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
             entry.setPortRange(String.valueOf(firewallOpenPortConfigIP.getPort()));
         }
         entry.setProtocol(firewallOpenPortConfigIP.getProtocol().toString());
-        entry.setPermittedNetwork(firewallOpenPortConfigIP.getPermittedNetwork()
-                .getIpAddress().getHostAddress() + "/"
+        entry.setPermittedNetwork(firewallOpenPortConfigIP.getPermittedNetwork().getIpAddress().getHostAddress() + "/"
                 + firewallOpenPortConfigIP.getPermittedNetwork().getPrefix());
-        entry.setPermittedInterfaceName(
-                firewallOpenPortConfigIP.getPermittedInterfaceName());
-        entry.setUnpermittedInterfaceName(
-                firewallOpenPortConfigIP.getUnpermittedInterfaceName());
+        entry.setPermittedInterfaceName(firewallOpenPortConfigIP.getPermittedInterfaceName());
+        entry.setUnpermittedInterfaceName(firewallOpenPortConfigIP.getUnpermittedInterfaceName());
         entry.setPermittedMAC(firewallOpenPortConfigIP.getPermittedMac());
         entry.setSourcePortRange(firewallOpenPortConfigIP.getSourcePortRange());
         return entry;
@@ -696,8 +692,7 @@ public class GwtNetworkServiceImpl extends OsgiRemoteServiceServlet implements G
         entry.setOutPort(firewallPortForwardConfigIP.getOutPort());
         String masquerade = firewallPortForwardConfigIP.isMasquerade() ? "yes" : "no";
         entry.setMasquerade(masquerade);
-        entry.setPermittedNetwork(
-                firewallPortForwardConfigIP.getPermittedNetwork().toString());
+        entry.setPermittedNetwork(firewallPortForwardConfigIP.getPermittedNetwork().toString());
         entry.setPermittedMAC(firewallPortForwardConfigIP.getPermittedMac());
         entry.setSourcePortRange(firewallPortForwardConfigIP.getSourcePortRange());
         return entry;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceAdapter.java
@@ -53,34 +53,37 @@ public class NetworkConfigurationServiceAdapter {
      * Return a {@link GwtNetInterfaceConfig} of the given network interface with
      * properties read from the NetworkConfigurationService
      * 
-     * @param ifName the network interface name
+     * @param ifName
+     *            the network interface name
      * @return a new {@link GwtNetInterfaceConfig}
      */
     public GwtNetInterfaceConfig getGwtNetInterfaceConfig(String ifName) {
-        return new GwtNetInterfaceConfigBuilder(this.netConfServProperties)
-                .forInterface(ifName).build();
+        return new GwtNetInterfaceConfigBuilder(this.netConfServProperties).forInterface(ifName).build();
     }
 
     /**
-     * Return a {@link GwtNetInterfaceConfig} for the given network interface
-     * name and type with default values
+     * Return a {@link GwtNetInterfaceConfig} of the given network interface name and type with
+     * properties read from the NetworkConfigurationService
      * 
-     * @param ifName the network interface name
-     * @param ifType the network interface type
+     * @param ifName
+     *            the network interface name
+     * @param ifType
+     *            the network interface type
      * @return a new {@link GwtNetInterfaceConfig}
      */
-    public GwtNetInterfaceConfig getDefaultGwtNetInterfaceConfig(String ifName, NetworkInterfaceType ifType) {
-        return new GwtNetInterfaceConfigBuilder()
-                .forInterface(ifName).forType(ifType).build();
+    public GwtNetInterfaceConfig getGwtNetInterfaceConfig(String ifName, NetworkInterfaceType ifType) {
+        return new GwtNetInterfaceConfigBuilder(this.netConfServProperties).forInterface(ifName).forType(ifType)
+                .build();
     }
 
     /**
      * Updates the {@link ConfigurationService} with the properties found in input
      * {@code gwtConfig}
      * 
-     * @param gwtConfig the configuration containing the properties to update
+     * @param gwtConfig
+     *            the configuration containing the properties to update
      * @throws KuraException
-     * @throws GwtKuraException 
+     * @throws GwtKuraException
      */
     public void updateConfiguration(GwtNetInterfaceConfig gwtConfig) throws KuraException, GwtKuraException {
         NetworkConfigurationServicePropertiesBuilder builder = new NetworkConfigurationServicePropertiesBuilder(


### PR DESCRIPTION
This PR removes the check of the content of the `net.interfaces` property when a new configuration is applied. Moreover, the webUI behavior has been changed to take into account the fact that a network interface cannot be listed in that property.

