### PR TITLE
perf(nm): Cancel modem reset Timer

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -245,6 +245,8 @@ public class ModemManagerDbusWrapper {
             return;
         }
 
+        resetHandlersDisable(deviceId);
+
         Modem mmModemDevice = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemManagerDbusPath.get(), Modem.class);
 
         NMModemResetHandler resetHandler = new NMModemResetHandler(networkManagerDbusPath, mmModemDevice,
@@ -270,6 +272,7 @@ public class ModemManagerDbusWrapper {
             } catch (DBusException e) {
                 logger.warn("Couldn't remove signal handler for: {}. Caused by:", handler.getNMDevicePath(), e);
             }
+            this.modemHandlers.remove(deviceId);
         }
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMModemResetHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMModemResetHandler.java
@@ -88,6 +88,7 @@ public class NMModemResetHandler implements DBusSigHandler<Device.StateChanged> 
             logger.info("Clearing timer for {}. Cancelling scheduled modem reset...", this.nmDevicePath);
             this.scheduledTasks.cancel();
             this.scheduledTasks = null;
+            this.modemResetTimer.cancel();
         }
         logger.debug("ModemStateHandler disarmed for {}", this.nmDevicePath);
     }


### PR DESCRIPTION
This PR improves the modem reset handler adding the cancellation of the Timer when the task is finished.

**Related Issue:** This PR fixes/closes N/A

