### PR TITLE
fix: correctly stopping gpsd thread

### DIFF
--- a/kura/org.eclipse.kura.linux.position/src/main/java/org/eclipse/kura/linux/position/gpsd/GpsdPositionProvider.java
+++ b/kura/org.eclipse.kura.linux.position/src/main/java/org/eclipse/kura/linux/position/gpsd/GpsdPositionProvider.java
@@ -87,6 +87,8 @@ public class GpsdPositionProvider implements PositionProvider, IObjectListener {
         }
 
         if (executor != null) {
+
+            this.checkFuture.cancel(true);
             executor.shutdown();
 
             try {


### PR DESCRIPTION
This PR fixes a bug that happened when the PositionService provider was switched from `gpsd` to an other service (MM or Serial): after applying the new configuration in the PositionProvider tab and refreshing the WebUI, the latter get stuck. In general, each call to the PositionService for a certain time after the switch would be stopped due to this problem.

This happened because when the [stop method](https://github.com/eclipse-kura/kura/blob/af10940fbd7528a5c6920ffe6d31ad7f74ee5844/kura/org.eclipse.kura.linux.position/src/main/java/org/eclipse/kura/linux/position/gpsd/GpsdPositionProvider.java#L84) was called, the code would take all the time allowed in the `executor.awaitTermination(1, TimeUnit.MINUTES)` before killing the thread, resulting in blocking the web ui that asks to update its location information.

The cause of the long await was that the [Future<?>](https://github.com/eclipse-kura/kura/blob/af10940fbd7528a5c6920ffe6d31ad7f74ee5844/kura/org.eclipse.kura.linux.position/src/main/java/org/eclipse/kura/linux/position/gpsd/GpsdPositionProvider.java#L68) was not canceled before the calling to the `executor.shutdown()`, so the latter would fall in a bad state that required the thread kill.

Now before the shutdown of the thread, the Future<?> is canceled and the web ui is not blocked.

-----------------------------------------------------

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
