### PR TITLE
fix(distrib): Update default LogManager property in kura.properties file

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/kura.properties
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/kura.properties
@@ -56,6 +56,7 @@ os.distribution.version=20.04
 kura.command.user=kura
 kura.legacy.bluetooth.beacon.scan=false
 kura.legacy.ppp.logging.enabled=true
+kura.default.log.manager=filesystem-kura-log
 
 
 ## -----------------------------------------------------------------------------

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura.properties
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura.properties
@@ -56,6 +56,7 @@ os.distribution.version=18.04
 kura.command.user=kura
 kura.legacy.bluetooth.beacon.scan=false
 kura.legacy.ppp.logging.enabled=true
+kura.default.log.manager=filesystem-kura-log
 
 
 ## -----------------------------------------------------------------------------

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/kura.properties
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/kura.properties
@@ -57,6 +57,7 @@ os.distribution.version=N/A
 kura.command.user=kura
 kura.legacy.bluetooth.beacon.scan=false
 kura.legacy.ppp.logging.enabled=true
+kura.default.log.manager=filesystem-kura-log
 
 
 ## -----------------------------------------------------------------------------

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura.properties
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura.properties
@@ -58,6 +58,7 @@ os.distribution.version=N/A
 kura.command.user=kura
 kura.legacy.bluetooth.beacon.scan=false
 kura.legacy.ppp.logging.enabled=true
+kura.default.log.manager=filesystem-kura-log
 
 
 ## -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the `kura.default.log.manager` property to the Nvidia Jetson Nano and Intel UP2 profiles.
