### PR TITLE
feat(osgi): add org.osgi.framework.executionenvironment 

### DIFF
--- a/kura/distrib/src/main/osgi/equinox_3.16.0/configuration/config.ini
+++ b/kura/distrib/src/main/osgi/equinox_3.16.0/configuration/config.ini
@@ -1,5 +1,6 @@
 #Configuration File
 osgi.framework=file\:plugins/org.eclipse.osgi_3.16.0.v20200828-0759.jar
+org.osgi.framework.executionenvironment=JavaSE-9
 equinox.use.ds=true
 osgi.nl=en_us
 osgi.clean=true

--- a/kura/distrib/src/main/osgi/equinox_3.16.0/configwindows/config.ini
+++ b/kura/distrib/src/main/osgi/equinox_3.16.0/configwindows/config.ini
@@ -1,5 +1,6 @@
 #Configuration File
 osgi.framework=file\:plugins/org.eclipse.osgi_3.16.0.v20200828-0759.jar
+org.osgi.framework.executionenvironment=JavaSE-9
 equinox.use.ds=true
 osgi.nl=en_us
 osgi.clean=true


### PR DESCRIPTION
This PR adds `org.osgi.framework.executionenvironment=JavaSE-9` to the config.ini, so that Equinox ClassLoaders do not load JRE-classes again. This avoids LinkageError for javax.* classes.

Equinox reads the lists "jvm packages" from the property `org.osgi.framework.bootdelegation` and "delegates" these packages to the jvm class loader.

Without "bootdelegation" an Equinox ClassLoader loads the javax.* classes and a LinkageError occurs. See related issues below.

**Related Issue:**
This PR fixes https://github.com/eclipse-kura/kura/issues/5630 and https://github.com/eclipse-kura/kura/issues/4141.

**Description of the solution adopted:**
The javax.* classes must not be loaded by Equinox, since they are provided by the jre and loaded by the jvm itself (boot classloader / platform classloader).

The solution is to specify org.osgi.framework.executionenvironment. This is based on the [following thread](https://stackoverflow.com/questions/1458425/who-loads-javax-swing-classes-in-equinox-osgi-container):

> So as long as you define a "org.osgi.framework.executionenvironment", equinox should load the right JVM packages and export them for consumption by the bundles.

From my understanding the setting `org.osgi.framework.executionenvironment` tells Equinox to load the JSE-9 profile which in turn contains the properties `org.osgi.framework.system.packages` and `org.osgi.framework.bootdelegation` (see [here](https://github.com/eclipse-equinox/equinox/blob/59d4c5b758e08c8fd892525f1b2991289bb6f0d8/bundles/org.eclipse.osgi/JavaSE-9.profile#L245) and [here](https://github.com/eclipse-equinox/equinox/blob/59d4c5b758e08c8fd892525f1b2991289bb6f0d8/bundles/org.eclipse.osgi/JavaSE-9.profile#L165))

The mechanism of Class Loading is explained in https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#framework.module.parentdelegation.

org.osgi.framework.executionenvironment is explained here: https://docs.osgi.org/specification/osgi.core/7.0.0/framework.lifecycle.html

Nore that org.osgi.framework.executionenvironment is deprecated in older OSGi releases, but valid in R4 like Equinox.

**Screenshots:**

N/A

**Manual Tests**

**Any side note on the changes made:**

StackTrace in Java 1.8:
`Caused by: java.util.concurrent.ExecutionException: java.lang.LinkageError: loader constraint violation in interface itable initialization: when resolving method "org.h2.jdbcx.JdbcXAConnection.getXAResource()Ljavax/transaction/xa/XAResource;" the class loader (instance of org/eclipse/osgi/internal/loader/EquinoxClassLoader) of the current class, org/h2/jdbcx/JdbcXAConnection, and the class loader (instance of <bootloader>) for interface javax/sql/XAConnection have different Class objects for the type javax/transaction/xa/XAResource used in the signature`

Especially look at the following: the class loader (instance of org/eclipse/osgi/internal/loader/**EquinoxClassLoader**) of the current class, org/h2/jdbcx/JdbcXAConnection, and the class loader (instance of <**bootloader**>) [...] have **different Class objects** for the type javax/transaction/xa/XAResource used in the signature.