### PR TITLE
feat(nm): Added modem reset timer when connection is failed

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -297,10 +297,10 @@ public class ModemManagerDbusWrapper {
 
         Modem mmModemDevice = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemManagerDbusPath.get(), Modem.class);
 
-        MMFailedModemResetTimer resetHandler = new MMFailedModemResetTimer(mmModemDevice, delayMinutes);
-        resetHandler.schedule();
+        MMFailedModemResetTimer resetTimer = new MMFailedModemResetTimer(mmModemDevice, delayMinutes);
+        resetTimer.schedule();
 
-        this.failedModemHandlers.put(deviceId, resetHandler);
+        this.failedModemHandlers.put(deviceId, resetTimer);
     }
 
     protected void failedModemResetTimerCancel() {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,10 +20,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Timer;
 
 import org.eclipse.kura.nm.enums.MMModemLocationSource;
 import org.eclipse.kura.nm.enums.MMModemState;
 import org.eclipse.kura.nm.signal.handlers.NMModemResetHandler;
+import org.eclipse.kura.nm.signal.handlers.NMModemResetTimerTask;
 import org.eclipse.kura.nm.status.SimProperties;
 import org.freedesktop.dbus.DBusPath;
 import org.freedesktop.dbus.connections.impl.DBusConnection;
@@ -49,6 +51,7 @@ public class ModemManagerDbusWrapper {
     private final DBusConnection dbusConnection;
 
     private final Map<String, NMModemResetHandler> modemHandlers = new HashMap<>();
+    private final Map<String, MMFailedModemResetHandler> failedModemHandlers = new HashMap<>();
 
     public ModemManagerDbusWrapper(DBusConnection dbusConnection) {
         this.dbusConnection = dbusConnection;
@@ -140,6 +143,15 @@ public class ModemManagerDbusWrapper {
 
     public MMModemState getMMModemState(Properties modemProperties) {
         return MMModemState.toMMModemState(modemProperties.Get(MM_MODEM_NAME, MM_MODEM_PROPERTY_STATE));
+    }
+
+    public MMModemState getMMModemState(String modemPath) throws DBusException {
+        Optional<Properties> properties = getModemProperties(modemPath);
+        if (properties.isPresent()) {
+            return getMMModemState(properties.get());
+        } else {
+            return MMModemState.MM_MODEM_STATE_UNKNOWN;
+        }
     }
 
     public Optional<Properties> getModemProperties(String modemPath) throws DBusException {
@@ -273,6 +285,86 @@ public class ModemManagerDbusWrapper {
                 logger.warn("Couldn't remove signal handler for: {}. Caused by:", handler.getNMDevicePath(), e);
             }
             this.modemHandlers.remove(deviceId);
+        }
+    }
+
+    protected void failedResetHandlerEnable(String deviceId, Optional<String> modemManagerDbusPath, int delayMinutes)
+            throws DBusException {
+        if (!modemManagerDbusPath.isPresent()) {
+            logger.warn("Cannot retrieve modem device for {}. Skipping modem reset monitor setup.", deviceId);
+            return;
+        }
+
+        Modem mmModemDevice = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemManagerDbusPath.get(), Modem.class);
+
+        MMFailedModemResetHandler resetHandler = new MMFailedModemResetHandler(mmModemDevice,
+                modemManagerDbusPath.get(), delayMinutes);
+        resetHandler.schedule();
+
+        this.failedModemHandlers.put(deviceId, resetHandler);
+    }
+
+    protected void failedResetHandlersDisable() {
+        for (String deviceId : this.failedModemHandlers.keySet()) {
+            failedResetHandlersDisable(deviceId);
+        }
+        this.modemHandlers.clear();
+    }
+
+    protected void failedResetHandlersDisable(String deviceId) {
+        if (this.failedModemHandlers.containsKey(deviceId)) {
+            MMFailedModemResetHandler handler = this.failedModemHandlers.get(deviceId);
+            handler.cancel();
+        }
+    }
+
+    protected boolean isMMFailedModemResetTimerArmed(String deviceId) {
+        return this.failedModemHandlers.containsKey(deviceId);
+    }
+
+    private class MMFailedModemResetTimerTask extends NMModemResetTimerTask {
+
+        private final String modemManagerDbusPath;
+
+        public MMFailedModemResetTimerTask(Modem modem, String modemManagerDbusPath) {
+            super(modem);
+            this.modemManagerDbusPath = modemManagerDbusPath;
+        }
+
+        @Override
+        public void run() {
+            try {
+                MMModemState modemState = getMMModemState(modemManagerDbusPath);
+                if (MMModemState.MM_MODEM_STATE_FAILED.equals(modemState)) {
+                    super.run();
+                }
+            } catch (DBusException e) {
+                ModemManagerDbusWrapper.logger.warn("Couldn't get state of modem interface, caused by:", e);
+            }
+        }
+
+    }
+
+    private class MMFailedModemResetHandler {
+
+        private final Timer timer = new Timer("FailedModemResetTimer");
+        private final MMFailedModemResetTimerTask task;
+        private final long delay;
+
+        public MMFailedModemResetHandler(Modem modem, String modemManagerDbusPath, long delayMinutes) {
+            this.delay = delayMinutes * 60L * 1000L;
+            this.task = new MMFailedModemResetTimerTask(modem, modemManagerDbusPath);
+        }
+
+        public void schedule() {
+            this.timer.schedule(this.task, this.delay);
+        }
+
+        public void cancel() {
+            if (this.task != null) {
+                this.task.cancel();
+            }
+            this.timer.cancel();
         }
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -334,10 +334,10 @@ public class ModemManagerDbusWrapper {
                 if (MMModemState.MM_MODEM_STATE_FAILED.equals(modemState)) {
                     super.run();
                 } else {
-                    logger.info("Modem state changed. Reset skipped.");
+                    NMModemResetTimerTask.logger.info("Modem state changed. Reset skipped.");
                 }
             } catch (DBusException e) {
-                logger.warn("Couldn't get state of modem interface, caused by:", e);
+                NMModemResetTimerTask.logger.warn("Couldn't get state of modem interface, caused by:", e);
             }
         }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -51,7 +51,7 @@ public class ModemManagerDbusWrapper {
     private final DBusConnection dbusConnection;
 
     private final Map<String, NMModemResetHandler> modemHandlers = new HashMap<>();
-    private final Map<String, MMFailedModemResetTimer> failedModemHandlers = new HashMap<>();
+    private final Map<String, MMFailedModemResetTimer> failedModemResetTimers = new HashMap<>();
 
     public ModemManagerDbusWrapper(DBusConnection dbusConnection) {
         this.dbusConnection = dbusConnection;
@@ -300,25 +300,25 @@ public class ModemManagerDbusWrapper {
         MMFailedModemResetTimer resetTimer = new MMFailedModemResetTimer(mmModemDevice, delayMinutes);
         resetTimer.schedule();
 
-        this.failedModemHandlers.put(deviceId, resetTimer);
+        this.failedModemResetTimers.put(deviceId, resetTimer);
     }
 
     protected void failedModemResetTimerCancel() {
-        for (String deviceId : this.failedModemHandlers.keySet()) {
+        for (String deviceId : this.failedModemResetTimers.keySet()) {
             failedModemResetTimerCancel(deviceId);
         }
         this.modemHandlers.clear();
     }
 
     protected void failedModemResetTimerCancel(String deviceId) {
-        if (this.failedModemHandlers.containsKey(deviceId)) {
-            MMFailedModemResetTimer timer = this.failedModemHandlers.get(deviceId);
+        if (this.failedModemResetTimers.containsKey(deviceId)) {
+            MMFailedModemResetTimer timer = this.failedModemResetTimers.get(deviceId);
             timer.cancel();
         }
     }
 
     protected boolean isMMFailedModemResetTimerArmed(String deviceId) {
-        return this.failedModemHandlers.containsKey(deviceId);
+        return this.failedModemResetTimers.containsKey(deviceId);
     }
 
     private class MMFailedModemResetTimerTask extends NMModemResetTimerTask {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -51,7 +51,7 @@ public class ModemManagerDbusWrapper {
     private final DBusConnection dbusConnection;
 
     private final Map<String, NMModemResetHandler> modemHandlers = new HashMap<>();
-    private final Map<String, MMFailedModemResetHandler> failedModemHandlers = new HashMap<>();
+    private final Map<String, MMFailedModemResetTimer> failedModemHandlers = new HashMap<>();
 
     public ModemManagerDbusWrapper(DBusConnection dbusConnection) {
         this.dbusConnection = dbusConnection;
@@ -288,7 +288,7 @@ public class ModemManagerDbusWrapper {
         }
     }
 
-    protected void failedResetHandlerEnable(String deviceId, Optional<String> modemManagerDbusPath, int delayMinutes)
+    protected void failedModemResetTimerEnable(String deviceId, Optional<String> modemManagerDbusPath, int delayMinutes)
             throws DBusException {
         if (!modemManagerDbusPath.isPresent()) {
             logger.warn("Cannot retrieve modem device for {}. Skipping modem reset monitor setup.", deviceId);
@@ -297,24 +297,23 @@ public class ModemManagerDbusWrapper {
 
         Modem mmModemDevice = this.dbusConnection.getRemoteObject(MM_BUS_NAME, modemManagerDbusPath.get(), Modem.class);
 
-        MMFailedModemResetHandler resetHandler = new MMFailedModemResetHandler(mmModemDevice,
-                modemManagerDbusPath.get(), delayMinutes);
+        MMFailedModemResetTimer resetHandler = new MMFailedModemResetTimer(mmModemDevice, delayMinutes);
         resetHandler.schedule();
 
         this.failedModemHandlers.put(deviceId, resetHandler);
     }
 
-    protected void failedResetHandlersDisable() {
+    protected void failedModemResetTimerDisable() {
         for (String deviceId : this.failedModemHandlers.keySet()) {
-            failedResetHandlersDisable(deviceId);
+            failedModemResetTimerDisable(deviceId);
         }
         this.modemHandlers.clear();
     }
 
-    protected void failedResetHandlersDisable(String deviceId) {
+    protected void failedModemResetTimerDisable(String deviceId) {
         if (this.failedModemHandlers.containsKey(deviceId)) {
-            MMFailedModemResetHandler handler = this.failedModemHandlers.get(deviceId);
-            handler.cancel();
+            MMFailedModemResetTimer timer = this.failedModemHandlers.get(deviceId);
+            timer.cancel();
         }
     }
 
@@ -324,36 +323,35 @@ public class ModemManagerDbusWrapper {
 
     private class MMFailedModemResetTimerTask extends NMModemResetTimerTask {
 
-        private final String modemManagerDbusPath;
-
-        public MMFailedModemResetTimerTask(Modem modem, String modemManagerDbusPath) {
+        public MMFailedModemResetTimerTask(Modem modem) {
             super(modem);
-            this.modemManagerDbusPath = modemManagerDbusPath;
         }
 
         @Override
         public void run() {
             try {
-                MMModemState modemState = getMMModemState(modemManagerDbusPath);
+                MMModemState modemState = getMMModemState(this.getModemDbusPath());
                 if (MMModemState.MM_MODEM_STATE_FAILED.equals(modemState)) {
                     super.run();
+                } else {
+                    logger.info("Modem state changed. Reset skipped.");
                 }
             } catch (DBusException e) {
-                ModemManagerDbusWrapper.logger.warn("Couldn't get state of modem interface, caused by:", e);
+                logger.warn("Couldn't get state of modem interface, caused by:", e);
             }
         }
 
     }
 
-    private class MMFailedModemResetHandler {
+    private class MMFailedModemResetTimer {
 
         private final Timer timer = new Timer("FailedModemResetTimer");
         private final MMFailedModemResetTimerTask task;
         private final long delay;
 
-        public MMFailedModemResetHandler(Modem modem, String modemManagerDbusPath, long delayMinutes) {
+        public MMFailedModemResetTimer(Modem modem, long delayMinutes) {
             this.delay = delayMinutes * 60L * 1000L;
-            this.task = new MMFailedModemResetTimerTask(modem, modemManagerDbusPath);
+            this.task = new MMFailedModemResetTimerTask(modem);
         }
 
         public void schedule() {

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/ModemManagerDbusWrapper.java
@@ -288,7 +288,7 @@ public class ModemManagerDbusWrapper {
         }
     }
 
-    protected void failedModemResetTimerEnable(String deviceId, Optional<String> modemManagerDbusPath, int delayMinutes)
+    protected void failedModemResetTimerSchedule(String deviceId, Optional<String> modemManagerDbusPath, int delayMinutes)
             throws DBusException {
         if (!modemManagerDbusPath.isPresent()) {
             logger.warn("Cannot retrieve modem device for {}. Skipping modem reset monitor setup.", deviceId);
@@ -303,14 +303,14 @@ public class ModemManagerDbusWrapper {
         this.failedModemHandlers.put(deviceId, resetHandler);
     }
 
-    protected void failedModemResetTimerDisable() {
+    protected void failedModemResetTimerCancel() {
         for (String deviceId : this.failedModemHandlers.keySet()) {
-            failedModemResetTimerDisable(deviceId);
+            failedModemResetTimerCancel(deviceId);
         }
         this.modemHandlers.clear();
     }
 
-    protected void failedModemResetTimerDisable(String deviceId) {
+    protected void failedModemResetTimerCancel(String deviceId) {
         if (this.failedModemHandlers.containsKey(deviceId)) {
             MMFailedModemResetTimer timer = this.failedModemHandlers.get(deviceId);
             timer.cancel();

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@ package org.eclipse.kura.nm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Timer;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.kura.KuraException;
@@ -41,6 +43,7 @@ import org.eclipse.kura.nm.signal.handlers.DeviceCreationLock;
 import org.eclipse.kura.nm.signal.handlers.DeviceStateLock;
 import org.eclipse.kura.nm.signal.handlers.NMConfigurationEnforcementHandler;
 import org.eclipse.kura.nm.signal.handlers.NMDeviceAddedHandler;
+import org.eclipse.kura.nm.signal.handlers.NMModemResetTimerTask;
 import org.eclipse.kura.nm.status.AccessPointsProperties;
 import org.eclipse.kura.nm.status.DevicePropertiesWrapper;
 import org.eclipse.kura.nm.status.NMStatusConverter;
@@ -54,6 +57,7 @@ import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.Variant;
+import org.freedesktop.modemmanager1.Modem;
 import org.freedesktop.modemmanager1.modem.Location;
 import org.freedesktop.networkmanager.Device;
 import org.freedesktop.networkmanager.Settings;
@@ -105,6 +109,7 @@ public class NMDbusConnector {
     private NMDeviceAddedHandler deviceAddedHandler = null;
 
     private boolean configurationEnforcementHandlerIsArmed = false;
+    private Map<String, NMFailedModemResetTimerTask> failedModemResetScheduledTasks = new HashMap<>();
 
     private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
@@ -558,9 +563,36 @@ public class NMDbusConnector {
 
         try {
             this.networkManager.activateConnection(connection.get(), device);
+            if (this.failedModemResetScheduledTasks.containsKey(deviceId)) {
+                this.failedModemResetScheduledTasks.get(deviceId).cancel();
+                this.failedModemResetScheduledTasks.remove(deviceId);
+            }
             dsLock.waitForSignal();
         } catch (DBusExecutionException e) {
             logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
+            // If the connection fails at the first try, check if the modem is in failed state (sim missing?) and
+            // schedule a reset after a delay time. When the timer is expired, check again for the state and perform the
+            // reset if needed.
+            if (isModemInFailedState(device, deviceType)) {
+                int delayMinutes = properties.get(Integer.class, "net.interface.%s.config.resetTimeout", deviceId);
+                Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
+                if (mmDbusPath.isPresent() && delayMinutes != 0) {
+                    if (this.failedModemResetScheduledTasks.containsKey(deviceId)) {
+                        this.failedModemResetScheduledTasks.get(deviceId).cancel();
+                        this.failedModemResetScheduledTasks.remove(deviceId);
+                    }
+                    Modem mmModemDevice = this.dbusConnection.getRemoteObject("org.freedesktop.ModemManager1",
+                            mmDbusPath.get(), Modem.class);
+
+                    logger.info("Modem {} in failed state or unavailable. Scheduling modem reset in {} minutes ...",
+                            device.getObjectPath(), delayMinutes);
+
+                    Timer failedModemResetTimer = new Timer("failedModemResetTimer");
+                    NMFailedModemResetTimerTask task = new NMFailedModemResetTimerTask(mmModemDevice, device);
+                    this.failedModemResetScheduledTasks.put(deviceId, task);
+                    failedModemResetTimer.schedule(task, delayMinutes * 60L * 1000L);
+                }
+            }
         }
 
         // Housekeeping
@@ -577,6 +609,36 @@ public class NMDbusConnector {
             if (delayMinutes != 0) {
                 Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
                 this.modemManager.resetHandlerEnable(deviceId, mmDbusPath, delayMinutes, device.getObjectPath());
+            }
+        }
+
+    }
+
+    private boolean isModemInFailedState(Device device, NMDeviceType deviceType) throws DBusException {
+        NMDeviceState state = this.networkManager.getDeviceState(device);
+        return deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM && (NMDeviceState.NM_DEVICE_STATE_FAILED.equals(state)
+                || NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE.equals(state));
+    }
+
+    private class NMFailedModemResetTimerTask extends NMModemResetTimerTask {
+
+        Device device;
+
+        public NMFailedModemResetTimerTask(Modem modem, Device device) {
+            super(modem);
+            this.device = device;
+        }
+
+        @Override
+        public void run() {
+            try {
+                NMDeviceState state = NMDbusConnector.this.networkManager.getDeviceState(this.device);
+                if (NMDeviceState.NM_DEVICE_STATE_FAILED.equals(state)
+                        || NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE.equals(state)) {
+                    super.run();
+                }
+            } catch (DBusException e) {
+                NMDbusConnector.logger.warn("Couldn't get state of modem interface, caused by:", e);
             }
         }
 
@@ -642,6 +704,10 @@ public class NMDbusConnector {
         if (!optDevice.isPresent()) {
             logger.warn("Can't disable missing device {}", deviceId);
             return;
+        }
+        if (this.failedModemResetScheduledTasks.containsKey(deviceId)) {
+            this.failedModemResetScheduledTasks.get(deviceId).cancel();
+            this.failedModemResetScheduledTasks.remove(deviceId);
         }
         Device device = optDevice.get();
         Optional<Connection> appliedConnection = this.networkManager.getAppliedConnection(device);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -561,26 +561,14 @@ public class NMDbusConnector {
             connection = Optional.of(createdConnection);
         }
 
+        boolean activationSucceeded = true;
         try {
-            this.modemManager.failedResetHandlersDisable(deviceId);
+            this.modemManager.failedModemResetTimerDisable(deviceId);
             this.networkManager.activateConnection(connection.get(), device);
             dsLock.waitForSignal();
         } catch (DBusExecutionException e) {
             logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
-            // If a modem connection fails at the first try, it stays in the failed state, thus not triggering the usual
-            // modem reset procedure. So, start a reset timer here.
-            if (isModemFailed(device, deviceType)) {
-                int delayMinutes = properties.get(Integer.class, "net.interface.%s.config.resetTimeout", deviceId);
-
-                if (delayMinutes != 0) {
-                    Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-
-                    logger.info("Modem {} in failed state or unavailable. Scheduling modem reset in {} minutes ...",
-                            device.getObjectPath(), delayMinutes);
-
-                    this.modemManager.failedResetHandlerEnable(deviceId, mmDbusPath, delayMinutes);
-                }
-            }
+            activationSucceeded = false;
         }
 
         // Housekeeping
@@ -593,24 +581,29 @@ public class NMDbusConnector {
 
         if (deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM) {
             int delayMinutes = properties.get(Integer.class, "net.interface.%s.config.resetTimeout", deviceId);
+            Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
 
-            if (delayMinutes != 0) {
-                Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-                this.modemManager.resetHandlerEnable(deviceId, mmDbusPath, delayMinutes, device.getObjectPath());
+            if (delayMinutes == 0 || !mmDbusPath.isPresent()) {
+                return;
             }
+
+            this.modemManager.resetHandlerEnable(deviceId, mmDbusPath, delayMinutes, device.getObjectPath());
+
+            // If a modem connection fails at the first try, it stays in the failed state, thus not triggering the usual
+            // modem reset procedure. So, start a reset timer here.
+            if (!activationSucceeded && isModemFailed(mmDbusPath.get())) {
+                logger.info("Modem {} in failed state or unavailable. Scheduling modem reset in {} minutes ...",
+                        device.getObjectPath(), delayMinutes);
+
+                this.modemManager.failedModemResetTimerEnable(deviceId, mmDbusPath, delayMinutes);
+            }
+
         }
 
     }
 
-    private boolean isModemFailed(Device device, NMDeviceType deviceType) throws DBusException {
-        if (deviceType != NMDeviceType.NM_DEVICE_TYPE_MODEM) {
-            return false;
-        }
-        Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-        if (!mmDbusPath.isPresent()) {
-            return false;
-        }
-        MMModemState modemState = this.modemManager.getMMModemState(mmDbusPath.get());
+    private boolean isModemFailed(String mmDbusPath) throws DBusException {
+        MMModemState modemState = this.modemManager.getMMModemState(mmDbusPath);
         return MMModemState.MM_MODEM_STATE_FAILED.equals(modemState);
     }
 
@@ -675,7 +668,7 @@ public class NMDbusConnector {
             logger.warn("Can't disable missing device {}", deviceId);
             return;
         }
-        this.modemManager.failedResetHandlersDisable(deviceId);
+        this.modemManager.failedModemResetTimerDisable(deviceId);
         Device device = optDevice.get();
         Optional<Connection> appliedConnection = this.networkManager.getAppliedConnection(device);
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -16,7 +16,6 @@ package org.eclipse.kura.nm;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +24,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Timer;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.kura.KuraException;
@@ -37,13 +35,13 @@ import org.eclipse.kura.net.wifi.WifiMode;
 import org.eclipse.kura.net.wifi.WifiSecurity;
 import org.eclipse.kura.nm.configuration.NMSettingsConverter;
 import org.eclipse.kura.nm.enums.MMModemLocationSource;
+import org.eclipse.kura.nm.enums.MMModemState;
 import org.eclipse.kura.nm.enums.NMDeviceState;
 import org.eclipse.kura.nm.enums.NMDeviceType;
 import org.eclipse.kura.nm.signal.handlers.DeviceCreationLock;
 import org.eclipse.kura.nm.signal.handlers.DeviceStateLock;
 import org.eclipse.kura.nm.signal.handlers.NMConfigurationEnforcementHandler;
 import org.eclipse.kura.nm.signal.handlers.NMDeviceAddedHandler;
-import org.eclipse.kura.nm.signal.handlers.NMModemResetTimerTask;
 import org.eclipse.kura.nm.status.AccessPointsProperties;
 import org.eclipse.kura.nm.status.DevicePropertiesWrapper;
 import org.eclipse.kura.nm.status.NMStatusConverter;
@@ -57,7 +55,6 @@ import org.freedesktop.dbus.exceptions.DBusException;
 import org.freedesktop.dbus.exceptions.DBusExecutionException;
 import org.freedesktop.dbus.interfaces.Properties;
 import org.freedesktop.dbus.types.Variant;
-import org.freedesktop.modemmanager1.Modem;
 import org.freedesktop.modemmanager1.modem.Location;
 import org.freedesktop.networkmanager.Device;
 import org.freedesktop.networkmanager.Settings;
@@ -109,7 +106,6 @@ public class NMDbusConnector {
     private NMDeviceAddedHandler deviceAddedHandler = null;
 
     private boolean configurationEnforcementHandlerIsArmed = false;
-    private Map<String, NMFailedModemResetHandler> failedModemResetHandlers = new HashMap<>();
 
     private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
@@ -138,9 +134,13 @@ public class NMDbusConnector {
         this.optionalSystemService = Optional.of(systemService);
     }
 
-    public boolean configurationEnforcementIsActive() {
+    protected boolean configurationEnforcementIsActive() {
         return Objects.nonNull(this.configurationEnforcementHandler) && Objects.nonNull(this.deviceAddedHandler)
                 && this.configurationEnforcementHandlerIsArmed;
+    }
+
+    protected boolean failedModemResetTimerIsActive(String modemId) {
+        return this.modemManager.isMMFailedModemResetTimerArmed(modemId);
     }
 
     public void checkPermissions() {
@@ -401,7 +401,7 @@ public class NMDbusConnector {
         logger.info("Applying configuration using NetworkManager Dbus connector");
         NetworkProperties properties = new NetworkProperties(networkConfiguration);
         List<String> availableDeviceIds = getInterfaceIds();
-        Set<String> availableDevices = new LinkedHashSet<String>(availableDeviceIds);
+        Set<String> availableDevices = new LinkedHashSet<>(availableDeviceIds);
         Optional<List<String>> configuredInterfaceIds = properties.getOptStringList("net.interfaces");
         if (configuredInterfaceIds.isPresent()) {
             availableDevices.addAll(configuredInterfaceIds.get());
@@ -562,27 +562,23 @@ public class NMDbusConnector {
         }
 
         try {
-            cancelAndRemoveModemResetTask(deviceId);
+            this.modemManager.failedResetHandlersDisable(deviceId);
             this.networkManager.activateConnection(connection.get(), device);
             dsLock.waitForSignal();
         } catch (DBusExecutionException e) {
             logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
             // If a modem connection fails at the first try, it stays in the failed state, thus not triggering the usual
             // modem reset procedure. So, start a reset timer here.
-            if (isModemNotConnected(device, deviceType)) {
+            if (isModemFailed(device, deviceType)) {
                 int delayMinutes = properties.get(Integer.class, "net.interface.%s.config.resetTimeout", deviceId);
-                Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
-                if (mmDbusPath.isPresent() && delayMinutes != 0) {
-                    Modem mmModemDevice = this.dbusConnection.getRemoteObject("org.freedesktop.ModemManager1",
-                            mmDbusPath.get(), Modem.class);
+
+                if (delayMinutes != 0) {
+                    Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
 
                     logger.info("Modem {} in failed state or unavailable. Scheduling modem reset in {} minutes ...",
                             device.getObjectPath(), delayMinutes);
 
-                    NMFailedModemResetTimerTask task = new NMFailedModemResetTimerTask(mmModemDevice, device);
-                    NMFailedModemResetHandler handler = new NMFailedModemResetHandler(task);
-                    this.failedModemResetHandlers.put(deviceId, handler);
-                    handler.schedule(delayMinutes);
+                    this.modemManager.failedResetHandlerEnable(deviceId, mmDbusPath, delayMinutes);
                 }
             }
         }
@@ -606,16 +602,16 @@ public class NMDbusConnector {
 
     }
 
-    private boolean isModemNotConnected(Device device, NMDeviceType deviceType) throws DBusException {
-        return deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM
-                && !NMDeviceState.isConnected(this.networkManager.getDeviceState(device));
-    }
-
-    private void cancelAndRemoveModemResetTask(String deviceId) {
-        if (this.failedModemResetHandlers.containsKey(deviceId)) {
-            this.failedModemResetHandlers.get(deviceId).cancel();
-            this.failedModemResetHandlers.remove(deviceId);
+    private boolean isModemFailed(Device device, NMDeviceType deviceType) throws DBusException {
+        if (deviceType != NMDeviceType.NM_DEVICE_TYPE_MODEM) {
+            return false;
         }
+        Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
+        if (!mmDbusPath.isPresent()) {
+            return false;
+        }
+        MMModemState modemState = this.modemManager.getMMModemState(mmDbusPath.get());
+        return MMModemState.MM_MODEM_STATE_FAILED.equals(modemState);
     }
 
     private void createVirtualInterface(String deviceId, NetworkProperties properties, NMDeviceType deviceType)
@@ -679,7 +675,7 @@ public class NMDbusConnector {
             logger.warn("Can't disable missing device {}", deviceId);
             return;
         }
-        cancelAndRemoveModemResetTask(deviceId);
+        this.modemManager.failedResetHandlersDisable(deviceId);
         Device device = optDevice.get();
         Optional<Connection> appliedConnection = this.networkManager.getAppliedConnection(device);
 
@@ -768,49 +764,4 @@ public class NMDbusConnector {
         return modemsPath;
     }
 
-    private class NMFailedModemResetTimerTask extends NMModemResetTimerTask {
-
-        Device device;
-
-        public NMFailedModemResetTimerTask(Modem modem, Device device) {
-            super(modem);
-            this.device = device;
-        }
-
-        @Override
-        public void run() {
-            try {
-                NMDeviceState state = NMDbusConnector.this.networkManager.getDeviceState(this.device);
-                if (!NMDeviceState.isConnected(state)) {
-                    super.run();
-                }
-            } catch (DBusException e) {
-                NMDbusConnector.logger.warn("Couldn't get state of modem interface, caused by:", e);
-            }
-        }
-
-    }
-
-    private class NMFailedModemResetHandler {
-
-        private Timer failedModemResetTimer = new Timer("FailedModemResetTimer");
-        private NMFailedModemResetTimerTask task;
-
-        public NMFailedModemResetHandler(NMFailedModemResetTimerTask task) {
-            this.task = task;
-        }
-
-        public void schedule(long delayMinutes) {
-            if (this.task != null) {
-                this.failedModemResetTimer.schedule(this.task, delayMinutes * 60L * 1000L);
-            }
-        }
-
-        public void cancel() {
-            if (this.task != null) {
-                this.task.cancel();
-            }
-            this.failedModemResetTimer.cancel();
-        }
-    }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -109,7 +109,7 @@ public class NMDbusConnector {
     private NMDeviceAddedHandler deviceAddedHandler = null;
 
     private boolean configurationEnforcementHandlerIsArmed = false;
-    private Map<String, NMFailedModemResetTimerTask> failedModemResetScheduledTasks = new HashMap<>();
+    private Map<String, NMFailedModemResetHandler> failedModemResetHandlers = new HashMap<>();
 
     private NMDbusConnector(DBusConnection dbusConnection) throws DBusException {
         this.dbusConnection = Objects.requireNonNull(dbusConnection);
@@ -562,35 +562,28 @@ public class NMDbusConnector {
         }
 
         try {
+            cancelAndRemoveModemResetTask(deviceId);
             this.networkManager.activateConnection(connection.get(), device);
-            if (this.failedModemResetScheduledTasks.containsKey(deviceId)) {
-                this.failedModemResetScheduledTasks.get(deviceId).cancel();
-                this.failedModemResetScheduledTasks.remove(deviceId);
-            }
             dsLock.waitForSignal();
         } catch (DBusExecutionException e) {
             logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
             // If the connection fails at the first try, check if the modem is in failed state (sim missing?) and
             // schedule a reset after a delay time. When the timer is expired, check again for the state and perform the
             // reset if needed.
-            if (isModemInFailedState(device, deviceType)) {
+            if (isModemNotConnected(device, deviceType)) {
                 int delayMinutes = properties.get(Integer.class, "net.interface.%s.config.resetTimeout", deviceId);
                 Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
                 if (mmDbusPath.isPresent() && delayMinutes != 0) {
-                    if (this.failedModemResetScheduledTasks.containsKey(deviceId)) {
-                        this.failedModemResetScheduledTasks.get(deviceId).cancel();
-                        this.failedModemResetScheduledTasks.remove(deviceId);
-                    }
                     Modem mmModemDevice = this.dbusConnection.getRemoteObject("org.freedesktop.ModemManager1",
                             mmDbusPath.get(), Modem.class);
 
                     logger.info("Modem {} in failed state or unavailable. Scheduling modem reset in {} minutes ...",
                             device.getObjectPath(), delayMinutes);
 
-                    Timer failedModemResetTimer = new Timer("failedModemResetTimer");
                     NMFailedModemResetTimerTask task = new NMFailedModemResetTimerTask(mmModemDevice, device);
-                    this.failedModemResetScheduledTasks.put(deviceId, task);
-                    failedModemResetTimer.schedule(task, delayMinutes * 60L * 1000L);
+                    NMFailedModemResetHandler handler = new NMFailedModemResetHandler(task);
+                    this.failedModemResetHandlers.put(deviceId, handler);
+                    handler.schedule(delayMinutes);
                 }
             }
         }
@@ -614,10 +607,16 @@ public class NMDbusConnector {
 
     }
 
-    private boolean isModemInFailedState(Device device, NMDeviceType deviceType) throws DBusException {
-        NMDeviceState state = this.networkManager.getDeviceState(device);
-        return deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM && (NMDeviceState.NM_DEVICE_STATE_FAILED.equals(state)
-                || NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE.equals(state));
+    private boolean isModemNotConnected(Device device, NMDeviceType deviceType) throws DBusException {
+        return deviceType == NMDeviceType.NM_DEVICE_TYPE_MODEM
+                && !NMDeviceState.isConnected(this.networkManager.getDeviceState(device));
+    }
+
+    private void cancelAndRemoveModemResetTask(String deviceId) {
+        if (this.failedModemResetHandlers.containsKey(deviceId)) {
+            this.failedModemResetHandlers.get(deviceId).cancel();
+            this.failedModemResetHandlers.remove(deviceId);
+        }
     }
 
     private class NMFailedModemResetTimerTask extends NMModemResetTimerTask {
@@ -633,8 +632,7 @@ public class NMDbusConnector {
         public void run() {
             try {
                 NMDeviceState state = NMDbusConnector.this.networkManager.getDeviceState(this.device);
-                if (NMDeviceState.NM_DEVICE_STATE_FAILED.equals(state)
-                        || NMDeviceState.NM_DEVICE_STATE_UNAVAILABLE.equals(state)) {
+                if (!NMDeviceState.isConnected(state)) {
                     super.run();
                 }
             } catch (DBusException e) {
@@ -642,6 +640,29 @@ public class NMDbusConnector {
             }
         }
 
+    }
+
+    private class NMFailedModemResetHandler {
+
+        private Timer failedModemResetTimer = new Timer("FailedModemResetTimer");
+        private NMFailedModemResetTimerTask task;
+
+        public NMFailedModemResetHandler(NMFailedModemResetTimerTask task) {
+            this.task = task;
+        }
+
+        public void schedule(long delayMinutes) {
+            if (this.task != null) {
+                this.failedModemResetTimer.schedule(this.task, delayMinutes * 60L * 1000L);
+            }
+        }
+
+        public void cancel() {
+            if (this.task != null) {
+                this.task.cancel();
+            }
+            this.failedModemResetTimer.cancel();
+        }
     }
 
     private void createVirtualInterface(String deviceId, NetworkProperties properties, NMDeviceType deviceType)
@@ -705,10 +726,7 @@ public class NMDbusConnector {
             logger.warn("Can't disable missing device {}", deviceId);
             return;
         }
-        if (this.failedModemResetScheduledTasks.containsKey(deviceId)) {
-            this.failedModemResetScheduledTasks.get(deviceId).cancel();
-            this.failedModemResetScheduledTasks.remove(deviceId);
-        }
+        cancelAndRemoveModemResetTask(deviceId);
         Device device = optDevice.get();
         Optional<Connection> appliedConnection = this.networkManager.getAppliedConnection(device);
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -567,9 +567,8 @@ public class NMDbusConnector {
             dsLock.waitForSignal();
         } catch (DBusExecutionException e) {
             logger.warn("Couldn't complete activation of {} interface, caused by:", deviceId, e);
-            // If the connection fails at the first try, check if the modem is in failed state (sim missing?) and
-            // schedule a reset after a delay time. When the timer is expired, check again for the state and perform the
-            // reset if needed.
+            // If a modem connection fails at the first try, it stays in the failed state, thus not triggering the usual
+            // modem reset procedure. So, start a reset timer here.
             if (isModemNotConnected(device, deviceType)) {
                 int delayMinutes = properties.get(Integer.class, "net.interface.%s.config.resetTimeout", deviceId);
                 Optional<String> mmDbusPath = this.networkManager.getModemManagerDbusPath(device.getObjectPath());
@@ -616,52 +615,6 @@ public class NMDbusConnector {
         if (this.failedModemResetHandlers.containsKey(deviceId)) {
             this.failedModemResetHandlers.get(deviceId).cancel();
             this.failedModemResetHandlers.remove(deviceId);
-        }
-    }
-
-    private class NMFailedModemResetTimerTask extends NMModemResetTimerTask {
-
-        Device device;
-
-        public NMFailedModemResetTimerTask(Modem modem, Device device) {
-            super(modem);
-            this.device = device;
-        }
-
-        @Override
-        public void run() {
-            try {
-                NMDeviceState state = NMDbusConnector.this.networkManager.getDeviceState(this.device);
-                if (!NMDeviceState.isConnected(state)) {
-                    super.run();
-                }
-            } catch (DBusException e) {
-                NMDbusConnector.logger.warn("Couldn't get state of modem interface, caused by:", e);
-            }
-        }
-
-    }
-
-    private class NMFailedModemResetHandler {
-
-        private Timer failedModemResetTimer = new Timer("FailedModemResetTimer");
-        private NMFailedModemResetTimerTask task;
-
-        public NMFailedModemResetHandler(NMFailedModemResetTimerTask task) {
-            this.task = task;
-        }
-
-        public void schedule(long delayMinutes) {
-            if (this.task != null) {
-                this.failedModemResetTimer.schedule(this.task, delayMinutes * 60L * 1000L);
-            }
-        }
-
-        public void cancel() {
-            if (this.task != null) {
-                this.task.cancel();
-            }
-            this.failedModemResetTimer.cancel();
         }
     }
 
@@ -813,5 +766,51 @@ public class NMDbusConnector {
         }
 
         return modemsPath;
+    }
+
+    private class NMFailedModemResetTimerTask extends NMModemResetTimerTask {
+
+        Device device;
+
+        public NMFailedModemResetTimerTask(Modem modem, Device device) {
+            super(modem);
+            this.device = device;
+        }
+
+        @Override
+        public void run() {
+            try {
+                NMDeviceState state = NMDbusConnector.this.networkManager.getDeviceState(this.device);
+                if (!NMDeviceState.isConnected(state)) {
+                    super.run();
+                }
+            } catch (DBusException e) {
+                NMDbusConnector.logger.warn("Couldn't get state of modem interface, caused by:", e);
+            }
+        }
+
+    }
+
+    private class NMFailedModemResetHandler {
+
+        private Timer failedModemResetTimer = new Timer("FailedModemResetTimer");
+        private NMFailedModemResetTimerTask task;
+
+        public NMFailedModemResetHandler(NMFailedModemResetTimerTask task) {
+            this.task = task;
+        }
+
+        public void schedule(long delayMinutes) {
+            if (this.task != null) {
+                this.failedModemResetTimer.schedule(this.task, delayMinutes * 60L * 1000L);
+            }
+        }
+
+        public void cancel() {
+            if (this.task != null) {
+                this.task.cancel();
+            }
+            this.failedModemResetTimer.cancel();
+        }
     }
 }

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -563,7 +563,7 @@ public class NMDbusConnector {
 
         boolean activationSucceeded = true;
         try {
-            this.modemManager.failedModemResetTimerDisable(deviceId);
+            this.modemManager.failedModemResetTimerCancel(deviceId);
             this.networkManager.activateConnection(connection.get(), device);
             dsLock.waitForSignal();
         } catch (DBusExecutionException e) {
@@ -595,7 +595,7 @@ public class NMDbusConnector {
                 logger.info("Modem {} in failed state or unavailable. Scheduling modem reset in {} minutes ...",
                         device.getObjectPath(), delayMinutes);
 
-                this.modemManager.failedModemResetTimerEnable(deviceId, mmDbusPath, delayMinutes);
+                this.modemManager.failedModemResetTimerSchedule(deviceId, mmDbusPath, delayMinutes);
             }
 
         }
@@ -668,7 +668,7 @@ public class NMDbusConnector {
             logger.warn("Can't disable missing device {}", deviceId);
             return;
         }
-        this.modemManager.failedModemResetTimerDisable(deviceId);
+        this.modemManager.failedModemResetTimerCancel(deviceId);
         Device device = optDevice.get();
         Optional<Connection> appliedConnection = this.networkManager.getAppliedConnection(device);
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMModemResetHandler.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMModemResetHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMModemResetTimerTask.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/signal/handlers/NMModemResetTimerTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 public class NMModemResetTimerTask extends TimerTask {
 
-    private static final Logger logger = LoggerFactory.getLogger(NMModemResetTimerTask.class);
+    protected static final Logger logger = LoggerFactory.getLogger(NMModemResetTimerTask.class);
 
     private final Modem modem;
     private boolean expired = false;

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1127,6 +1127,32 @@ public class NMDbusConnectorTest {
         thenActivateConnectionIsNotCalledFor("wlan0");
     }
 
+    @Test
+    public void shouldNotStartFailedModemResetTimerIfConnectionSucceeds() throws DBusException, IOException {
+        givenBasicMockedDbusConnector();
+        givenMockedDevice("1-6", "wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_ACTIVATED,
+                true, false, false);
+        givenMockedDeviceList();
+        givenNetworkConfigMapWith("net.interfaces", "1-6");
+        givenNetworkConfigMapWith("net.interface.1-6.config.resetTimeout", 2);
+        givenNetworkConfigMapWith("net.interface.1-6.config.dhcpClient4.enabled", true);
+        givenNetworkConfigMapWith("net.interface.1-6.config.ip4.status", "netIPv4StatusEnabledWAN");
+
+        whenApplyIsCalledWith(this.netConfig);
+
+        thenNoExceptionIsThrown();
+    }
+
+    // @Test
+    // public void shouldStartFailedModemResetTimerIfConnectionFails() {
+    //
+    // }
+    //
+    // @Test
+    // public void shouldResetFailedModemAfterDelay() {
+    //
+    // }
+
     /*
      * Given
      */

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/NMDbusConnectorTest.java
@@ -1141,17 +1141,26 @@ public class NMDbusConnectorTest {
         whenApplyIsCalledWith(this.netConfig);
 
         thenNoExceptionIsThrown();
+        thenFailedModemResetTimerIsActive(false, "1-6");
     }
 
-    // @Test
-    // public void shouldStartFailedModemResetTimerIfConnectionFails() {
-    //
-    // }
-    //
-    // @Test
-    // public void shouldResetFailedModemAfterDelay() {
-    //
-    // }
+    @Test
+    public void shouldStartFailedModemResetTimerIfConnectionFails() throws DBusException, IOException {
+        givenBasicMockedDbusConnector();
+        givenNMActivationFailed();
+        givenMockedDevice("1-6", "wwan0", NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceState.NM_DEVICE_STATE_FAILED, true,
+                false, false);
+        givenMockedDeviceList();
+        givenNetworkConfigMapWith("net.interfaces", "1-6");
+        givenNetworkConfigMapWith("net.interface.1-6.config.resetTimeout", 2);
+        givenNetworkConfigMapWith("net.interface.1-6.config.dhcpClient4.enabled", true);
+        givenNetworkConfigMapWith("net.interface.1-6.config.ip4.status", "netIPv4StatusEnabledWAN");
+
+        whenApplyIsCalledWith(this.netConfig);
+
+        thenNoExceptionIsThrown();
+        thenFailedModemResetTimerIsActive(true, "1-6");
+    }
 
     /*
      * Given
@@ -1178,6 +1187,11 @@ public class NMDbusConnectorTest {
 
         this.instanceNMDbusConnector = NMDbusConnector.getInstance(this.dbusConnection);
 
+    }
+
+    private void givenNMActivationFailed() {
+        when(this.mockedNetworkManager.ActivateConnection(any(), any(), any()))
+                .thenThrow(new DBusExecutionException("Activation Failed!"));
     }
 
     private void givenMockedPermissions() {
@@ -1452,7 +1466,7 @@ public class NMDbusConnectorTest {
                 .thenReturn(Arrays.asList(new UInt32[] { new UInt32(40), new UInt32(69) }));
         when(modemProperties.Get(MM_MODEM_BUS_NAME, "PrimarySimSlot")).thenReturn(new UInt32(0));
         when(modemProperties.Get(MM_MODEM_BUS_NAME, "UnlockRequired")).thenReturn(new UInt32(1));
-        when(modemProperties.Get(MM_MODEM_BUS_NAME, "State")).thenReturn(8);
+        when(modemProperties.Get(MM_MODEM_BUS_NAME, "State")).thenReturn(-1);
         when(modemProperties.Get(MM_MODEM_BUS_NAME, "AccessTechnologies")).thenReturn(new UInt32(0));
         when(modemProperties.Get(MM_MODEM_BUS_NAME, "SignalQuality"))
                 .thenReturn(new UInt32[] { new UInt32(97), new UInt32(2) });
@@ -1839,7 +1853,7 @@ public class NMDbusConnectorTest {
         assertTrue(modemStatus.isGpsSupported());
         assertEquals(EnumSet.of(ModemGpsMode.UNMANAGED, ModemGpsMode.MANAGED_GPS), modemStatus.getSupporteGpsModes());
         assertFalse(modemStatus.isSimLocked());
-        assertEquals(ModemConnectionStatus.REGISTERED, modemStatus.getConnectionStatus());
+        assertEquals(ModemConnectionStatus.FAILED, modemStatus.getConnectionStatus());
         assertEquals(1, modemStatus.getAccessTechnologies().size());
         assertTrue(modemStatus.getAccessTechnologies().contains(AccessTechnology.UNKNOWN));
         assertEquals(97, modemStatus.getSignalQuality());
@@ -1875,6 +1889,10 @@ public class NMDbusConnectorTest {
 
     private void thenDeviceExists(String interfaceName) {
         assertTrue(this.mockDevices.containsKey(interfaceName));
+    }
+
+    public void thenFailedModemResetTimerIsActive(boolean expectedValue, String modemId) {
+        assertEquals(expectedValue, this.instanceNMDbusConnector.failedModemResetTimerIsActive(modemId));
     }
 
     private void simulateIwCommandOutputs(String interfaceName, Properties preMockedProperties)


### PR DESCRIPTION
This PR adds a modem reset timer when the connection fails.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** When a cellular connection fails at the first try (most likely because of an error on the sim), the modem stays in `FAILED` state and NM/MM refuse to start a connection. As a result, no dbus signals are reported and the usual modem reset timer is never triggered.
This PR adds a reset timer when the connection fails. If the connection is recovered before the timeout of the timer, the task is terminated. If the connection is down, instead, a modem reset is requested.

**Manual Tests**: To trigger this behavior, power on a device without a sim inserted. Then try to setup a cellular connection. Observe in the logs that after `Modem Reset Timeout` minutes the modem is reset. Insert the sim and observe that after a further modem reset, the connection can be established.

