### PR TITLE
fix(web2): Fixed wireless mode selection

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -361,11 +361,11 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         setPasswordValidation();
 
         this.tcp4Tab.status.addChangeHandler(event -> {
-                evalActiveConfig();
+            evalActiveConfig();
         });
 
         this.tcp6Tab.status.addChangeHandler(event -> {
-                evalActiveConfig();
+            evalActiveConfig();
         });
 
         logger.info("Constructor done.");
@@ -380,8 +380,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                     || !tcpIp6Status.equals(TabWirelessUi.this.tcp6Status);
 
             if (isStatusChanged) {
-                if (tcpIp4Status.equals(GwtNetIfStatus.netIPv4StatusEnabledWAN.name())
-                        || tcpIp6Status.equals(GwtNetIfStatus.netIPv6StatusEnabledWAN.name())) {
+                if (tcpIp4Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv4StatusEnabledWAN.name()))
+                        || tcpIp6Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv6StatusEnabledWAN.name()))) {
                     TabWirelessUi.this.activeConfig = TabWirelessUi.this.selectedNetIfConfig.getStationWifiConfig();
                 } else {
                     TabWirelessUi.this.activeConfig = TabWirelessUi.this.selectedNetIfConfig.getActiveWifiConfig();
@@ -390,7 +390,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
                 TabWirelessUi.this.tcp4Status = tcpIp4Status;
                 TabWirelessUi.this.tcp6Status = tcpIp6Status;
                 TabWirelessUi.this.netTabs.updateTabs();
-                
+
                 update();
             }
         }
@@ -619,8 +619,8 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         String tcpip6Status = this.tcp6Tab.getStatus();
 
         // Tcp/IP disabled
-        if (tcpip4Status.equals(GwtNetIfStatus.netIPv4StatusDisabled.getValue())
-                && tcpip6Status.equals(GwtNetIfStatus.netIPv6StatusDisabled.getValue())) {
+        if (tcpip4Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv4StatusDisabled.name()))
+                && tcpip6Status.equals(MessageUtils.get(GwtNetIfStatus.netIPv6StatusDisabled.name()))) {
             setForm(false);
         } else {
             setForm(true);
@@ -732,7 +732,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
             if (this.security.getSelectedItemText().equals(WIFI_SECURITY_WPA2_WPA3_ENTERPRISE_MESSAGE)) {
                 this.password.setEnabled(false);
             }
-            
+
             loadCountryCode();
         }
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

This PR fixes a weird behavior in the Wireless tab when the `Enable for WAN` is selected.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** When the Wireless tab is selected and the interface is configured as `Enabled for WAN` and DHCP, the Station Mode is not selectable. This PR fixes this wrong behavior. The cause of this is a wrong enum comparison.

BTW, the `release-5.6.0` contains the wrong comparison, while the Kura 5.6.0 tag doesn't.
