### PR TITLE
fix: Ignore modem state when getting position from MM

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -33,7 +33,6 @@ import org.eclipse.kura.net.status.NetworkInterfaceStatus;
 import org.eclipse.kura.net.wifi.WifiChannel;
 import org.eclipse.kura.nm.configuration.NMSettingsConverter;
 import org.eclipse.kura.nm.enums.MMModemLocationSource;
-import org.eclipse.kura.nm.enums.MMModemState;
 import org.eclipse.kura.nm.enums.NMDeviceState;
 import org.eclipse.kura.nm.enums.NMDeviceType;
 import org.eclipse.kura.nm.signal.handlers.DeviceCreationLock;
@@ -650,7 +649,7 @@ public class NMDbusConnector {
     public List<Location> getAvailableMMLocations() {
         List<Location> availableLocations = new ArrayList<>();
 
-        this.getEnabledModemsPaths().forEach(modemPath -> {
+        this.getModemsPaths().forEach(modemPath -> {
             try {
                 Properties locationProperties = this.modemManager
                         .getLocationProperties(this.modemManager.getModemManagerLocation(modemPath));
@@ -671,30 +670,22 @@ public class NMDbusConnector {
 
     }
 
-    private List<String> getEnabledModemsPaths() {
-        List<String> enabledModemsPath = new ArrayList<>();
+    private List<String> getModemsPaths() {
+        List<String> modemsPath = new ArrayList<>();
 
         try {
 
             for (Device device : this.networkManager.getAllDevices()) {
                 if (networkManager.getDeviceType(device.getObjectPath()).equals(NMDeviceType.NM_DEVICE_TYPE_MODEM)) {
                     Optional<String> modemPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-                    if (modemPath.isPresent()) {
-                        Optional<Properties> modemProps = this.modemManager.getModemProperties(modemPath.get());
-                        modemProps.ifPresent(props -> {
-                            MMModemState modemState = this.modemManager.getMMModemState(props);
-                            if (modemState.equals(MMModemState.MM_MODEM_STATE_CONNECTED)
-                                    || modemState.equals(MMModemState.MM_MODEM_STATE_REGISTERED)) {
-                                enabledModemsPath.add(modemPath.get());
-                            }
-                        });
-                    }
+
+                    modemPath.ifPresent(modemsPath::add);
                 }
             }
         } catch (DBusException ex) {
             logger.debug("Impossible to retrieve information regarding available modems");
         }
 
-        return enabledModemsPath;
+        return modemsPath;
     }
 }


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

The ModemManager position provider currently tries to get the location only from modems that are in the MM_MODEM_STATE_CONNECTED or MM_MODEM_STATE_REGISTERED state. This prevents to be able to get the location at least in the following cases:

* Modem GPS is enabled in Kura web UI but IPv4 and IPv6 status is set to disabled
* The modem is enabled for wan but it is not registered to a cellular network (e.g. the cellular antenna is not connected or cellular signal level is low) 

This PR removes the filtering based on modem state to decouple the ability to get the location information from the state of the cellular connection.