### PR TITLE
fix: fixed nmea position unit of measurement

### DIFF
--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/position/NmeaPosition.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/position/NmeaPosition.java
@@ -24,8 +24,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * <li>Latitude in degrees
  * <li>Track in degrees
  * <li>Altitude in meters
- * <li>Speed in km/h
- * <li>Speed in mph
+ * <li>Speed in m/s (this field has different getters to retrieved value in m/s, km/h or mph)
  * </ul>
  * It adds to the OSGI Position class the following fields:<br>
  * <ul>
@@ -47,11 +46,14 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public class NmeaPosition {
 
-    private double latitude;
-    private double longitude;
-    private double altitude;
-    private double speed;
-    private double track;
+    private static final double MS_TO_KMH = 3.6;
+    private static final double MS_TO_MPH = 2.24;
+
+    private double latitudeDegrees;
+    private double longitudeDegrees;
+    private double altitudeMeters;
+    private double speedMetersPerSecond;
+    private double trackDegrees;
     private int fixQuality;
     private int nrSatellites;
     private double mDOP;
@@ -63,28 +65,29 @@ public class NmeaPosition {
     private char latitudeHemisphere;
     private char longitudeHemisphere;
 
-    public NmeaPosition(double lat, double lon, double alt, double speed, double track) {
-        this(lat, lon, alt, speed, track, 0, 0, 0.0, 0.0, 0.0, 0.0, 0, '0', '0', '0');
+    public NmeaPosition(double latDegrees, double lonDegrees, double altDegrees, double speedMps, double trackDegrees) {
+        this(latDegrees, lonDegrees, altDegrees, speedMps, trackDegrees, 0, 0, 0.0, 0.0, 0.0, 0.0, 0, '0', '0', '0');
     }
 
     @SuppressWarnings("checkstyle:parameterNumber")
-    public NmeaPosition(double lat, double lon, double alt, double speed, double track, int fixQuality,
-            int nrSatellites, double dop, double pdop, double hdop, double vdop, int fix3D) {
-        this(lat, lon, alt, speed, track, fixQuality, nrSatellites, dop, pdop, hdop, vdop, fix3D, '0', '0', '0');
+    public NmeaPosition(double latDegrees, double lonDegrees, double altDegrees, double speedMps, double trackDegrees,
+            int fixQuality, int nrSatellites, double dop, double pdop, double hdop, double vdop, int fix3D) {
+        this(latDegrees, lonDegrees, altDegrees, speedMps, trackDegrees, fixQuality, nrSatellites, dop, pdop, hdop,
+                vdop, fix3D, '0', '0', '0');
     }
 
     /**
      * @since 2.0
      */
     @SuppressWarnings("checkstyle:parameterNumber")
-    public NmeaPosition(double lat, double lon, double alt, double speed, double track, int fixQuality,
-            int nrSatellites, double dop, double pdop, double hdop, double vdop, int fix3D, char validF, char hemiLat,
-            char hemiLon) {
-        this.latitude = lat;
-        this.longitude = lon;
-        this.altitude = alt;
-        this.speed = speed;
-        this.track = track;
+    public NmeaPosition(double latDegrees, double lonDegrees, double altDegrees, double speedMps, double trackDegrees,
+            int fixQuality, int nrSatellites, double dop, double pdop, double hdop, double vdop, int fix3D, char validF,
+            char hemiLat, char hemiLon) {
+        this.latitudeDegrees = latDegrees;
+        this.longitudeDegrees = lonDegrees;
+        this.altitudeMeters = altDegrees;
+        this.speedMetersPerSecond = speedMps;
+        this.trackDegrees = trackDegrees;
         this.fixQuality = fixQuality;
         this.nrSatellites = nrSatellites;
         this.mDOP = dop;
@@ -101,69 +104,69 @@ public class NmeaPosition {
      * Return the latitude in degrees
      */
     public double getLatitude() {
-        return this.latitude;
+        return this.latitudeDegrees;
     }
 
     public void setLatitude(double latitude) {
-        this.latitude = latitude;
+        this.latitudeDegrees = latitude;
     }
 
     /**
      * Return the longitude in degrees
      */
     public double getLongitude() {
-        return this.longitude;
+        return this.longitudeDegrees;
     }
 
     public void setLongitude(double longitude) {
-        this.longitude = longitude;
+        this.longitudeDegrees = longitude;
     }
 
     /**
      * Return the altitude in meters
      */
     public double getAltitude() {
-        return this.altitude;
+        return this.altitudeMeters;
     }
 
     public void setAltitude(double altitude) {
-        this.altitude = altitude;
+        this.altitudeMeters = altitude;
     }
 
     /**
      * Return the speed in km/h
      */
     public double getSpeedKmh() {
-        return this.speed * 3.6;
+        return this.speedMetersPerSecond * MS_TO_KMH;
     }
 
     /**
      * Return the speed in mph
      */
     public double getSpeedMph() {
-        return this.speed * 2.24;
+        return this.speedMetersPerSecond * MS_TO_MPH;
     }
 
     /**
      * Return the speed in m/s
      */
     public double getSpeed() {
-        return this.speed;
+        return this.speedMetersPerSecond;
     }
 
     public void setSpeed(double speed) {
-        this.speed = speed;
+        this.speedMetersPerSecond = speed;
     }
 
     /**
      * Return the track in degrees
      */
     public double getTrack() {
-        return this.track;
+        return this.trackDegrees;
     }
 
     public void setTrack(double track) {
-        this.track = track;
+        this.trackDegrees = track;
     }
 
     public int getFixQuality() {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/position/MMLocationParser.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/position/MMLocationParser.java
@@ -39,7 +39,7 @@ public class MMLocationParser {
     private static final Logger logger = LoggerFactory.getLogger(MMLocationParser.class);
 
     private static final double KNOTS_TO_MS = 1 / 1.94384449;
-    private static final double MS_TO_KMH = 3.6;
+
     private int gnssTypeUpdateCounter = 0;
     private static final int GNSSTYPE_RESET_COUNTER = 50;
 
@@ -88,15 +88,10 @@ public class MMLocationParser {
         return this.isFix;
     }
 
-    /*
-     * Conversion required since org.eclipse.kura.position.NmeaPosition requires speed in Kilometers per hour instead of
-     * meters per second
-     */
     public NmeaPosition getNmeaPosition() {
         return new NmeaPosition(this.latitudeDegrees, this.longitudeDegrees, this.altitudeMeters,
-                this.speedMetersPerSecond * MS_TO_KMH, this.trackDegrees, this.fixQuality, this.nrSatellites, this.mDOP,
-                this.mPDOP, this.mHDOP, this.mVDOP, this.m3Dfix, this.validFix, this.latitudeHemisphere,
-                this.longitudeHemisphere);
+                this.speedMetersPerSecond, this.trackDegrees, this.fixQuality, this.nrSatellites, this.mDOP, this.mPDOP,
+                this.mHDOP, this.mVDOP, this.m3Dfix, this.validFix, this.latitudeHemisphere, this.longitudeHemisphere);
     }
 
     public String getNmeaTime() {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/position/MMLocationParser.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/position/MMLocationParser.java
@@ -43,11 +43,11 @@ public class MMLocationParser {
     private int gnssTypeUpdateCounter = 0;
     private static final int GNSSTYPE_RESET_COUNTER = 50;
 
-    private Double lat = 0.0;
-    private Double lon = 0.0;
-    private Double alt = 0.0;
-    private Double speed = 0.0;
-    private Double track = 0.0;
+    private Double latitudeDegree = 0.0;
+    private Double longitudeDegree = 0.0;
+    private Double altitudeMeter = 0.0;
+    private Double speedMetersPerSeconds = 0.0;
+    private Double trackDegree = 0.0;
 
     private int fixQuality;
     private int nrSatellites;
@@ -69,10 +69,15 @@ public class MMLocationParser {
         return Objects.requireNonNull(LocalDateTime.of(date, time));
     }
 
+    /*
+     * Conversions are required since org.osgi.util.position.Position requires values in radians for latitude, longitude
+     * and track.
+     */
     public Position getPosition() {
-        return Objects.requireNonNull(new Position(new Measurement(this.lat, Unit.rad),
-                new Measurement(this.lon, Unit.rad), new Measurement(this.alt, Unit.m),
-                new Measurement(this.speed, Unit.m_s), new Measurement(this.track, Unit.rad)));
+        return Objects.requireNonNull(new Position(new Measurement(Math.toRadians(this.latitudeDegree), Unit.rad),
+                new Measurement(Math.toRadians(this.longitudeDegree), Unit.rad),
+                new Measurement(this.altitudeMeter, Unit.m), new Measurement(this.speedMetersPerSeconds, Unit.m_s),
+                new Measurement(Math.toRadians(this.trackDegree), Unit.rad)));
     }
 
     public Set<GNSSType> getGnssTypes() {
@@ -83,10 +88,15 @@ public class MMLocationParser {
         return this.isFix;
     }
 
+    /*
+     * Conversion required since org.eclipse.kura.position.NmeaPosition requires speed in Kilometers per hour instead of
+     * meters per second
+     */
     public NmeaPosition getNmeaPosition() {
-        return new NmeaPosition(Math.toDegrees(this.lat), Math.toDegrees(this.lon), this.alt, this.speed * MS_TO_KMH,
-                Math.toDegrees(this.track), this.fixQuality, this.nrSatellites, this.mDOP, this.mPDOP, this.mHDOP,
-                this.mVDOP, this.m3Dfix, this.validFix, this.latitudeHemisphere, this.longitudeHemisphere);
+        return new NmeaPosition(this.latitudeDegree, this.longitudeDegree, this.altitudeMeter,
+                this.speedMetersPerSeconds * MS_TO_KMH, this.trackDegree, this.fixQuality, this.nrSatellites, this.mDOP,
+                this.mPDOP, this.mHDOP, this.mVDOP, this.m3Dfix, this.validFix, this.latitudeHemisphere,
+                this.longitudeHemisphere);
     }
 
     public String getNmeaTime() {
@@ -103,15 +113,15 @@ public class MMLocationParser {
 
             switch (rawEntry.getKey()) {
             case "latitude":
-                this.lat = Math.toRadians((Double) rawEntry.getValue().getValue());
+                this.latitudeDegree = (Double) rawEntry.getValue().getValue();
                 break;
 
             case "longitude":
-                this.lon = Math.toRadians((Double) rawEntry.getValue().getValue());
+                this.longitudeDegree = (Double) rawEntry.getValue().getValue();
                 break;
 
             case "altitude":
-                this.alt = (Double) rawEntry.getValue().getValue();
+                this.altitudeMeter = (Double) rawEntry.getValue().getValue();
                 break;
 
             // time comes in format HHmmss.SS, so we cut the string after the dot to extract only the util information
@@ -211,10 +221,10 @@ public class MMLocationParser {
             this.date = LocalDate.parse(rmcTokens.get(9), DateTimeFormatter.ofPattern("ddMyy"));
         }
         if (!rmcTokens.get(7).isEmpty()) {
-            this.speed = Double.parseDouble(rmcTokens.get(7)) * KNOTS_TO_MS;
+            this.speedMetersPerSeconds = Double.parseDouble(rmcTokens.get(7)) * KNOTS_TO_MS;
         }
         if (!rmcTokens.get(8).isEmpty()) {
-            this.track = Math.toRadians(Double.parseDouble(rmcTokens.get(8)));
+            this.trackDegree = Double.parseDouble(rmcTokens.get(8));
         }
         if (!rmcTokens.get(4).isEmpty()) {
             this.latitudeHemisphere = rmcTokens.get(4).charAt(0);
@@ -288,7 +298,8 @@ public class MMLocationParser {
 
     @Override
     public String toString() {
-        return "ModemManagerProvider [latitude=" + lat + ", longitude=" + lon + ", altitude=" + alt + ", speed=" + speed
-                + ", timestamp=" + time + ", date=" + date + ", gnssType=" + gnssTypes + "]";
+        return "ModemManagerProvider [latitude=" + latitudeDegree + ", longitude=" + longitudeDegree + ", altitude="
+                + altitudeMeter + ", speed=" + speedMetersPerSeconds + ", timestamp=" + time + ", date=" + date
+                + ", gnssType=" + gnssTypes + "]";
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/position/MMLocationParser.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/position/MMLocationParser.java
@@ -43,11 +43,11 @@ public class MMLocationParser {
     private int gnssTypeUpdateCounter = 0;
     private static final int GNSSTYPE_RESET_COUNTER = 50;
 
-    private Double latitudeDegree = 0.0;
-    private Double longitudeDegree = 0.0;
-    private Double altitudeMeter = 0.0;
-    private Double speedMetersPerSeconds = 0.0;
-    private Double trackDegree = 0.0;
+    private Double latitudeDegrees = 0.0;
+    private Double longitudeDegrees = 0.0;
+    private Double altitudeMeters = 0.0;
+    private Double speedMetersPerSecond = 0.0;
+    private Double trackDegrees = 0.0;
 
     private int fixQuality;
     private int nrSatellites;
@@ -74,10 +74,10 @@ public class MMLocationParser {
      * and track.
      */
     public Position getPosition() {
-        return Objects.requireNonNull(new Position(new Measurement(Math.toRadians(this.latitudeDegree), Unit.rad),
-                new Measurement(Math.toRadians(this.longitudeDegree), Unit.rad),
-                new Measurement(this.altitudeMeter, Unit.m), new Measurement(this.speedMetersPerSeconds, Unit.m_s),
-                new Measurement(Math.toRadians(this.trackDegree), Unit.rad)));
+        return Objects.requireNonNull(new Position(new Measurement(Math.toRadians(this.latitudeDegrees), Unit.rad),
+                new Measurement(Math.toRadians(this.longitudeDegrees), Unit.rad),
+                new Measurement(this.altitudeMeters, Unit.m), new Measurement(this.speedMetersPerSecond, Unit.m_s),
+                new Measurement(Math.toRadians(this.trackDegrees), Unit.rad)));
     }
 
     public Set<GNSSType> getGnssTypes() {
@@ -93,8 +93,8 @@ public class MMLocationParser {
      * meters per second
      */
     public NmeaPosition getNmeaPosition() {
-        return new NmeaPosition(this.latitudeDegree, this.longitudeDegree, this.altitudeMeter,
-                this.speedMetersPerSeconds * MS_TO_KMH, this.trackDegree, this.fixQuality, this.nrSatellites, this.mDOP,
+        return new NmeaPosition(this.latitudeDegrees, this.longitudeDegrees, this.altitudeMeters,
+                this.speedMetersPerSecond * MS_TO_KMH, this.trackDegrees, this.fixQuality, this.nrSatellites, this.mDOP,
                 this.mPDOP, this.mHDOP, this.mVDOP, this.m3Dfix, this.validFix, this.latitudeHemisphere,
                 this.longitudeHemisphere);
     }
@@ -113,15 +113,15 @@ public class MMLocationParser {
 
             switch (rawEntry.getKey()) {
             case "latitude":
-                this.latitudeDegree = (Double) rawEntry.getValue().getValue();
+                this.latitudeDegrees = (Double) rawEntry.getValue().getValue();
                 break;
 
             case "longitude":
-                this.longitudeDegree = (Double) rawEntry.getValue().getValue();
+                this.longitudeDegrees = (Double) rawEntry.getValue().getValue();
                 break;
 
             case "altitude":
-                this.altitudeMeter = (Double) rawEntry.getValue().getValue();
+                this.altitudeMeters = (Double) rawEntry.getValue().getValue();
                 break;
 
             // time comes in format HHmmss.SS, so we cut the string after the dot to extract only the util information
@@ -221,10 +221,10 @@ public class MMLocationParser {
             this.date = LocalDate.parse(rmcTokens.get(9), DateTimeFormatter.ofPattern("ddMyy"));
         }
         if (!rmcTokens.get(7).isEmpty()) {
-            this.speedMetersPerSeconds = Double.parseDouble(rmcTokens.get(7)) * KNOTS_TO_MS;
+            this.speedMetersPerSecond = Double.parseDouble(rmcTokens.get(7)) * KNOTS_TO_MS;
         }
         if (!rmcTokens.get(8).isEmpty()) {
-            this.trackDegree = Double.parseDouble(rmcTokens.get(8));
+            this.trackDegrees = Double.parseDouble(rmcTokens.get(8));
         }
         if (!rmcTokens.get(4).isEmpty()) {
             this.latitudeHemisphere = rmcTokens.get(4).charAt(0);
@@ -298,8 +298,8 @@ public class MMLocationParser {
 
     @Override
     public String toString() {
-        return "ModemManagerProvider [latitude=" + latitudeDegree + ", longitude=" + longitudeDegree + ", altitude="
-                + altitudeMeter + ", speed=" + speedMetersPerSeconds + ", timestamp=" + time + ", date=" + date
+        return "ModemManagerProvider [latitude=" + latitudeDegrees + ", longitude=" + longitudeDegrees + ", altitude="
+                + altitudeMeters + ", speed=" + speedMetersPerSecond + ", timestamp=" + time + ", date=" + date
                 + ", gnssType=" + gnssTypes + "]";
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/position/MMLocationParser.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/position/MMLocationParser.java
@@ -38,7 +38,8 @@ public class MMLocationParser {
 
     private static final Logger logger = LoggerFactory.getLogger(MMLocationParser.class);
 
-    private static final double KNOTS_TO_M_S = 1 / 1.94384449;
+    private static final double KNOTS_TO_MS = 1 / 1.94384449;
+    private static final double MS_TO_KMH = 3.6;
     private int gnssTypeUpdateCounter = 0;
     private static final int GNSSTYPE_RESET_COUNTER = 50;
 
@@ -83,9 +84,9 @@ public class MMLocationParser {
     }
 
     public NmeaPosition getNmeaPosition() {
-        return new NmeaPosition(this.lat, this.lon, this.alt, this.speed, this.track, this.fixQuality,
-                this.nrSatellites, this.mDOP, this.mPDOP, this.mHDOP, this.mVDOP, this.m3Dfix, this.validFix,
-                this.latitudeHemisphere, this.longitudeHemisphere);
+        return new NmeaPosition(Math.toDegrees(this.lat), Math.toDegrees(this.lon), this.alt, this.speed * MS_TO_KMH,
+                Math.toDegrees(this.track), this.fixQuality, this.nrSatellites, this.mDOP, this.mPDOP, this.mHDOP,
+                this.mVDOP, this.m3Dfix, this.validFix, this.latitudeHemisphere, this.longitudeHemisphere);
     }
 
     public String getNmeaTime() {
@@ -210,7 +211,7 @@ public class MMLocationParser {
             this.date = LocalDate.parse(rmcTokens.get(9), DateTimeFormatter.ofPattern("ddMyy"));
         }
         if (!rmcTokens.get(7).isEmpty()) {
-            this.speed = Double.parseDouble(rmcTokens.get(7)) * KNOTS_TO_M_S;
+            this.speed = Double.parseDouble(rmcTokens.get(7)) * KNOTS_TO_MS;
         }
         if (!rmcTokens.get(8).isEmpty()) {
             this.track = Math.toRadians(Double.parseDouble(rmcTokens.get(8)));


### PR DESCRIPTION
This PR fixes the unit measurment of latitude, longitude, track and speed for the MM Position Provider. The first three values were reported in radians instead of degrees, and the last one in meter per seconds instead of km per hour.

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
