### PR TITLE
docs(6.0): correctly document supported parameters

### DIFF
--- a/docs/gateway-configuration/cellular-configuration.md
+++ b/docs/gateway-configuration/cellular-configuration.md
@@ -21,7 +21,7 @@ The **Cellular** tab contains the following configuration parameters:
 
 - **Interface #**: provides a unique number for the modem interface (e.g., an interface # of 0 would name the modem interface ppp0).
 
-- **Dial String**: instructs how the modem should attempt to connect. Typical dial strings are as follows:
+- **Dial String**: legacy setting that used to help establishing PPP data sessions for GSM-based modems. Deprecated by NetworkManager and not used anymore. Kura will read it and populate the configuration with the correct values but NetworkManager might not honor the setting depending on its version. Typical dial strings are as follows:
     - HSPA modem: atd&ast;99&ast;&ast;&ast;1#
     - EVDO/CDMA modem: atd#777
 
@@ -49,16 +49,6 @@ The **Cellular** tab contains the following configuration parameters:
 - **Password**: supplies the password; disabled if no authentication method is specified.
 
 - **Modem Reset Timeout**: sets the modem reset timeout in minutes. If set to a non-zero value, the modem is reset after n consecutive minutes of unsuccessful connection attempts. If set to zero, the modem keeps trying to establish a PPP connection without resetting. The default value is 5 minutes.
-
-- **Reopen Connection on Termination**: sets the _persist_ option of the PPP daemon that specifies if PPP daemon should exit after connection is terminated. Note that the _maxfail_ option still has an effect on persistent connections.
-
-- **Connection Attempts Retry Delay**: Sets the _holdoff_ parameter to instruct the PPP daemon on how many seconds to wait before re-initiating the link after it terminates. This option only has any effect if the persist option (Reopen Connection on Termination) is set to true. The holdoff period is not applied if the link was terminated because it was idle. The default value is 1 second.
-
-- **Connection Attempts**: sets the _maxfail_ option of the PPP daemon that limits the number of consecutive failed PPP connection attempts. The default value is 5 connection attempts. A value of zero means no limit. The PPP daemon terminates after the specified number of failed PPP connection attempts and restarts by the _ModemMonitor_ thread.  
-
-- **Disconnect if Idle**: sets the _idle_ option of the PPP daemon, which terminates the PPP connection if the link is idle for a specified number of seconds. The default value is 95 seconds. To disable this option, set it to zero.
-
-- **Active Filter**: sets the _active-filter_ option of the PPP daemon. This option specifies a packet filter _(filter-expression)_ to be applied to data packets in order to determine which packets are regarded as link activity, and thereby, reset the idle timer. The _filter-expression_ syntax is as described for tcpdump(1); however, qualifiers that do not apply to a PPP link, such as _ether_ and _arp_, are not permitted. The default value is _inbound_. To disable the _active-filter_ option, leave it blank.
 
 - **LCP Echo Interval**: sets the _lcp-echo-interval_ option of the PPP daemon. If set to a positive number, the modem sends LCP echo request to the peer at the specified number of seconds. To disable this option, set it to zero. This option may be used with the _lcp-echo-failure_ option to detect that the peer is no longer connected.
 

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -583,4 +583,4 @@ This section presents some snapshot examples to perform basic operations on netw
 ```
 
 [^1]: Legacy setting that used to help establishing PPP data sessions for GSM-based modems. Deprecated by NetworkManager and not used anymore. Kura will read it and populate the configuration with the correct values but NetworkManager might not honor the setting depending on its version.
-[^2]: Supported for compatibility reasons. The behaviour of `netIPv4StatusL2Only`/`netIPv6StatusL2Only` corresponds to `netIPv4StatusDisabled`/`netIPv6StatusDisabled` (i.e. the interface will be brought up but no IP address will be assigned).
+[^2]: Supported for compatibility reasons. The behaviour of `netIPv4StatusL2Only`/`netIPv6StatusL2Only` corresponds to `netIPv4StatusUnmanaged`/`netIPv6StatusUnmanaged` (i.e. the interface will be brought up but IP configuration is left to the user).

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -17,7 +17,7 @@ The **IPv4** and **IPv6** tabs contain the following configuration parameters:
     - Enabled for LAN: designates the interface for a local network. It can be set as a DHCP server for hosts on the local network and can serve as a default gateway for those hosts; however, it cannot be set as an actual gateway interface for this device. That is, packets must be routed from this interface to another interface that is configured as WAN. The interface is automatically brought up at boot.
     - Enabled for WAN: designates the interface as a gateway to an external network. The interface is automatically brought up at boot.
     - Not Managed: the interface will be ignored by Kura (available only for **IPv4**).
-    - Layer 2 Only: only the Layer 2 portion of the interface will be configured. The interface is automatically brought up at boot (available only for **IPv4**).
+    - Layer 2 Only[^2]: only the Layer 2 portion of the interface will be configured. The interface is automatically brought up at boot.
 - **WAN Priority** - configure the network failover. See [here](network-failover.md) for more details.
 - **Configure**
     - Manually: allows manual entry of the _IP Address_ and _Netmask_ fields, if the interface is configured as LAN; allows manual entry of the _IP Address_, _Netmask_, _Gateway_, and _DNS Servers_ fields, if the interface is designated as WAN.
@@ -119,8 +119,8 @@ Name                                             | Type     | Description       
 
 Name                                                | Type     | Description                              | Default value
 ----------------------------------------------------|----------|------------------------------------------|----------------------------
-`net.interface.<interface>.config.ip4.status`	    | String   | The status of the interface for the IPv4 configuration; possibile values are: `netIPv4StatusDisabled`, `netIPv4StatusUnmanaged`, `netIPv4StatusL2Only`, `netIPv4StatusEnabledLAN`, `netIPv4StatusEnabledWAN`, `netIPv4StatusUnknown` | `netIPv4StatusDisabled` (see note below)
-`net.interface.<interface>.config.ip4.wan.priority` | Integer  | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
+`net.interface.<interface>.config.ip4.status`	    | String   | The status of the interface for the IPv4 configuration; possibile values are: `netIPv4StatusDisabled`, `netIPv4StatusUnmanaged`, `netIPv4StatusL2Only`[^2], `netIPv4StatusEnabledLAN`, `netIPv4StatusEnabledWAN`, `netIPv4StatusUnknown` | `netIPv4StatusDisabled` (see note below)
+`net.interface.<interface>.config.ip4.wan.priority` | Integer  | Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
 `net.interface.<interface>.config.ip4.address`      | String   | The IPv4 address assigned to the network interface |
 `net.interface.<interface>.config.ip4.prefix`	    | Short    | The IPv4 netmask assigned to the network interface | -1
 `net.interface.<interface>.config.ip4.gateway`      | String   | The IPv4 address of the default gateway |
@@ -152,8 +152,8 @@ Name                                                     | Type     | Descriptio
 
 Name                                                  | Type     | Description                              | Default value
 ------------------------------------------------------|----------|------------------------------------------|----------------------------
-`net.interface.<interface>.config.ip6.status`	      | String   | The status of the interface for the IPv6 configuration; possibile values are: `netIPv6StatusDisabled`, `netIPv6StatusUnmanaged`, `netIPv6StatusL2Only`, `netIPv6StatusEnabledLAN`, `netIPv6StatusEnabledWAN`, `netIPv6StatusUnknown` | `netIPv6StatusDisabled` (see note below)
-`net.interface.<interface>.config.ip6.wan.priority`   | Integer | (NetworkManager only) Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
+`net.interface.<interface>.config.ip6.status`	      | String   | The status of the interface for the IPv6 configuration; possibile values are: `netIPv6StatusDisabled`, `netIPv6StatusUnmanaged`, `netIPv6StatusL2Only`[^2], `netIPv6StatusEnabledLAN`, `netIPv6StatusEnabledWAN`, `netIPv6StatusUnknown` | `netIPv6StatusDisabled` (see note below)
+`net.interface.<interface>.config.ip6.wan.priority`   | Integer  | Priority used to determine which interface select as primary WAN. Allowed values range from -1 to 2147483647, inclusive. See [Network Failover](./network-failover.md) for further details | -1
 `net.interface.<interface>.config.ip6.address.method` | String   | The IPv6 configuration method; possible values are: `AUTO`, `DHCP`, `MANUAL`. | `AUTO`
 `net.interface.<interface>.config.ip6.address`        | String   | The IPv6 address assigned to the network interface |
 `net.interface.<interface>.config.ip6.prefix`	      | Short    | The IPv6 netmask assigned to the network interface | -1
@@ -187,12 +187,9 @@ Name                                                             | Type      | D
 -----------------------------------------------------------------|-----------|------------------------------------------|--------------------------------
 `net.interface.<interface>.config.wifi.infra.ssid`	             | String	 | The SSID of the wireless network to connect to |
 `net.interface.<interface>.config.wifi.infra.channel`	         | String	 | The channel of the wireless network to connect to | 1
-`net.interface.<interface>.config.wifi.infra.bgscan`	         | String	 | Set the background scans; possible values have the form `<mode>:<shortInterval>:<rssiThreshold>:<longInterval>` where `mode` (String) is one of NONE, SIMPLE, or LEARN, `shortInterval` (Integer) sets the Bgscan short interval (secs), `rssiThreshold` (Integer) sets the Bgscan Signal strength threshold (dBm), and `longInterval` (Integer) sets the Bgscan long interval (secs) | 
 `net.interface.<interface>.config.wifi.infra.passphrase`	     | Password	 | The password for the wireless network |
 `net.interface.<interface>.config.wifi.infra.ignoreSSID`	     | Boolean	 | Specify if a scan for SSID is required before attempting to associate | false
 `net.interface.<interface>.config.wifi.infra.mode`	             | String	 | The mode of the wireless connection; for station mode set to `INFRA` | `INFRA`
-`net.interface.<interface>.config.wifi.infra.pingAccessPoint`	 | Boolean	 | Enable pinging the access point after connection is established | false
-`net.interface.<interface>.config.wifi.infra.driver`	         | String	 | The driver used for the connection | 
 `net.interface.<interface>.config.wifi.infra.securityType`       | String	 | The security protocol for the wireless network; possible values are `SECURITY_NONE`, `SECURITY_WEP`, `SECURITY_WPA`, `SECURITY_WPA2`, `SECURITY_WPA_WPA2`, `SECURITY_WPA3`, `SECURITY_WPA2_WPA3` (see [here](../wifi-configuration#notes-about-wpa3-security) for more details about WPA3) | `SECURITY_NONE`
 `net.interface.<interface>.config.wifi.infra.groupCiphers`       | String    | Group ciphers i.e. group/broadcast encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms set, possible values are `CCMP`, `TKIP`, and `CCMP_TKIP` | `CCMP_TKIP`
 `net.interface.<interface>.config.wifi.infra.pairwiseCiphers`    | String    | Pairwise ciphers i.e. pairwise encryption algorithms which prevents connections to Wi-Fi networks that do not utilize one of the algorithms set, possible values are `CCMP`, `TKIP`, and `CCMP_TKIP` | `CCMP_TKIP`
@@ -202,24 +199,15 @@ Name                                                             | Type      | D
 Name                                                  | Type     | Description                                                            | Default value
 ------------------------------------------------------|----------|------------------------------------------------------------------------|-----------------------------
 `net.interface.<interface>.config.enabled`	          | Boolean  | Enable the interface                                                   | false
-`net.interface.<interface>.config.idle`               | Integer  | The idle option of the PPP daemon                                      | 95
 `net.interface.<interface>.config.username`           | String   | The username used for the connection                                   |
 `net.interface.<interface>.config.password`           | Password | The password used for the connection                                   |
-`net.interface.<interface>.config.pdpType`            | String   | The PdP type; possible values are IP, PPP and IPv6                     | IP
-`net.interface.<interface>.config.maxFail`            | Integer  | The maxfail option of the PPP daemon                                   | 5
-`net.interface.<interface>.config.authType`           | String   | The authentication type; possible values are `NONE`, `AUTO`, `CHAP` and `PAP`  | `NONE`
 `net.interface.<interface>.config.lpcEchoInterval`    | Integer  | The lcp-echo-interval option of the PPP daemon                         | 0
-`net.interface.<interface>.config.activeFilter`       | String   | The active-filter option of the PPP daemon                             | inbound
 `net.interface.<interface>.config.lpcEchoFailure`     | Integer  | The lcp-echo-failure option of the PPP daemon                          | 0
-`net.interface.<interface>.config.diversityEnabled`   | Boolean  | Enable the LTE diversity antenna                                       | false
 `net.interface.<interface>.config.resetTimeout`       | Integer  | The modem reset timeout in minutes                                     | 5
 `net.interface.<interface>.config.gpsEnabled`         | Boolean  | Enable the GPS device in the modem if available                        | false
 `net.interface.<interface>.config.gpsMode`            | String   | Select the GPS mode to activate for the modem if available             | `kuraModemGpsModeUnmanaged`
-`net.interface.<interface>.config.persist`            | Boolean  | The persist option of the PPP daemon                                   | true
 `net.interface.<interface>.config.apn`                | String   | The modem Access Point Name                                            |
-`net.interface.<interface>.config.dialString`         | String   | The dial string used for connecting to the APN                         |
-`net.interface.<interface>.config.holdoff`            | Integer  | The holdoff option of the PPP daemon (in seconds)                      | 1
-`net.interface.<interface>.config.pppNum`             | Integer  | Assigned ppp interface number                                          | 0
+`net.interface.<interface>.config.dialString`         | String   | The dial string used for connecting to the APN[^1]                     |
 
 #### GPS Mode
 
@@ -419,9 +407,6 @@ This section presents some snapshot examples to perform basic operations on netw
             <esf:property array="false" encrypted="false" name="net.interface.wlp1s0.config.wifi.mode" type="String">
                 <esf:value>MASTER</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp1s0.config.wifi.master.driver" type="String">
-                <esf:value>nl80211</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="true" name="net.interface.wlp1s0.config.wifi.master.passphrase" type="Password">
                 <esf:value>ZW5hYmxlbWVwbGVhc2U=</esf:value>
             </esf:property>
@@ -479,9 +464,6 @@ This section presents some snapshot examples to perform basic operations on netw
             <esf:property array="false" encrypted="false" name="net.interface.wlp1s0.config.wifi.infra.ssid" type="String">
                 <esf:value>MyWirelessNetwork</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp1s0.config.wifi.infra.bgscan" type="String">
-                <esf:value/>
-            </esf:property>
             <esf:property array="false" encrypted="true" name="net.interface.wlp1s0.config.wifi.infra.passphrase" type="Password">
                 <esf:value>MyPasswordBase64</esf:value>
             </esf:property>
@@ -490,12 +472,6 @@ This section presents some snapshot examples to perform basic operations on netw
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp1s0.config.wifi.infra.mode" type="String">
                 <esf:value>INFRA</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp1s0.config.wifi.infra.pingAccessPoint" type="Boolean">
-                <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.wlp1s0.config.wifi.infra.driver" type="String">
-                <esf:value>nl80211</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.wlp1s0.config.wifi.infra.securityType" type="String">
                 <esf:value>SECURITY_WPA2</esf:value>
@@ -527,20 +503,8 @@ This section presents some snapshot examples to perform basic operations on netw
             <esf:property array="false" encrypted="false" name="net.interface.1-1.config.dhcpServer4.enabled" type="Boolean">
                 <esf:value>false</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.1-1.config.idle" type="Integer">
-                <esf:value>95</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="true" name="net.interface.1-1.config.password" type="Password">
                 <esf:value/>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.1-1.config.pdpType" type="String">
-                <esf:value>IP</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.1-1.config.ipAddress" type="String">
-                <esf:value/>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.1-1.config.maxFail" type="Integer">
-                <esf:value>5</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.1-1.config.authType" type="String">
                 <esf:value>NONE</esf:value>
@@ -551,26 +515,14 @@ This section presents some snapshot examples to perform basic operations on netw
             <esf:property array="false" encrypted="false" name="net.interface.1-1.config.enabled" type="Boolean">
                 <esf:value>true</esf:value>
             </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.1-1.config.activeFilter" type="String">
-                <esf:value>inbound</esf:value>
-            </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.1-1.config.lcpEchoFailure" type="Integer">
                 <esf:value>0</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.1-1.config.diversityEnabled" type="Boolean">
-                <esf:value>false</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.1-1.config.resetTimeout" type="Integer">
                 <esf:value>5</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.1-1.config.gpsEnabled" type="Boolean">
                 <esf:value>false</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.1-1.config.persist" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="net.interface.1-1.config.dialString" type="String">
-                <esf:value>atd*99***2#</esf:value>
             </esf:property>
             <esf:property array="false" encrypted="false" name="net.interface.1-1.config.apn" type="String">
                 <esf:value>web.omnitel.it</esf:value>
@@ -579,6 +531,7 @@ This section presents some snapshot examples to perform basic operations on netw
     </esf:configuration>
 </esf:configurations>
 ```
+
 ### Create a VLAN
 
 ```xml
@@ -628,3 +581,6 @@ This section presents some snapshot examples to perform basic operations on netw
     </esf:configuration>
 </esf:configurations>
 ```
+
+[^1]: Legacy setting that used to help establishing PPP data sessions for GSM-based modems. Deprecated by NetworkManager and not used anymore. Kura will read it and populate the configuration with the correct values but NetworkManager might not honor the setting depending on its version.
+[^2]: Supported for compatibility reasons. The behaviour of `netIPv4StatusL2Only`/`netIPv6StatusL2Only` corresponds to `netIPv4StatusDisabled`/`netIPv6StatusDisabled` (i.e. the interface will be brought up but no IP address will be assigned).

--- a/docs/gateway-configuration/network-failover.md
+++ b/docs/gateway-configuration/network-failover.md
@@ -1,6 +1,6 @@
 # Network Failover
 
-Eclipse Kura _Netwok Failover_ functionality allows to configure multiple WAN interfaces and a basic network failover functionality.
+Eclipse Kura _Network Failover_ functionality allows to configure multiple WAN interfaces and a basic network failover functionality.
 
 As in the picture below, the Kura UI allows for multiple WAN interfaces to be defined. Each WAN interface can be configured with a **WAN Priority**. WAN Priority is used to determine which interface will be selected for primary WAN. In the case where the primary WAN interface loses connection, then the next highest priority interface is assigned.
 

--- a/docs/gateway-configuration/network-failover.md
+++ b/docs/gateway-configuration/network-failover.md
@@ -1,6 +1,6 @@
 # Network Failover
 
-For devices configured to use [NetworkManager](https://networkmanager.dev), it is possible to configure multiple WAN interfaces and a basic network failover functionality.
+Eclipse Kura _Netwok Failover_ functionality allows to configure multiple WAN interfaces and a basic network failover functionality.
 
 As in the picture below, the Kura UI allows for multiple WAN interfaces to be defined. Each WAN interface can be configured with a **WAN Priority**. WAN Priority is used to determine which interface will be selected for primary WAN. In the case where the primary WAN interface loses connection, then the next highest priority interface is assigned.
 
@@ -25,7 +25,7 @@ The `metric` flag will correspond to the set **WAN Priority**. *NetworkManager* 
 
 
 
-## Operating modes
+## Operating modes
 
 The *NetworkManager* failover mechanism can work at two different levels:
 

--- a/docs/gateway-configuration/wifi-configuration.md
+++ b/docs/gateway-configuration/wifi-configuration.md
@@ -36,10 +36,6 @@ The **Wireless** tab contains the following configuration parameters:
     - WEP: 64-bit or 128-bit encryption key
     - WPA/WPA2: pre-shared key
 
-- **Verify Password**: sets the password verification field.
-    - In _Access Point_ mode, allows the wireless password to be retyped for verification.
-    - In _Station_ mode, this field is disabled.
-
 - **Pairwise Ciphers**: lists accepted pairwise (unicast) ciphers for WPA/WPA2.
     - In _Access Point_ mode, this option is disabled.
     - In _Station_ mode,
@@ -53,17 +49,6 @@ The **Wireless** tab contains the following configuration parameters:
         - CCMP (AES-based encryption mode with strong security)
         - TKIP (Temporal Key Integrity Protocol)
         - CCMP and TKIP
-
-- **Bgscan Module**: requests background scans for the purpose of roaming within an ESS (i.e., within a single network block with all the APs using the same SSID).
-    - None: background scan is disabled
-    - Simple: periodic background scans based on signal strength
-    - Learn: learn channels used by the network and try to avoid bgscans on other channels
-
-- **Bgscan Signal Strength Threshold**: defines a threshold (in dBm) that determines which one of the following two parameters (i.e., _Short Interval_ or _Long Interval_) will be effective.
-
-- **Bgscan Short Interval**: defines the interval between background scans (in seconds) if the actual signal level of the currently connected access point is worse than signal_strength.
-
-- **Bgscan Long Interval**: defines the interval  between background scans (in seconds) if the actual signal level of the currently connected access point is better than signal_strength.
 
 - **Ignore Broadcast SSID**: operates as follows if set to _true_:
     - In _Access Point_ mode, sends an empty SSID in beacons and ignores probe request frames that do not specify full SSID.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -218,6 +218,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - footnotes
 
 extra:
   version:


### PR DESCRIPTION
This PR removes the unsupported features from the documentation and updates the behaviour of the L2Only mode according to #5663.

Given that Kura 6.0 will remove the so-called "_specific profiles_" (See #5315), the goal of this PR is to remove the documentation citing specific profiles-only features.