### PR TITLE
feat(linux.net): DHCP server selection method

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -58,7 +58,8 @@ public class DhcpServerManager {
 
     public static DhcpServerTool getTool() {
         if (dhcpServerTool == DhcpServerTool.NONE) {
-            if (LinuxNetworkUtil.toolExists(DhcpServerTool.DNSMASQ.getValue())) {
+            if (LinuxNetworkUtil.toolExists(DhcpServerTool.DNSMASQ.getValue())
+                    && LinuxNetworkUtil.systemdSystemUnitExists(DhcpServerTool.DNSMASQ.getValue() + ".service")) {
                 dhcpServerTool = DhcpServerTool.DNSMASQ;
             } else if (LinuxNetworkUtil.toolExists(DhcpServerTool.UDHCPD.getValue())) {
                 dhcpServerTool = DhcpServerTool.UDHCPD;

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManager.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
@@ -42,10 +42,10 @@ public class DnsmasqTool implements DhcpLinuxTool {
     private String globalConfigFilename = "/etc/dnsmasq.d/dnsmasq-globals.conf";
     private static final String GLOBAL_CONFIGURATION = "port=0\nbind-dynamic\n";
 
-    static final Command IS_ACTIVE_COMMAND = new Command(new String[] { "systemctl", "is-active", "--quiet",
-            DhcpServerTool.DNSMASQ.getValue() });
-    static final Command RESTART_COMMAND = new Command(new String[] { "systemctl", "restart",
-            DhcpServerTool.DNSMASQ.getValue() });
+    static final Command IS_ACTIVE_COMMAND = new Command(
+            new String[] { "systemctl", "is-active", "--quiet", DhcpServerTool.DNSMASQ.getValue() });
+    static final Command RESTART_COMMAND = new Command(
+            new String[] { "systemctl", "restart", DhcpServerTool.DNSMASQ.getValue() });
 
     private CommandExecutorService executorService;
     private Map<String, byte[]> configsLastHash = Collections.synchronizedMap(new HashMap<>());
@@ -88,6 +88,7 @@ public class DnsmasqTool implements DhcpLinuxTool {
         CommandStatus restartStatus = this.executorService.execute(RESTART_COMMAND);
 
         if (!restartStatus.getExitStatus().isSuccessful()) {
+            logger.error("dnsmasq Systemd unit startup failed. Is dnsmasq package installed on the system?");
             removeInterfaceConfig(interfaceName);
             restartStatus = this.executorService.execute(RESTART_COMMAND);
         }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqTool.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kura.linux.net.dhcp.server;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -42,10 +43,10 @@ public class DnsmasqTool implements DhcpLinuxTool {
     private String globalConfigFilename = "/etc/dnsmasq.d/dnsmasq-globals.conf";
     private static final String GLOBAL_CONFIGURATION = "port=0\nbind-dynamic\n";
 
-    static final Command IS_ACTIVE_COMMAND = new Command(
-            new String[] { "systemctl", "is-active", "--quiet", DhcpServerTool.DNSMASQ.getValue() });
-    static final Command RESTART_COMMAND = new Command(
-            new String[] { "systemctl", "restart", DhcpServerTool.DNSMASQ.getValue() });
+    static final String[] IS_ACTIVE_COMMANDLINE = new String[] { "systemctl", "is-active", "--quiet",
+            DhcpServerTool.DNSMASQ.getValue() };
+    static final String[] RESTART_COMMANDLINE = new String[] { "systemctl", "restart",
+            DhcpServerTool.DNSMASQ.getValue() };
 
     private CommandExecutorService executorService;
     private Map<String, byte[]> configsLastHash = Collections.synchronizedMap(new HashMap<>());
@@ -57,7 +58,7 @@ public class DnsmasqTool implements DhcpLinuxTool {
 
     @Override
     public boolean isRunning(String interfaceName) throws KuraProcessExecutionErrorException {
-        CommandStatus status = this.executorService.execute(IS_ACTIVE_COMMAND);
+        CommandStatus status = this.executorService.execute(new Command(IS_ACTIVE_COMMANDLINE));
 
         boolean isRunning;
         try {
@@ -85,12 +86,19 @@ public class DnsmasqTool implements DhcpLinuxTool {
                     "Failed to start DHCP server for interface: " + interfaceName);
         }
 
-        CommandStatus restartStatus = this.executorService.execute(RESTART_COMMAND);
+        Command restartCommand = new Command(RESTART_COMMANDLINE);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        restartCommand.setErrorStream(err);
+        restartCommand.setOutputStream(out);
+        CommandStatus restartStatus = this.executorService.execute(restartCommand);
 
         if (!restartStatus.getExitStatus().isSuccessful()) {
-            logger.error("dnsmasq Systemd unit startup failed. Is dnsmasq package installed on the system?");
+            logger.error("dnsmasq Systemd unit startup failed. Check if the tool is properly installed on the system.");
+            logger.error("dnsmasq stderr {}", new String(err.toByteArray(), StandardCharsets.UTF_8));
+            logger.error("dnsmasq stdout {}", new String(out.toByteArray(), StandardCharsets.UTF_8));
             removeInterfaceConfig(interfaceName);
-            restartStatus = this.executorService.execute(RESTART_COMMAND);
+            restartStatus = this.executorService.execute(restartCommand);
         }
 
         return restartStatus;
@@ -101,7 +109,7 @@ public class DnsmasqTool implements DhcpLinuxTool {
         boolean isInterfaceDisabled = true;
 
         if (removeInterfaceConfig(interfaceName)) {
-            CommandStatus status = this.executorService.execute(RESTART_COMMAND);
+            CommandStatus status = this.executorService.execute(new Command(RESTART_COMMANDLINE));
             isInterfaceDisabled = status.getExitStatus().isSuccessful();
         }
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -273,8 +273,8 @@ public class LinuxNetworkUtil {
             return true;
         } else {
             for (String folder : DEFAULT_PATH) {
-                File fUnit = new File(folder + tool);
-                if (fUnit.exists()) {
+                File fTool = new File(folder + tool);
+                if (fTool.exists()) {
                     TOOLS.add(tool);
                     return true;
                 }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -17,6 +17,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,6 +28,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 import org.apache.commons.io.Charsets;
 import org.eclipse.kura.KuraErrorCode;
@@ -66,12 +75,8 @@ public class LinuxNetworkUtil {
     private static final String ERR_EXECUTING_CMD_MSG = "error executing command --- {} --- exit value={}";
     private static final String FAKE_MAC_ADDRESS = "12:34:56:78:ab:cd";
     private static final String ETHTOOL_COMMAND = "ethtool";
-    private static final String[] DEFAULT_SYSTEMD_SYSTEM_FOLDERS = new String[] { "/lib/systemd/system/",
-            "/etc/systemd/system.control/", "/run/systemd/system.control/", "/run/systemd/transient/",
-            "/run/systemd/generator.early/", "/etc/systemd/system/", "run/systemd/system/", "/run/systemd/generator/",
-            "/usr/local/lib/systemd/system/", "/usr/lib/systemd/system/", "/run/systemd/generator.late/" };
-    private static final ArrayList<String> SYSTEMD_SYSTEM_UNITS = new ArrayList<>();
-
+    private static final String[] DEFAULT_PATH = new String[] { "/sbin/", "/usr/sbin/", "/bin/", "/usr/bin/" };
+    private static final ProcessBuilder PROCESS_BUILDER = new ProcessBuilder();
     private final CommandExecutorService executorService;
     private final WifiOptions wifiOptions;
 
@@ -264,40 +269,45 @@ public class LinuxNetworkUtil {
     }
 
     public static boolean toolExists(String tool) {
-        return searchResourceInFolders(tool, TOOLS, new String[] { "/sbin/", "/usr/sbin/", "/bin/", "/usr/bin/" });
-    }
-
-    /**
-     * Checks if the given Systemd system unit is installed.
-     * This method search the unit in the default folders presented in
-     * https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Unit%20File%20Load%20Path
-     * If the unit is installed in a no-standard folder, this method will not
-     * be able to find it.
-     * 
-     * It applies only to system units, not user ones.
-     * 
-     * @param unitName
-     *            the name of the Systemd system unit
-     * @return true if it is present
-     */
-    public static boolean systemdSystemUnitExists(String unitName) {
-        return searchResourceInFolders(unitName, SYSTEMD_SYSTEM_UNITS, DEFAULT_SYSTEMD_SYSTEM_FOLDERS);
-    }
-
-    private static boolean searchResourceInFolders(String resourceName, List<String> resourceList, String[] folders) {
-
-        if (resourceList.contains(resourceName)) {
+        if (TOOLS.contains(tool)) {
             return true;
         } else {
-            for (String folder : folders) {
-                File fUnit = new File(folder + resourceName);
+            for (String folder : DEFAULT_PATH) {
+                File fUnit = new File(folder + tool);
                 if (fUnit.exists()) {
-                    resourceList.add(resourceName);
+                    TOOLS.add(tool);
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    /**
+     * Checks if the given Systemd system unit is installed.
+     * The result is based on the exit code of "systemctl status <unitName>"
+     * as presented in https://www.man7.org/linux/man-pages/man1/systemctl.1.html#EXIT_STATUS
+     * 
+     * @param unitName
+     *            the name of the Systemd system unit
+     * @return true if the unit is installed
+     */
+    public static boolean systemdSystemUnitExists(String unitName) {
+        PROCESS_BUILDER.command("sh", "-c", "systemctl status " + unitName);
+        Process process;
+        try {
+            process = PROCESS_BUILDER.start();
+            StreamGobbler streamGobbler = new StreamGobbler(process.getInputStream(), logger::debug);
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            Future<?> future = executor.submit(streamGobbler);
+
+            int exitCode = process.waitFor();
+            future.get(10, TimeUnit.SECONDS);
+            return exitCode < 4;
+        } catch (IOException | ExecutionException | TimeoutException | InterruptedException e) {
+            logger.error(String.format("Cannot check %s unit existence", unitName), e);
+            return false;
+        }
     }
 
     /**
@@ -1194,6 +1204,22 @@ public class LinuxNetworkUtil {
         command.setOutputStream(new ByteArrayOutputStream());
         command.setErrorStream(new ByteArrayOutputStream());
         return this.executorService.execute(command);
+    }
+
+    private static class StreamGobbler implements Runnable {
+
+        private InputStream inputStream;
+        private Consumer<String> consumer;
+
+        public StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
+            this.inputStream = inputStream;
+            this.consumer = consumer;
+        }
+
+        @Override
+        public void run() {
+            new BufferedReader(new InputStreamReader(inputStream)).lines().forEach(consumer);
+        }
     }
 
 }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -28,12 +28,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import org.apache.commons.io.Charsets;
@@ -312,14 +306,9 @@ public class LinuxNetworkUtil {
         Process process;
         try {
             process = PROCESS_BUILDER.start();
-            StreamGobbler streamGobbler = new StreamGobbler(process.getInputStream(), logger::debug);
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            Future<?> future = executor.submit(streamGobbler);
-
             int exitCode = process.waitFor();
-            future.get(10, TimeUnit.SECONDS);
             return exitCode < 4;
-        } catch (IOException | ExecutionException | TimeoutException e) {
+        } catch (IOException e) {
             logger.error("Cannot check {} unit existence", unitName, e);
             return false;
         } catch (InterruptedException e1) {

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -293,19 +293,23 @@ public class LinuxNetworkUtil {
      * @return true if the unit is installed
      */
     public static boolean systemdSystemUnitExists(String unitName) {
-        PROCESS_BUILDER.command("sh", "-c", "systemctl status " + unitName);
+        PROCESS_BUILDER.command("systemctl", "status", unitName);
         Process process;
         try {
             process = PROCESS_BUILDER.start();
-            StreamGobbler streamGobbler = new StreamGobbler(process.getInputStream(), logger::debug);
+            StreamGobbler streamGobbler = new StreamGobbler(process.getInputStream(), logger::info);
             ExecutorService executor = Executors.newSingleThreadExecutor();
             Future<?> future = executor.submit(streamGobbler);
 
             int exitCode = process.waitFor();
             future.get(10, TimeUnit.SECONDS);
             return exitCode < 4;
-        } catch (IOException | ExecutionException | TimeoutException | InterruptedException e) {
+        } catch (IOException | ExecutionException | TimeoutException e) {
             logger.error(String.format("Cannot check %s unit existence", unitName), e);
+            return false;
+        } catch (InterruptedException e1) {
+            Thread.currentThread().interrupt();
+            logger.error(String.format("Cannot check %s unit existence", unitName), e1);
             return false;
         }
     }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -44,12 +44,9 @@ import org.slf4j.LoggerFactory;
 
 public class LinuxNetworkUtil {
 
-    public static final String ACCESS_POINT_INTERFACE_SUFFIX = "_ap";
-
-    private static final String ETHTOOL_COMMAND = "ethtool";
-
     private static final Logger logger = LoggerFactory.getLogger(LinuxNetworkUtil.class);
 
+    public static final String ACCESS_POINT_INTERFACE_SUFFIX = "_ap";
     private static Map<String, LinuxIfconfig> ifconfigs = new HashMap<>();
     private static final String[] IGNORE_IFACES = { "can", "sit", "mon.wlan" };
     private static final ArrayList<String> TOOLS = new ArrayList<>();
@@ -65,12 +62,15 @@ public class LinuxNetworkUtil {
     private static final String IFCONFIG = "ifconfig";
     private static final String IWCONFIG = "iwconfig";
     private static final String IP = "ip";
-
     private static final String LINE_MSG = "line: {}";
-
     private static final String ERR_EXECUTING_CMD_MSG = "error executing command --- {} --- exit value={}";
-
     private static final String FAKE_MAC_ADDRESS = "12:34:56:78:ab:cd";
+    private static final String ETHTOOL_COMMAND = "ethtool";
+    private static final String[] DEFAULT_SYSTEMD_SYSTEM_FOLDERS = new String[] { "/etc/systemd/system.control/",
+            "/run/systemd/system.control/", "/run/systemd/transient/", "/run/systemd/generator.early/",
+            "/etc/systemd/system/", "run/systemd/system/", "/run/systemd/generator/", "/usr/local/lib/systemd/system/",
+            "/usr/lib/systemd/system/", "/run/systemd/generator.late/" };
+    private static final ArrayList<String> SYSTEMD_SYSTEM_UNITS = new ArrayList<>();
 
     private final CommandExecutorService executorService;
     private final WifiOptions wifiOptions;
@@ -264,22 +264,40 @@ public class LinuxNetworkUtil {
     }
 
     public static boolean toolExists(String tool) {
-        boolean ret = false;
-        final String[] searchFolders = new String[] { "/sbin/", "/usr/sbin/", "/bin/", "/usr/bin/" };
+        return searchResourceInFolders(tool, TOOLS, new String[] { "/sbin/", "/usr/sbin/", "/bin/", "/usr/bin/" });
+    }
 
-        if (TOOLS.contains(tool)) {
-            ret = true;
+    /**
+     * Checks if the given Systemd system unit is installed.
+     * This method search the unit in the default folders presented in
+     * https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Unit%20File%20Load%20Path
+     * If the unit is installed in a no-standard folder, this method will not
+     * be able to find it.
+     * 
+     * It applies only to system units, not user ones.
+     * 
+     * @param unitName
+     *            the name of the Systemd system unit
+     * @return true if it is present
+     */
+    public static boolean systemdSystemUnitExists(String unitName) {
+        return searchResourceInFolders(unitName, SYSTEMD_SYSTEM_UNITS, DEFAULT_SYSTEMD_SYSTEM_FOLDERS);
+    }
+
+    private static boolean searchResourceInFolders(String resourceName, List<String> resourceList, String[] folders) {
+
+        if (resourceList.contains(resourceName)) {
+            return true;
         } else {
-            for (String folder : searchFolders) {
-                File fTool = new File(folder + tool);
-                if (fTool.exists()) {
-                    TOOLS.add(tool);
-                    ret = true;
-                    break;
+            for (String folder : folders) {
+                File fUnit = new File(folder + resourceName);
+                if (fUnit.exists()) {
+                    resourceList.add(resourceName);
+                    return true;
                 }
             }
         }
-        return ret;
+        return false;
     }
 
     /**

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -17,8 +17,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,7 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.function.Consumer;
 
 import org.apache.commons.io.Charsets;
 import org.eclipse.kura.KuraErrorCode;
@@ -1212,22 +1209,6 @@ public class LinuxNetworkUtil {
         command.setOutputStream(new ByteArrayOutputStream());
         command.setErrorStream(new ByteArrayOutputStream());
         return this.executorService.execute(command);
-    }
-
-    private static class StreamGobbler implements Runnable {
-
-        private final InputStream inputStream;
-        private final Consumer<String> consumer;
-
-        public StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
-            this.inputStream = inputStream;
-            this.consumer = consumer;
-        }
-
-        @Override
-        public void run() {
-            new BufferedReader(new InputStreamReader(this.inputStream)).lines().forEach(this.consumer);
-        }
     }
 
 }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -314,7 +314,7 @@ public class LinuxNetworkUtil {
         Process process;
         try {
             process = PROCESS_BUILDER.start();
-            StreamGobbler streamGobbler = new StreamGobbler(process.getInputStream(), logger::info);
+            StreamGobbler streamGobbler = new StreamGobbler(process.getInputStream(), logger::debug);
             ExecutorService executor = Executors.newSingleThreadExecutor();
             Future<?> future = executor.submit(streamGobbler);
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -66,10 +66,10 @@ public class LinuxNetworkUtil {
     private static final String ERR_EXECUTING_CMD_MSG = "error executing command --- {} --- exit value={}";
     private static final String FAKE_MAC_ADDRESS = "12:34:56:78:ab:cd";
     private static final String ETHTOOL_COMMAND = "ethtool";
-    private static final String[] DEFAULT_SYSTEMD_SYSTEM_FOLDERS = new String[] { "/etc/systemd/system.control/",
-            "/run/systemd/system.control/", "/run/systemd/transient/", "/run/systemd/generator.early/",
-            "/etc/systemd/system/", "run/systemd/system/", "/run/systemd/generator/", "/usr/local/lib/systemd/system/",
-            "/usr/lib/systemd/system/", "/run/systemd/generator.late/" };
+    private static final String[] DEFAULT_SYSTEMD_SYSTEM_FOLDERS = new String[] { "/lib/systemd/system/",
+            "/etc/systemd/system.control/", "/run/systemd/system.control/", "/run/systemd/transient/",
+            "/run/systemd/generator.early/", "/etc/systemd/system/", "run/systemd/system/", "/run/systemd/generator/",
+            "/usr/local/lib/systemd/system/", "/usr/lib/systemd/system/", "/run/systemd/generator.late/" };
     private static final ArrayList<String> SYSTEMD_SYSTEM_UNITS = new ArrayList<>();
 
     private final CommandExecutorService executorService;

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/
@@ -287,7 +287,7 @@ public class LinuxNetworkUtil {
      * Checks if the given Systemd system unit is installed.
      * The result is based on the exit code of "systemctl status <unitName>"
      * as presented in https://www.man7.org/linux/man-pages/man1/systemctl.1.html#EXIT_STATUS
-     * 
+     *
      * @param unitName
      *            the name of the Systemd system unit
      * @return true if the unit is installed
@@ -1152,7 +1152,7 @@ public class LinuxNetworkUtil {
             return;
         }
 
-        CommandStatus status = this.executeCommand(formIwDevIfaceInterfaceAddAp(ifaceName, dedicatedApInterface));
+        CommandStatus status = executeCommand(formIwDevIfaceInterfaceAddAp(ifaceName, dedicatedApInterface));
 
         if (!status.getExitStatus().isSuccessful()) {
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR,
@@ -1165,7 +1165,7 @@ public class LinuxNetworkUtil {
             return;
         }
 
-        CommandStatus status = this.executeCommand(formIpLinkSetAddress(ifaceName, FAKE_MAC_ADDRESS));
+        CommandStatus status = executeCommand(formIpLinkSetAddress(ifaceName, FAKE_MAC_ADDRESS));
 
         if (!status.getExitStatus().isSuccessful()) {
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR,
@@ -1178,7 +1178,7 @@ public class LinuxNetworkUtil {
             return;
         }
 
-        CommandStatus status = this.executeCommand(formIpLinkSetStatus(ifaceName, "up"));
+        CommandStatus status = executeCommand(formIpLinkSetStatus(ifaceName, "up"));
 
         if (!status.getExitStatus().isSuccessful()) {
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, "Failed to set link up for interface " + ifaceName);
@@ -1190,7 +1190,7 @@ public class LinuxNetworkUtil {
             return;
         }
 
-        CommandStatus status = this.executeCommand(formIpLinkSetStatus(ifaceName, "down"));
+        CommandStatus status = executeCommand(formIpLinkSetStatus(ifaceName, "down"));
 
         if (!status.getExitStatus().isSuccessful()) {
             throw new KuraException(KuraErrorCode.OS_COMMAND_ERROR, "Failed to set link up for interface " + ifaceName);
@@ -1208,8 +1208,8 @@ public class LinuxNetworkUtil {
 
     private static class StreamGobbler implements Runnable {
 
-        private InputStream inputStream;
-        private Consumer<String> consumer;
+        private final InputStream inputStream;
+        private final Consumer<String> consumer;
 
         public StreamGobbler(InputStream inputStream, Consumer<String> consumer) {
             this.inputStream = inputStream;
@@ -1218,7 +1218,7 @@ public class LinuxNetworkUtil {
 
         @Override
         public void run() {
-            new BufferedReader(new InputStreamReader(inputStream)).lines().forEach(consumer);
+            new BufferedReader(new InputStreamReader(this.inputStream)).lines().forEach(this.consumer);
         }
     }
 

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -290,9 +290,7 @@ public class LinuxNetworkUtil {
     }
 
     private static Optional<String> getCachedTool(String tool) {
-        return TOOLS.stream().filter(item -> {
-            return item.endsWith(tool);
-        }).findFirst();
+        return TOOLS.stream().filter(item -> item.endsWith(tool)).findFirst();
     }
 
     /**
@@ -322,11 +320,11 @@ public class LinuxNetworkUtil {
             future.get(10, TimeUnit.SECONDS);
             return exitCode < 4;
         } catch (IOException | ExecutionException | TimeoutException e) {
-            logger.error(String.format("Cannot check %s unit existence", unitName), e);
+            logger.error("Cannot check {} unit existence", unitName, e);
             return false;
         } catch (InterruptedException e1) {
             Thread.currentThread().interrupt();
-            logger.error(String.format("Cannot check %s unit existence", unitName), e1);
+            logger.error("Cannot check {} unit existence", unitName, e1);
             return false;
         }
     }

--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -269,18 +269,30 @@ public class LinuxNetworkUtil {
     }
 
     public static boolean toolExists(String tool) {
-        if (TOOLS.contains(tool)) {
-            return true;
+        return getToolPath(tool).isPresent();
+    }
+
+    public static Optional<String> getToolPath(String tool) {
+        Optional<String> optionalToolPath = getCachedTool(tool);
+        if (optionalToolPath.isPresent()) {
+            return optionalToolPath;
         } else {
             for (String folder : DEFAULT_PATH) {
-                File fTool = new File(folder + tool);
-                if (fTool.exists()) {
-                    TOOLS.add(tool);
-                    return true;
+                String toolPath = folder + tool;
+                File toolFile = new File(toolPath);
+                if (toolFile.exists()) {
+                    TOOLS.add(toolPath);
+                    return Optional.of(toolPath);
                 }
             }
         }
-        return false;
+        return Optional.empty();
+    }
+
+    private static Optional<String> getCachedTool(String tool) {
+        return TOOLS.stream().filter(item -> {
+            return item.endsWith(tool);
+        }).findFirst();
     }
 
     /**
@@ -293,7 +305,12 @@ public class LinuxNetworkUtil {
      * @return true if the unit is installed
      */
     public static boolean systemdSystemUnitExists(String unitName) {
-        PROCESS_BUILDER.command("systemctl", "status", unitName);
+        Optional<String> optionalSystemctlPath = getToolPath("systemctl");
+        if (!optionalSystemctlPath.isPresent()) {
+            logger.debug("Systemctl command not found in default paths");
+            return false;
+        }
+        PROCESS_BUILDER.command(optionalSystemctlPath.get(), "status", unitName);
         Process process;
         try {
             process = PROCESS_BUILDER.start();

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
@@ -27,9 +27,12 @@ import org.eclipse.kura.linux.net.dhcp.server.DnsmasqConfigConverter;
 import org.eclipse.kura.linux.net.dhcp.server.DnsmasqLeaseReader;
 import org.eclipse.kura.linux.net.dhcp.server.UdhcpdConfigConverter;
 import org.eclipse.kura.linux.net.dhcp.server.UdhcpdLeaseReader;
+import org.eclipse.kura.linux.net.util.LinuxNetworkUtil;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 public class DhcpServerManagerTest {
@@ -50,6 +53,8 @@ public class DhcpServerManagerTest {
     private Optional<DhcpServerConfigConverter> returnedConfigConverter;
     private Optional<DhcpServerLeaseReader> returnedLeaseReader;
     private Exception occurredException;
+    private MockedStatic<LinuxNetworkUtil> mockedLinuxNetworkUtil;
+    private DhcpServerTool tool;
 
     /*
      * Scenarios
@@ -268,6 +273,63 @@ public class DhcpServerManagerTest {
         thenReturnedLeaseReaderIsEmpty();
     }
 
+    @Test
+    public void shouldGetDnsmasqToolIfBinaryAndUnitArePresent() throws NoSuchFieldException {
+        givenLinuxNetworkUtil("dnsmasq", Optional.of("dnsmasq.service"));
+        givenDhcpServerManager(DhcpServerTool.NONE);
+
+        whenGetTool();
+
+        thenToolIs(DhcpServerTool.DNSMASQ);
+    }
+
+    @Test
+    public void shouldNotGetDnsmasqToolIfOnlyBinaryIsPresent() throws NoSuchFieldException {
+        givenLinuxNetworkUtil("dnsmasq", Optional.empty());
+        givenDhcpServerManager(DhcpServerTool.NONE);
+
+        whenGetTool();
+
+        thenToolIs(DhcpServerTool.NONE);
+    }
+
+    @Test
+    public void shouldGetDhcpdTool() throws NoSuchFieldException {
+        givenLinuxNetworkUtil("dhcpd", Optional.empty());
+        givenDhcpServerManager(DhcpServerTool.NONE);
+
+        whenGetTool();
+
+        thenToolIs(DhcpServerTool.DHCPD);
+    }
+
+    @Test
+    public void shouldGetUdhcpdTool() throws NoSuchFieldException {
+        givenLinuxNetworkUtil("udhcpd", Optional.empty());
+        givenDhcpServerManager(DhcpServerTool.NONE);
+
+        whenGetTool();
+
+        thenToolIs(DhcpServerTool.UDHCPD);
+    }
+
+    @Test
+    public void shouldNotGetAnyTool() throws NoSuchFieldException {
+        givenLinuxNetworkUtil("", Optional.empty());
+        givenDhcpServerManager(DhcpServerTool.NONE);
+
+        whenGetTool();
+
+        thenToolIs(DhcpServerTool.NONE);
+    }
+
+    @After
+    public void deregisterStaticMocks() {
+        if (this.mockedLinuxNetworkUtil != null) {
+            mockedLinuxNetworkUtil.close();
+        }
+    }
+
     /*
      * Steps
      */
@@ -282,6 +344,15 @@ public class DhcpServerManagerTest {
         TestUtil.setFieldValue(new DhcpServerManager(null), "dhcpServerTool", dhcpServerTool);
 
         this.dhcpServerManager = new DhcpServerManager(executorMock);
+    }
+
+    private void givenLinuxNetworkUtil(String toolName, Optional<String> unitName) {
+        this.mockedLinuxNetworkUtil = Mockito.mockStatic(LinuxNetworkUtil.class);
+        mockedLinuxNetworkUtil.when(() -> LinuxNetworkUtil.toolExists(toolName)).thenReturn(true);
+        if (unitName.isPresent()) {
+            mockedLinuxNetworkUtil.when(() -> LinuxNetworkUtil.systemdSystemUnitExists(unitName.get()))
+                    .thenReturn(true);
+        }
     }
 
     /*
@@ -328,6 +399,14 @@ public class DhcpServerManagerTest {
         }
     }
 
+    private void whenGetTool() {
+        try {
+            this.tool = DhcpServerManager.getTool();
+        } catch (Exception e) {
+            this.occurredException = e;
+        }
+    }
+
     /*
      * Then
      */
@@ -364,4 +443,11 @@ public class DhcpServerManagerTest {
         assertEquals(dhcpServerLeaseReader, this.returnedLeaseReader.get().getClass());
     }
 
+    private void thenToolIs(DhcpServerTool expectedTool) {
+        assertEquals(expectedTool, this.tool);
+    }
+
+    private void thenConverterIsNotPresent() {
+        assertFalse(this.returnedConfigConverter.isPresent());
+    }
 }

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
@@ -446,8 +446,4 @@ public class DhcpServerManagerTest {
     private void thenToolIs(DhcpServerTool expectedTool) {
         assertEquals(expectedTool, this.tool);
     }
-
-    private void thenConverterIsNotPresent() {
-        assertFalse(this.returnedConfigConverter.isPresent());
-    }
 }

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/DhcpServerManagerTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2017, 2024 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  ******************************************************************************/
@@ -326,7 +326,7 @@ public class DhcpServerManagerTest {
     @After
     public void deregisterStaticMocks() {
         if (this.mockedLinuxNetworkUtil != null) {
-            mockedLinuxNetworkUtil.close();
+            this.mockedLinuxNetworkUtil.close();
         }
     }
 
@@ -343,14 +343,14 @@ public class DhcpServerManagerTest {
 
         TestUtil.setFieldValue(new DhcpServerManager(null), "dhcpServerTool", dhcpServerTool);
 
-        this.dhcpServerManager = new DhcpServerManager(executorMock);
+        this.dhcpServerManager = new DhcpServerManager(this.executorMock);
     }
 
     private void givenLinuxNetworkUtil(String toolName, Optional<String> unitName) {
         this.mockedLinuxNetworkUtil = Mockito.mockStatic(LinuxNetworkUtil.class);
-        mockedLinuxNetworkUtil.when(() -> LinuxNetworkUtil.toolExists(toolName)).thenReturn(true);
+        this.mockedLinuxNetworkUtil.when(() -> LinuxNetworkUtil.toolExists(toolName)).thenReturn(true);
         if (unitName.isPresent()) {
-            mockedLinuxNetworkUtil.when(() -> LinuxNetworkUtil.systemdSystemUnitExists(unitName.get()))
+            this.mockedLinuxNetworkUtil.when(() -> LinuxNetworkUtil.systemdSystemUnitExists(unitName.get()))
                     .thenReturn(true);
         }
     }

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/server/DhcpdToolTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/server/DhcpdToolTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.kura.KuraProcessExecutionErrorException;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.executor.ExitStatus;
@@ -160,7 +161,7 @@ public class DhcpdToolTest {
 
         thenDisableInterfaceReturned(false);
     }
-    
+
     /*
      * Steps
      */
@@ -183,9 +184,10 @@ public class DhcpdToolTest {
             public boolean isSuccessful() {
                 return isSuccessful;
             }
-            
+
         };
-        CommandStatus returnedStatus = new CommandStatus(DnsmasqTool.IS_ACTIVE_COMMAND, returnedExitStatus);
+        CommandStatus returnedStatus = new CommandStatus(new Command(DnsmasqTool.IS_ACTIVE_COMMANDLINE),
+                returnedExitStatus);
 
         when(this.mockExecutor.execute(any())).thenReturn(returnedStatus);
         when(this.mockExecutor.isRunning(any(String[].class))).thenReturn(isSuccessful);
@@ -197,7 +199,8 @@ public class DhcpdToolTest {
 
     private void givenDhcpServerManagerReturn(String interfaceName, String returnedConfigFilename) {
         mockServerManager = mockStatic(DhcpServerManager.class);
-        mockServerManager.when(() -> DhcpServerManager.getPidFilename(interfaceName)).thenReturn(returnedConfigFilename);
+        mockServerManager.when(() -> DhcpServerManager.getPidFilename(interfaceName))
+                .thenReturn(returnedConfigFilename);
     }
 
     private void givenConfigFile(String filename) throws IOException {
@@ -212,7 +215,7 @@ public class DhcpdToolTest {
             public int getPid() {
                 return 1234;
             }
-            
+
         });
 
         when(this.mockExecutor.getPids(any())).thenReturn(this.runningPids);

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqToolTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/dhcp/server/DnsmasqToolTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.kura.KuraProcessExecutionErrorException;
+import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.executor.ExitStatus;
@@ -47,7 +48,7 @@ public class DnsmasqToolTest {
     private CommandStatus startInterfaceStatus;
     private boolean interfaceDisabled;
     private Exception occurredException;
-    
+
     /*
      * Scenarios
      */
@@ -151,9 +152,10 @@ public class DnsmasqToolTest {
             public boolean isSuccessful() {
                 return isSuccessful;
             }
-            
+
         };
-        CommandStatus returnedStatus = new CommandStatus(DnsmasqTool.IS_ACTIVE_COMMAND, returnedExitStatus);
+        CommandStatus returnedStatus = new CommandStatus(new Command(DnsmasqTool.IS_ACTIVE_COMMANDLINE),
+                returnedExitStatus);
 
         when(this.mockExecutor.execute(any())).thenReturn(returnedStatus);
     }
@@ -166,13 +168,15 @@ public class DnsmasqToolTest {
     private void givenConfigFile(String filename) throws IOException {
         try {
             this.tmpFolder.newFolder("etc", "dnsmasq.d");
-        } catch (Exception e) {}
+        } catch (Exception e) {
+        }
         this.tmpConfigFile = this.tmpFolder.newFile(filename);
     }
 
     private void givenDnsmasqTool() throws Exception {
         this.tool = new DnsmasqTool(this.mockExecutor);
-        this.tool.setDnsmasqGlobalConfigFile(this.tmpConfigFile.getAbsoluteFile().getParent() + "/dnsmasq-globals.conf");
+        this.tool
+                .setDnsmasqGlobalConfigFile(this.tmpConfigFile.getAbsoluteFile().getParent() + "/dnsmasq-globals.conf");
     }
 
     private void givenStartInterface(String interfaceName) throws KuraProcessExecutionErrorException {
@@ -196,7 +200,7 @@ public class DnsmasqToolTest {
             this.interfaceDisabled = this.tool.disableInterface(interfaceName);
         } catch (Exception e) {
             this.occurredException = e;
-        }        
+        }
     }
 
     /*

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,20 @@
 package org.eclipse.kura.linux.net.util;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
@@ -29,6 +42,8 @@ public class LinuxNetworkUtilTest {
     private CommandExecutorServiceStub commandExecutorServiceStub;
     private String macAddress;
     private String linkStatus;
+    private boolean toolExists;
+    private boolean systemdUnitExists;
 
     @Test
     public void createApNetworkInterface() {
@@ -70,11 +85,56 @@ public class LinuxNetworkUtilTest {
         thenNetworkInterfaceLinkIsDown();
     }
 
+    @Test
+    public void shouldCheckToolExistence() throws NoSuchFieldException, IllegalAccessException, IOException {
+        givenLinuxNetworkUtil();
+        givenToolPaths("/tmp/");
+        givenTool("/tmp/dhcpd");
+
+        whenCheckTool("dhcpd");
+
+        thenToolExists();
+    }
+
+    @Test
+    public void shouldCheckSystemdUnitExistence()
+            throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
+        givenLinuxNetworkUtil();
+        givenProcessBuilder(0);
+
+        whenCheckSystemdUnit("dnsmask.service");
+
+        thenSystemdUnitExists();
+    }
+
+    @Test
+    public void shouldNotCheckSystemdUnitExistence()
+            throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
+        givenLinuxNetworkUtil();
+        givenProcessBuilder(4);
+
+        whenCheckSystemdUnit("dnsmask.service");
+
+        thenSystemdUnitNotExist();
+    }
+
     private void givenLinuxNetworkUtil() {
         CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         this.commandExecutorServiceStub = new CommandExecutorServiceStub(status);
         this.linuxNetworkUtil = new LinuxNetworkUtil(this.commandExecutorServiceStub);
+    }
 
+    private void givenToolPaths(String path) throws NoSuchFieldException, IllegalAccessException {
+        setFinalStaticField(LinuxNetworkUtil.class, "DEFAULT_PATH", new String[] { path });
+    }
+
+    private void givenTool(String tool) throws IOException {
+        Path newFilePath = Paths.get(tool);
+        try {
+            Files.createFile(newFilePath);
+        } catch (FileAlreadyExistsException e) {
+            // do nothing
+        }
     }
 
     private void givenInterfaceName(String interfaceName) {
@@ -83,16 +143,32 @@ public class LinuxNetworkUtilTest {
 
     private void givenMacAddress(String macAddress) {
         this.macAddress = macAddress;
-
-    }
-
-    private void whenDedicatedInterfaceName(String dedicatedInterfaceName) {
-        this.dedicatedInterfaceName = dedicatedInterfaceName;
-
     }
 
     private void givenLinkStatus(String linkStatus) {
         this.linkStatus = linkStatus;
+    }
+
+    private void givenProcessBuilder(int returnCode)
+            throws NoSuchFieldException, IOException, InterruptedException, IllegalAccessException {
+        Process mockedProcess = mock(Process.class);
+        when(mockedProcess.waitFor()).thenReturn(returnCode);
+        when(mockedProcess.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[] {}));
+        ProcessBuilder mockedProcessBuilder = mock(ProcessBuilder.class);
+        when(mockedProcessBuilder.start()).thenReturn(mockedProcess);
+        setFinalStaticField(LinuxNetworkUtil.class, "PROCESS_BUILDER", mockedProcessBuilder);
+    }
+
+    private void whenDedicatedInterfaceName(String dedicatedInterfaceName) {
+        this.dedicatedInterfaceName = dedicatedInterfaceName;
+    }
+
+    private void whenCheckTool(String toolName) {
+        this.toolExists = LinuxNetworkUtil.toolExists(toolName);
+    }
+
+    private void whenCheckSystemdUnit(String unitName) {
+        this.systemdUnitExists = LinuxNetworkUtil.systemdSystemUnitExists(unitName);
     }
 
     private void thenApNetworkInterfaceIsCreated() {
@@ -134,6 +210,28 @@ public class LinuxNetworkUtilTest {
         } catch (KuraException e) {
             fail();
         }
+    }
+
+    private void thenToolExists() {
+        assertTrue(this.toolExists);
+    }
+
+    private void thenSystemdUnitExists() {
+        assertTrue(this.systemdUnitExists);
+    }
+
+    private void thenSystemdUnitNotExist() {
+        assertFalse(this.systemdUnitExists);
+    }
+
+    static void setFinalStaticField(Class clazz, String fieldName, Object value)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        Field modifiers = field.getClass().getDeclaredField("modifiers");
+        modifiers.setAccessible(true);
+        modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(null, value);
     }
 
 }

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.kura.linux.net.util;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -27,6 +28,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
@@ -44,6 +46,7 @@ public class LinuxNetworkUtilTest {
     private String linkStatus;
     private boolean toolExists;
     private boolean systemdUnitExists;
+    private Optional<String> toolPath;
 
     @Test
     public void createApNetworkInterface() {
@@ -100,6 +103,8 @@ public class LinuxNetworkUtilTest {
     public void shouldCheckSystemdUnitExistence()
             throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
         givenLinuxNetworkUtil();
+        givenToolPaths("/tmp/");
+        givenTool("/tmp/systemctl");
         givenProcessBuilder(0);
 
         whenCheckSystemdUnit("dnsmask.service");
@@ -111,11 +116,35 @@ public class LinuxNetworkUtilTest {
     public void shouldNotCheckSystemdUnitExistence()
             throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
         givenLinuxNetworkUtil();
+        givenToolPaths("/tmp/");
+        givenTool("/tmp/systemctl");
         givenProcessBuilder(4);
 
         whenCheckSystemdUnit("dnsmask.service");
 
         thenSystemdUnitNotExist();
+    }
+
+    @Test
+    public void shouldNotCheckSystemdUnitExistenceIfSystemctlNotExist()
+            throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
+        givenLinuxNetworkUtil();
+
+        whenCheckSystemdUnit("dnsmask.service");
+
+        thenSystemdUnitNotExist();
+    }
+
+    @Test
+    public void shouldGetToolPath()
+            throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
+        givenLinuxNetworkUtil();
+        givenToolPaths("/tmp/");
+        givenTool("/tmp/myAwesomeCommand");
+
+        whenGetTool("myAwesomeCommand");
+
+        thenToolIsRetrieved("/tmp/myAwesomeCommand");
     }
 
     private void givenLinuxNetworkUtil() {
@@ -171,6 +200,10 @@ public class LinuxNetworkUtilTest {
         this.systemdUnitExists = LinuxNetworkUtil.systemdSystemUnitExists(unitName);
     }
 
+    private void whenGetTool(String tool) {
+        this.toolPath = LinuxNetworkUtil.getToolPath(tool);
+    }
+
     private void thenApNetworkInterfaceIsCreated() {
         try {
             this.linuxNetworkUtil.createApNetworkInterface(this.interfaceName, this.dedicatedInterfaceName);
@@ -222,6 +255,11 @@ public class LinuxNetworkUtilTest {
 
     private void thenSystemdUnitNotExist() {
         assertFalse(this.systemdUnitExists);
+    }
+
+    private void thenToolIsRetrieved(String expectedToolPath) {
+        assertTrue(this.toolPath.isPresent());
+        assertEquals(expectedToolPath, this.toolPath.get());
     }
 
     static void setFinalStaticField(Class clazz, String fieldName, Object value)


### PR DESCRIPTION
This PR updates the method used to check if `dnsmasq` is available on the system.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** Since the DHCP server manager uses the Systemd unit for `dnsmasq`, the method used to check the presence of the tool on the system has to check the existence of the unit and the command. This PR adds this check.

The check runs this command: `systemctl status dnsmasq`. Then the exit code is checked, based on the [official documentation](https://www.man7.org/linux/man-pages/man1/systemctl.1.html#EXIT_STATUS). Since the `DhcpServerManager` class uses a static method to check the tools, the method in `LinuxNetworkUtil` has to be static too.
This implies that the `CommandExecutorService` cannot be used since we haven't a reference to it. So, the method uses the standard `ProcessBuilder` class to run the command. 

I don't like it.

In addition to the test for this specific feature, this PR adds few test on the `getTool` method.