### PR TITLE
docs(5.3): document specific profiles-only network features

### DIFF
--- a/docs/gateway-configuration/cellular-configuration.md
+++ b/docs/gateway-configuration/cellular-configuration.md
@@ -24,7 +24,7 @@ The **Cellular** tab contains the following configuration parameters:
 
 - **APN**: defines the modem access point name (HSPA modems only).
 
-- **Auth Type**: specifies the authentication type (HSPA modems only).
+- **Auth Type**[1]: specifies the authentication type (HSPA modems only).
     - None
     - Auto
     - CHAP
@@ -36,21 +36,21 @@ The **Cellular** tab contains the following configuration parameters:
 
 - **Modem Reset Timeout**: sets the modem reset timeout in minutes. If set to a non-zero value, the modem is reset after n consecutive minutes of unsuccessful connection attempts. If set to zero, the modem keeps trying to establish a PPP connection without resetting. The default value is 5 minutes.
 
-- **Reopen Connection on Termination**: sets the _persist_ option of the PPP daemon that specifies if PPP daemon should exit after connection is terminated. Note that the _maxfail_ option still has an effect on persistent connections.
+- **Reopen Connection on Termination**[^1]: sets the _persist_ option of the PPP daemon that specifies if PPP daemon should exit after connection is terminated. Note that the _maxfail_ option still has an effect on persistent connections.
 
-- **Connection Attempts Retry Delay**: Sets the _holdoff_ parameter to instruct the PPP daemon on how many seconds to wait before re-initiating the link after it terminates. This option only has any effect if the persist option (Reopen Connection on Termination) is set to true. The holdoff period is not applied if the link was terminated because it was idle. The default value is 1 second.
+- **Connection Attempts Retry Delay**[^1]: Sets the _holdoff_ parameter to instruct the PPP daemon on how many seconds to wait before re-initiating the link after it terminates. This option only has any effect if the persist option (Reopen Connection on Termination) is set to true. The holdoff period is not applied if the link was terminated because it was idle. The default value is 1 second.
 
-- **Connection Attempts**: sets the _maxfail_ option of the PPP daemon that limits the number of consecutive failed PPP connection attempts. The default value is 5 connection attempts. A value of zero means no limit. The PPP daemon terminates after the specified number of failed PPP connection attempts and restarts by the _ModemMonitor_ thread.  
+- **Connection Attempts**[^1]: sets the _maxfail_ option of the PPP daemon that limits the number of consecutive failed PPP connection attempts. The default value is 5 connection attempts. A value of zero means no limit. The PPP daemon terminates after the specified number of failed PPP connection attempts and restarts by the _ModemMonitor_ thread.  
 
-- **Disconnect if Idle**: sets the _idle_ option of the PPP daemon, which terminates the PPP connection if the link is idle for a specified number of seconds. The default value is 95 seconds. To disable this option, set it to zero.
+- **Disconnect if Idle**[^1]: sets the _idle_ option of the PPP daemon, which terminates the PPP connection if the link is idle for a specified number of seconds. The default value is 95 seconds. To disable this option, set it to zero.
 
-- **Active Filter**: sets the _active-filter_ option of the PPP daemon. This option specifies a packet filter _(filter-expression)_ to be applied to data packets in order to determine which packets are regarded as link activity, and thereby, reset the idle timer. The _filter-expression_ syntax is as described for tcpdump(1); however, qualifiers that do not apply to a PPP link, such as _ether_ and _arp_, are not permitted. The default value is _inbound_. To disable the _active-filter_ option, leave it blank.
+- **Active Filter**[^1]: sets the _active-filter_ option of the PPP daemon. This option specifies a packet filter _(filter-expression)_ to be applied to data packets in order to determine which packets are regarded as link activity, and thereby, reset the idle timer. The _filter-expression_ syntax is as described for tcpdump(1); however, qualifiers that do not apply to a PPP link, such as _ether_ and _arp_, are not permitted. The default value is _inbound_. To disable the _active-filter_ option, leave it blank.
 
-- **LCP Echo Interval**: sets the _lcp-echo-interval_ option of the PPP daemon. If set to a positive number, the modem sends LCP echo request to the peer at the specified number of seconds. To disable this option, set it to zero. This option may be used with the _lcp-echo-failure_ option to detect that the peer is no longer connected.
+- **LCP Echo Interval**[^1]: sets the _lcp-echo-interval_ option of the PPP daemon. If set to a positive number, the modem sends LCP echo request to the peer at the specified number of seconds. To disable this option, set it to zero. This option may be used with the _lcp-echo-failure_ option to detect that the peer is no longer connected.
 
-- **LCP Echo Failure**: sets the _lcp-echo-failure_ option of the PPP daemon. If set to a positive number, the modem presumes the peer to be dead if a specified number of LCP echo-requests are sent without receiving a valid LCP echo-reply. To disable this option, set it to zero.
+- **LCP Echo Failure**[^1]: sets the _lcp-echo-failure_ option of the PPP daemon. If set to a positive number, the modem presumes the peer to be dead if a specified number of LCP echo-requests are sent without receiving a valid LCP echo-reply. To disable this option, set it to zero.
 
-- **Enable GPS**: enables GPS with the following conditions:
+- **Enable GPS**[^1]: enables GPS with the following conditions:
     - One modem port will be dedicated to NMEA data stream.
     - This port may not be used to send AT commands to the modem.
     - _PositionService_ should be enabled. Serial settings of _PositionService_ should not be changed; it will be redirected to the modem GPS port automatically.

--- a/docs/gateway-configuration/cellular-configuration.md
+++ b/docs/gateway-configuration/cellular-configuration.md
@@ -24,7 +24,7 @@ The **Cellular** tab contains the following configuration parameters:
 
 - **APN**: defines the modem access point name (HSPA modems only).
 
-- **Auth Type**[1]: specifies the authentication type (HSPA modems only).
+- **Auth Type**[^1]: specifies the authentication type (HSPA modems only).
     - None
     - Auto
     - CHAP

--- a/docs/gateway-configuration/cellular-configuration.md
+++ b/docs/gateway-configuration/cellular-configuration.md
@@ -18,7 +18,7 @@ The **Cellular** tab contains the following configuration parameters:
 
 - **Interface #**: provides a unique number for the modem interface (e.g., an interface # of 0 would name the modem interface ppp0).
 
-- **Dial String**: instructs how the modem should attempt to connect. Typical dial strings are as follows:
+- **Dial String**[^1]: instructs how the modem should attempt to connect. Typical dial strings are as follows:
     - HSPA modem: atd&ast;99&ast;&ast;&ast;1#
     - EVDO/CDMA modem: atd#777
 
@@ -150,3 +150,5 @@ OK	"\d\d\d"
 ""	"atd#777"
 CONNECT	"\c"
 ```
+
+[^1]: This feature is only available in Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).

--- a/docs/gateway-configuration/cellular-configuration.md
+++ b/docs/gateway-configuration/cellular-configuration.md
@@ -151,4 +151,4 @@ OK	"\d\d\d"
 CONNECT	"\c"
 ```
 
-[^1]: This feature is only available in Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).
+[^1]: This feature is only available in Eclipse Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -17,7 +17,7 @@ The **TCP/IP** tab contains the following configuration parameters:
     - Enabled for LAN: designates the interface for a local network. It can be set as a DHCP server for hosts on the local network and can serve as a default gateway for those hosts; however, it cannot be set as an actual gateway interface for this device. That is, packets must be routed from this interface to another interface that is configured as WAN. The interface is automatically brought up at boot.
     - Enabled for WAN: designates the interface as a gateway to an external network. The interface is automatically brought up at boot.
     - Not Managed: the interface will be ignored by Kura.
-    - Layer 2 Only: only the Layer 2 portion of the interface will be configured. The interface is automatically brought up at boot.
+    - Layer 2 Only[^1]: only the Layer 2 portion of the interface will be configured. The interface is automatically brought up at boot.
 - **Configure**
     - Manually: allows manual entry of the _IP Address_ and _Netmask_ fields, if the interface is configured as LAN; allows manual entry of the _IP Address_, _Netmask_, _Gateway_, and _DNS Servers_ fields, if the interface is designated as WAN.
     - Using DHCP: configures the interface as a DHCP client obtaining the IP address from a network DHCP server.
@@ -110,7 +110,7 @@ Name                                             | Type     | Description
 
 Name                                                | Type     | Description
 ----------------------------------------------------|----------|------------------------------------------
-`net.interface.<interface>.config.ip4.status`	    | String   | The status of the interface for the IPv4 configuration; possibile values are: netIPv4StatusDisabled, netIPv4StatusUnmanaged, netIPv4StatusL2Only, netIPv4StatusEnabledLAN, netIPv4StatusEnabledWAN, netIPv4StatusUnknown
+`net.interface.<interface>.config.ip4.status`	    | String   | The status of the interface for the IPv4 configuration; possibile values are: netIPv4StatusDisabled, netIPv4StatusUnmanaged, netIPv4StatusL2Only[^1], netIPv4StatusEnabledLAN, netIPv4StatusEnabledWAN, netIPv4StatusUnknown
 `net.interface.<interface>.config.ip4.wan.priority` | Integer | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details
 `net.interface.<interface>.config.ip4.address`    | String   | The IPv4 address assigned to the network interface
 `net.interface.<interface>.config.ip4.prefix`	    | Short    | The IPv4 netmask assigned to the network interface
@@ -160,7 +160,7 @@ Name                                                             | Type      | D
 `net.interface.<interface>.config.wifi.infra.passphrase`	     | Password	 | The password for the wireless network
 `net.interface.<interface>.config.wifi.infra.ignoreSSID`	     | Boolean	 | Specify if a scan for SSID is required before attempting to associate
 `net.interface.<interface>.config.wifi.infra.mode`	             | String	 | The mode of the wireless connection; for station mode set to INFRA
-`net.interface.<interface>.config.wifi.infra.pingAccessPoint`	 | Boolean	 | Enable pinging the access point after connection is established
+`net.interface.<interface>.config.wifi.infra.pingAccessPoint`[^1]| Boolean	 | Enable pinging the access point after connection is established
 `net.interface.<interface>.config.wifi.infra.driver`	         | String	 | The driver used for the connection
 `net.interface.<interface>.config.wifi.infra.securityType`       | String	 | The security protocol for the wireless network; possible values are SECURITY_NONE, SECURITY_WEP, SECURITY_WPA, SECURITY_WPA2, SECURITY_WPA_WPA2
 `net.interface.<interface>.config.wifi.infra.groupCiphers`       | String    | Group ciphers i.e. group/broadcast encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms set, possible values are `CCMP`, `TKIP`, and `CCMP_TKIP`
@@ -185,7 +185,7 @@ Name                                                  | Type     | Description
 `net.interface.<interface>.config.gpsEnabled`         | Boolean  | Enable the GPS device in the modem if available
 `net.interface.<interface>.config.persist`            | Boolean  | The persist option of the PPP daemon
 `net.interface.<interface>.config.apn`                | String   | The modem Access Point Name
-`net.interface.<interface>.config.dialString`         | String   | The dial string used for connecting to the APN
+`net.interface.<interface>.config.dialString`[^1]     | String   | The dial string used for connecting to the APN
 `net.interface.<interface>.config.holdoff`            | Integer  | The holdoff option of the PPP daemon (in seconds)
 `net.interface.<interface>.config.pppNum`             | Integer  | Assigned ppp interface number
 
@@ -515,3 +515,5 @@ This section presents some snapshot examples to perform basic operations on netw
     </esf:configuration>
 </esf:configurations>
 ```
+
+[^1]: This feature is only available in Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -156,38 +156,38 @@ Name                                                             | Type      | D
 -----------------------------------------------------------------|-----------|------------------------------------------
 `net.interface.<interface>.config.wifi.infra.ssid`	             | String	 | The SSID of the wireless network to connect to
 `net.interface.<interface>.config.wifi.infra.channel`	         | String	 | The channel of the wireless network to connect to
-`net.interface.<interface>.config.wifi.infra.bgscan`	         | String	 | Set the background scans; possible values have the form `<mode>:<shortInterval>:<rssiThreshold>:<longInterval>` where `mode` (String) is one of NONE, SIMPLE, or LEARN, `shortInterval` (Integer) sets the Bgscan short interval (secs), `rssiThreshold` (Integer) sets the Bgscan Signal strength threshold (dBm), and `longInterval` (Integer) sets the Bgscan long interval (secs)
+`net.interface.<interface>.config.wifi.infra.bgscan`[^1]         | String	 | Set the background scans; possible values have the form `<mode>:<shortInterval>:<rssiThreshold>:<longInterval>` where `mode` (String) is one of NONE, SIMPLE, or LEARN, `shortInterval` (Integer) sets the Bgscan short interval (secs), `rssiThreshold` (Integer) sets the Bgscan Signal strength threshold (dBm), and `longInterval` (Integer) sets the Bgscan long interval (secs)
 `net.interface.<interface>.config.wifi.infra.passphrase`	     | Password	 | The password for the wireless network
 `net.interface.<interface>.config.wifi.infra.ignoreSSID`	     | Boolean	 | Specify if a scan for SSID is required before attempting to associate
 `net.interface.<interface>.config.wifi.infra.mode`	             | String	 | The mode of the wireless connection; for station mode set to INFRA
 `net.interface.<interface>.config.wifi.infra.pingAccessPoint`[^1]| Boolean	 | Enable pinging the access point after connection is established
-`net.interface.<interface>.config.wifi.infra.driver`	         | String	 | The driver used for the connection
+`net.interface.<interface>.config.wifi.infra.driver`[^1]         | String	 | The driver used for the connection
 `net.interface.<interface>.config.wifi.infra.securityType`       | String	 | The security protocol for the wireless network; possible values are SECURITY_NONE, SECURITY_WEP, SECURITY_WPA, SECURITY_WPA2, SECURITY_WPA_WPA2
 `net.interface.<interface>.config.wifi.infra.groupCiphers`       | String    | Group ciphers i.e. group/broadcast encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms set, possible values are `CCMP`, `TKIP`, and `CCMP_TKIP`
 `net.interface.<interface>.config.wifi.infra.pairwiseCiphers`    | String    | Pairwise ciphers i.e. pairwise encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms set, possible values are `CCMP`, `TKIP`, and `CCMP_TKIP`
 
 ### Cellular Modem properties
 
-Name                                                  | Type     | Description
-------------------------------------------------------|----------|------------------------------------------
-`net.interface.<interface>.config.enabled`	          | Boolean  | Enable the interface
-`net.interface.<interface>.config.idle`               | Integer  | The idle option of the PPP daemon
-`net.interface.<interface>.config.username`           | String   | The username used for the connection
-`net.interface.<interface>.config.password`           | Password | The password used for the connection
-`net.interface.<interface>.config.pdpType`            | String   | The PdP type; possible values are IP, PPP and IPv6
-`net.interface.<interface>.config.maxFail`            | Integer  | The maxfail option of the PPP daemon
-`net.interface.<interface>.config.authType`           | String   | The authentication type; possible values are None, Auto, CHAP and PAP
-`net.interface.<interface>.config.lpcEchoInterval`    | Integer  | The lcp-echo-interval option of the PPP daemon
-`net.interface.<interface>.config.activeFilter`       | String   | The active-filter option of the PPP daemon
-`net.interface.<interface>.config.lpcEchoFailure`     | Integer  | The lcp-echo-failure option of the PPP daemon
-`net.interface.<interface>.config.diversityEnabled`   | Boolean  | Enable the LTE diversity antenna
-`net.interface.<interface>.config.resetTimeout`       | Integer  | The modem reset timeout in minutes
-`net.interface.<interface>.config.gpsEnabled`         | Boolean  | Enable the GPS device in the modem if available
-`net.interface.<interface>.config.persist`            | Boolean  | The persist option of the PPP daemon
-`net.interface.<interface>.config.apn`                | String   | The modem Access Point Name
-`net.interface.<interface>.config.dialString`[^1]     | String   | The dial string used for connecting to the APN
-`net.interface.<interface>.config.holdoff`            | Integer  | The holdoff option of the PPP daemon (in seconds)
-`net.interface.<interface>.config.pppNum`             | Integer  | Assigned ppp interface number
+Name                                                   | Type     | Description
+-------------------------------------------------------|----------|------------------------------------------
+`net.interface.<interface>.config.enabled`             | Boolean  | Enable the interface
+`net.interface.<interface>.config.idle`[^1]            | Integer  | The idle option of the PPP daemon
+`net.interface.<interface>.config.username`            | String   | The username used for the connection
+`net.interface.<interface>.config.password`            | Password | The password used for the connection
+`net.interface.<interface>.config.pdpType`[^1]         | String   | The PdP type; possible values are IP, PPP and IPv6
+`net.interface.<interface>.config.maxFail`[^1]         | Integer  | The maxfail option of the PPP daemon
+`net.interface.<interface>.config.authType`[^1]        | String   | The authentication type; possible values are None, Auto, CHAP and PAP
+`net.interface.<interface>.config.lpcEchoInterval`[^1] | Integer  | The lcp-echo-interval option of the PPP daemon
+`net.interface.<interface>.config.activeFilter`[^1]    | String   | The active-filter option of the PPP daemon
+`net.interface.<interface>.config.lpcEchoFailure`[^1]  | Integer  | The lcp-echo-failure option of the PPP daemon
+`net.interface.<interface>.config.diversityEnabled`[^1]|Boolean  | Enable the LTE diversity antenna
+`net.interface.<interface>.config.resetTimeout`        | Integer  | The modem reset timeout in minutes
+`net.interface.<interface>.config.gpsEnabled`[^1]      | Boolean  | Enable the GPS device in the modem if available
+`net.interface.<interface>.config.persist`[^1]         | Boolean  | The persist option of the PPP daemon
+`net.interface.<interface>.config.apn`                 | String   | The modem Access Point Name
+`net.interface.<interface>.config.dialString`[^1]      | String   | The dial string used for connecting to the APN
+`net.interface.<interface>.config.holdoff`[^1]         | Integer  | The holdoff option of the PPP daemon (in seconds)
+`net.interface.<interface>.config.pppNum`[^1]          | Integer  | Assigned ppp interface number
 
 ## Network Configuration recipes
 

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -516,4 +516,4 @@ This section presents some snapshot examples to perform basic operations on netw
 </esf:configurations>
 ```
 
-[^1]: This feature is only available in Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).
+[^1]: This feature is only available in Eclipse Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).

--- a/docs/gateway-configuration/wifi-configuration.md
+++ b/docs/gateway-configuration/wifi-configuration.md
@@ -63,7 +63,7 @@ The **Wireless** tab contains the following configuration parameters:
 
 - **Bgscan Long Interval**: defines the interval  between background scans (in seconds) if the actual signal level of the currently connected access point is better than signal_strength.
 
-- **Ping Access Point & renew DHCP lease if not reachable**: enables pinging the access point after connection is established.
+- **Ping Access Point & renew DHCP lease if not reachable**[^1]: enables pinging the access point after connection is established.
     - In _Access Point_ mode, this option is disabled.
     - In _Station_ mode, if set to _true_, the unit will ping the access point and attempt to renew the DHCP lease if the access point is not reachable.
 
@@ -197,3 +197,5 @@ network={
     bgscan=""
 }
 ```
+
+[^1]: This feature is only available in Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).

--- a/docs/gateway-configuration/wifi-configuration.md
+++ b/docs/gateway-configuration/wifi-configuration.md
@@ -34,7 +34,7 @@ The **Wireless** tab contains the following configuration parameters:
     - WEP: 64-bit or 128-bit encryption key
     - WPA/WPA2: pre-shared key
 
-- **Verify Password**: sets the password verification field.
+- **Verify Password**[^1]: sets the password verification field.
     - In _Access Point_ mode, allows the wireless password to be retyped for verification.
     - In _Station_ mode, this field is disabled.
 
@@ -52,16 +52,16 @@ The **Wireless** tab contains the following configuration parameters:
         - TKIP (Temporal Key Integrity Protocol)
         - CCMP and TKIP
 
-- **Bgscan Module**: requests background scans for the purpose of roaming within an ESS (i.e., within a single network block with all the APs using the same SSID).
+- **Bgscan Module**[^1]: requests background scans for the purpose of roaming within an ESS (i.e., within a single network block with all the APs using the same SSID).
     - None: background scan is disabled
     - Simple: periodic background scans based on signal strength
     - Learn: learn channels used by the network and try to avoid bgscans on other channels
 
-- **Bgscan Signal Strength Threshold**: defines a threshold (in dBm) that determines which one of the following two parameters (i.e., _Short Interval_ or _Long Interval_) will be effective.
+- **Bgscan Signal Strength Threshold**[^1]: defines a threshold (in dBm) that determines which one of the following two parameters (i.e., _Short Interval_ or _Long Interval_) will be effective.
 
-- **Bgscan Short Interval**: defines the interval between background scans (in seconds) if the actual signal level of the currently connected access point is worse than signal_strength.
+- **Bgscan Short Interval**[^1]: defines the interval between background scans (in seconds) if the actual signal level of the currently connected access point is worse than signal_strength.
 
-- **Bgscan Long Interval**: defines the interval  between background scans (in seconds) if the actual signal level of the currently connected access point is better than signal_strength.
+- **Bgscan Long Interval**[^1]: defines the interval  between background scans (in seconds) if the actual signal level of the currently connected access point is better than signal_strength.
 
 - **Ping Access Point & renew DHCP lease if not reachable**[^1]: enables pinging the access point after connection is established.
     - In _Access Point_ mode, this option is disabled.

--- a/docs/gateway-configuration/wifi-configuration.md
+++ b/docs/gateway-configuration/wifi-configuration.md
@@ -198,4 +198,4 @@ network={
 }
 ```
 
-[^1]: This feature is only available in Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).
+[^1]: This feature is only available in Eclipse Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,6 +197,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - footnotes
 
 extra:
   version:


### PR DESCRIPTION
This PR introduces a series of footnotes highlighting the features that are supported only on specific profiles.

I chose to use [footnotes](https://squidfunk.github.io/mkdocs-material/reference/footnotes) since it was the best way to re-use a description for multiple entries.

Alternatives I considered:
- https://squidfunk.github.io/mkdocs-material/reference/annotations/
- https://squidfunk.github.io/mkdocs-material/reference/tooltips/

@MMaiero let me know if this is clear enough for users.

**Notes**: This is the first of a series of PRs that will span across all Kura versions
