### PR TITLE
fix: Extended log download timeframe. Improved messages.

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/device/LogTabUi.java
@@ -95,10 +95,12 @@ public class LogTabUi extends Composite {
     private final String nonce = Integer.toString(Random.nextInt());
 
     private static final int DOWNLOAD_COMPLETE_WAIT_TIMEOUT = 5000;
+    private static final int DOWNLOAD_COMPLETION_RETRIES= 60; 
+    
     private Timer waitDownloadCompleted = new Timer() {
 
         // safety parameter, 9 = 45secs
-        private short retryLimit = 9;
+        private short retryLimit = DOWNLOAD_COMPLETION_RETRIES;
         private String cookieName;
 
         @Override
@@ -121,7 +123,7 @@ public class LogTabUi extends Composite {
         private void hideModalAndStop() {
             EntryClassUi.hideWaitModal();
             Cookies.removeCookie(cookieName, "/");
-            this.retryLimit = 9;
+            this.retryLimit = DOWNLOAD_COMPLETION_RETRIES;
             this.cancel();
         }
 

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -880,7 +880,7 @@ pwdMaxLength=New password can be at most 255 characters long
 pwdWhitespaceCharacters=New password cannot contain whitespace characters
 pwdEmpty=New password cannot be empty
 
-logDownload=Click this button to download all system logs in a single zip file
+logDownload=Click this button to download all system logs in a single zip file. The process may take up to 5 minutes.
 
 configurationChangeEventNotification=Another user has modified configuration for {0}. You might see an inconsistent state and a page refresh might be needed to show the latest changes.
 configurationChangeEventNotificationGeneric=Another user has modified some configuration. You might see an inconsistent state and a page refresh might be needed to show the latest changes.


### PR DESCRIPTION
Extended the time frame where the spinning cog will stay displayed to 5 minutes. Improved messaging to the user.

