### PR TITLE
docs(5.5): document specific profiles-only network features

### DIFF
--- a/docs/gateway-configuration/cellular-configuration.md
+++ b/docs/gateway-configuration/cellular-configuration.md
@@ -25,17 +25,6 @@ The **Cellular** tab contains the following configuration parameters:
 - **APN**: defines the modem access point name (HSPA modems only).
 
 - **Auth Type**: specifies the authentication type (HSPA modems only).
-    This parameter is mandatory for standard profiles and optional for generic ones. 
-    In the case of generic profiles, if it is left empty, the value is automatically picked up from the Mobile Broadband Provider the modem is registered to. If a value is filled, the APN value is explicitly configured.
-
-    To avoid misconfiguration issues, it is strongly recommended to set it manually.
-  
-    !!! note
-        **APN value configuration**
-
-        A good practice is to set the interface status to **Disabled** and then **Enable For WAN** when the APN is explicitly set. NetworkManager, indeed, will fallback to the default value if a wrong APN is specified, causing misleading behaviors. This does not happen if the interface is disabled and re-enabled after APN changes.
-
-- **Auth Type**: specifies the authentication type.
     - None
     - Auto
     - CHAP

--- a/docs/gateway-configuration/cellular-configuration.md
+++ b/docs/gateway-configuration/cellular-configuration.md
@@ -18,13 +18,24 @@ The **Cellular** tab contains the following configuration parameters:
 
 - **Interface #**: provides a unique number for the modem interface (e.g., an interface # of 0 would name the modem interface ppp0).
 
-- **Dial String**: instructs how the modem should attempt to connect. Typical dial strings are as follows:
+- **Dial String**[^1]: instructs how the modem should attempt to connect. Typical dial strings are as follows:
     - HSPA modem: atd&ast;99&ast;&ast;&ast;1#
     - EVDO/CDMA modem: atd#777
 
 - **APN**: defines the modem access point name (HSPA modems only).
 
 - **Auth Type**: specifies the authentication type (HSPA modems only).
+    This parameter is mandatory for standard profiles and optional for generic ones. 
+    In the case of generic profiles, if it is left empty, the value is automatically picked up from the Mobile Broadband Provider the modem is registered to. If a value is filled, the APN value is explicitly configured.
+
+    To avoid misconfiguration issues, it is strongly recommended to set it manually.
+  
+    !!! note
+        **APN value configuration**
+
+        A good practice is to set the interface status to **Disabled** and then **Enable For WAN** when the APN is explicitly set. NetworkManager, indeed, will fallback to the default value if a wrong APN is specified, causing misleading behaviors. This does not happen if the interface is disabled and re-enabled after APN changes.
+
+- **Auth Type**: specifies the authentication type.
     - None
     - Auto
     - CHAP
@@ -36,15 +47,15 @@ The **Cellular** tab contains the following configuration parameters:
 
 - **Modem Reset Timeout**: sets the modem reset timeout in minutes. If set to a non-zero value, the modem is reset after n consecutive minutes of unsuccessful connection attempts. If set to zero, the modem keeps trying to establish a PPP connection without resetting. The default value is 5 minutes.
 
-- **Reopen Connection on Termination**: sets the _persist_ option of the PPP daemon that specifies if PPP daemon should exit after connection is terminated. Note that the _maxfail_ option still has an effect on persistent connections.
+- **Reopen Connection on Termination**[^1]: sets the _persist_ option of the PPP daemon that specifies if PPP daemon should exit after connection is terminated. Note that the _maxfail_ option still has an effect on persistent connections.
 
-- **Connection Attempts Retry Delay**: Sets the _holdoff_ parameter to instruct the PPP daemon on how many seconds to wait before re-initiating the link after it terminates. This option only has any effect if the persist option (Reopen Connection on Termination) is set to true. The holdoff period is not applied if the link was terminated because it was idle. The default value is 1 second.
+- **Connection Attempts Retry Delay**[^1]: Sets the _holdoff_ parameter to instruct the PPP daemon on how many seconds to wait before re-initiating the link after it terminates. This option only has any effect if the persist option (Reopen Connection on Termination) is set to true. The holdoff period is not applied if the link was terminated because it was idle. The default value is 1 second.
 
-- **Connection Attempts**: sets the _maxfail_ option of the PPP daemon that limits the number of consecutive failed PPP connection attempts. The default value is 5 connection attempts. A value of zero means no limit. The PPP daemon terminates after the specified number of failed PPP connection attempts and restarts by the _ModemMonitor_ thread.  
+- **Connection Attempts**[^1]: sets the _maxfail_ option of the PPP daemon that limits the number of consecutive failed PPP connection attempts. The default value is 5 connection attempts. A value of zero means no limit. The PPP daemon terminates after the specified number of failed PPP connection attempts and restarts by the _ModemMonitor_ thread.  
 
-- **Disconnect if Idle**: sets the _idle_ option of the PPP daemon, which terminates the PPP connection if the link is idle for a specified number of seconds. The default value is 95 seconds. To disable this option, set it to zero.
+- **Disconnect if Idle**[^1]: sets the _idle_ option of the PPP daemon, which terminates the PPP connection if the link is idle for a specified number of seconds. The default value is 95 seconds. To disable this option, set it to zero.
 
-- **Active Filter**: sets the _active-filter_ option of the PPP daemon. This option specifies a packet filter _(filter-expression)_ to be applied to data packets in order to determine which packets are regarded as link activity, and thereby, reset the idle timer. The _filter-expression_ syntax is as described for tcpdump(1); however, qualifiers that do not apply to a PPP link, such as _ether_ and _arp_, are not permitted. The default value is _inbound_. To disable the _active-filter_ option, leave it blank.
+- **Active Filter**[^1]: sets the _active-filter_ option of the PPP daemon. This option specifies a packet filter _(filter-expression)_ to be applied to data packets in order to determine which packets are regarded as link activity, and thereby, reset the idle timer. The _filter-expression_ syntax is as described for tcpdump(1); however, qualifiers that do not apply to a PPP link, such as _ether_ and _arp_, are not permitted. The default value is _inbound_. To disable the _active-filter_ option, leave it blank.
 
 - **LCP Echo Interval**: sets the _lcp-echo-interval_ option of the PPP daemon. If set to a positive number, the modem sends LCP echo request to the peer at the specified number of seconds. To disable this option, set it to zero. This option may be used with the _lcp-echo-failure_ option to detect that the peer is no longer connected.
 
@@ -150,3 +161,5 @@ OK	"\d\d\d"
 ""	"atd#777"
 CONNECT	"\c"
 ```
+
+[^1]: This feature is only available in Eclipse Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -105,7 +105,7 @@ Name                                             | Type     | Description       
 `net.interface.<interface>.type`                 | String	| The type of the network interface; possible values are: `ETHERNET`, `WIFI`, `MODEM`, `VLAN`, `LOOPBACK` and `UNKNOWN` | `UNKNOWN`
 `net.interface.<interface>.config.wifi.mode`     | String   | For wifi interfaces, specify the modality; possible values are `INFRA`, `MASTER` and `UNKNOWN`   | `UNKNOWN`
 `net.interface.<interface>.config.nat.enabled`   | Boolean  | Enable the NAT feature                                                                           | false
-`net.interface.<interface>.config.promisc`       | Integer  | Enable the Promiscuous Mode; possible values are: -1 (System default), 0 (Disabled), 1 (Enabled) | -1
+`net.interface.<interface>.config.promisc`[^2]   | Integer  | Enable the Promiscuous Mode; possible values are: -1 (System default), 0 (Disabled), 1 (Enabled) | -1
 
 ### IPv4 properties
 

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -109,15 +109,15 @@ Name                                             | Type     | Description       
 
 ### IPv4 properties
 
-Name                                                | Type     | Description                              | Default value
-----------------------------------------------------|----------|------------------------------------------|----------------------------
-`net.interface.<interface>.config.ip4.status`	    | String   | The status of the interface for the IPv4 configuration; possibile values are: `netIPv4StatusDisabled`, `netIPv4StatusUnmanaged`, `netIPv4StatusL2Only`[^1], `netIPv4StatusEnabledLAN`, `netIPv4StatusEnabledWAN`, `netIPv4StatusUnknown` | `netIPv4StatusDisabled` (see note below)
-`net.interface.<interface>.config.ip4.wan.priority` | Integer  | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
-`net.interface.<interface>.config.ip4.address`      | String   | The IPv4 address assigned to the network interface |
-`net.interface.<interface>.config.ip4.prefix`	    | Short    | The IPv4 netmask assigned to the network interface | -1
-`net.interface.<interface>.config.ip4.gateway`      | String   | The IPv4 address of the default gateway |
-`net.interface.<interface>.config.ip4.dnsServers`	| String   | Comma-separated list of dns servers |
-`net.interface.<interface>.config.ip4.mtu`[^2]      | Integer  | The Maximum Transition Unit (MTU) for this interface
+Name                                                   | Type     | Description                              | Default value
+-------------------------------------------------------|----------|------------------------------------------|----------------------------
+`net.interface.<interface>.config.ip4.status`	       | String   | The status of the interface for the IPv4 configuration; possibile values are: `netIPv4StatusDisabled`, `netIPv4StatusUnmanaged`, `netIPv4StatusL2Only`[^1], `netIPv4StatusEnabledLAN`, `netIPv4StatusEnabledWAN`, `netIPv4StatusUnknown` | `netIPv4StatusDisabled` (see note below)
+`net.interface.<interface>.config.ip4.wan.priority`[^2]| Integer  | Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
+`net.interface.<interface>.config.ip4.address`         | String   | The IPv4 address assigned to the network interface |
+`net.interface.<interface>.config.ip4.prefix`	       | Short    | The IPv4 netmask assigned to the network interface | -1
+`net.interface.<interface>.config.ip4.gateway`         | String   | The IPv4 address of the default gateway |
+`net.interface.<interface>.config.ip4.dnsServers`	   | String   | Comma-separated list of dns servers |
+`net.interface.<interface>.config.ip4.mtu`[^2]         | Integer  | The Maximum Transition Unit (MTU) for this interface
 
 !!! note
     For physical interfaces the default status is `netIPv4StatusDisabled`. For virtual ones, instead, the default status is defined by the `kura.net.virtual.devices.config` property in the `kura.properties` file.
@@ -145,7 +145,7 @@ Name                                                     | Type     | Descriptio
 Name                                                     | Type     | Description                              | Default value
 ---------------------------------------------------------|----------|------------------------------------------|----------------------------
 `net.interface.<interface>.config.ip6.status`[^2]        | String   | The status of the interface for the IPv6 configuration; possibile values are: `netIPv6StatusDisabled`, `netIPv6StatusUnmanaged`, `netIPv6StatusL2Only`[^1], `netIPv6StatusEnabledLAN`, `netIPv6StatusEnabledWAN`, `netIPv6StatusUnknown` | `netIPv6StatusDisabled` (see note below)
-`net.interface.<interface>.config.ip6.wan.priority`[^2]  | Integer | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
+`net.interface.<interface>.config.ip6.wan.priority`[^2]  | Integer  | Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
 `net.interface.<interface>.config.ip6.address.method`[^2]| String   | The IPv6 configuration method; possible values are: `AUTO`, `DHCP`, `MANUAL`. | `AUTO`
 `net.interface.<interface>.config.ip6.address`[^2]       | String   | The IPv6 address assigned to the network interface |
 `net.interface.<interface>.config.ip6.prefix`[^2]        | Short    | The IPv6 netmask assigned to the network interface | -1

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -17,7 +17,7 @@ The **TCP/IP** tab contains the following configuration parameters:
     - Enabled for LAN: designates the interface for a local network. It can be set as a DHCP server for hosts on the local network and can serve as a default gateway for those hosts; however, it cannot be set as an actual gateway interface for this device. That is, packets must be routed from this interface to another interface that is configured as WAN. The interface is automatically brought up at boot.
     - Enabled for WAN: designates the interface as a gateway to an external network. The interface is automatically brought up at boot.
     - Not Managed: the interface will be ignored by Kura.
-    - Layer 2 Only: only the Layer 2 portion of the interface will be configured. The interface is automatically brought up at boot.
+    - Layer 2 Only[^1]: only the Layer 2 portion of the interface will be configured. The interface is automatically brought up at boot.
 - **Configure**
     - Manually: allows manual entry of the _IP Address_ and _Netmask_ fields, if the interface is configured as LAN; allows manual entry of the _IP Address_, _Netmask_, _Gateway_, and _DNS Servers_ fields, if the interface is designated as WAN.
     - Using DHCP: configures the interface as a DHCP client obtaining the IP address from a network DHCP server.
@@ -111,13 +111,13 @@ Name                                             | Type     | Description       
 
 Name                                                | Type     | Description                              | Default value
 ----------------------------------------------------|----------|------------------------------------------|----------------------------
-`net.interface.<interface>.config.ip4.status`	    | String   | The status of the interface for the IPv4 configuration; possibile values are: `netIPv4StatusDisabled`, `netIPv4StatusUnmanaged`, `netIPv4StatusL2Only`, `netIPv4StatusEnabledLAN`, `netIPv4StatusEnabledWAN`, `netIPv4StatusUnknown` | `netIPv4StatusDisabled` (see note below)
+`net.interface.<interface>.config.ip4.status`	    | String   | The status of the interface for the IPv4 configuration; possibile values are: `netIPv4StatusDisabled`, `netIPv4StatusUnmanaged`, `netIPv4StatusL2Only`[^1], `netIPv4StatusEnabledLAN`, `netIPv4StatusEnabledWAN`, `netIPv4StatusUnknown` | `netIPv4StatusDisabled` (see note below)
 `net.interface.<interface>.config.ip4.wan.priority` | Integer  | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
 `net.interface.<interface>.config.ip4.address`      | String   | The IPv4 address assigned to the network interface |
 `net.interface.<interface>.config.ip4.prefix`	    | Short    | The IPv4 netmask assigned to the network interface | -1
 `net.interface.<interface>.config.ip4.gateway`      | String   | The IPv4 address of the default gateway |
 `net.interface.<interface>.config.ip4.dnsServers`	| String   | Comma-separated list of dns servers |
-`net.interface.<interface>.config.ip4.mtu`	        | Integer  | The Maximum Transition Unit (MTU) for this interface
+`net.interface.<interface>.config.ip4.mtu`[^2]      | Integer  | The Maximum Transition Unit (MTU) for this interface
 
 !!! note
     For physical interfaces the default status is `netIPv4StatusDisabled`. For virtual ones, instead, the default status is defined by the `kura.net.virtual.devices.config` property in the `kura.properties` file.
@@ -142,18 +142,18 @@ Name                                                     | Type     | Descriptio
 
 ### IPv6 properties
 
-Name                                                  | Type     | Description                              | Default value
-------------------------------------------------------|----------|------------------------------------------|----------------------------
-`net.interface.<interface>.config.ip6.status`	      | String   | The status of the interface for the IPv6 configuration; possibile values are: `netIPv6StatusDisabled`, `netIPv6StatusUnmanaged`, `netIPv6StatusL2Only`, `netIPv6StatusEnabledLAN`, `netIPv6StatusEnabledWAN`, `netIPv6StatusUnknown` | `netIPv6StatusDisabled` (see note below)
-`net.interface.<interface>.config.ip6.wan.priority`   | Integer | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
-`net.interface.<interface>.config.ip6.address.method` | String   | The IPv6 configuration method; possible values are: `AUTO`, `DHCP`, `MANUAL`. | `AUTO`
-`net.interface.<interface>.config.ip6.address`        | String   | The IPv6 address assigned to the network interface |
-`net.interface.<interface>.config.ip6.prefix`	      | Short    | The IPv6 netmask assigned to the network interface | -1
-`net.interface.<interface>.config.ip6.gateway`        | String   | The IPv6 address of the default gateway |
-`net.interface.<interface>.config.ip6.dnsServers`	  | String   | Comma-separated list of dns servers |
-`net.interface.<interface>.config.ip6.addr.gen.mode`  | String   | The IPv6 address generation mode; possible values are `EUI64`, `STABLE_PRIVACY` | 
-`net.interface.<interface>.config.ip6.privacy`        | String   | The IPv6 Privacy Extensions for SLAAC; possible values are `DISABLED`, `ENABLED_PUBLIC_ADD`, `ENABLED_TEMP_ADD` |
-`net.interface.<interface>.config.ip6.mtu`	          | Integer  | The Maximum Transition Unit (MTU) for Ipv6 traffic on this interface. Requires NetworkManager 1.40 or newer |
+Name                                                     | Type     | Description                              | Default value
+---------------------------------------------------------|----------|------------------------------------------|----------------------------
+`net.interface.<interface>.config.ip6.status`[^2]        | String   | The status of the interface for the IPv6 configuration; possibile values are: `netIPv6StatusDisabled`, `netIPv6StatusUnmanaged`, `netIPv6StatusL2Only`[^1], `netIPv6StatusEnabledLAN`, `netIPv6StatusEnabledWAN`, `netIPv6StatusUnknown` | `netIPv6StatusDisabled` (see note below)
+`net.interface.<interface>.config.ip6.wan.priority`[^2]  | Integer | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
+`net.interface.<interface>.config.ip6.address.method`[^2]| String   | The IPv6 configuration method; possible values are: `AUTO`, `DHCP`, `MANUAL`. | `AUTO`
+`net.interface.<interface>.config.ip6.address`[^2]       | String   | The IPv6 address assigned to the network interface |
+`net.interface.<interface>.config.ip6.prefix`[^2]        | Short    | The IPv6 netmask assigned to the network interface | -1
+`net.interface.<interface>.config.ip6.gateway`[^2]       | String   | The IPv6 address of the default gateway |
+`net.interface.<interface>.config.ip6.dnsServers`[^2]    | String   | Comma-separated list of dns servers |
+`net.interface.<interface>.config.ip6.addr.gen.mode`[^2] | String   | The IPv6 address generation mode; possible values are `EUI64`, `STABLE_PRIVACY` | 
+`net.interface.<interface>.config.ip6.privacy`[^2]       | String   | The IPv6 Privacy Extensions for SLAAC; possible values are `DISABLED`, `ENABLED_PUBLIC_ADD`, `ENABLED_TEMP_ADD` |
+`net.interface.<interface>.config.ip6.mtu`[^2]           | Integer  | The Maximum Transition Unit (MTU) for Ipv6 traffic on this interface. Requires NetworkManager 1.40 or newer |
 
 !!! note
     For physical interfaces the default status is `netIPv6StatusDisabled`. For virtual ones, instead, the default status is defined by the `kura.net.virtual.devices.config` property in the `kura.properties` file.
@@ -179,61 +179,61 @@ Name                                                             | Type      | D
 -----------------------------------------------------------------|-----------|------------------------------------------|--------------------------------
 `net.interface.<interface>.config.wifi.infra.ssid`	             | String	 | The SSID of the wireless network to connect to |
 `net.interface.<interface>.config.wifi.infra.channel`	         | String	 | The channel of the wireless network to connect to | 1
-`net.interface.<interface>.config.wifi.infra.bgscan`	         | String	 | Set the background scans; possible values have the form `<mode>:<shortInterval>:<rssiThreshold>:<longInterval>` where `mode` (String) is one of NONE, SIMPLE, or LEARN, `shortInterval` (Integer) sets the Bgscan short interval (secs), `rssiThreshold` (Integer) sets the Bgscan Signal strength threshold (dBm), and `longInterval` (Integer) sets the Bgscan long interval (secs) | 
+`net.interface.<interface>.config.wifi.infra.bgscan`[^1]         | String	 | Set the background scans; possible values have the form `<mode>:<shortInterval>:<rssiThreshold>:<longInterval>` where `mode` (String) is one of NONE, SIMPLE, or LEARN, `shortInterval` (Integer) sets the Bgscan short interval (secs), `rssiThreshold` (Integer) sets the Bgscan Signal strength threshold (dBm), and `longInterval` (Integer) sets the Bgscan long interval (secs) | 
 `net.interface.<interface>.config.wifi.infra.passphrase`	     | Password	 | The password for the wireless network |
 `net.interface.<interface>.config.wifi.infra.ignoreSSID`	     | Boolean	 | Specify if a scan for SSID is required before attempting to associate | false
 `net.interface.<interface>.config.wifi.infra.mode`	             | String	 | The mode of the wireless connection; for station mode set to `INFRA` | `INFRA`
-`net.interface.<interface>.config.wifi.infra.pingAccessPoint`	 | Boolean	 | Enable pinging the access point after connection is established | false
-`net.interface.<interface>.config.wifi.infra.driver`	         | String	 | The driver used for the connection | 
+`net.interface.<interface>.config.wifi.infra.pingAccessPoint`[^1]| Boolean	 | Enable pinging the access point after connection is established | false
+`net.interface.<interface>.config.wifi.infra.driver`[^1]         | String	 | The driver used for the connection | 
 `net.interface.<interface>.config.wifi.infra.securityType`       | String	 | The security protocol for the wireless network; possible values are `SECURITY_NONE`, `SECURITY_WEP`, `SECURITY_WPA`, `SECURITY_WPA2`, `SECURITY_WPA_WPA2` | `SECURITY_NONE`
 `net.interface.<interface>.config.wifi.infra.groupCiphers`       | String    | Group ciphers i.e. group/broadcast encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms set, possible values are `CCMP`, `TKIP`, and `CCMP_TKIP` | `CCMP_TKIP`
 `net.interface.<interface>.config.wifi.infra.pairwiseCiphers`    | String    | Pairwise ciphers i.e. pairwise encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms set, possible values are `CCMP`, `TKIP`, and `CCMP_TKIP` | `CCMP_TKIP`
 
 ### Cellular Modem properties
 
-Name                                                  | Type     | Description                                                            | Default value
-------------------------------------------------------|----------|------------------------------------------------------------------------|-----------------------------
-`net.interface.<interface>.config.enabled`	          | Boolean  | Enable the interface                                                   | false
-`net.interface.<interface>.config.idle`               | Integer  | The idle option of the PPP daemon                                      | 95
-`net.interface.<interface>.config.username`           | String   | The username used for the connection                                   |
-`net.interface.<interface>.config.password`           | Password | The password used for the connection                                   |
-`net.interface.<interface>.config.pdpType`            | String   | The PdP type; possible values are IP, PPP and IPv6                     | IP
-`net.interface.<interface>.config.maxFail`            | Integer  | The maxfail option of the PPP daemon                                   | 5
-`net.interface.<interface>.config.authType`           | String   | The authentication type; possible values are `NONE`, `AUTO`, `CHAP` and `PAP`  | `NONE`
-`net.interface.<interface>.config.lpcEchoInterval`    | Integer  | The lcp-echo-interval option of the PPP daemon                         | 0
-`net.interface.<interface>.config.activeFilter`       | String   | The active-filter option of the PPP daemon                             | inbound
-`net.interface.<interface>.config.lpcEchoFailure`     | Integer  | The lcp-echo-failure option of the PPP daemon                          | 0
-`net.interface.<interface>.config.diversityEnabled`   | Boolean  | Enable the LTE diversity antenna                                       | false
-`net.interface.<interface>.config.resetTimeout`       | Integer  | The modem reset timeout in minutes                                     | 5
-`net.interface.<interface>.config.gpsEnabled`         | Boolean  | Enable the GPS device in the modem if available                        | false
-`net.interface.<interface>.config.persist`            | Boolean  | The persist option of the PPP daemon                                   | true
-`net.interface.<interface>.config.apn`                | String   | The modem Access Point Name                                            |
-`net.interface.<interface>.config.dialString`         | String   | The dial string used for connecting to the APN                         |
-`net.interface.<interface>.config.holdoff`            | Integer  | The holdoff option of the PPP daemon (in seconds)                      | 1
-`net.interface.<interface>.config.pppNum`             | Integer  | Assigned ppp interface number                                          | 0
+Name                                                   | Type     | Description                                                            | Default value
+-------------------------------------------------------|----------|------------------------------------------------------------------------|-----------------------------
+`net.interface.<interface>.config.enabled`             | Boolean  | Enable the interface                                                   | false
+`net.interface.<interface>.config.idle`[^1]            | Integer  | The idle option of the PPP daemon                                      | 95
+`net.interface.<interface>.config.username`            | String   | The username used for the connection                                   |
+`net.interface.<interface>.config.password`            | Password | The password used for the connection                                   |
+`net.interface.<interface>.config.pdpType`[^1]         | String   | The PdP type; possible values are IP, PPP and IPv6                     | IP
+`net.interface.<interface>.config.maxFail`[^1]         | Integer  | The maxfail option of the PPP daemon                                   | 5
+`net.interface.<interface>.config.authType`            | String   | The authentication type; possible values are `NONE`, `AUTO`, `CHAP` and `PAP`  | `NONE`
+`net.interface.<interface>.config.lpcEchoInterval`     | Integer  | The lcp-echo-interval option of the PPP daemon                         | 0
+`net.interface.<interface>.config.activeFilter`[^1]    | String   | The active-filter option of the PPP daemon                             | inbound
+`net.interface.<interface>.config.lpcEchoFailure`      | Integer  | The lcp-echo-failure option of the PPP daemon                          | 0
+`net.interface.<interface>.config.diversityEnabled`[^1]| Boolean  | Enable the LTE diversity antenna                                       | false
+`net.interface.<interface>.config.resetTimeout`        | Integer  | The modem reset timeout in minutes                                     | 5
+`net.interface.<interface>.config.gpsEnabled`          | Boolean  | Enable the GPS device in the modem if available                        | false
+`net.interface.<interface>.config.persist`[^1]         | Boolean  | The persist option of the PPP daemon                                   | true
+`net.interface.<interface>.config.apn`                 | String   | The modem Access Point Name                                            |
+`net.interface.<interface>.config.dialString`[^1]      | String   | The dial string used for connecting to the APN                         |
+`net.interface.<interface>.config.holdoff`[^1]         | Integer  | The holdoff option of the PPP daemon (in seconds)                      | 1
+`net.interface.<interface>.config.pppNum`[^1]          | Integer  | Assigned ppp interface number                                          | 0
 
 ### VLAN properties
 
 Name                                                  | Type     | Description                              | Default value
 ------------------------------------------------------|----------|------------------------------------------|-------------------------
-`net.interface.<interface>.config.vlan.parent`        | String   | Physical interface Vlan is bound to | 
-`net.interface.<interface>.config.vlan.id`            | Integer  | Vlan tag identifier, between 0 and 4094 | 
-`net.interface.<interface>.config.vlan.ingress`       | String   | Incoming traffic priorities in the format from:to, as comma separated pairs of unsigned integers (Optional) |
-`net.interface.<interface>.config.vlan.egress`        | String   | Outgoing traffic priorities in the format from:to, as comma separated pairs of unsigned integer (Optional) |
-`net.interface.<interface>.config.vlan.flags`         | String   | Configuration flags, between 0 and 15 (Optional) | 1
+`net.interface.<interface>.config.vlan.parent`[^2]    | String   | Physical interface Vlan is bound to | 
+`net.interface.<interface>.config.vlan.id`[^2]        | Integer  | Vlan tag identifier, between 0 and 4094 | 
+`net.interface.<interface>.config.vlan.ingress`[^2]   | String   | Incoming traffic priorities in the format from:to, as comma separated pairs of unsigned integers (Optional) |
+`net.interface.<interface>.config.vlan.egress`[^2]    | String   | Outgoing traffic priorities in the format from:to, as comma separated pairs of unsigned integer (Optional) |
+`net.interface.<interface>.config.vlan.flags`[^2]     | String   | Configuration flags, between 0 and 15 (Optional) | 1
 
 ### 802.1x properties
 
-Name                                                         | Type     | Description
--------------------------------------------------------------|----------|------------------------------------------
-`net.interface.<interface>.config.802-1x.eap`                | String   | The EAP method to be used when authenticating to the network with 802.1x. Supported methods: "_Kura8021xEapTls_", "_Kura8021xEapPeap_", "_Kura8021xEapTtls_".
-`net.interface.<interface>.config.802-1x.innerAuth`          | String   | Specifies the "phase 2" inner authentication method when an EAP method that uses an inner TLS tunnel is specified in the "eap" property. Supported methods: "_Kura8021xInnerAuthNone_", "_Kura8021xInnerAuthMschapv2_".
-`net.interface.<interface>.config.802-1x.identity`           | String   | Identity string for EAP authentication methods. Typically the user's user or login name.
-`net.interface.<interface>.config.802-1x.password`           | String   | Password used for EAP authentication methods.
-`net.interface.<interface>.config.802-1x.client-cert-name`   | String   | Name referring to the corresponding Kura keystore entry containing the client certificate if used by the EAP method specified in the "eap" property. Typically is set to the same name as the `net.interface.<interface>.config.802-1x.private-key-name` when using EAP-TLS.
-`net.interface.<interface>.config.802-1x.private-key-name`   | String   | Name referring to the corresponding Kura keystore entry containing the private key when the "eap" property is set to "Kura8021xEapTls". Typically is set to the same name as the `net.interface.<interface>.config.802-1x.client-cert-name`.
-`net.interface.<interface>.config.802-1x.ca-cert-name`       | String   | Name referring to the corresponding Kura keystore entry containing the CA certificate if used by the EAP method specified in the "eap" property. This parameter is optional but this allows man-in-the-middle attacks and is **NOT recommended**.
-`net.interface.<interface>.config.802-1x.anonymous-identity` | String   | Anonymous identity string for EAP authentication methods. Used as the unencrypted identity with EAP types that support different tunneled identity like EAP-TTLS (Optional)
+Name                                                             | Type     | Description
+-----------------------------------------------------------------|----------|------------------------------------------
+`net.interface.<interface>.config.802-1x.eap`[^2]                | String   | The EAP method to be used when authenticating to the network with 802.1x. Supported methods: "_Kura8021xEapTls_", "_Kura8021xEapPeap_", "_Kura8021xEapTtls_".
+`net.interface.<interface>.config.802-1x.innerAuth`[^2]          | String   | Specifies the "phase 2" inner authentication method when an EAP method that uses an inner TLS tunnel is specified in the "eap" property. Supported methods: "_Kura8021xInnerAuthNone_", "_Kura8021xInnerAuthMschapv2_".
+`net.interface.<interface>.config.802-1x.identity`[^2]           | String   | Identity string for EAP authentication methods. Typically the user's user or login name.
+`net.interface.<interface>.config.802-1x.password`[^2]           | String   | Password used for EAP authentication methods.
+`net.interface.<interface>.config.802-1x.client-cert-name`[^2]   | String   | Name referring to the corresponding Kura keystore entry containing the client certificate if used by the EAP method specified in the "eap" property. Typically is set to the same name as the `net.interface.<interface>.config.802-1x.private-key-name` when using EAP-TLS.
+`net.interface.<interface>.config.802-1x.private-key-name`[^2]   | String   | Name referring to the corresponding Kura keystore entry containing the private key when the "eap" property is set to "Kura8021xEapTls". Typically is set to the same name as the `net.interface.<interface>.config.802-1x.client-cert-name`.
+`net.interface.<interface>.config.802-1x.ca-cert-name`[^2]       | String   | Name referring to the corresponding Kura keystore entry containing the CA certificate if used by the EAP method specified in the "eap" property. This parameter is optional but this allows man-in-the-middle attacks and is **NOT recommended**.
+`net.interface.<interface>.config.802-1x.anonymous-identity`[^2] | String   | Anonymous identity string for EAP authentication methods. Used as the unencrypted identity with EAP types that support different tunneled identity like EAP-TTLS (Optional)
 
 ## Network Configuration recipes
 
@@ -610,3 +610,6 @@ This section presents some snapshot examples to perform basic operations on netw
     </esf:configuration>
 </esf:configurations>
 ```
+
+[^1]: This feature is only available in Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).
+[^2]: This feature is only available in Kura _generic_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).

--- a/docs/gateway-configuration/wifi-configuration.md
+++ b/docs/gateway-configuration/wifi-configuration.md
@@ -35,7 +35,7 @@ The **Wireless** tab contains the following configuration parameters:
     - WEP: 64-bit or 128-bit encryption key
     - WPA/WPA2: pre-shared key
 
-- **Verify Password**: sets the password verification field.
+- **Verify Password**[^1]: sets the password verification field.
     - In _Access Point_ mode, allows the wireless password to be retyped for verification.
     - In _Station_ mode, this field is disabled.
 
@@ -53,18 +53,18 @@ The **Wireless** tab contains the following configuration parameters:
         - TKIP (Temporal Key Integrity Protocol)
         - CCMP and TKIP
 
-- **Bgscan Module**: requests background scans for the purpose of roaming within an ESS (i.e., within a single network block with all the APs using the same SSID).
+- **Bgscan Module**[^1]: requests background scans for the purpose of roaming within an ESS (i.e., within a single network block with all the APs using the same SSID).
     - None: background scan is disabled
     - Simple: periodic background scans based on signal strength
     - Learn: learn channels used by the network and try to avoid bgscans on other channels
 
-- **Bgscan Signal Strength Threshold**: defines a threshold (in dBm) that determines which one of the following two parameters (i.e., _Short Interval_ or _Long Interval_) will be effective.
+- **Bgscan Signal Strength Threshold**[^1]: defines a threshold (in dBm) that determines which one of the following two parameters (i.e., _Short Interval_ or _Long Interval_) will be effective.
 
-- **Bgscan Short Interval**: defines the interval between background scans (in seconds) if the actual signal level of the currently connected access point is worse than signal_strength.
+- **Bgscan Short Interval**[^1]: defines the interval between background scans (in seconds) if the actual signal level of the currently connected access point is worse than signal_strength.
 
-- **Bgscan Long Interval**: defines the interval  between background scans (in seconds) if the actual signal level of the currently connected access point is better than signal_strength.
+- **Bgscan Long Interval**[^1]: defines the interval  between background scans (in seconds) if the actual signal level of the currently connected access point is better than signal_strength.
 
-- **Ping Access Point & renew DHCP lease if not reachable**: enables pinging the access point after connection is established.
+- **Ping Access Point & renew DHCP lease if not reachable**[^1]: enables pinging the access point after connection is established.
     - In _Access Point_ mode, this option is disabled.
     - In _Station_ mode, if set to _true_, the unit will ping the access point and attempt to renew the DHCP lease if the access point is not reachable.
 
@@ -92,7 +92,7 @@ In addition to the options described above, the **Wireless** configuration displ
 
     If you select one of these access points, respective wireless controls (i.e., _Network Name_, _Wireless Security_, and _Channel_) are filled with information obtained during the scan operation.
 
-- **Password Verification**: clicking this button triggers password verification before a full connection is established.
+- **Password Verification**[^1]: clicking this button triggers password verification before a full connection is established.
 
 !!! warning "Generic Profiles Access Point Scan Issue"
     Due to a limitation in our current implementation of Access Point scanning in the generic profiles, a scan triggered while the device Wireless Mode is set as _Access Point_ will result in it reporting itself as the only reachable Access Point.
@@ -198,3 +198,5 @@ network={
     bgscan=""
 }
 ```
+
+[^1]: This feature is only available in Eclipse Kura _specific_ profiles. For more informations about the various Kura profiles see [Kura installer types](../getting-started/install-kura.md#installer-types).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,6 +220,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - footnotes
 
 extra:
   version:


### PR DESCRIPTION
This is a backport of #5653 for release 5.5 with the corrections of #5657.