### PR TITLE
ci: add force merge automation

### DIFF
--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -1,0 +1,108 @@
+name: "Force merge automation"
+description: Merge a pull request when N committers post a comment with the command /force-merge
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+env:
+  quorum: 1
+
+jobs:
+  force_merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check pull request
+        id: should-run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = await github.rest.issues.get({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+
+            const isPR = issue.data.pull_request != null
+            const isClosed = issue.data.closed_at != null
+            const isDraft = issue.data.draft
+
+            return isPR && !isClosed && !isDraft
+
+      - name: Count votes
+        id: count-votes
+        if: ${{ steps.should-run.outputs.result == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+
+            const votes = new Map();
+            for(const comment of comments.data) {
+              const hasPermissions = comment.author_association === 'MEMBER' || comment.author_association === 'OWNER'
+              const hasCastedVote = comment.body === '/force-merge'
+
+              if(hasPermissions && hasCastedVote) {
+                const username = comment.user.login
+                votes.set(username, comment.author_association);
+              }
+            }
+
+            // Display voters and role
+            console.table(votes)
+
+            return votes.size
+
+      - name: Set lables
+        if: ${{ steps.should-run.outputs.result == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+            const labelsToAdd = []
+            for(const label of labels.data) {
+              if(!label.name.startsWith('force-merge-votes-')) {
+                labelsToAdd.push(label.name)
+              }
+            }
+
+            const votes = ${{ steps.count-votes.outputs.result }}
+            if(votes >= 1 && votes < ${{env.quorum}}) {
+                labelsToAdd.push("force-merge-votes-" + votes)
+            }
+
+            console.log(labelsToAdd) // Debug
+            const result = github.rest.issues.setLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: labelsToAdd
+            })
+
+      - name: Perform merge
+        if: ${{ (steps.should-run.outputs.result == 'true') && (steps.count-votes.outputs.result >= env.quorum) }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }} // Personal Access Token TBD
+          script: |
+            await github.rest.pulls.merge({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              merge_method: "squash"
+            });
+

--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -49,12 +49,11 @@ jobs:
 
             const votes = new Map();
             for(const comment of comments.data) {
-              const hasPermissions = comment.author_association === 'MEMBER' || comment.author_association === 'OWNER'
+              const hasVotingRights = comment.author_association === 'MEMBER' || comment.author_association === 'OWNER'
               const hasCastedVote = comment.body === '/force-merge'
 
-              if(hasPermissions && hasCastedVote) {
-                const username = comment.user.login
-                votes.set(username, comment.author_association);
+              if(hasVotingRights && hasCastedVote) {
+                votes.set(comment.user.login, comment.author_association);
               }
             }
 

--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -11,7 +11,7 @@ permissions:
   issues: read
 
 env:
-  quorum: 1
+  quorum: 3
 
 jobs:
   force_merge:

--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -96,7 +96,7 @@ jobs:
         if: ${{ (steps.should-run.outputs.result == 'true') && (steps.count-votes.outputs.result >= env.quorum) }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN }} // Personal Access Token TBD
+          github-token: ${{ secrets.KURA_BOT_GITHUB_TOKEN }}
           script: |
             await github.rest.pulls.merge({
               pull_number: context.issue.number,


### PR DESCRIPTION
This PR introduces a new Github workflows that allow to bypass the CI status checks via team member voting.

**How it works**

When a new comment is posted(or edited) in a PR, the workflow will:
1. Check if the PR is yet to be merged and not in draft status
2. Count how many comments containing the command `/force-merge` were posted. Only repo maintainer votes will be counted (this is not a democracy) and duplicates will be discarded.
3. Set a label to the PR with the number of counted votes
4. If enough votes are reached, the workflow will merge the PR bypassing the branch protection rules.

It uses the new PAT introduced in https://github.com/eclipse-kura/.eclipsefdn/pull/24

**Possible improvements**

- Instead of relying on the `author_associtation` to grant vote rights we can create a new organization team and have that only belonging to that team will grant you voting rights. This offers more granularity and flexibility at the expense of an additional REST API call and some more admin work.