### PR TITLE
build: add copyright header checks using maven checkstyle plugin

### DIFF
--- a/checkstyle_checks.xml
+++ b/checkstyle_checks.xml
@@ -48,8 +48,8 @@
 
     <!-- Checks for Headers                                -->
     <!-- See https://checkstyle.org/config_header.html   -->
-    <module name="Header">
-    <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+    <module name="RegexpHeader">
+        <property name="headerFile" value="header.txt"/>
         <property name="fileExtensions" value="java"/>
     </module>
 

--- a/checkstyle_checks.xml
+++ b/checkstyle_checks.xml
@@ -20,23 +20,23 @@
         <property name="fileExtensions" value="java"/>
         <property name="message" value="Do not use Windows line endings"/>
     </module>
-    
+
     <!-- Checks whether files end with a new line.                        -->
     <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
     <!--<module name="NewlineAtEndOfFile"/>-->
-    
+
     <!-- Checks that property files contain the same keys.         -->
     <!-- See https://checkstyle.org/config_misc.html#Translation -->
     <module name="Translation"/>
-    
+
     <!-- Checks for Size Violations.                    -->
     <!-- See https://checkstyle.org/config_sizes.html -->
     <module name="FileLength"/>
-    
+
     <!-- Checks for whitespace                               -->
     <!-- See https://checkstyle.org/config_whitespace.html -->
     <module name="FileTabCharacter"/>
-    
+
     <!-- Miscellaneous other checks.                   -->
     <!-- See https://checkstyle.org/config_misc.html -->
     <module name="RegexpSingleline">
@@ -45,7 +45,7 @@
         <property name="maximum" value="0"/>
         <property name="message" value="Line has trailing spaces."/>
     </module>
-    
+
     <!-- Checks for Headers                                -->
     <!-- See https://checkstyle.org/config_header.html   -->
     <module name="Header">
@@ -54,10 +54,10 @@
     </module>
 
     <module name="SuppressWarningsFilter"/>
-    
+
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder" />
-        
+
         <!-- Checks for Javadoc comments.                     -->
         <!-- See https://checkstyle.org/config_javadoc.html -->
         <!--<module name="InvalidJavadocPosition"/>
@@ -70,8 +70,8 @@
         <!-- Checks for Naming Conventions.                  -->
         <!-- See https://checkstyle.org/config_naming.html -->
         <module name="ConstantName">
-        	<property name="format" value="^auditLogger|log(ger)?|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
-		</module>
+            <property name="format" value="^auditLogger|log(ger)?|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
+        </module>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
         <module name="MemberName"/>
@@ -80,7 +80,7 @@
         <module name="ParameterName"/>
         <module name="StaticVariableName"/>
         <module name="TypeName"/>
-        
+
         <!-- Checks for imports                              -->
         <!-- See https://checkstyle.org/config_import.html -->
         <module name="AvoidStarImport"/>
@@ -90,15 +90,15 @@
         <module name="UnusedImports">
             <property name="processJavadoc" value="false"/>
         </module>
-        
+
         <!-- Checks for Size Violations.                    -->
         <!-- See https://checkstyle.org/config_sizes.html -->
         <module name="LineLength">
-        	<property name="max" value="150"/>
+            <property name="max" value="150"/>
         </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
-        
+
         <!-- Checks for whitespace                               -->
         <!-- See https://checkstyle.org/config_whitespace.html -->
         <module name="EmptyForIteratorPad"/>
@@ -113,12 +113,12 @@
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
         <module name="WhitespaceAround"/>
-        
+
         <!-- Modifier Checks                                    -->
         <!-- See https://checkstyle.org/config_modifiers.html -->
         <module name="ModifierOrder"/>
         <!--<module name="RedundantModifier"/>-->
-        
+
         <!-- Checks for blocks. You know, those {}'s         -->
         <!-- See https://checkstyle.org/config_blocks.html -->
         <module name="AvoidNestedBlocks"/>
@@ -126,7 +126,7 @@
         <module name="LeftCurly"/>
         <module name="NeedBraces"/>
         <module name="RightCurly"/>
-        
+
         <!-- Checks for common coding problems               -->
         <!-- See https://checkstyle.org/config_coding.html -->
         <module name="EmptyStatement"/>
@@ -145,7 +145,7 @@
         <module name="MultipleVariableDeclarations"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
-        
+
         <!-- Checks for class design                         -->
         <!-- See https://checkstyle.org/config_design.html -->
         <!--<module name="DesignForExtension"/>-->
@@ -158,7 +158,7 @@
             <property name="packageAllowed" value="true" />
             <property name="protectedAllowed" value="true" />
         </module>
-        
+
         <!-- Miscellaneous other checks.                   -->
         <!-- See https://checkstyle.org/config_misc.html -->
         <module name="ArrayTypeStyle"/>

--- a/header.txt
+++ b/header.txt
@@ -3,7 +3,7 @@
 ^\s\*\s?$
 ^\s\* This program and the accompanying materials are made$
 ^\s\* available under the terms of the Eclipse Public License 2\.0$
-^\s\* which is available at https:\/\/www.eclipse.org\/legal\/epl-2.0\/$
+^\s\* which is available at https:\/\/www\.eclipse\.org\/legal\/epl-2\.0\/$
 ^\s\*\s?$
 ^\s\* SPDX-License-Identifier: EPL\-2\.0$
 ^\s\*\s?$

--- a/header.txt
+++ b/header.txt
@@ -1,0 +1,11 @@
+^\/\*{50,}$
+^\s\* Copyright \(c\) (\d{4}|\d{4}, \d{4}) Eurotech and/or its affiliates and others$
+^\s\*\s?$
+^\s\* This program and the accompanying materials are made$
+^\s\* available under the terms of the Eclipse Public License 2\.0$
+^\s\* which is available at https:\/\/www.eclipse.org\/legal\/epl-2.0\/$
+^\s\*\s?$
+^\s\* SPDX-License-Identifier: EPL\-2\.0$
+^\s\*\s?$
+^\s\* Contributors:$
+^\s\*  Eurotech$

--- a/header.txt
+++ b/header.txt
@@ -1,5 +1,5 @@
-^\/\*{50,}$
-^\s\* Copyright \(c\) (\d{4}|\d{4}, \d{4}) Eurotech and/or its affiliates and others$
+^\/\*{2,}$
+^\s\* Copyright \(c\) (\d{4}|\d{4}, \d{4}) .+ (and/or its affiliates )?and others$
 ^\s\*\s?$
 ^\s\* This program and the accompanying materials are made$
 ^\s\* available under the terms of the Eclipse Public License 2\.0$
@@ -8,4 +8,4 @@
 ^\s\* SPDX-License-Identifier: EPL\-2\.0$
 ^\s\*\s?$
 ^\s\* Contributors:$
-^\s\*  Eurotech$
+^\s\*  .+$

--- a/kura/examples/test/org.eclipse.kura.example.wire.logic.multiport.provider.test/src/main/java/org/eclipse/kura/example/wire/logic/multiport/provider/test/BoolLogicTest.java
+++ b/kura/examples/test/org.eclipse.kura.example.wire.logic.multiport.provider.test/src/main/java/org/eclipse/kura/example/wire/logic/multiport/provider/test/BoolLogicTest.java
@@ -1,11 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eurotech and others
+ * Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
  *******************************************************************************/
 
 package org.eclipse.kura.example.wire.logic.multiport.provider.test;

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/le/beacon/AdvertisingReportPhy.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/le/beacon/AdvertisingReportPhy.java
@@ -1,13 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eurotech and/or its affiliates
+ * Copyright (c) 2020, 2025 Eurotech and/or its affiliates and others
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
- *    Scott Ware
+ *  Scott Ware
+ *  Eurotech
  *******************************************************************************/
 package org.eclipse.kura.bluetooth.le.beacon;
 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/PasswordRegistryCredentials.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/PasswordRegistryCredentials.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
-  * Copyright (c) 2022 Eurotech and/or its affiliates and others
-  *
-  * This program and the accompanying materials are made
-  * available under the terms of the Eclipse Public License 2.0
-  * which is available at https://www.eclipse.org/legal/epl-2.0/
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  *
-  * Contributors:
-  *  Eurotech
-  *******************************************************************************/
+ * Copyright (c) 2022, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 
 package org.eclipse.kura.container.orchestration;
 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/RegistryCredentials.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/container/orchestration/RegistryCredentials.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
-  * Copyright (c) 2022 Eurotech and/or its affiliates and others
-  *
-  * This program and the accompanying materials are made
-  * available under the terms of the Eclipse Public License 2.0
-  * which is available at https://www.eclipse.org/legal/epl-2.0/
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  *
-  * Contributors:
-  *  Eurotech
-  *******************************************************************************/
+ * Copyright (c) 2022, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 
 package org.eclipse.kura.container.orchestration;
 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/db/keyvalue/KeyValueDbService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/db/keyvalue/KeyValueDbService.java
@@ -1,7 +1,5 @@
-package org.eclipse.kura.db.keyvalue;
-
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,6 +10,7 @@ package org.eclipse.kura.db.keyvalue;
  * Contributors:
  *  Eurotech
  *******************************************************************************/
+package org.eclipse.kura.db.keyvalue;
 
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.connection.listener.ConnectionListener;

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/ethernet/package-info.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/ethernet/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 20230 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/loopback/package-info.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/loopback/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 20230 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/package-info.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/modem/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 20230 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/package-info.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 20230 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/package-info.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/net/status/wifi/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 20230 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/FloodingProtectionConfigurationChangeEvent.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/security/FloodingProtectionConfigurationChangeEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  * 
  * Contributors:
- * Eurotech
+ *  Eurotech
  ******************************************************************************/
 package org.eclipse.kura.security;
 

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
-  * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
-  *
-  * This program and the accompanying materials are made
-  * available under the terms of the Eclipse Public License 2.0
-  * which is available at https://www.eclipse.org/legal/epl-2.0/
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  *
-  * Contributors:
-  *  Eurotech
-  *******************************************************************************/
+ * Copyright (c) 2022, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 
 package org.eclipse.kura.container.provider;
 

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstanceOptions.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
-  * Copyright (c) 2022, 2024 Eurotech and/or its affiliates and others
-  *
-  * This program and the accompanying materials are made
-  * available under the terms of the Eclipse Public License 2.0
-  * which is available at https://www.eclipse.org/legal/epl-2.0/
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  *
-  * Contributors:
-  *  Eurotech
-  *******************************************************************************/
+ * Copyright (c) 2022, 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 
 package org.eclipse.kura.container.provider;
 

--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CertificateUtil.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/util/CertificateUtil.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- * Eurotech
+ *   Eurotech
  *******************************************************************************/
 
 package org.eclipse.kura.core.keystore.util;

--- a/kura/org.eclipse.kura.driver.ble.xdk/src/main/java/org/eclipse/kura/internal/driver/ble/xdk/SensorListener.java
+++ b/kura/org.eclipse.kura.driver.ble.xdk/src/main/java/org/eclipse/kura/internal/driver/ble/xdk/SensorListener.java
@@ -1,10 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- *
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
  * Contributors:
  *  Eurotech
  *******************************************************************************/

--- a/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionConfigurator.java
+++ b/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- * Eurotech
+ *   Eurotech
  ******************************************************************************/
 package org.eclipse.kura.internal.floodingprotection;
 

--- a/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
+++ b/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  * 
  * Contributors:
- * Eurotech
+ *  Eurotech
  ******************************************************************************/
 package org.eclipse.kura.internal.floodingprotection;
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NetworkManagerDbusWrapper.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
 package org.eclipse.kura.nm;
 
 import java.util.ArrayList;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/SimProperties.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/status/SimProperties.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
 package org.eclipse.kura.nm.status;
 
 import org.freedesktop.dbus.interfaces.Properties;

--- a/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/store/listener/package-info.java
+++ b/kura/org.eclipse.kura.util/src/main/java/org/eclipse/kura/util/store/listener/package-info.java
@@ -1,1 +1,14 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+
 package org.eclipse.kura.util.store.listener;

--- a/kura/org.eclipse.kura.wire.script.tools/src/main/java/org/eclipse/kura/wire/script/tools/conditional/component/ConditionalComponent.java
+++ b/kura/org.eclipse.kura.wire.script.tools/src/main/java/org/eclipse/kura/wire/script/tools/conditional/component/ConditionalComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Eurotech and/or its affiliates and others 
+ * Copyright (c) 2022, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraErrorHandler.java
+++ b/target-platform/org.eclipse.kura.jetty.customizer/src/main/java/org/eclipse/kura/jetty/customizer/KuraErrorHandler.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
- 
+ * Copyright (c) 2019, 2025 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     Eurotech
+ *  Eurotech
  *******************************************************************************/
 package org.eclipse.kura.jetty.customizer;
 


### PR DESCRIPTION
This PR introduces the check for copyright headers consistency leveraging the maven checkstyle plugin.

**Details**: with this PR we're now leveraging the [RegexpHeader](https://checkstyle.sourceforge.io/checks/header/regexpheader.html) check implemented by the maven checkstyle plugin. The checkstyle plugin now checks whether the header of the file matches the regex contained in the newly introduced `header.txt` file in the root directory.

Please be aware that the check won't notify the developer of the need to update the copyright year when the file is edited. This type of check is not available in the checkstyle plugin (we would need to know which files with respect to the develop branch, probably a CI of sorts is better suited for the task).

---

While working on this check I found out a file that was not matching our current license. The file is the following:

https://github.com/eclipse-kura/kura/blob/5d524669cff80b1b4dffd5ae26c4a4c1a2ba4ea9/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/bluetooth/le/beacon/AdvertisingReportPhy.java#L5

introduced in https://github.com/eclipse-kura/kura/pull/3377 by @srware.

I took the chance to update the licence to EPL2.0 for consistency with the rest of the project. and [in accordance to Eclipse Foundation guidelines](https://www.eclipse.org/legal/epl-2.0/faq/) (see: a29bec75ec1c615a3ecf23228872a57a52b11774)

Referring [to the FAQ](https://www.eclipse.org/legal/epl-2.0/faq/#h.cktcxkzh8ks4) I would like to ask @srware whether they're OK with us updating the license of the above-mentioned file.