### PR TITLE
feat(nm): L2Only as alias of Unmanaged mode

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
@@ -22,6 +22,7 @@ public enum KuraInterfaceStatus {
         Boolean ip4Enabled = KuraIpStatus.isEnabled(ip4Status);
         boolean ip4Disabled = ip4Status == KuraIpStatus.DISABLED;
         boolean ip4Unmanaged = ip4Status == KuraIpStatus.UNMANAGED;
+        boolean ip4L2Only = ip4Status == KuraIpStatus.L2ONLY;
         boolean ip4Unknown = ip4Status == KuraIpStatus.UNKNOWN;
 
         Boolean ip6Enabled = KuraIpStatus.isEnabled(ip6Status);
@@ -33,7 +34,7 @@ public enum KuraInterfaceStatus {
             return ENABLED;
         }
 
-        if (ip4Unmanaged && ip6Unmanaged) {
+        if (ip4L2Only || (ip4Unmanaged && ip6Unmanaged)) {
             return UNMANAGED;
         }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
@@ -30,6 +30,10 @@ public enum KuraInterfaceStatus {
         boolean ip6Unmanaged = ip6Status == KuraIpStatus.UNMANAGED;
         boolean ip6Unknown = ip6Status == KuraIpStatus.UNKNOWN;
 
+        if (ip4Unknown || ip6Unknown) {
+            throw new IllegalArgumentException("ip4 and ip6 status should not be UNKNOWN");
+        }
+
         if (ip4Enabled && ip6Enabled || ip4Enabled && ip6Disabled || ip4Disabled && ip6Enabled) {
             return ENABLED;
         }
@@ -40,10 +44,6 @@ public enum KuraInterfaceStatus {
 
         if (ip4Unmanaged || ip6Unmanaged) { // && (ip4Status != ip6Status)
             throw new IllegalArgumentException("ip4 and ip6 status should be both UNMANAGED");
-        }
-
-        if (ip4Unknown || ip6Unknown) {
-            throw new IllegalArgumentException("ip4 and ip6 status should not be UNKNOWN");
         }
 
         return DISABLED;

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
@@ -22,18 +22,21 @@ public enum KuraInterfaceStatus {
         Boolean ip4Enabled = KuraIpStatus.isEnabled(ip4Status);
         boolean ip4Disabled = ip4Status == KuraIpStatus.DISABLED;
         boolean ip4Unmanaged = ip4Status == KuraIpStatus.UNMANAGED;
+        boolean ip4L2Only = ip4Status == KuraIpStatus.L2ONLY;
         boolean ip4Unknown = ip4Status == KuraIpStatus.UNKNOWN;
 
         Boolean ip6Enabled = KuraIpStatus.isEnabled(ip6Status);
         boolean ip6Disabled = ip6Status == KuraIpStatus.DISABLED;
         boolean ip6Unmanaged = ip6Status == KuraIpStatus.UNMANAGED;
+        boolean ip6L2Only = ip6Status == KuraIpStatus.L2ONLY;
         boolean ip6Unknown = ip6Status == KuraIpStatus.UNKNOWN;
 
         if (ip4Enabled && ip6Enabled || ip4Enabled && ip6Disabled || ip4Disabled && ip6Enabled) {
             return ENABLED;
         }
 
-        if (ip4Unmanaged && ip6Unmanaged) {
+        if (ip4Unmanaged && ip6Unmanaged || ip4L2Only && ip6L2Only || ip4L2Only && ip6Unmanaged
+                || ip4Unmanaged && ip6L2Only || ip4L2Only && ip6Disabled) {
             return UNMANAGED;
         }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
@@ -28,15 +28,13 @@ public enum KuraInterfaceStatus {
         Boolean ip6Enabled = KuraIpStatus.isEnabled(ip6Status);
         boolean ip6Disabled = ip6Status == KuraIpStatus.DISABLED;
         boolean ip6Unmanaged = ip6Status == KuraIpStatus.UNMANAGED;
-        boolean ip6L2Only = ip6Status == KuraIpStatus.L2ONLY;
         boolean ip6Unknown = ip6Status == KuraIpStatus.UNKNOWN;
 
         if (ip4Enabled && ip6Enabled || ip4Enabled && ip6Disabled || ip4Disabled && ip6Enabled) {
             return ENABLED;
         }
 
-        if (ip4Unmanaged && ip6Unmanaged || ip4L2Only && ip6L2Only || ip4L2Only && ip6Unmanaged
-                || ip4Unmanaged && ip6L2Only || ip4L2Only && ip6Disabled) {
+        if (ip4L2Only || (ip4Unmanaged && ip6Unmanaged)) {
             return UNMANAGED;
         }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraInterfaceStatus.java
@@ -22,7 +22,6 @@ public enum KuraInterfaceStatus {
         Boolean ip4Enabled = KuraIpStatus.isEnabled(ip4Status);
         boolean ip4Disabled = ip4Status == KuraIpStatus.DISABLED;
         boolean ip4Unmanaged = ip4Status == KuraIpStatus.UNMANAGED;
-        boolean ip4L2Only = ip4Status == KuraIpStatus.L2ONLY;
         boolean ip4Unknown = ip4Status == KuraIpStatus.UNKNOWN;
 
         Boolean ip6Enabled = KuraIpStatus.isEnabled(ip6Status);
@@ -34,7 +33,7 @@ public enum KuraInterfaceStatus {
             return ENABLED;
         }
 
-        if (ip4L2Only || (ip4Unmanaged && ip6Unmanaged)) {
+        if (ip4Unmanaged && ip6Unmanaged) {
             return UNMANAGED;
         }
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIpStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIpStatus.java
@@ -39,10 +39,9 @@ public enum KuraIpStatus {
             return KuraIpStatus.DISABLED;
         case "netIPv4StatusUnmanaged":
         case "netIPv6StatusUnmanaged":
-            return KuraIpStatus.UNMANAGED;
         case "netIPv4StatusL2Only":
         case "netIPv6StatusL2Only":
-            return KuraIpStatus.L2ONLY;
+            return KuraIpStatus.UNMANAGED;
         case "netIPv4StatusEnabledLAN":
         case "netIPv6StatusEnabledLAN":
             return KuraIpStatus.ENABLEDLAN;
@@ -65,10 +64,9 @@ public enum KuraIpStatus {
                 return Optional.of(KuraIpStatus.DISABLED);
             case "netIPv4StatusUnmanaged":
             case "netIPv6StatusUnmanaged":
-                return Optional.of(KuraIpStatus.UNMANAGED);
             case "netIPv4StatusL2Only":
             case "netIPv6StatusL2Only":
-                return Optional.of(KuraIpStatus.L2ONLY);
+                return Optional.of(KuraIpStatus.UNMANAGED);
             case "netIPv4StatusEnabledLAN":
             case "netIPv6StatusEnabledLAN":
                 return Optional.of(KuraIpStatus.ENABLEDLAN);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIpStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIpStatus.java
@@ -39,9 +39,10 @@ public enum KuraIpStatus {
             return KuraIpStatus.DISABLED;
         case "netIPv4StatusUnmanaged":
         case "netIPv6StatusUnmanaged":
+            return KuraIpStatus.UNMANAGED;
         case "netIPv4StatusL2Only":
         case "netIPv6StatusL2Only":
-            return KuraIpStatus.UNMANAGED;
+            return KuraIpStatus.L2ONLY;
         case "netIPv4StatusEnabledLAN":
         case "netIPv6StatusEnabledLAN":
             return KuraIpStatus.ENABLEDLAN;
@@ -64,9 +65,10 @@ public enum KuraIpStatus {
                 return Optional.of(KuraIpStatus.DISABLED);
             case "netIPv4StatusUnmanaged":
             case "netIPv6StatusUnmanaged":
+                return Optional.of(KuraIpStatus.UNMANAGED);
             case "netIPv4StatusL2Only":
             case "netIPv6StatusL2Only":
-                return Optional.of(KuraIpStatus.UNMANAGED);
+                return Optional.of(KuraIpStatus.L2ONLY);
             case "netIPv4StatusEnabledLAN":
             case "netIPv6StatusEnabledLAN":
                 return Optional.of(KuraIpStatus.ENABLEDLAN);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIpStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIpStatus.java
@@ -26,7 +26,7 @@ public enum KuraIpStatus {
     UNKNOWN;
 
     private static final List<KuraIpStatus> ENABLED_STATUS = Arrays.asList(KuraIpStatus.ENABLEDLAN,
-            KuraIpStatus.ENABLEDWAN, KuraIpStatus.L2ONLY);
+            KuraIpStatus.ENABLEDWAN);
 
     public static Boolean isEnabled(KuraIpStatus status) {
         return ENABLED_STATUS.contains(status);
@@ -39,9 +39,10 @@ public enum KuraIpStatus {
             return KuraIpStatus.DISABLED;
         case "netIPv4StatusUnmanaged":
         case "netIPv6StatusUnmanaged":
+            return KuraIpStatus.UNMANAGED;
         case "netIPv4StatusL2Only":
         case "netIPv6StatusL2Only":
-            return KuraIpStatus.UNMANAGED;
+            return KuraIpStatus.L2ONLY;
         case "netIPv4StatusEnabledLAN":
         case "netIPv6StatusEnabledLAN":
             return KuraIpStatus.ENABLEDLAN;
@@ -64,9 +65,10 @@ public enum KuraIpStatus {
                 return Optional.of(KuraIpStatus.DISABLED);
             case "netIPv4StatusUnmanaged":
             case "netIPv6StatusUnmanaged":
+                return Optional.of(KuraIpStatus.UNMANAGED);
             case "netIPv4StatusL2Only":
             case "netIPv6StatusL2Only":
-                return Optional.of(KuraIpStatus.UNMANAGED);
+                return Optional.of(KuraIpStatus.L2ONLY);
             case "netIPv4StatusEnabledLAN":
             case "netIPv6StatusEnabledLAN":
                 return Optional.of(KuraIpStatus.ENABLEDLAN);

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIpStatus.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/KuraIpStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -85,7 +85,7 @@ public class NMDbusConnector {
     private static final List<NMDeviceType> CONFIGURATION_SUPPORTED_VIRTUAL_DEVICE_TYPES = Arrays
             .asList(NMDeviceType.NM_DEVICE_TYPE_VLAN);
     private static final List<KuraIpStatus> CONFIGURATION_SUPPORTED_STATUSES = Arrays.asList(KuraIpStatus.DISABLED,
-            KuraIpStatus.ENABLEDLAN, KuraIpStatus.ENABLEDWAN, KuraIpStatus.UNMANAGED, KuraIpStatus.L2ONLY);
+            KuraIpStatus.ENABLEDLAN, KuraIpStatus.ENABLEDWAN, KuraIpStatus.UNMANAGED);
 
     private static final List<NMDeviceType> STATUS_SUPPORTED_DEVICE_TYPES = Arrays.asList(
             NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceType.NM_DEVICE_TYPE_WIFI,

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java
@@ -85,7 +85,7 @@ public class NMDbusConnector {
     private static final List<NMDeviceType> CONFIGURATION_SUPPORTED_VIRTUAL_DEVICE_TYPES = Arrays
             .asList(NMDeviceType.NM_DEVICE_TYPE_VLAN);
     private static final List<KuraIpStatus> CONFIGURATION_SUPPORTED_STATUSES = Arrays.asList(KuraIpStatus.DISABLED,
-            KuraIpStatus.ENABLEDLAN, KuraIpStatus.ENABLEDWAN, KuraIpStatus.UNMANAGED);
+            KuraIpStatus.ENABLEDLAN, KuraIpStatus.ENABLEDWAN, KuraIpStatus.UNMANAGED, KuraIpStatus.L2ONLY);
 
     private static final List<NMDeviceType> STATUS_SUPPORTED_DEVICE_TYPES = Arrays.asList(
             NMDeviceType.NM_DEVICE_TYPE_MODEM, NMDeviceType.NM_DEVICE_TYPE_ETHERNET, NMDeviceType.NM_DEVICE_TYPE_WIFI,

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabIp4Ui.java
@@ -61,7 +61,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
     private static final String DNS_REGEX = "[\\s,;\\n\\t]+";
     private static final String NET_IPV4_STATUS_ENABLED_WAN = "netIPv4StatusEnabledWAN";
     private static final String NET_IPV4_STATUS_ENABLED_LAN = "netIPv4StatusEnabledLAN";
-    private static final String NET_IPV4_STATUS_L2_ONLY = "netIPv4StatusL2Only";
     private static final String NET_IPV4_STATUS_UNMANAGED = "netIPv4StatusUnmanaged";
     private static final String NET_IPV4_STATUS_DISABLED = "netIPv4StatusDisabled";
     private static final String IPV4_MODE_MANUAL = GwtNetIfConfigMode.netIPv4ConfigModeManual.name();
@@ -72,7 +71,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
     private static final String IPV4_STATUS_LAN = GwtNetIfStatus.netIPv4StatusEnabledLAN.name();
     private static final String IPV4_STATUS_LAN_MESSAGE = MessageUtils.get(IPV4_STATUS_LAN);
     private static final String IPV4_STATUS_UNMANAGED = GwtNetIfStatus.netIPv4StatusUnmanaged.name();
-    private static final String IPV4_STATUS_L2ONLY = GwtNetIfStatus.netIPv4StatusL2Only.name();
 
     private static final String IPV4_STATUS_DISABLED = GwtNetIfStatus.netIPv4StatusDisabled.name();
     private static final String IPV4_STATUS_DISABLED_MESSAGE = MessageUtils.get(IPV4_STATUS_DISABLED);
@@ -220,7 +218,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
         this.status.addItem(MessageUtils.get(NET_IPV4_STATUS_UNMANAGED));
 
         if (this.selectedNetIfConfig != null && this.selectedNetIfConfig.getHwTypeEnum() != GwtNetIfType.MODEM) {
-            this.status.addItem(MessageUtils.get(NET_IPV4_STATUS_L2_ONLY));
             this.status.addItem(MessageUtils.get(NET_IPV4_STATUS_ENABLED_LAN));
         }
         this.status.addItem(MessageUtils.get(NET_IPV4_STATUS_ENABLED_WAN));
@@ -232,8 +229,6 @@ public class TabIp4Ui extends Composite implements NetworkTab {
 
             if (this.status.getSelectedItemText().equals(MessageUtils.get(NET_IPV4_STATUS_UNMANAGED))) {
                 updatedNetIf.setStatus(IPV4_STATUS_UNMANAGED);
-            } else if (this.status.getSelectedItemText().equals(MessageUtils.get(NET_IPV4_STATUS_L2_ONLY))) {
-                updatedNetIf.setStatus(IPV4_STATUS_L2ONLY);
             } else if (this.status.getSelectedItemText().equals(MessageUtils.get(NET_IPV4_STATUS_ENABLED_LAN))) {
                 updatedNetIf.setStatus(IPV4_STATUS_LAN);
             } else if (this.status.getSelectedItemText().equals(MessageUtils.get(NET_IPV4_STATUS_ENABLED_WAN))) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.core.net.util.NetworkUtil;
+import org.eclipse.kura.web.shared.model.GwtNetIfStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,8 +92,8 @@ public class NetworkConfigurationServiceProperties {
                 this.properties.get(String.format(NET_INTERFACE_CONFIG_IP4_STATUS, ifname)));
 
         // L2Only is an alias for Unmanaged
-        if (ip4Status.isPresent() && ip4Status.get().equals("netIPv4StatusL2Only")) {
-            return Optional.of("netIPv4StatusUnmanaged");
+        if (ip4Status.isPresent() && ip4Status.get().equals(GwtNetIfStatus.netIPv4StatusL2Only.name())) {
+            return Optional.of(GwtNetIfStatus.netIPv4StatusUnmanaged.name());
         }
 
         return ip4Status;

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -87,7 +87,15 @@ public class NetworkConfigurationServiceProperties {
     private static final String NET_INTERFACE_CONFIG_IP4_DNS_SERVERS = "net.interface.%s.config.ip4.dnsServers";
 
     public Optional<String> getIp4Status(String ifname) {
-        return getNonEmptyStringProperty(this.properties.get(String.format(NET_INTERFACE_CONFIG_IP4_STATUS, ifname)));
+        Optional<String> ip4Status = getNonEmptyStringProperty(
+                this.properties.get(String.format(NET_INTERFACE_CONFIG_IP4_STATUS, ifname)));
+
+        // L2Only is an alias for Unmanaged
+        if (ip4Status.isPresent() && ip4Status.get().equals("netIPv4StatusL2Only")) {
+            return Optional.of("netIPv4StatusUnmanaged");
+        } else {
+            return ip4Status;
+        }
     }
 
     public void setIp4Status(String ifname, String status) {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *  Areti

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServiceProperties.java
@@ -93,9 +93,9 @@ public class NetworkConfigurationServiceProperties {
         // L2Only is an alias for Unmanaged
         if (ip4Status.isPresent() && ip4Status.get().equals("netIPv4StatusL2Only")) {
             return Optional.of("netIPv4StatusUnmanaged");
-        } else {
-            return ip4Status;
         }
+
+        return ip4Status;
     }
 
     public void setIp4Status(String ifname, String status) {

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
 package org.eclipse.kura.nm;
 
 import static org.junit.Assert.assertEquals;

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
@@ -32,6 +32,10 @@ public class KuraInterfaceStatusTest {
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][] { //
                 { KuraIpStatus.DISABLED, KuraIpStatus.DISABLED, KuraInterfaceStatus.DISABLED, null }, //
+                { KuraIpStatus.ENABLEDLAN, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.ENABLED, null }, //
+                { KuraIpStatus.ENABLEDWAN, KuraIpStatus.ENABLEDWAN, KuraInterfaceStatus.ENABLED, null }, //
+                { KuraIpStatus.ENABLEDLAN, KuraIpStatus.ENABLEDWAN, KuraInterfaceStatus.ENABLED, null }, //
+                { KuraIpStatus.ENABLEDWAN, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.ENABLED, null }, //
                 { KuraIpStatus.ENABLEDLAN, KuraIpStatus.DISABLED, KuraInterfaceStatus.ENABLED, null }, //
                 { KuraIpStatus.ENABLEDWAN, KuraIpStatus.DISABLED, KuraInterfaceStatus.ENABLED, null }, //
                 { KuraIpStatus.DISABLED, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.ENABLED, null }, //

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
@@ -1,0 +1,18 @@
+package org.eclipse.kura.nm;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class KuraInterfaceStatusTest {
+
+    @Test
+    public void test() {
+        KuraIpStatus ip4Status = KuraIpStatus.DISABLED;
+        KuraIpStatus ip6Status = KuraIpStatus.DISABLED;
+
+        assertEquals(KuraInterfaceStatus.DISABLED, KuraInterfaceStatus.fromKuraIpStatus(ip4Status, ip6Status));
+
+    }
+
+}

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
@@ -2,17 +2,70 @@ package org.eclipse.kura.nm;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
+import java.util.Arrays;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
 public class KuraInterfaceStatusTest {
 
+    @Parameter(0)
+    public KuraIpStatus ip4Status;
+    @Parameter(1)
+    public KuraIpStatus ip6Status;
+    @Parameter(2)
+    public KuraInterfaceStatus expectedResult;
+
+    @Parameter(3)
+    public Class<? extends Exception> expectedException;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Parameters
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] { //
+                { KuraIpStatus.DISABLED, KuraIpStatus.DISABLED, KuraInterfaceStatus.DISABLED, null }, //
+                { KuraIpStatus.ENABLEDLAN, KuraIpStatus.DISABLED, KuraInterfaceStatus.ENABLED, null }, //
+                { KuraIpStatus.ENABLEDWAN, KuraIpStatus.DISABLED, KuraInterfaceStatus.ENABLED, null }, //
+                { KuraIpStatus.DISABLED, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.ENABLED, null }, //
+                { KuraIpStatus.DISABLED, KuraIpStatus.ENABLEDWAN, KuraInterfaceStatus.ENABLED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.DISABLED, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.ENABLEDWAN, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.L2ONLY, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.UNKNOWN, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.UNMANAGED, KuraIpStatus.UNMANAGED, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.UNMANAGED, KuraIpStatus.DISABLED, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNMANAGED, KuraIpStatus.ENABLEDLAN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNMANAGED, KuraIpStatus.ENABLEDWAN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNMANAGED, KuraIpStatus.L2ONLY, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNKNOWN, KuraIpStatus.DISABLED, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNKNOWN, KuraIpStatus.ENABLEDLAN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNKNOWN, KuraIpStatus.ENABLEDWAN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNKNOWN, KuraIpStatus.L2ONLY, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNKNOWN, KuraIpStatus.UNMANAGED, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNKNOWN, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.DISABLED, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.ENABLEDLAN, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.ENABLEDWAN, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNMANAGED, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
+        });
+    }
+
     @Test
-    public void test() {
-        KuraIpStatus ip4Status = KuraIpStatus.DISABLED;
-        KuraIpStatus ip6Status = KuraIpStatus.DISABLED;
+    public void test() throws IllegalArgumentException {
+        if (expectedException != null) {
+            thrown.expect(expectedException);
+        }
 
-        assertEquals(KuraInterfaceStatus.DISABLED, KuraInterfaceStatus.fromKuraIpStatus(ip4Status, ip6Status));
-
+        assertEquals(expectedResult, KuraInterfaceStatus.fromKuraIpStatus(ip4Status, ip6Status));
     }
 
 }

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
@@ -44,7 +44,6 @@ public class KuraInterfaceStatusTest {
                 { KuraIpStatus.L2ONLY, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.UNMANAGED, null }, //
                 { KuraIpStatus.L2ONLY, KuraIpStatus.ENABLEDWAN, KuraInterfaceStatus.UNMANAGED, null }, //
                 { KuraIpStatus.L2ONLY, KuraIpStatus.L2ONLY, KuraInterfaceStatus.UNMANAGED, null }, //
-                { KuraIpStatus.L2ONLY, KuraIpStatus.UNKNOWN, KuraInterfaceStatus.UNMANAGED, null }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.UNMANAGED, KuraInterfaceStatus.UNMANAGED, null }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.DISABLED, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.ENABLEDLAN, null, IllegalArgumentException.class }, //
@@ -60,6 +59,7 @@ public class KuraInterfaceStatusTest {
                 { KuraIpStatus.ENABLEDLAN, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.ENABLEDWAN, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
         });
     }
 

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
@@ -40,13 +40,20 @@ public class KuraInterfaceStatusTest {
                 { KuraIpStatus.ENABLEDWAN, KuraIpStatus.DISABLED, KuraInterfaceStatus.ENABLED, null }, //
                 { KuraIpStatus.DISABLED, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.ENABLED, null }, //
                 { KuraIpStatus.DISABLED, KuraIpStatus.ENABLEDWAN, KuraInterfaceStatus.ENABLED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.DISABLED, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.ENABLEDWAN, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.L2ONLY, KuraInterfaceStatus.UNMANAGED, null }, //
+                { KuraIpStatus.L2ONLY, KuraIpStatus.UNKNOWN, KuraInterfaceStatus.UNMANAGED, null }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.UNMANAGED, KuraInterfaceStatus.UNMANAGED, null }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.DISABLED, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.ENABLEDLAN, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.ENABLEDWAN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNMANAGED, KuraIpStatus.L2ONLY, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.DISABLED, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.ENABLEDLAN, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.ENABLEDWAN, null, IllegalArgumentException.class }, //
+                { KuraIpStatus.UNKNOWN, KuraIpStatus.L2ONLY, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.UNMANAGED, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.DISABLED, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/KuraInterfaceStatusTest.java
@@ -40,20 +40,13 @@ public class KuraInterfaceStatusTest {
                 { KuraIpStatus.ENABLEDWAN, KuraIpStatus.DISABLED, KuraInterfaceStatus.ENABLED, null }, //
                 { KuraIpStatus.DISABLED, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.ENABLED, null }, //
                 { KuraIpStatus.DISABLED, KuraIpStatus.ENABLEDWAN, KuraInterfaceStatus.ENABLED, null }, //
-                { KuraIpStatus.L2ONLY, KuraIpStatus.DISABLED, KuraInterfaceStatus.UNMANAGED, null }, //
-                { KuraIpStatus.L2ONLY, KuraIpStatus.ENABLEDLAN, KuraInterfaceStatus.UNMANAGED, null }, //
-                { KuraIpStatus.L2ONLY, KuraIpStatus.ENABLEDWAN, KuraInterfaceStatus.UNMANAGED, null }, //
-                { KuraIpStatus.L2ONLY, KuraIpStatus.L2ONLY, KuraInterfaceStatus.UNMANAGED, null }, //
-                { KuraIpStatus.L2ONLY, KuraIpStatus.UNKNOWN, KuraInterfaceStatus.UNMANAGED, null }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.UNMANAGED, KuraInterfaceStatus.UNMANAGED, null }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.DISABLED, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.ENABLEDLAN, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNMANAGED, KuraIpStatus.ENABLEDWAN, null, IllegalArgumentException.class }, //
-                { KuraIpStatus.UNMANAGED, KuraIpStatus.L2ONLY, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.DISABLED, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.ENABLEDLAN, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.ENABLEDWAN, null, IllegalArgumentException.class }, //
-                { KuraIpStatus.UNKNOWN, KuraIpStatus.L2ONLY, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.UNMANAGED, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.UNKNOWN, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //
                 { KuraIpStatus.DISABLED, KuraIpStatus.UNKNOWN, null, IllegalArgumentException.class }, //


### PR DESCRIPTION
This PR fixes the behaviour of the `netIPv4StatusL2Only`/`netIPv6StatusL2Only` parameter.

Up until now `netIPvXStatusL2Only` was not correctly supported in our codebase in our generic profiles. See: 

https://github.com/eclipse-kura/kura/blob/ca95dd7a2e92ae50999c89bef3847193da2c83f0/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java#L87-L88

This meant that, when configured as `netIPvXStatusL2Only`, Kura would quit configuration without touching the interface. See 

https://github.com/eclipse-kura/kura/blob/ca95dd7a2e92ae50999c89bef3847193da2c83f0/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/NMDbusConnector.java#L467-L472

This behaviour technically still obtains the desired configuration (interface is up and the user is free to configure it) but is not quite correct.

This PR simply promotes `netIPv4StatusL2Only` to an alias of `netIPv4StatusUnmanaged` thus obtaining the expected behaviour.

**Note**: To preserve the compatibility with older Kura versions and the old-networking profiles, specifying only IPv4 as "L2Only" will suffice to set the whole interface as "Unmanaged". This is due to the fact that originally, there was no IPv6 support.

For "Unmanaged" we require users to set both IPv4 and IPv6 as "Unmanaged" otherwise we will throw an error. This is because "Unmanaged" is a property of the **whole network interface** not only the IPv4/6 part of the settings. The same applies for L2Only **but**, requiring the IPv4 and IPv6 status to be both set to L2Only would break compatibility with old snapshots.

@pierantoniomerlino I have only one doubt: currently, if the IPv6 status is `UNKNOWN` the method won't throw an exception. The original idea was to throw an exception when any of the statuses was `UNKNOWN` but, if we do with `L2ONLY`, we might risk breaking existing snapshots? What do you think?

You can use the introduced tests to understand what's going on.