### PR TITLE
test: re-enable and fix DeploymentAgentTest

### DIFF
--- a/kura/test/org.eclipse.kura.deployment.agent.test/pom.xml
+++ b/kura/test/org.eclipse.kura.deployment.agent.test/pom.xml
@@ -43,6 +43,11 @@ Eurotech
         <artifactId>mockserver-netty-no-dependencies</artifactId>
         <version>${mockserver.version}</version>
     </dependency>
+    <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>4.8.1</version>
+    </dependency>
 </dependencies>
 
 <build>

--- a/kura/test/org.eclipse.kura.deployment.agent.test/src/test/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgentTest.java
+++ b/kura/test/org.eclipse.kura.deployment.agent.test/src/test/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgentTest.java
@@ -54,7 +54,6 @@ import org.eclipse.kura.system.SystemService;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.logging.MockServerLogger;
@@ -66,7 +65,6 @@ import org.osgi.service.deploymentadmin.DeploymentPackage;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 
-@Ignore
 public class DeploymentAgentTest {
 
     private static final String VERSION_1_0_0 = "1.0.0";


### PR DESCRIPTION
In #5602 we disabled some tests that were failing due to the Java 17 change. This PR re-enables one of them.

We were getting the following error after switching to Java 17:

```
[ERROR] testRemovePackageToConfFile(org.eclipse.kura.deployment.agent.impl.DeploymentAgentTest)  Time elapsed: 1.299 s  <<< ERROR!
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.ConcurrentHashMap.entrySet()" because "this.map" is null
	at org.eclipse.kura.deployment.agent.impl.DeploymentAgentTest.testRemovePackageToConfFile(DeploymentAgentTest.java:507)

[ERROR] testAddPackageToConfFileStoreException(org.eclipse.kura.deployment.agent.impl.DeploymentAgentTest)  Time elapsed: 0.025 s  <<< ERROR!
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.ConcurrentHashMap.entrySet()" because "this.map" is null
	at org.eclipse.kura.deployment.agent.impl.DeploymentAgentTest.testAddPackageToConfFileStoreException(DeploymentAgentTest.java:421)

[ERROR] testRemovePackageToConfFileStoreException(org.eclipse.kura.deployment.agent.impl.DeploymentAgentTest)  Time elapsed: 0.025 s  <<< ERROR!
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.ConcurrentHashMap.entrySet()" because "this.map" is null
	at org.eclipse.kura.deployment.agent.impl.DeploymentAgentTest.testRemovePackageToConfFileStoreException(DeploymentAgentTest.java:476)
```

This seems to be an issue with Mockito and `spy`ing Threads as per:
- https://github.com/mockito/mockito/issues/2628
- https://github.com/mockito/mockito/issues/2589

As suggested in https://github.com/mockito/mockito/issues/2628, switching to `mockito-inline` seems to fix it.

---

**Note**: there seems to be another issue with this same test suite related to `mockserver`. When running these tests we get:

```
java.lang.IllegalStateException: javax.security.cert.CertificateException: Could not find class: java.lang.ClassNotFoundException: com/sun/security/cert/internal/x509/X509V1CertImpl
```

which is related to https://github.com/mock-server/mockserver/issues/1739.

This does not break our current tests because, even if it fails to decode the client certificate, it proceeds with the rest of the test anyway.