### PR TITLE
fix(distrib): Fixed Kura SystemD Unit dependencies

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -397,13 +397,19 @@ fi]]>
         <copy file="src/main/resources/common/kura.service"
             tofile="${project.build.directory}/${build.output.name}/kura.service"
             failonerror="false" />
+        <copy file="src/main/resources/common/kura.service.nn"
+            tofile="${project.build.directory}/${build.output.name}/kura.service.nn"
+            failonerror="false" />
         <replaceregexp
             file="${project.build.directory}/${build.output.name}/kura_install.sh"
             match="INSTALL_DIR=.*" replace="INSTALL_DIR=${kura.install.dir}" />
         <replaceregexp
             file="${project.build.directory}/${build.output.name}/kura.service"
             match="INSTALL_DIR" replace="${kura.install.dir}" />
-
+        <replaceregexp
+            file="${project.build.directory}/${build.output.name}/kura.service.nn"
+            match="INSTALL_DIR" replace="${kura.install.dir}" />
+    	
         <zip destfile="${project.build.directory}/${build.output.name}.zip">
 
             <zipfileset
@@ -448,6 +454,9 @@ fi]]>
 
             <zipfileset
                 file="${project.build.directory}/${build.output.name}/kura.service"
+                prefix="${build.output.name}/${install.folder}" />
+            <zipfileset
+                file="${project.build.directory}/${build.output.name}/kura.service.nn"
                 prefix="${build.output.name}/${install.folder}" />
             <zipfileset file="src/main/resources/${build.name}/firewall.service"
                 prefix="${build.output.name}/${install.folder}" filemode="700" />

--- a/kura/distrib/src/main/resources/aarch64-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/aarch64-nn/kura_install.sh
@@ -33,7 +33,7 @@ INSTALL_DIR=/opt/eclipse
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 
 # set up kura init
-sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
+sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service.nn > /lib/systemd/system/kura.service
 systemctl daemon-reload
 systemctl enable kura
 chmod +x ${INSTALL_DIR}/kura/bin/*.sh

--- a/kura/distrib/src/main/resources/common/kura.service.nn
+++ b/kura/distrib/src/main/resources/common/kura.service.nn
@@ -1,7 +1,7 @@
 [Unit]
 Description=Kura
-Wants=NetworkManager.service ModemManager.service dbus.service
-After=NetworkManager.service ModemManager.service dbus.service
+Wants=dbus.service
+After=dbus.service
 
 [Service]
 User=kurad

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/kura_install.sh
@@ -18,7 +18,7 @@ INSTALL_DIR=/opt/eclipse
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 
 #set up Kura init
-sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
+sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service.nn > /lib/systemd/system/kura.service
 systemctl daemon-reload
 systemctl enable kura
 chmod +x ${INSTALL_DIR}/kura/bin/*.sh

--- a/kura/distrib/src/main/resources/x86_64-nn/kura_install.sh
+++ b/kura/distrib/src/main/resources/x86_64-nn/kura_install.sh
@@ -33,7 +33,7 @@ INSTALL_DIR=/opt/eclipse
 ln -sf ${INSTALL_DIR}/kura_* ${INSTALL_DIR}/kura
 
 # set up kura init
-sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service > /lib/systemd/system/kura.service
+sed "s|INSTALL_DIR|${INSTALL_DIR}|" ${INSTALL_DIR}/kura/install/kura.service.nn > /lib/systemd/system/kura.service
 systemctl daemon-reload
 systemctl enable kura
 chmod +x ${INSTALL_DIR}/kura/bin/*.sh


### PR DESCRIPTION
This PR update the Kura SystemD unit dependencies both for standard and NN installers.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** The `kura.service` file has been updated in order to depend on `NetworkManager`, `Modemmanager` and `dbus`. A new `kura.service` file has been added for NN installer that depends only on `dbus`.

