### PR TITLE
docs(5.6): correctly document supported parameters

### DIFF
--- a/docs/gateway-configuration/cellular-configuration.md
+++ b/docs/gateway-configuration/cellular-configuration.md
@@ -34,7 +34,7 @@ The **Cellular** tab contains the following configuration parameters:
 
         A good practice is to set the interface status to **Disabled** and then **Enable For WAN** when the APN is explicitly set. NetworkManager, indeed, will fallback to the default value if a wrong APN is specified, causing misleading behaviors. This does not happen if the interface is disabled and re-enabled after APN changes.
 
-- **Auth Type**[^1]: specifies the authentication type.
+- **Auth Type**: specifies the authentication type.
     - None
     - Auto
     - CHAP
@@ -56,9 +56,9 @@ The **Cellular** tab contains the following configuration parameters:
 
 - **Active Filter**[^1]: sets the _active-filter_ option of the PPP daemon. This option specifies a packet filter _(filter-expression)_ to be applied to data packets in order to determine which packets are regarded as link activity, and thereby, reset the idle timer. The _filter-expression_ syntax is as described for tcpdump(1); however, qualifiers that do not apply to a PPP link, such as _ether_ and _arp_, are not permitted. The default value is _inbound_. To disable the _active-filter_ option, leave it blank.
 
-- **LCP Echo Interval**[^1]: sets the _lcp-echo-interval_ option of the PPP daemon. If set to a positive number, the modem sends LCP echo request to the peer at the specified number of seconds. To disable this option, set it to zero. This option may be used with the _lcp-echo-failure_ option to detect that the peer is no longer connected.
+- **LCP Echo Interval**: sets the _lcp-echo-interval_ option of the PPP daemon. If set to a positive number, the modem sends LCP echo request to the peer at the specified number of seconds. To disable this option, set it to zero. This option may be used with the _lcp-echo-failure_ option to detect that the peer is no longer connected.
 
-- **LCP Echo Failure**[^1]: sets the _lcp-echo-failure_ option of the PPP daemon. If set to a positive number, the modem presumes the peer to be dead if a specified number of LCP echo-requests are sent without receiving a valid LCP echo-reply. To disable this option, set it to zero.
+- **LCP Echo Failure**: sets the _lcp-echo-failure_ option of the PPP daemon. If set to a positive number, the modem presumes the peer to be dead if a specified number of LCP echo-requests are sent without receiving a valid LCP echo-reply. To disable this option, set it to zero.
 
 ### GPS
 

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -199,10 +199,10 @@ Name                                                   | Type     | Description 
 `net.interface.<interface>.config.password`            | Password | The password used for the connection                                   |
 `net.interface.<interface>.config.pdpType`[^1]         | String   | The PdP type; possible values are IP, PPP and IPv6                     | IP
 `net.interface.<interface>.config.maxFail`[^1]         | Integer  | The maxfail option of the PPP daemon                                   | 5
-`net.interface.<interface>.config.authType`[^1]        | String   | The authentication type; possible values are `NONE`, `AUTO`, `CHAP` and `PAP`  | `NONE`
-`net.interface.<interface>.config.lpcEchoInterval`[^1] | Integer  | The lcp-echo-interval option of the PPP daemon                         | 0
+`net.interface.<interface>.config.authType`            | String   | The authentication type; possible values are `NONE`, `AUTO`, `CHAP` and `PAP`  | `NONE`
+`net.interface.<interface>.config.lpcEchoInterval`     | Integer  | The lcp-echo-interval option of the PPP daemon                         | 0
 `net.interface.<interface>.config.activeFilter`[^1]    | String   | The active-filter option of the PPP daemon                             | inbound
-`net.interface.<interface>.config.lpcEchoFailure`[^1]  | Integer  | The lcp-echo-failure option of the PPP daemon                          | 0
+`net.interface.<interface>.config.lpcEchoFailure`      | Integer  | The lcp-echo-failure option of the PPP daemon                          | 0
 `net.interface.<interface>.config.diversityEnabled`[^1]| Boolean  | Enable the LTE diversity antenna                                       | false
 `net.interface.<interface>.config.resetTimeout`        | Integer  | The modem reset timeout in minutes                                     | 5
 `net.interface.<interface>.config.gpsEnabled`          | Boolean  | Enable the GPS device in the modem if available                        | false

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -105,7 +105,7 @@ Name                                             | Type     | Description       
 `net.interface.<interface>.type`                 | String	| The type of the network interface; possible values are: `ETHERNET`, `WIFI`, `MODEM`, `VLAN`, `LOOPBACK` and `UNKNOWN` | `UNKNOWN`
 `net.interface.<interface>.config.wifi.mode`     | String   | For wifi interfaces, specify the modality; possible values are `INFRA`, `MASTER` and `UNKNOWN`   | `UNKNOWN`
 `net.interface.<interface>.config.nat.enabled`   | Boolean  | Enable the NAT feature                                                                           | false
-`net.interface.<interface>.config.promisc`       | Integer  | Enable the Promiscuous Mode; possible values are: -1 (System default), 0 (Disabled), 1 (Enabled) | -1
+`net.interface.<interface>.config.promisc`[^2]   | Integer  | Enable the Promiscuous Mode; possible values are: -1 (System default), 0 (Disabled), 1 (Enabled) | -1
 
 ### IPv4 properties
 

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -109,15 +109,15 @@ Name                                             | Type     | Description       
 
 ### IPv4 properties
 
-Name                                                | Type     | Description                              | Default value
-----------------------------------------------------|----------|------------------------------------------|----------------------------
-`net.interface.<interface>.config.ip4.status`	    | String   | The status of the interface for the IPv4 configuration; possibile values are: `netIPv4StatusDisabled`, `netIPv4StatusUnmanaged`, `netIPv4StatusL2Only`[^1], `netIPv4StatusEnabledLAN`, `netIPv4StatusEnabledWAN`, `netIPv4StatusUnknown` | `netIPv4StatusDisabled` (see note below)
-`net.interface.<interface>.config.ip4.wan.priority` | Integer  | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
-`net.interface.<interface>.config.ip4.address`      | String   | The IPv4 address assigned to the network interface |
-`net.interface.<interface>.config.ip4.prefix`	    | Short    | The IPv4 netmask assigned to the network interface | -1
-`net.interface.<interface>.config.ip4.gateway`      | String   | The IPv4 address of the default gateway |
-`net.interface.<interface>.config.ip4.dnsServers`	| String   | Comma-separated list of dns servers |
-`net.interface.<interface>.config.ip4.mtu`[^2]      | Integer  | The Maximum Transition Unit (MTU) for this interface
+Name                                                   | Type     | Description                              | Default value
+-------------------------------------------------------|----------|------------------------------------------|----------------------------
+`net.interface.<interface>.config.ip4.status`	       | String   | The status of the interface for the IPv4 configuration; possibile values are: `netIPv4StatusDisabled`, `netIPv4StatusUnmanaged`, `netIPv4StatusL2Only`[^1], `netIPv4StatusEnabledLAN`, `netIPv4StatusEnabledWAN`, `netIPv4StatusUnknown` | `netIPv4StatusDisabled` (see note below)
+`net.interface.<interface>.config.ip4.wan.priority`[^2]| Integer  | Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
+`net.interface.<interface>.config.ip4.address`         | String   | The IPv4 address assigned to the network interface |
+`net.interface.<interface>.config.ip4.prefix`	       | Short    | The IPv4 netmask assigned to the network interface | -1
+`net.interface.<interface>.config.ip4.gateway`         | String   | The IPv4 address of the default gateway |
+`net.interface.<interface>.config.ip4.dnsServers`	   | String   | Comma-separated list of dns servers |
+`net.interface.<interface>.config.ip4.mtu`[^2]         | Integer  | The Maximum Transition Unit (MTU) for this interface
 
 !!! note
     For physical interfaces the default status is `netIPv4StatusDisabled`. For virtual ones, instead, the default status is defined by the `kura.net.virtual.devices.config` property in the `kura.properties` file.
@@ -145,7 +145,7 @@ Name                                                     | Type     | Descriptio
 Name                                                     | Type     | Description                              | Default value
 ---------------------------------------------------------|----------|------------------------------------------|----------------------------
 `net.interface.<interface>.config.ip6.status`[^2]        | String   | The status of the interface for the IPv6 configuration; possibile values are: `netIPv6StatusDisabled`, `netIPv6StatusUnmanaged`, `netIPv6StatusL2Only`[^1], `netIPv6StatusEnabledLAN`, `netIPv6StatusEnabledWAN`, `netIPv6StatusUnknown` | `netIPv6StatusDisabled` (see note below)
-`net.interface.<interface>.config.ip6.wan.priority`[^2]  | Integer | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
+`net.interface.<interface>.config.ip6.wan.priority`[^2]  | Integer  | Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
 `net.interface.<interface>.config.ip6.address.method`[^2]| String   | The IPv6 configuration method; possible values are: `AUTO`, `DHCP`, `MANUAL`. | `AUTO`
 `net.interface.<interface>.config.ip6.address`[^2]       | String   | The IPv6 address assigned to the network interface |
 `net.interface.<interface>.config.ip6.prefix`[^2]        | Short    | The IPv6 netmask assigned to the network interface | -1


### PR DESCRIPTION
This PR performs a correction on #5653: some parameter are actually supported.

See: https://github.com/eclipse-kura/kura/blob/ca95dd7a2e92ae50999c89bef3847193da2c83f0/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java#L619-L634