### PR TITLE
feat: Made PositionService dependency optional for CloudServices

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/META-INF/MANIFEST.MF
@@ -38,5 +38,7 @@ Import-Package: com.eclipsesource.json;version="0.9.5",
  org.osgi.framework;version="1.5.0",
  org.osgi.service.component;version="1.2.0",
  org.osgi.service.event;version="1.3.0",
+ org.osgi.util.measurement;version="[1.0,2.0)",
+ org.osgi.util.position;version="[1.0,2.0)",
  org.osgi.util.tracker;version="1.5.1",
  org.slf4j;version="1.6.4"

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/cloud.xml
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/cloud.xml
@@ -51,7 +51,7 @@
               cardinality="0..1" 
               bind="setPositionService" 
               interface="org.eclipse.kura.position.PositionService" 
-              policy="static" 
+              policy="dynamic" 
               unbind="unsetPositionService"/>
    <reference name="EventAdmin"              
               cardinality="1..1" 

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/cloud.xml
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/cloud.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2018, 2024 Eurotech and/or its affiliates and others
+   Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
 
    This program and the accompanying materials are made
    available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -120,7 +120,7 @@ public class CloudConnectionManagerImpl
     private SystemService systemService;
     private SystemAdminService systemAdminService;
     private NetworkService networkService;
-    private PositionService positionService;
+    private Optional<PositionService> positionService = Optional.empty();
     private EventAdmin eventAdmin;
     private CertificatesService certificatesService;
     private Unmarshaller jsonUnmarshaller;
@@ -220,16 +220,16 @@ public class CloudConnectionManagerImpl
     }
 
     public void setPositionService(PositionService positionService) {
-        this.positionService = positionService;
+        this.positionService = Optional.of(positionService);
     }
 
     public void unsetPositionService(PositionService positionService) {
-        if (this.positionService.equals(positionService)) {
-            this.positionService = null;
+        if (this.positionService.isPresent() && this.positionService.get().equals(positionService)) {
+            this.positionService = Optional.empty();
         }
     }
 
-    public PositionService getPositionService() {
+    public Optional<PositionService> getPositionService() {
         return this.positionService;
     }
 
@@ -623,7 +623,7 @@ public class CloudConnectionManagerImpl
             logger.info("framework is stopping.. not republishing birth certificate");
             return;
         }
-        
+
         readModemProfile();
         LifecycleMessage birthToPublish = new LifecycleMessage(this.options, this).asBirthCertificateMessage();
 
@@ -829,7 +829,7 @@ public class CloudConnectionManagerImpl
     public void unregisterCloudDeliveryListener(CloudDeliveryListener cloudDeliveryListener) {
         this.registeredCloudDeliveryListeners.remove(cloudDeliveryListener);
     }
-    
+
     private boolean isFrameworkStopping() {
         try {
             final Bundle ownBundle = FrameworkUtil.getBundle(CloudConnectionManagerImpl.class);

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -346,7 +346,7 @@ public class CloudConnectionManagerImpl
         this.systemService = null;
         this.systemAdminService = null;
         this.networkService = null;
-        this.positionService = null;
+        this.positionService = Optional.empty();
         this.eventAdmin = null;
 
         this.cloudServiceRegistration.unregister();

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
 package org.eclipse.kura.internal.cloudconnection.eclipseiot.mqtt.cloud;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.kura.core.util.NetUtil;
 import org.eclipse.kura.message.KuraBirthPayload;
@@ -23,10 +24,10 @@ import org.eclipse.kura.message.KuraPosition;
 import org.eclipse.kura.net.NetInterface;
 import org.eclipse.kura.net.NetInterfaceAddress;
 import org.eclipse.kura.net.NetworkService;
-import org.eclipse.kura.position.NmeaPosition;
 import org.eclipse.kura.position.PositionService;
 import org.eclipse.kura.system.SystemAdminService;
 import org.eclipse.kura.system.SystemService;
+import org.osgi.util.position.Position;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,8 +81,7 @@ public class LifeCyclePayloadBuilder {
                 .withTotalMemory(deviceProfile.getTotalMemory()).withOsArch(deviceProfile.getOsArch())
                 .withOsgiFramework(deviceProfile.getOsgiFramework())
                 .withOsgiFrameworkVersion(deviceProfile.getOsgiFrameworkVersion()).withPayloadEncoding(payloadEncoding)
-                .withJvmVendor(deviceProfile.getJvmVendor())
-                .withJdkVendorVersion(deviceProfile.getJdkVendorVersion());
+                .withJvmVendor(deviceProfile.getJvmVendor()).withJdkVendorVersion(deviceProfile.getJdkVendorVersion());
 
         if (this.cloudConnectionManagerImpl.imei != null && this.cloudConnectionManagerImpl.imei.length() > 0
                 && !this.cloudConnectionManagerImpl.imei.equals(ERROR)) {
@@ -136,7 +136,7 @@ public class LifeCyclePayloadBuilder {
         SystemService systemService = this.cloudConnectionManagerImpl.getSystemService();
         SystemAdminService sysAdminService = this.cloudConnectionManagerImpl.getSystemAdminService();
         NetworkService networkService = this.cloudConnectionManagerImpl.getNetworkService();
-        PositionService positionService = this.cloudConnectionManagerImpl.getPositionService();
+        Optional<PositionService> positionService = this.cloudConnectionManagerImpl.getPositionService();
 
         //
         // get the network information
@@ -172,12 +172,12 @@ public class LifeCyclePayloadBuilder {
         double latitude = 0.0;
         double longitude = 0.0;
         double altitude = 0.0;
-        if (positionService != null) {
-            NmeaPosition position = positionService.getNmeaPosition();
+        if (positionService.isPresent()) {
+            Position position = positionService.get().getPosition();
             if (position != null) {
-                latitude = position.getLatitude();
-                longitude = position.getLongitude();
-                altitude = position.getAltitude();
+                latitude = position.getLatitude().getValue();
+                longitude = position.getLongitude().getValue();
+                altitude = position.getAltitude().getValue();
             } else {
                 logger.warn("Unresolved PositionService reference.");
             }

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
@@ -175,8 +175,8 @@ public class LifeCyclePayloadBuilder {
         if (positionService.isPresent()) {
             Position position = positionService.get().getPosition();
             if (position != null) {
-                latitude = (position.getLatitude().getValue() / Math.PI) * 180;
-                longitude = (position.getLongitude().getValue() / Math.PI) * 180;
+                latitude = Math.toDegrees(position.getLatitude().getValue());
+                longitude = Math.toDegrees(position.getLongitude().getValue());
                 altitude = position.getAltitude().getValue();
             } else {
                 logger.warn("Unresolved PositionService reference.");

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
@@ -175,8 +175,8 @@ public class LifeCyclePayloadBuilder {
         if (positionService.isPresent()) {
             Position position = positionService.get().getPosition();
             if (position != null) {
-                latitude = position.getLatitude().getValue();
-                longitude = position.getLongitude().getValue();
+                latitude = (position.getLatitude().getValue() / Math.PI) * 180;
+                longitude = (position.getLongitude().getValue() / Math.PI) * 180;
                 altitude = position.getAltitude().getValue();
             } else {
                 logger.warn("Unresolved PositionService reference.");

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/META-INF/MANIFEST.MF
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/META-INF/MANIFEST.MF
@@ -47,5 +47,7 @@ Import-Package: com.eclipsesource.json;version="0.9.5",
  org.osgi.framework;version="1.5.0",
  org.osgi.service.component;version="1.2.0",
  org.osgi.service.event;version="1.3.0",
+ org.osgi.util.measurement;version="[1.0,2.0)",
+ org.osgi.util.position;version="[1.0,2.0)",
  org.osgi.util.tracker;version="1.5.1",
  org.slf4j;version="1.6.4"

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/OSGI-INF/cloud.xml
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/OSGI-INF/cloud.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+   Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
 
    This program and the accompanying materials are made
    available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/OSGI-INF/cloud.xml
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/OSGI-INF/cloud.xml
@@ -49,10 +49,10 @@
               unbind="unsetNetworkService"
               interface="org.eclipse.kura.net.NetworkService"/>
    <reference name="PositionService" 
-              cardinality="1..1" 
+              cardinality="0..1" 
               bind="setPositionService" 
               interface="org.eclipse.kura.position.PositionService" 
-              policy="static" 
+              policy="dynamic" 
               unbind="unsetPositionService"/>
    <reference name="EventAdmin"              
               cardinality="1..1" 

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -402,7 +402,7 @@ public class CloudServiceImpl
         this.systemService = null;
         this.systemAdminService = null;
         this.networkService = null;
-        this.positionService = null;
+        this.positionService = Optional.empty();
         this.eventAdmin = null;
         this.certificatesService = null;
 

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -138,7 +138,7 @@ public class CloudServiceImpl
     private SystemService systemService;
     private SystemAdminService systemAdminService;
     private NetworkService networkService;
-    private PositionService positionService;
+    private Optional<PositionService> positionService = Optional.empty();
     private EventAdmin eventAdmin;
     private CertificatesService certificatesService;
     private Unmarshaller jsonUnmarshaller;
@@ -252,16 +252,16 @@ public class CloudServiceImpl
     }
 
     public void setPositionService(PositionService positionService) {
-        this.positionService = positionService;
+        this.positionService = Optional.of(positionService);
     }
 
     public void unsetPositionService(PositionService positionService) {
-        if (this.positionService != null && this.positionService.equals(positionService)) {
-            this.positionService = null;
+        if (this.positionService.isPresent() && this.positionService.get().equals(positionService)) {
+            this.positionService = Optional.empty();
         }
     }
 
-    public PositionService getPositionService() {
+    public Optional<PositionService> getPositionService() {
         return this.positionService;
     }
 

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
@@ -223,8 +223,8 @@ public class LifeCyclePayloadBuilder {
         if (positionService.isPresent()) {
             Position position = positionService.get().getPosition();
             if (position != null) {
-                latitude = position.getLatitude().getValue();
-                longitude = position.getLongitude().getValue();
+                latitude = (position.getLatitude().getValue() / Math.PI) * 180;
+                longitude = (position.getLongitude().getValue() / Math.PI) * 180;
                 altitude = position.getAltitude().getValue();
             } else {
                 logger.warn("Unresolved PositionService reference.");

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,13 +26,13 @@ import org.eclipse.kura.message.KuraPosition;
 import org.eclipse.kura.net.NetInterface;
 import org.eclipse.kura.net.NetInterfaceAddress;
 import org.eclipse.kura.net.NetworkService;
-import org.eclipse.kura.position.NmeaPosition;
 import org.eclipse.kura.position.PositionService;
 import org.eclipse.kura.security.tamper.detection.TamperDetectionService;
 import org.eclipse.kura.system.ExtendedProperties;
 import org.eclipse.kura.system.ExtendedPropertyGroup;
 import org.eclipse.kura.system.SystemAdminService;
 import org.eclipse.kura.system.SystemService;
+import org.osgi.util.position.Position;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,8 +92,7 @@ public class LifeCyclePayloadBuilder {
                 .withTotalMemory(deviceProfile.getTotalMemory()).withOsArch(deviceProfile.getOsArch())
                 .withOsgiFramework(deviceProfile.getOsgiFramework())
                 .withOsgiFrameworkVersion(deviceProfile.getOsgiFrameworkVersion()).withPayloadEncoding(payloadEncoding)
-                .withJvmVendor(deviceProfile.getJvmVendor())
-                .withJdkVendorVersion(deviceProfile.getJdkVendorVersion());
+                .withJvmVendor(deviceProfile.getJvmVendor()).withJdkVendorVersion(deviceProfile.getJdkVendorVersion());
 
         tryAddTamperStatus(birthPayloadBuilder);
 
@@ -185,7 +184,7 @@ public class LifeCyclePayloadBuilder {
         SystemService systemService = this.cloudServiceImpl.getSystemService();
         SystemAdminService sysAdminService = this.cloudServiceImpl.getSystemAdminService();
         NetworkService networkService = this.cloudServiceImpl.getNetworkService();
-        PositionService positionService = this.cloudServiceImpl.getPositionService();
+        Optional<PositionService> positionService = this.cloudServiceImpl.getPositionService();
 
         //
         // get the network information
@@ -221,12 +220,12 @@ public class LifeCyclePayloadBuilder {
         double latitude = 0.0;
         double longitude = 0.0;
         double altitude = 0.0;
-        if (positionService != null) {
-            NmeaPosition position = positionService.getNmeaPosition();
+        if (positionService.isPresent()) {
+            Position position = positionService.get().getPosition();
             if (position != null) {
-                latitude = position.getLatitude();
-                longitude = position.getLongitude();
-                altitude = position.getAltitude();
+                latitude = position.getLatitude().getValue();
+                longitude = position.getLongitude().getValue();
+                altitude = position.getAltitude().getValue();
             } else {
                 logger.warn("Unresolved PositionService reference.");
             }

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
@@ -223,8 +223,8 @@ public class LifeCyclePayloadBuilder {
         if (positionService.isPresent()) {
             Position position = positionService.get().getPosition();
             if (position != null) {
-                latitude = (position.getLatitude().getValue() / Math.PI) * 180;
-                longitude = (position.getLongitude().getValue() / Math.PI) * 180;
+                latitude = Math.toDegrees(position.getLatitude().getValue());
+                longitude = Math.toDegrees(position.getLongitude().getValue());
                 altitude = position.getAltitude().getValue();
             } else {
                 logger.warn("Unresolved PositionService reference.");

--- a/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/main/java/org/eclipse/kura/core/cloud/CloudServiceTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/main/java/org/eclipse/kura/core/cloud/CloudServiceTest.java
@@ -394,8 +394,8 @@ public class CloudServiceTest {
 
     }
 
-    private JsonObject publishBirthAndGetMetrics() throws InterruptedException, ExecutionException, TimeoutException,
-            KuraException, InvalidSyntaxException {
+    private JsonObject publishBirthAndGetMetrics()
+            throws InterruptedException, ExecutionException, TimeoutException, KuraException, InvalidSyntaxException {
         final CompletableFuture<Void> disconnected = underTestInspector.disconnected();
 
         cloudServiceImpl.disconnect();

--- a/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
@@ -361,8 +361,7 @@ public class BirthMessagesTest {
     }
 
     private void thenBirthIsPublishedAfter(long delayMillis, String expectedTopic) throws KuraException {
-        verify(this.dataService, after(delayMillis).never()).publish(eq(expectedTopic), any(), eq(0), eq(false),
-                eq(0));
+        verify(this.dataService, after(delayMillis).never()).publish(eq(expectedTopic), any(), eq(0), eq(false), eq(0));
         verify(this.dataService, after(delayMillis + SLACK_DELAY).times(1)).publish(eq(expectedTopic), any(), eq(1),
                 eq(false), eq(0));
     }

--- a/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * 
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.core.cloud;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.message.KuraDeviceProfile;
+import org.eclipse.kura.net.NetInterface;
+import org.eclipse.kura.net.NetInterfaceAddress;
+import org.eclipse.kura.net.NetworkService;
+import org.eclipse.kura.position.PositionService;
+import org.eclipse.kura.system.SystemAdminService;
+import org.eclipse.kura.system.SystemService;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.util.measurement.Measurement;
+import org.osgi.util.measurement.Unit;
+import org.osgi.util.position.Position;
+
+public class LifeCyclePayloadBuilderTest {
+
+    private SystemService systemService;
+    private SystemAdminService sysAdminService;
+    private NetworkService networkService;
+    private Optional<PositionService> positionService;
+    private CloudServiceImpl cloudServiceImpl;
+    private LifeCyclePayloadBuilder lifeCyclePayloadBuilder;
+    private KuraDeviceProfile kuraDeviceProfile;
+
+    private final List<NetInterface<? extends NetInterfaceAddress>> emptyNetInterfacesList = new ArrayList<NetInterface<? extends NetInterfaceAddress>>();
+
+    @Test
+    public void shoudBuildDeviceProfileWithPositionIfPositionServiceIsAvaiable() throws KuraException {
+        givenSystemService();
+        givenSystemAdminService();
+        givenNetworkService(emptyNetInterfacesList);
+        givenPositionService();
+        givenCloudServiceImpl();
+        givenLifeCyclePayloadBuilder();
+
+        whenBuildDeviceProfile();
+
+        thenDeviceProfileHasPosition();
+    }
+
+    @Test
+    public void shoudBuildDeviceProfileWithoutPositionIfPositionServiceIsNotAvaiable() throws KuraException {
+        givenSystemService();
+        givenSystemAdminService();
+        givenNetworkService(emptyNetInterfacesList);
+        givenCloudServiceImpl();
+        givenLifeCyclePayloadBuilder();
+
+        whenBuildDeviceProfile();
+
+        thenDeviceProfileHasNotPosition();
+    }
+
+    private void givenCloudServiceImpl() {
+        this.cloudServiceImpl = mock(CloudServiceImpl.class);
+        when(this.cloudServiceImpl.getSystemService()).thenReturn(this.systemService);
+        when(this.cloudServiceImpl.getSystemAdminService()).thenReturn(this.sysAdminService);
+        when(this.cloudServiceImpl.getNetworkService()).thenReturn(this.networkService);
+        when(this.cloudServiceImpl.getPositionService()).thenReturn(this.positionService);
+    }
+
+    private void givenLifeCyclePayloadBuilder() {
+        this.lifeCyclePayloadBuilder = new LifeCyclePayloadBuilder(this.cloudServiceImpl);
+    }
+
+    private void givenSystemService() {
+        this.systemService = mock(SystemService.class);
+        when(this.systemService.getDeviceName()).thenReturn("deviceName");
+        when(this.systemService.getModelName()).thenReturn("modelName");
+        when(this.systemService.getModelId()).thenReturn("modelId");
+        when(this.systemService.getPartNumber()).thenReturn("partNumber");
+        when(this.systemService.getSerialNumber()).thenReturn("serialNumber");
+        when(this.systemService.getFirmwareVersion()).thenReturn("firmwareVersion");
+        when(this.systemService.getCpuVersion()).thenReturn("cpuVersion");
+        when(this.systemService.getBiosVersion()).thenReturn("biosVersion");
+        when(this.systemService.getOsName()).thenReturn("osName");
+        when(this.systemService.getOsVersion()).thenReturn("osVersion");
+        when(this.systemService.getJavaVmName()).thenReturn("javaVmName");
+        when(this.systemService.getJavaVmVersion()).thenReturn("javaVmVersion");
+        when(this.systemService.getJavaVmInfo()).thenReturn("javaVmInfo");
+        when(this.systemService.getJavaVendor()).thenReturn("javaVendor");
+        when(this.systemService.getJavaVersion()).thenReturn("javaVersion");
+        when(this.systemService.getKuraVersion()).thenReturn("kuraVersion");
+        when(this.systemService.getNumberOfProcessors()).thenReturn(1);
+        when(this.systemService.getTotalMemory()).thenReturn(1L);
+        when(this.systemService.getOsArch()).thenReturn("osArch");
+        when(this.systemService.getOsgiFwName()).thenReturn("osgiFwName");
+        when(this.systemService.getOsgiFwVersion()).thenReturn("osgiFwVersion");
+        when(this.systemService.getJavaVmVendor()).thenReturn("javaVmVendor");
+        when(this.systemService.getJdkVendorVersion()).thenReturn("jdkVendorVersion");
+    }
+
+    private void givenSystemAdminService() {
+        this.sysAdminService = mock(SystemAdminService.class);
+        when(this.sysAdminService.getUptime()).thenReturn("0");
+    }
+
+    private void givenNetworkService(List<NetInterface<? extends NetInterfaceAddress>> netInterfaces)
+            throws KuraException {
+        this.networkService = mock(NetworkService.class);
+        when(this.networkService.getActiveNetworkInterfaces()).thenReturn(netInterfaces);
+    }
+
+    private void givenPositionService() {
+        this.positionService = Optional.of(mock(PositionService.class));
+        Position position = new Position(new Measurement(Math.toRadians(1.0), Unit.rad),
+                new Measurement(Math.toRadians(2.0), Unit.rad), new Measurement(3.0, Unit.m),
+                new Measurement(4.0, Unit.m_s), new Measurement(Math.toRadians(5.0), Unit.rad));
+        when(this.positionService.get().getPosition()).thenReturn(position);
+    }
+
+    private void whenBuildDeviceProfile() {
+        this.kuraDeviceProfile = this.lifeCyclePayloadBuilder.buildDeviceProfile();
+    }
+
+    private void thenDeviceProfileHasPosition() {
+        assertEquals(new Double(1.0), kuraDeviceProfile.getLatitude());
+        assertEquals(new Double(2.0), kuraDeviceProfile.getLongitude());
+        assertEquals(new Double(3.0), kuraDeviceProfile.getAltitude());
+    }
+
+    private void thenDeviceProfileHasNotPosition() {
+        assertEquals(new Double(0.0), kuraDeviceProfile.getLatitude());
+        assertEquals(new Double(0.0), kuraDeviceProfile.getLongitude());
+        assertEquals(new Double(0.0), kuraDeviceProfile.getAltitude());
+    }
+
+    @Before
+    public void clear() {
+        this.positionService = Optional.empty();
+    }
+}

--- a/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
@@ -136,15 +136,15 @@ public class LifeCyclePayloadBuilderTest {
     }
 
     private void thenDeviceProfileHasPosition() {
-        assertEquals(new Double(1.0), kuraDeviceProfile.getLatitude());
-        assertEquals(new Double(2.0), kuraDeviceProfile.getLongitude());
-        assertEquals(new Double(3.0), kuraDeviceProfile.getAltitude());
+        assertEquals(Double.valueOf(1.0), kuraDeviceProfile.getLatitude());
+        assertEquals(Double.valueOf(2.0), kuraDeviceProfile.getLongitude());
+        assertEquals(Double.valueOf(3.0), kuraDeviceProfile.getAltitude());
     }
 
     private void thenDeviceProfileHasNotPosition() {
-        assertEquals(new Double(0.0), kuraDeviceProfile.getLatitude());
-        assertEquals(new Double(0.0), kuraDeviceProfile.getLongitude());
-        assertEquals(new Double(0.0), kuraDeviceProfile.getAltitude());
+        assertEquals(Double.valueOf(0.0), kuraDeviceProfile.getLatitude());
+        assertEquals(Double.valueOf(0.0), kuraDeviceProfile.getLongitude());
+        assertEquals(Double.valueOf(0.0), kuraDeviceProfile.getAltitude());
     }
 
     @Before


### PR DESCRIPTION
This PR modifies the `CloudService`s dependencies making the `PositionService` optional.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** In order to optimize the dependency list of the `CloudService` implementations, this PR removes the `PoistionService` static dependency and makes it optional (dynamic, 0..1). Moreover, some small improvements have been done on the code. The modifications impact only `org.eclipse.kura.cloudconnection.kapua.mqtt.provider` and `org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider`. 

