### PR TITLE
feat: added MTU limits in webUI

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabAdvancedUi.java
@@ -44,6 +44,10 @@ public class TabAdvancedUi extends Composite implements NetworkTab {
     private static final String PROMISC_ENABLED = "netAdvPromiscEnabled";
     private static final String PROMISC_DISABLED = "netAdvPromiscDisabled";
 
+    private static final int IPV4_MIN_MTU = 576;
+    private static final int IPV6_MIN_MTU = 1280;
+    private static final int MAX_MTU_SUPPORTED = 1500;
+
     interface TabAdvancedUiUiBinder extends UiBinder<Widget, TabAdvancedUi> {
     }
 
@@ -166,7 +170,7 @@ public class TabAdvancedUi extends Composite implements NetworkTab {
             setDirty(true);
 
             Integer inputValue = this.mtu.getValue();
-            boolean isValidValue = isValidIntegerInRange(inputValue, 0, Integer.MAX_VALUE);
+            boolean isValidValue = isValidIntegerInRange(inputValue, IPV4_MIN_MTU, MAX_MTU_SUPPORTED);
 
             if (isValidValue) {
                 this.groupMtu.setValidationState(ValidationState.NONE);
@@ -190,7 +194,7 @@ public class TabAdvancedUi extends Composite implements NetworkTab {
             setDirty(true);
 
             Integer inputValue = this.ip6Mtu.getValue();
-            boolean isValidValue = isValidIntegerInRange(inputValue, 0, Integer.MAX_VALUE);
+            boolean isValidValue = isValidIntegerInRange(inputValue, IPV6_MIN_MTU, MAX_MTU_SUPPORTED);
 
             if (isValidValue) {
                 this.groupIp6Mtu.setValidationState(ValidationState.NONE);
@@ -202,11 +206,19 @@ public class TabAdvancedUi extends Composite implements NetworkTab {
         });
     }
 
+    /*
+     * Minimum values are 576 for IPv4 and 1280 for IPv6.
+     * Maximum value is 1500 for both of them.
+     * 0 accepted for MTU Auto-discovery.
+     */
     private boolean isValidIntegerInRange(Integer integerValue, int min, int max) {
         if (integerValue == null) {
             return false;
         }
-        return integerValue >= min && integerValue <= max;
+
+        boolean isZero = integerValue == 0;
+        boolean isInsideLimits = integerValue >= min && integerValue <= max;
+        return isZero || isInsideLimits;
     }
 
     private void setHelpText(String message) {

--- a/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
+++ b/kura/org.eclipse.kura.web2/src/main/resources/org/eclipse/kura/web/client/messages/Messages.properties
@@ -381,10 +381,10 @@ netIPv6ToolTipPrivacy=Configure IPv6 Privacy Extensions for SLAAC, described in 
 
 netAdvanced=Advanced
 netAdvIPv4Mtu=IPv4 MTU
-netAdvIPv4InvalidMtu=IPv4 MTU must be a positive Integer.
+netAdvIPv4InvalidMtu=IPv4 MTU must be 0, or a positive Integer between 576 and 1500.
 netAdvIPv4ToolTipMtu=Selects the Maximum Transition Unit (MTU) for IPv4 traffic over this interface.<br/> A value of 0 allows MTU auto-discovery.
 netAdvIPv6Mtu=IPv6 MTU
-netAdvIPv6InvalidMtu=IPv6 MTU must be an positive Integer.
+netAdvIPv6InvalidMtu=IPv6 MTU must be 0, or a positive Integer between 1280 and 1500.
 netAdvIPv6ToolTipMtu=Selects the Maximum Transition Unit (MTU) for IPv6 traffic over this interface.<br/> A value of 0 allows MTU auto-discovery.<br/>Requires NetworkManager 1.40 or newer.
 netAdvPromisc=Promiscuous Mode
 netAdvToolTipPromisc=Configures the promiscuous mode for current interface.<br/>Requires NetworkManager 1.32 or newer.


### PR DESCRIPTION
This PR updates the checks made in the web UI for the MTU values set in the Advanced Tab of a network interface.

The old limits just checked that the input was a valid integer (0 to MaxInteger), while now they limit the range from the minimum valid MTU value (576 for IPv4 and 1280 for IPv6) to the max value accepted which is 1500. The `0` value is still accepted and translated into the automatic retrieve of the MTU from the physical interface.

Actually the MTU can be higher than 1500, if the physical link supports the Jumbo frame: we could rise the upper limit of `9000`, but it would create more cons than pros.

The main one is that the NM docs tells that the MTU setting is considered only if it's in higher or equal the minimum value (always granted) and lower or equal the maximum value **allowed by the physical link**, otherwise **it's ignored and the automatica value is used**, meaning that the user is not always sure of what configuration it's applying.

Moreover, to avoid problems in the network (bad performances, missing data, and so on), all the devices should be correctly set with a proper MTU: if, for example, a user set by mistake a high value of MTU, the device may result slow or unable to comunicate with other devices correctly.

For all this reasons we decided to limit the range to a value of 1500, which is the maximum standard for **ALL* the routers, switches and so on.

**Related Issue:**

**Description of the solution adopted:**

**Screenshots:**

**Manual Tests:**

**Any side note on the changes made:**
