### PR TITLE
fix: Cleanup of birth and app publish logic [backport release-5.6.0] 

### DIFF
--- a/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.core.cloud/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -50,6 +50,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -176,9 +177,8 @@ public class CloudServiceImpl
     private String ownPid;
 
     private ScheduledFuture<?> scheduledBirthPublisherFuture;
-    private final ScheduledExecutorService scheduledBirthPublisher = Executors.newScheduledThreadPool(1);
-    private LifecycleMessage lastBirthMessage;
-    private LifecycleMessage lastAppMessage;
+    private final ScheduledExecutorService scheduledBirthPublisher = Executors.newSingleThreadScheduledExecutor();
+    private final AtomicBoolean shouldPublishDelayedBirth = new AtomicBoolean();
 
     public CloudServiceImpl() {
         this.cloudClients = new CopyOnWriteArrayList<>();
@@ -862,12 +862,11 @@ public class CloudServiceImpl
         }
 
         readModemProfile();
-        LifecycleMessage birthToPublish = new LifecycleMessage(this.options, this).asBirthCertificateMessage();
 
         if (isNewConnection) {
-            publishLifeCycleMessage(birthToPublish);
+            publishLifeCycleMessage(new LifecycleMessage(this.options, this).asBirthCertificateMessage());
         } else {
-            publishWithDelay(birthToPublish);
+            publishWithDelay(false);
         }
     }
 
@@ -880,42 +879,43 @@ public class CloudServiceImpl
             logger.info("framework is stopping.. not republishing app certificate");
             return;
         }
-        publishWithDelay(new LifecycleMessage(this.options, this).asAppCertificateMessage());
+        publishWithDelay(true);
     }
 
-    private void publishWithDelay(LifecycleMessage message) {
-        if (Objects.nonNull(this.scheduledBirthPublisherFuture)) {
-            this.scheduledBirthPublisherFuture.cancel(false);
-            logger.debug("CloudServiceImpl: BIRTH message cache timer restarted.");
+    private void publishWithDelay(boolean isAppUpdate) {
+        synchronized (this.shouldPublishDelayedBirth) {
+            if (!isAppUpdate) {
+                this.shouldPublishDelayedBirth.set(true);
+            }
+
+            if (Objects.nonNull(this.scheduledBirthPublisherFuture)) {
+                this.scheduledBirthPublisherFuture.cancel(false);
+                logger.debug("CloudServiceImpl: BIRTH message cache timer restarted.");
+            }
+            logger.info("isAppUpdate? {}", isAppUpdate, new RuntimeException());
+
+            logger.debug("CloudServiceImpl: BIRTH message cached for 30s.");
+
+            this.scheduledBirthPublisherFuture = this.scheduledBirthPublisher.schedule(this::publishDelayedMessage, 30L,
+                    TimeUnit.SECONDS);
         }
+    }
 
-        logger.debug("CloudServiceImpl: BIRTH message cached for 30s.");
-
-        if (message.isBirthCertificateMessage()) {
-            this.lastBirthMessage = message;
-        }
-
-        if (message.isAppCertificateMessage()) {
-            this.lastAppMessage = message;
-        }
-
-        this.scheduledBirthPublisherFuture = this.scheduledBirthPublisher.schedule(() -> {
+    private void publishDelayedMessage() {
+        synchronized (this.shouldPublishDelayedBirth) {
             try {
 
-                if (Objects.nonNull(this.lastBirthMessage)) {
-                    logger.debug("CloudServiceImpl: publishing cached BIRTH message.");
-                    publishLifeCycleMessage(this.lastBirthMessage);
+                if (this.shouldPublishDelayedBirth.get()) {
+                    publishLifeCycleMessage(new LifecycleMessage(this.options, this).asBirthCertificateMessage());
+                } else {
+                    publishLifeCycleMessage(new LifecycleMessage(this.options, this).asAppCertificateMessage());
                 }
-
-                if (Objects.nonNull(this.lastAppMessage)) {
-                    logger.debug("CloudServiceImpl: publishing cached APP message.");
-                    publishLifeCycleMessage(this.lastAppMessage);
-                }
+                this.shouldPublishDelayedBirth.set(false);
 
             } catch (KuraException e) {
                 logger.error("Error sending cached BIRTH/APP certificate.", e);
             }
-        }, 30L, TimeUnit.SECONDS);
+        }
     }
 
     private void publishLifeCycleMessage(LifecycleMessage message) throws KuraException {


### PR DESCRIPTION
Fixed the way we manage app updates preferring a delayed evaluation of the Lifecycle messages
