### PR TITLE
ci(5.3): fix Github actions permissions for documentation branches

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - 'docs-develop'
       - 'docs-release-*.*'
+
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix issue with permissions see #5387 and https://github.com/eclipse-kura/kura/actions/runs/12827707783/job/35770246116