### PR TITLE
test: re-enable and fix LinuxNetworkUtilTest

### DIFF
--- a/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
+++ b/kura/org.eclipse.kura.linux.net/src/main/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtil.java
@@ -260,15 +260,23 @@ public class LinuxNetworkUtil {
     }
 
     public static boolean toolExists(String tool) {
-        return getToolPath(tool).isPresent();
+        return toolExists(tool, DEFAULT_PATH);
+    }
+
+    public static boolean toolExists(String tool, String[] searchPaths) {
+        return getToolPath(tool, searchPaths).isPresent();
     }
 
     public static Optional<String> getToolPath(String tool) {
+        return getToolPath(tool, DEFAULT_PATH);
+    }
+
+    public static Optional<String> getToolPath(String tool, String[] searchPaths) {
         Optional<String> optionalToolPath = getCachedTool(tool);
         if (optionalToolPath.isPresent()) {
             return optionalToolPath;
         } else {
-            for (String folder : DEFAULT_PATH) {
+            for (String folder : searchPaths) {
                 String toolPath = folder + tool;
                 File toolFile = new File(toolPath);
                 if (toolFile.exists()) {
@@ -294,7 +302,21 @@ public class LinuxNetworkUtil {
      * @return true if the unit is installed
      */
     public static boolean systemdSystemUnitExists(String unitName) {
-        Optional<String> optionalSystemctlPath = getToolPath("systemctl");
+        return systemdSystemUnitExists(unitName, DEFAULT_PATH);
+    }
+    /**
+     * Checks if the given Systemd system unit is installed.
+     * The result is based on the exit code of "systemctl status <unitName>"
+     * as presented in https://www.man7.org/linux/man-pages/man1/systemctl.1.html#EXIT_STATUS
+     *
+     * @param unitName
+     *            the name of the Systemd system unit
+     * @param searchPaths
+     *            the paths to search for the systemctl command
+     * @return true if the unit is installed
+     */
+    public static boolean systemdSystemUnitExists(String unitName, String[] searchPaths) {
+        Optional<String> optionalSystemctlPath = getToolPath("systemctl", searchPaths);
         if (!optionalSystemctlPath.isPresent()) {
             logger.debug("Systemctl command not found in default paths");
             return false;

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
@@ -34,10 +34,8 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandStatus;
-import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
 public class LinuxNetworkUtilTest {
 
     private LinuxNetworkUtil linuxNetworkUtil;
@@ -91,60 +89,52 @@ public class LinuxNetworkUtilTest {
     }
 
     @Test
-    public void shouldCheckToolExistence() throws NoSuchFieldException, IllegalAccessException, IOException {
+    public void shouldCheckToolExistence() throws IOException {
         givenLinuxNetworkUtil();
-        givenToolPaths("/tmp/");
         givenTool("/tmp/dhcpd");
 
-        whenCheckTool("dhcpd");
+        whenCheckTool("dhcpd", "/tmp/");
 
         thenToolExists();
     }
 
     @Test
-    public void shouldCheckSystemdUnitExistence()
-            throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
+    public void shouldCheckSystemdUnitExistence() throws IOException, InterruptedException {
         givenLinuxNetworkUtil();
-        givenToolPaths("/tmp/");
         givenTool("/tmp/systemctl");
         givenProcessBuilder(0);
 
-        whenCheckSystemdUnit("dnsmask.service");
+        whenCheckSystemdUnit("dnsmask.service", "/tmp/");
 
         thenSystemdUnitExists();
     }
 
     @Test
-    public void shouldNotCheckSystemdUnitExistence()
-            throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
+    public void shouldNotCheckSystemdUnitExistence() throws IOException, InterruptedException {
         givenLinuxNetworkUtil();
-        givenToolPaths("/tmp/");
         givenTool("/tmp/systemctl");
         givenProcessBuilder(4);
 
-        whenCheckSystemdUnit("dnsmask.service");
+        whenCheckSystemdUnit("dnsmask.service", "/tmp/");
 
         thenSystemdUnitNotExist();
     }
 
     @Test
-    public void shouldNotCheckSystemdUnitExistenceIfSystemctlNotExist()
-            throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
+    public void shouldNotCheckSystemdUnitExistenceIfSystemctlNotExist() {
         givenLinuxNetworkUtil();
 
-        whenCheckSystemdUnit("dnsmask.service");
+        whenCheckSystemdUnit("dnsmask.service", "/tmp/");
 
         thenSystemdUnitNotExist();
     }
 
     @Test
-    public void shouldGetToolPath()
-            throws NoSuchFieldException, IllegalAccessException, IOException, InterruptedException {
+    public void shouldGetToolPath() throws IOException {
         givenLinuxNetworkUtil();
-        givenToolPaths("/tmp/");
         givenTool("/tmp/myAwesomeCommand");
 
-        whenGetTool("myAwesomeCommand");
+        whenGetTool("myAwesomeCommand", "/tmp/");
 
         thenToolIsRetrieved("/tmp/myAwesomeCommand");
     }
@@ -153,10 +143,6 @@ public class LinuxNetworkUtilTest {
         CommandStatus status = new CommandStatus(new Command(new String[] {}), new LinuxExitStatus(0));
         this.commandExecutorServiceStub = new CommandExecutorServiceStub(status);
         this.linuxNetworkUtil = new LinuxNetworkUtil(this.commandExecutorServiceStub);
-    }
-
-    private void givenToolPaths(String path) throws NoSuchFieldException, IllegalAccessException {
-        setFinalStaticField(LinuxNetworkUtil.class, "DEFAULT_PATH", new String[] { path });
     }
 
     private void givenTool(String tool) throws IOException {
@@ -181,29 +167,28 @@ public class LinuxNetworkUtilTest {
     }
 
     private void givenProcessBuilder(int returnCode)
-            throws NoSuchFieldException, IOException, InterruptedException, IllegalAccessException {
+            throws IOException, InterruptedException {
         Process mockedProcess = mock(Process.class);
         when(mockedProcess.waitFor()).thenReturn(returnCode);
         when(mockedProcess.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[] {}));
         ProcessBuilder mockedProcessBuilder = mock(ProcessBuilder.class);
         when(mockedProcessBuilder.start()).thenReturn(mockedProcess);
-        setFinalStaticField(LinuxNetworkUtil.class, "PROCESS_BUILDER", mockedProcessBuilder);
     }
 
     private void whenDedicatedInterfaceName(String dedicatedInterfaceName) {
         this.dedicatedInterfaceName = dedicatedInterfaceName;
     }
 
-    private void whenCheckTool(String toolName) {
-        this.toolExists = LinuxNetworkUtil.toolExists(toolName);
+    private void whenCheckTool(String toolName, String searchPath) {
+        this.toolExists = LinuxNetworkUtil.toolExists(toolName, new String[] { searchPath });
     }
 
-    private void whenCheckSystemdUnit(String unitName) {
-        this.systemdUnitExists = LinuxNetworkUtil.systemdSystemUnitExists(unitName);
+    private void whenCheckSystemdUnit(String unitName, String searchPath) {
+        this.systemdUnitExists = LinuxNetworkUtil.systemdSystemUnitExists(unitName, new String[] { searchPath });
     }
 
-    private void whenGetTool(String tool) {
-        this.toolPath = LinuxNetworkUtil.getToolPath(tool);
+    private void whenGetTool(String tool, String searchPath) {
+        this.toolPath = LinuxNetworkUtil.getToolPath(tool, new String[] { searchPath });
     }
 
     private void thenApNetworkInterfaceIsCreated() {
@@ -262,16 +247,6 @@ public class LinuxNetworkUtilTest {
     private void thenToolIsRetrieved(String expectedToolPath) {
         assertTrue(this.toolPath.isPresent());
         assertEquals(expectedToolPath, this.toolPath.get());
-    }
-
-    static void setFinalStaticField(Class clazz, String fieldName, Object value)
-            throws NoSuchFieldException, IllegalAccessException {
-        Field field = clazz.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        Field modifiers = field.getClass().getDeclaredField("modifiers");
-        modifiers.setAccessible(true);
-        modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        field.set(null, value);
     }
 
 }

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
@@ -97,8 +97,7 @@ public class LinuxNetworkUtilTest {
     }
 
     @Test
-    @Ignore // Given the current implementation, we cannot inject the exit code
-            // of the command execution and therefore this test will fail.
+    @Ignore("Given the current implementation, we cannot inject the exit code of the command execution and therefore this test will fail.")
     public void shouldCheckSystemdUnitExistence() throws IOException {
         givenLinuxNetworkUtil();
         givenTool("/tmp/systemctl");

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
@@ -17,10 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
@@ -34,6 +34,7 @@ import org.eclipse.kura.KuraException;
 import org.eclipse.kura.core.linux.executor.LinuxExitStatus;
 import org.eclipse.kura.executor.Command;
 import org.eclipse.kura.executor.CommandStatus;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class LinuxNetworkUtilTest {
@@ -99,10 +100,10 @@ public class LinuxNetworkUtilTest {
     }
 
     @Test
-    public void shouldCheckSystemdUnitExistence() throws IOException, InterruptedException {
+    @Ignore
+    public void shouldCheckSystemdUnitExistence() throws IOException {
         givenLinuxNetworkUtil();
         givenTool("/tmp/systemctl");
-        givenProcessBuilder(0);
 
         whenCheckSystemdUnit("dnsmask.service", "/tmp/");
 
@@ -110,10 +111,9 @@ public class LinuxNetworkUtilTest {
     }
 
     @Test
-    public void shouldNotCheckSystemdUnitExistence() throws IOException, InterruptedException {
+    public void shouldNotCheckSystemdUnitExistence() throws IOException {
         givenLinuxNetworkUtil();
         givenTool("/tmp/systemctl");
-        givenProcessBuilder(4);
 
         whenCheckSystemdUnit("dnsmask.service", "/tmp/");
 
@@ -164,15 +164,6 @@ public class LinuxNetworkUtilTest {
 
     private void givenLinkStatus(String linkStatus) {
         this.linkStatus = linkStatus;
-    }
-
-    private void givenProcessBuilder(int returnCode)
-            throws IOException, InterruptedException {
-        Process mockedProcess = mock(Process.class);
-        when(mockedProcess.waitFor()).thenReturn(returnCode);
-        when(mockedProcess.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[] {}));
-        ProcessBuilder mockedProcessBuilder = mock(ProcessBuilder.class);
-        when(mockedProcessBuilder.start()).thenReturn(mockedProcess);
     }
 
     private void whenDedicatedInterfaceName(String dedicatedInterfaceName) {

--- a/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
+++ b/kura/test/org.eclipse.kura.linux.net.test/src/test/java/org/eclipse/kura/linux/net/util/LinuxNetworkUtilTest.java
@@ -100,7 +100,8 @@ public class LinuxNetworkUtilTest {
     }
 
     @Test
-    @Ignore
+    @Ignore // Given the current implementation, we cannot inject the exit code
+            // of the command execution and therefore this test will fail.
     public void shouldCheckSystemdUnitExistence() throws IOException {
         givenLinuxNetworkUtil();
         givenTool("/tmp/systemctl");


### PR DESCRIPTION
In #5602 we disabled some tests that were failing due to the Java 17 change. This PR re-enables one of them.

Here I refactored the `LinuxNetworkUtil` class so that it exposes a few methods allowing for specifying the search path of the tool. This allows the unit test to not rely on reflection anymore.

Originally this tests were leveraging a behaviour that is no longer supported in Java 17, see: https://stackoverflow.com/questions/56039341/get-declared-fields-of-java-lang-reflect-fields-in-jdk12. This was causing the tests to fail.

One of the tests still fails since I cannot inject a mock `BuildProcess` into the static class. In our offline discussion we decided that this was acceptable for now. A bigger rework of the `LinuxNetworkUtil` class is needed (1200 LOC, static class with state... you name it)