### PR TITLE
ci(5.4): fix Github actions permissions for documentation branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -5,6 +5,10 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     name: Backport

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - 'docs-develop'
       - 'docs-release-*.*'
+
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backport of #5387 

* ci: fix Github actions permissions for documentation branches

* ci: add contents:write permissions

(cherry picked from commit d9bb8d9893dbabee84acfcbe6092e72993e981d1)
