### PR TITLE
fix: release notes automation after Github executors update

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -28,6 +28,12 @@ jobs:
       with:
         fetch-depth: '0'
 
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin' # See 'Supported distributions' for available options
+        java-version: '11' # Required by the git-changelog-command-line tool
+
     - name: Get version
       id: get-version
       run: "echo \"resolved-version=\


### PR DESCRIPTION
Due to https://github.com/actions/runner-images/issues/10636 the Release Notes automation broke. To fix it we'll pin the Java version used for running the CLI responsible for generating the release notes.
