### PR TITLE
ci: add `permissions` settings following good practices

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
Following https://github.com/amannn/action-semantic-pull-request/pull/215 this PR assigns the correct permissions to the PR lint Github action.