### PR TITLE
feat(ui): hide "renew dhcp lease" button

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
@@ -469,6 +469,12 @@ public class TabIp4Ui extends Composite implements NetworkTab {
             });
         });
 
+        // As of ESF 8, the NetworkManager-based networking backend doesn't support
+        // renewing DHCP leases. Therefore we hide the "Renew DHCP lease" button.
+        // This is a temporary solution until the NetworkManager backend is updated to
+        // support this feature.
+        this.renew.setVisible(false);
+
         this.renew.addMouseOverHandler(event -> {
             if (TabIp4Ui.this.renew.isEnabled()) {
                 TabIp4Ui.this.helpText.clear();

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
@@ -469,10 +469,10 @@ public class TabIp4Ui extends Composite implements NetworkTab {
             });
         });
 
-        // As of ESF 8, the NetworkManager-based networking backend doesn't support
-        // renewing DHCP leases. Therefore we hide the "Renew DHCP lease" button.
-        // This is a temporary solution until the NetworkManager backend is updated to
-        // support this feature.
+        // Currently the NetworkManager-based networking backend doesn't support
+        // renewing DHCP leases. Given this we decided to hide the "Renew DHCP lease"
+        // button since it's non-functional. This is a temporary solution until
+        // NetworkManager and our backend are updated to support this feature.
         this.renew.setVisible(false);
 
         this.renew.addMouseOverHandler(event -> {


### PR DESCRIPTION
This PR hides the "Renew DHCP lease" button from Kura web UI.

---

When we switched from the old Kura networking to NetworkManager we lost the ability to renew the DHCP lease. We investigated the possibility to add this functionality back in. The results are the following:

1. There seems to be no "native" way to explicitly handle this in NetworkManager (for now) see [Issue #1662](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1662).
2. There are alternative methods but either they are not really a "renewal" of the DHCP lease (i.e. result in lost connection) or they are quite invasive (see [here](https://www.kc8apf.net/2019/03/renewing-dhcp-while-keeping-a-networkmanager-connection-up/)) and rely on specific configurations (i.e. dhclient as dhcp client which might not be always true).
3. The real "DHCP lease renewal" should not lose the connection.

Given the above and the fact that the "Renew DHCP lease" functionality is not a hard requirement for our project, in agreement with @MMaiero, we decided to leave the feature out for now. When [issue #1662](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1662) will be resolved we'll enable the feature back in.

To avoid confusion for our users we decided to hide the "Renew DHCP lease" button from Kura web UI, since it is currently non-functional. This is what this PR achieves.

---

Results:

<img width="842" alt="image" src="https://github.com/user-attachments/assets/ee17417f-12e5-43b1-8773-e30cbe0c1c48" />
