### PR TITLE
feat(core.configuration): Improved snapshot rollback

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -984,7 +984,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         long sid = new Date().getTime();
 
         // Do not save the snapshot in the past
-        SortedSet<Long> snapshotIDs = getSnapshotsInternal();
+        SortedSet<Long> snapshotIDs = (SortedSet<Long>) getSnapshots();
         if (snapshotIDs != null && !snapshotIDs.isEmpty()) {
             Long lastestID = snapshotIDs.last();
 

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -17,12 +17,11 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -49,6 +48,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
+import org.eclipse.kura.KuraIOException;
 import org.eclipse.kura.KuraPartialSuccessException;
 import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.ConfigurableComponent;
@@ -587,7 +587,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             try {
                 updateWithDefaultConfiguration(metatypePid, ocd);
             } catch (IOException e) {
-                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+                throw new KuraIOException(e);
             }
         }
     }
@@ -617,8 +617,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                 if (factoryOCD != null) {
                     try {
                         updateWithDefaultConfiguration(pid, factoryOCD);
-                    } catch (KuraException e) {
-                        logger.info("Error seeding updated configuration for pid: {}", pid);
                     } catch (IOException e) {
                         logger.info("Error seeding updated configuration for pid: {}", pid);
                     }
@@ -657,7 +655,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         this.allActivatedPids.remove(pid);
     }
 
-    boolean mergeWithDefaults(OCD ocd, Map<String, Object> properties) throws KuraException {
+    boolean mergeWithDefaults(OCD ocd, Map<String, Object> properties) {
         boolean changed = false;
         Set<String> keys = properties.keySet();
 
@@ -680,7 +678,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         return changed;
     }
 
-    Map<String, Object> getDefaultProperties(OCD ocd) throws KuraException {
+    Map<String, Object> getDefaultProperties(OCD ocd) {
         return ComponentUtil.getDefaultProperties(ocd, this.ctx);
     }
 
@@ -689,13 +687,16 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             Object configValue = property.getValue();
 
             if (configValue instanceof Password || configValue instanceof Password[]) {
+                Object decryptedValue;
                 try {
-                    Object decryptedValue = decryptPasswordProperties(configValue);
+                    decryptedValue = decryptPasswordProperties(configValue);
                     configProperties.put(property.getKey(), decryptedValue);
-                } catch (Exception e) {
+                } catch (KuraException e) {
+                    logger.error("Failed to decrypt password properties", e);
                 }
             }
         }
+
     }
 
     private Object decryptPasswordProperties(Object encryptedValue) throws KuraException {
@@ -788,7 +789,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                     configs.add(cc);
                 }
             } catch (Exception e) {
-                logger.error("Error getting configuration for component " + pid, e);
                 throw new KuraException(KuraErrorCode.CONFIGURATION_ERROR, e,
                         "Error getting configuration for component " + pid);
             }
@@ -871,7 +871,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         return cc;
     }
 
-    private void updateWithDefaultConfiguration(String pid, Tocd ocd) throws KuraException, IOException {
+    private void updateWithDefaultConfiguration(String pid, Tocd ocd) throws IOException {
         String servicePid = this.servicePidByPid.get(pid);
         if (servicePid == null) {
             servicePid = pid;
@@ -904,33 +904,29 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                 try {
                     updateWithDefaultConfiguration(entry.getKey(), ocd);
                 } catch (IOException e) {
-                    throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+                    throw new KuraIOException(e);
                 }
             }
         }
     }
 
-    private boolean allSnapshotsUnencrypted() {
+    private boolean allSnapshotsAreUnencrypted() {
+        Set<Long> snapshotIDs;
         try {
-            Set<Long> snapshotIDs = getSnapshots();
-            if (snapshotIDs == null || snapshotIDs.isEmpty()) {
-                return false;
-            }
-            Long[] snapshots = snapshotIDs.toArray(new Long[] {});
-
-            for (Long snapshot : snapshots) {
-
-                try {
-                    // Verify if the current snapshot is encrypted
-                    loadEncryptedSnapshotFileContent(snapshot);
-                    return false;
-                } catch (Exception e) {
-                }
-            }
-            return true;
-        } catch (Exception e) {
+            snapshotIDs = getSnapshots();
+        } catch (KuraException e) {
             return false;
         }
+
+        for (Long snapshot : snapshotIDs) {
+            try {
+                loadEncryptedSnapshotFileContent(snapshot);
+                return false;
+            } catch (Exception e) {
+                // Do nothing...
+            }
+        }
+        return true;
     }
 
     private static String readFully(final File file) throws IOException {
@@ -1010,53 +1006,25 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
 
         // Marshall the configuration into an XML
         String xmlResult;
-        try {
-            xmlResult = marshal(conf);
-            if (xmlResult == null || xmlResult.trim().isEmpty()) {
-                throw new KuraException(KuraErrorCode.INVALID_PARAMETER, conf);
-            }
-        } catch (KuraException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
+        xmlResult = marshal(conf);
+        if (xmlResult == null || xmlResult.trim().isEmpty()) {
+            throw new KuraException(KuraErrorCode.INVALID_PARAMETER, conf);
         }
 
         // Encrypt the XML
         char[] encryptedXML = this.cryptoService.encryptAes(xmlResult.toCharArray());
 
         // Write the snapshot
-        FileOutputStream fos = null;
-        OutputStreamWriter osw = null;
-        try {
+        try (FileOutputStream fos = new FileOutputStream(fSnapshot);
+                OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);) {
             logger.info("Writing snapshot - Saving {}...", fSnapshot.getAbsolutePath());
-            fos = new FileOutputStream(fSnapshot);
-            osw = new OutputStreamWriter(fos, "UTF-8");
             osw.append(new String(encryptedXML));
             osw.flush();
             fos.flush();
             fos.getFD().sync();
             logger.info("Writing snapshot - Saving {}... Done.", fSnapshot.getAbsolutePath());
-        } catch (FileNotFoundException e) {
-            throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
-        } catch (UnsupportedEncodingException e) {
-            throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
         } catch (IOException e) {
-            throw new KuraException(KuraErrorCode.INTERNAL_ERROR, e);
-        } finally {
-            if (osw != null) {
-                try {
-                    osw.close();
-                } catch (IOException e) {
-
-                }
-            }
-            if (fos != null) {
-                try {
-                    fos.close();
-                } catch (IOException e) {
-
-                }
-            }
+            throw new KuraIOException(e);
         }
     }
 
@@ -1294,7 +1262,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         // Get the latest snapshot file to use as initialization
         Set<Long> snapshotIDs = getSnapshots();
         if (snapshotIDs == null || snapshotIDs.isEmpty()) {
-            return null;
+            return Collections.emptyList();
         }
 
         Long[] snapshots = snapshotIDs.toArray(new Long[] {});
@@ -1313,12 +1281,12 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         } catch (Exception e) {
             logger.info("Unable to decrypt snapshot! Fallback to unencrypted snapshots mode.");
             try {
-                if (allSnapshotsUnencrypted()) {
+                if (allSnapshotsAreUnencrypted()) {
                     encryptPlainSnapshots();
                     configs = loadLatestSnapshotConfigurations();
                 }
             } catch (Exception ex) {
-                throw new KuraException(KuraErrorCode.INTERNAL_ERROR, ex);
+                throw new KuraIOException(ex);
             }
         }
 
@@ -1415,9 +1383,10 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         if (!this.activatedSelfConfigComponents.contains(pid)) {
 
             // load the ocd to do the validation
-            BundleContext ctx = this.ctx.getBundleContext();
+            BundleContext bundleCtx = this.ctx.getBundleContext();
             // FIXME: why the returned ocd is always null?
-            ObjectClassDefinition ocd = ComponentUtil.getObjectClassDefinition(ctx, this.servicePidByPid.get(pid));
+            ObjectClassDefinition ocd = ComponentUtil.getObjectClassDefinition(bundleCtx,
+                    this.servicePidByPid.get(pid));
 
             // Validate the properties to be applied and set them
             validateProperties(pid, ocd, mergedProperties);
@@ -1542,7 +1511,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         // complete the returned configurations adding the snapshot configurations
         // of those components not yet in the list.
         List<ComponentConfiguration> snapshotConfigs = loadLatestSnapshotConfigurations();
-        if (snapshotConfigs != null) {
+        if (snapshotConfigs != null && !snapshotConfigs.isEmpty()) {
             for (ComponentConfiguration snapshotConfig : snapshotConfigs) {
                 boolean found = false;
                 for (ComponentConfiguration config : result) {
@@ -1720,7 +1689,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
     }
 
     private void rollbackConfigurationInternal(final ComponentConfiguration snapshotConfig,
-            final Optional<Configuration> existingConfig) throws IOException, KuraException {
+            final Optional<Configuration> existingConfig) throws IOException {
         final Optional<String> factoryPid = Optional
                 .ofNullable(snapshotConfig.getConfigurationProperties().get(ConfigurationAdmin.SERVICE_FACTORYPID))
                 .filter(String.class::isInstance).map(String.class::cast);
@@ -1743,11 +1712,11 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         if (existingConfig.isPresent()) {
             target = existingConfig.get();
         } else if (factoryPid.isPresent()) {
-            logger.info("creating new factory configuration for pid {} and factory pid {}", snapshotConfig.getPid(),
+            logger.info("Creating new factory configuration for pid {} and factory pid {}", snapshotConfig.getPid(),
                     factoryPid.get());
             target = this.configurationAdmin.createFactoryConfiguration(factoryPid.get(), null);
         } else {
-            logger.info("creating new configuration for pid {}", snapshotConfig.getPid());
+            logger.info("Creating new configuration for pid {}", snapshotConfig.getPid());
             target = this.configurationAdmin.getConfiguration(snapshotConfig.getPid());
         }
 
@@ -1758,7 +1727,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         }
 
         if (!CollectionsUtil.equals(resultAsDictionary, currentProperties)) {
-            logger.info("updating configuration for pid {}", snapshotConfig.getPid());
+            logger.info("Updating configuration for pid {}", snapshotConfig.getPid());
             target.update(resultAsDictionary);
             if (factoryPid.isPresent()) {
                 registerComponentConfiguration(snapshotConfig.getPid(), target.getPid(), factoryPid.get());

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -1669,7 +1669,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                 .ofNullable(currentConfigs.get(snapshotConfig.getPid()));
 
         try {
-            logger.info("Procession configuration rollback for component with pid {}...", snapshotConfig.getPid());
+            logger.info("Processing configuration rollback for component with pid {}...", snapshotConfig.getPid());
             rollbackConfigurationInternal(snapshotConfig, optionalCurrentConfig);
         } catch (IOException e) {
             logger.warn("Failed to rollback configuration for pid {}", snapshotConfig.getPid(), e);

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -726,25 +726,10 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
 
     private synchronized void updateConfigurationsInternal(List<ComponentConfiguration> configsToUpdate,
             boolean takeSnapshot) throws KuraException {
-        boolean snapshotOnConfirmation = false;
         List<Throwable> causes = new ArrayList<>();
-
         List<ComponentConfiguration> configs = buildCurrentConfiguration(configsToUpdate);
 
-        for (ComponentConfiguration config : configs) {
-            for (ComponentConfiguration configToUpdate : configsToUpdate) {
-                if (config.getPid().equals(configToUpdate.getPid())) {
-                    try {
-                        updateConfigurationInternal(config.getPid(), config.getConfigurationProperties(),
-                                snapshotOnConfirmation);
-                    } catch (KuraException e) {
-                        logger.warn("Error during updateConfigurations for component " + config.getPid(), e);
-                        causes.add(e);
-                    }
-                    break;
-                }
-            }
-        }
+        updateConfigurationInternal(configsToUpdate, configs, causes);
 
         // this step creates any not yet existing factory configuration present in configsToUpdate
         for (ComponentConfiguration config : configsToUpdate) {
@@ -772,6 +757,23 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
 
         if (!causes.isEmpty()) {
             throw new KuraPartialSuccessException("updateConfigurations", causes);
+        }
+    }
+
+    private void updateConfigurationInternal(List<ComponentConfiguration> configsToUpdate,
+            List<ComponentConfiguration> configs, List<Throwable> causes) {
+        for (ComponentConfiguration config : configs) {
+            for (ComponentConfiguration configToUpdate : configsToUpdate) {
+                if (config.getPid().equals(configToUpdate.getPid())) {
+                    try {
+                        updateConfigurationInternal(config.getPid(), config.getConfigurationProperties(), false);
+                    } catch (KuraException e) {
+                        logger.warn("Error during updateConfigurations for component " + config.getPid(), e);
+                        causes.add(e);
+                    }
+                    break;
+                }
+            }
         }
     }
 
@@ -1224,36 +1226,45 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                     String factoryPid = (String) props.get(ConfigurationAdmin.SERVICE_FACTORYPID);
 
                     if (factoryPid != null) {
-                        String pid = config.getPid();
-                        logger.info("Creating configuration with pid: {} and factory pid: {}", pid, factoryPid);
-                        try {
-                            createFactoryConfiguration(factoryPid, pid, props, false);
-                        } catch (KuraException e) {
-                            logger.warn("Error creating configuration with pid: {} and factory pid: {}", pid,
-                                    factoryPid, e);
-                        }
+                        createFactoryConfiguration(config, props, factoryPid);
                     } else {
-                        try {
-                            logger.debug("Pushing config to config admin: {}", config.getPid());
-
-                            // push it to the ConfigAdmin
-                            Configuration cfg = this.configurationAdmin.getConfiguration(config.getPid(), "?");
-
-                            // set kura.service.pid if missing
-                            Map<String, Object> newProperties = new HashMap<>(props);
-                            if (!newProperties.containsKey(ConfigurationService.KURA_SERVICE_PID)) {
-                                newProperties.put(ConfigurationService.KURA_SERVICE_PID, config.getPid());
-                            }
-
-                            cfg.update(CollectionsUtil.mapToDictionary(newProperties));
-
-                        } catch (IOException e) {
-                            logger.warn("Error seeding initial properties to ConfigAdmin for pid: {}", config.getPid(),
-                                    e);
-                        }
+                        loadConfiguration(config, props);
                     }
                 }
             }
+        }
+    }
+
+    private void loadConfiguration(ComponentConfiguration config, Map<String, Object> props) {
+        try {
+            logger.debug("Pushing config to config admin: {}", config.getPid());
+
+            // push it to the ConfigAdmin
+            Configuration cfg = this.configurationAdmin.getConfiguration(config.getPid(), "?");
+
+            // set kura.service.pid if missing
+            Map<String, Object> newProperties = new HashMap<>(props);
+            if (!newProperties.containsKey(ConfigurationService.KURA_SERVICE_PID)) {
+                newProperties.put(ConfigurationService.KURA_SERVICE_PID, config.getPid());
+            }
+
+            cfg.update(CollectionsUtil.mapToDictionary(newProperties));
+
+        } catch (IOException e) {
+            logger.warn("Error seeding initial properties to ConfigAdmin for pid: {}", config.getPid(),
+                    e);
+        }
+    }
+
+    private void createFactoryConfiguration(ComponentConfiguration config, Map<String, Object> props,
+            String factoryPid) {
+        String pid = config.getPid();
+        logger.info("Creating configuration with pid: {} and factory pid: {}", pid, factoryPid);
+        try {
+            createFactoryConfiguration(factoryPid, pid, props, false);
+        } catch (KuraException e) {
+            logger.warn("Error creating configuration with pid: {} and factory pid: {}", pid,
+                    factoryPid, e);
         }
     }
 
@@ -1373,7 +1384,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             updateComponentConfiguration(pid, mergedProperties, snapshotOnConfirmation);
             logger.info("Updating Configuration of ConfigurableComponent {} ... Done.", pid);
         } catch (IOException e) {
-            logger.warn("Error updating Configuration of ConfigurableComponent with pid {}", pid, e);
             throw new KuraException(KuraErrorCode.CONFIGURATION_UPDATE, e, pid);
         }
     }
@@ -1420,59 +1430,52 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
 
     private void validateProperties(String pid, ObjectClassDefinition ocd, Map<String, Object> updatedProps)
             throws KuraException {
-        if (ocd != null) {
+        if (ocd == null) {
+            return;
+        }
 
-            // build a map of all the attribute definitions
-            Map<String, AttributeDefinition> attrDefs = new HashMap<>();
-            AttributeDefinition[] defs = ocd.getAttributeDefinitions(ObjectClassDefinition.ALL);
-            for (AttributeDefinition def : defs) {
-                attrDefs.put(def.getID(), def);
+        // build a map of all the attribute definitions
+        List<AttributeDefinition> definitions = Arrays.asList(ocd.getAttributeDefinitions(ObjectClassDefinition.ALL));
+        Map<String, AttributeDefinition> attributeDefinitions = definitions.stream()
+                .collect(Collectors.toMap(AttributeDefinition::getID, Function.identity()));
+
+        // loop over the proposed property values
+        // and validate them against the definition
+        for (Entry<String, Object> property : updatedProps.entrySet()) {
+
+            String key = property.getKey();
+            AttributeDefinition attributeDefinition = attributeDefinitions.get(key);
+
+            if (attributeDefinition == null) {
+                // For the attribute for which we do not have a definition, just accept them.
+                continue;
             }
 
-            // loop over the proposed property values
-            // and validate them against the definition
-            for (Entry<String, Object> property : updatedProps.entrySet()) {
+            validateAttribute(property, attributeDefinition);
+        }
 
-                String key = property.getKey();
-                AttributeDefinition attrDef = attrDefs.get(key);
-
-                // is attribute undefined?
-                if (attrDef == null) {
-                    // we do not have an attribute descriptor to the validation
-                    // against
-                    // As OSGI insert attributes at runtime like service.pid,
-                    // component.name,
-                    // for the attribute for which we do not have a definition,
-                    // just accept them.
-                    continue;
-                }
-
-                // validate the attribute value
-                Object objectValue = property.getValue();
-                String stringValue = StringUtil.valueToString(objectValue);
-                if (stringValue != null) {
-                    String result = attrDef.validate(stringValue);
-                    if (result != null && !result.isEmpty()) {
-                        throw new KuraException(KuraErrorCode.CONFIGURATION_ATTRIBUTE_INVALID, attrDef.getID(),
-                                stringValue, result);
-                    }
+        // make sure all required properties are set
+        OCD ocdFull = getOCDForPid(pid);
+        if (ocdFull != null) {
+            for (AD attrDef : ocdFull.getAD()) {
+                // to the required attributes make sure a value is defined.
+                if (attrDef.isRequired() && updatedProps.get(attrDef.getId()) == null) {
+                    // if the default one is not defined, throw exception.
+                    throw new KuraException(KuraErrorCode.CONFIGURATION_REQUIRED_ATTRIBUTE_MISSING, attrDef.getId());
                 }
             }
+        }
+    }
 
-            // make sure all required properties are set
-            OCD ocdFull = getOCDForPid(pid);
-            if (ocdFull != null) {
-                for (AD attrDef : ocdFull.getAD()) {
-                    // to the required attributes make sure a value is defined.
-                    if (attrDef.isRequired()) {
-                        if (updatedProps.get(attrDef.getId()) == null) {
-                            // if the default one is not defined, throw
-                            // exception.
-                            throw new KuraException(KuraErrorCode.CONFIGURATION_REQUIRED_ATTRIBUTE_MISSING,
-                                    attrDef.getId());
-                        }
-                    }
-                }
+    private void validateAttribute(Entry<String, Object> property, AttributeDefinition attributeDefinition)
+            throws KuraException {
+        // validate the attribute value
+        String stringValue = StringUtil.valueToString(property.getValue());
+        if (stringValue != null) {
+            String result = attributeDefinition.validate(stringValue);
+            if (result != null && !result.isEmpty()) {
+                throw new KuraException(KuraErrorCode.CONFIGURATION_ATTRIBUTE_INVALID, attributeDefinition.getID(),
+                        stringValue, result);
             }
         }
     }
@@ -1481,33 +1484,28 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             List<ComponentConfiguration> configsToUpdate) throws KuraException {
         List<ComponentConfiguration> result = new ArrayList<>();
 
-        // Merge the current configuration of registered components with the provided configurations.
-        // It is assumed that the PIDs in the provided configurations is a subset of the registered PIDs.
-        List<ComponentConfiguration> currentConfigs = getComponentConfigurationsInternal();
-        if (currentConfigs != null) {
-            for (ComponentConfiguration currentConfig : currentConfigs) {
-                // either add this configuration or a new one obtained by merging its properties with the ones provided
-                ComponentConfiguration cc = currentConfig;
-                String pid = currentConfig.getPid();
-                if (configsToUpdate != null) {
-                    for (ComponentConfiguration configToUpdate : configsToUpdate) {
-                        if (configToUpdate.getPid().equals(pid)) {
-                            Map<String, Object> props = new HashMap<>();
-                            if (currentConfig.getConfigurationProperties() != null) {
-                                props.putAll(currentConfig.getConfigurationProperties());
-                            }
-                            if (configToUpdate.getConfigurationProperties() != null) {
-                                props.putAll(configToUpdate.getConfigurationProperties());
-                            }
-                            cc = new ComponentConfigurationImpl(pid, (Tocd) configToUpdate.getDefinition(), props);
-                            break;
-                        }
-                    }
+        mergeConfigurations(configsToUpdate, result);
+        addSnapshotConfigurations(result);
+
+        // remove configurations being deleted
+        for (String deletedPid : this.pendingDeletePids) {
+            for (ComponentConfiguration config : result) {
+                if (config.getPid().equals(deletedPid)) {
+                    result.remove(config);
+                    break;
                 }
-                result.add(cc);
             }
         }
 
+        for (final ComponentConfiguration config : result) {
+            ConfigurationUpgrade.upgrade(config, this.bundleContext);
+        }
+
+        return result;
+
+    }
+
+    private void addSnapshotConfigurations(List<ComponentConfiguration> result) throws KuraException {
         // complete the returned configurations adding the snapshot configurations
         // of those components not yet in the list.
         List<ComponentConfiguration> snapshotConfigs = loadLatestSnapshotConfigurations();
@@ -1526,23 +1524,44 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                 }
             }
         }
+    }
 
-        // remove configurations being deleted
-        for (String deletedPid : this.pendingDeletePids) {
-            for (ComponentConfiguration config : result) {
-                if (config.getPid().equals(deletedPid)) {
-                    result.remove(config);
+    private void mergeConfigurations(List<ComponentConfiguration> configsToUpdate, List<ComponentConfiguration> result)
+            throws KuraException {
+        // Merge the current configuration of registered components with the provided configurations.
+        // It is assumed that the PIDs in the provided configurations is a subset of the registered PIDs.
+        
+        List<ComponentConfiguration> currentConfigs = getComponentConfigurationsInternal();
+        if (configsToUpdate == null || configsToUpdate.isEmpty()) {
+            result.addAll(currentConfigs);
+            return;
+        }
+
+        for (ComponentConfiguration currentConfig : currentConfigs) {
+            // add new configuration obtained by merging its properties with the ones provided
+            ComponentConfiguration cc = currentConfig;
+            String pid = currentConfig.getPid();
+            for (ComponentConfiguration configToUpdate : configsToUpdate) {
+                if (configToUpdate.getPid().equals(pid)) {
+                    Map<String, Object> props = getAllProperties(currentConfig, configToUpdate);
+                    cc = new ComponentConfigurationImpl(pid, (Tocd) configToUpdate.getDefinition(), props);
                     break;
                 }
             }
+            result.add(cc);
         }
+    }
 
-        for (final ComponentConfiguration config : result) {
-            ConfigurationUpgrade.upgrade(config, this.bundleContext);
+    private Map<String, Object> getAllProperties(ComponentConfiguration currentConfig,
+            ComponentConfiguration configToUpdate) {
+        Map<String, Object> props = new HashMap<>();
+        if (currentConfig.getConfigurationProperties() != null) {
+            props.putAll(currentConfig.getConfigurationProperties());
         }
-
-        return result;
-
+        if (configToUpdate.getConfigurationProperties() != null) {
+            props.putAll(configToUpdate.getConfigurationProperties());
+        }
+        return props;
     }
 
     private Tocd getOCDForPid(String pid) {
@@ -1653,7 +1672,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
 
         try {
             rollbackConfig(snapshotConfig, optionalCurrentConfig);
-        } catch (IOException | KuraException e) {
+        } catch (IOException e) {
             logger.warn("Failed to rollback configuration for pid {}", snapshotConfig.getPid(), e);
             causes.add(e);
         }
@@ -1670,7 +1689,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             if (!optionalSnapshotConfig.isPresent() && this.allActivatedPids.contains(currentConfigEntry.getKey())) {
                 try {
                     rollbackToDefaultConfig(currentConfigEntry);
-                } catch (IOException | KuraException e) {
+                } catch (IOException e) {
                     logger.warn("Failed to revert to factory configuration {}", currentConfigEntry.getKey(), e);
                     causes.add(e);
                 }
@@ -1736,7 +1755,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
     }
 
     private void rollbackConfig(final ComponentConfiguration snapshotConfig,
-            final Optional<Configuration> optionalCurrentConfig) throws IOException, KuraException {
+            final Optional<Configuration> optionalCurrentConfig) throws IOException {
         logger.info("Rolling back configuration for component with pid {}...", snapshotConfig.getPid());
         rollbackConfigurationInternal(snapshotConfig, optionalCurrentConfig);
     }
@@ -1749,8 +1768,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         unregisterComponentConfiguration(currentConfigEntry.getKey());
     }
 
-    private void rollbackToDefaultConfig(final Entry<String, Configuration> currentConfigEntry)
-            throws IOException, KuraException {
+    private void rollbackToDefaultConfig(final Entry<String, Configuration> currentConfigEntry) throws IOException {
         logger.info("Rolling back to default configuration for component pid: '{}'", currentConfigEntry.getKey());
         rollbackConfigurationInternal(
                 new ComponentConfigurationImpl(currentConfigEntry.getKey(), null, new HashMap<>()),

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -27,22 +27,25 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
@@ -94,6 +97,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
     private static final String GETTING_CONFIGURATION_ERROR = "Error getting Configuration for component: {}. Ignoring it.";
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigurationServiceImpl.class);
+    private static final Pattern SNAPSHOT_FILENAME_PATTERN = Pattern.compile("snapshot_(\\d+)\\.xml");
 
     private ComponentContext ctx;
     private BundleContext bundleContext;
@@ -141,66 +145,32 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         this.configurationAdmin = configAdmin;
     }
 
-    public void unsetConfigurationAdmin(ConfigurationAdmin configAdmin) {
-        this.configurationAdmin = null;
-    }
-
     public void setMetaTypeService(MetaTypeService metaTypeService) {
         this.metaTypeService = metaTypeService;
-    }
-
-    public void unsetMetaTypeService(MetaTypeService metaTypeService) {
-        this.metaTypeService = null;
     }
 
     public void setSystemService(SystemService systemService) {
         this.systemService = systemService;
     }
 
-    public void unsetSystemService(SystemService systemService) {
-        this.systemService = null;
-    }
-
     public void setCryptoService(CryptoService cryptoService) {
         this.cryptoService = cryptoService;
-    }
-
-    public void unsetCryptoService(CryptoService cryptoService) {
-        this.cryptoService = null;
     }
 
     public void setScrService(ServiceComponentRuntime scrService) {
         this.scrService = scrService;
     }
 
-    public void unsetScrService(ServiceComponentRuntime scrService) {
-        this.scrService = null;
-    }
-
     public void setXmlMarshaller(final Marshaller marshaller) {
         this.xmlMarshaller = marshaller;
-    }
-
-    public void unsetXmlMarshaller(final Marshaller marshaller) {
-        this.xmlMarshaller = null;
     }
 
     public void setXmlUnmarshaller(final Unmarshaller unmarshaller) {
         this.xmlUnmarshaller = unmarshaller;
     }
 
-    public void unsetXmlUnmarshaller(final Unmarshaller unmarshaller) {
-        this.xmlUnmarshaller = null;
-    }
-
     public void setEventAdmin(EventAdmin eventAdmin) {
         this.eventAdmin = eventAdmin;
-    }
-
-    public void unsetEventAdmin(EventAdmin eventAdmin) {
-        if (this.eventAdmin == eventAdmin) {
-            this.eventAdmin = null;
-        }
     }
 
     public ConfigurationServiceImpl() {
@@ -391,7 +361,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             throws KuraException { // don't call this method internally
         for (ComponentConfiguration config : configsToUpdate) {
             if (config != null) {
-                encryptConfigurationProperties(config.getConfigurationProperties());
+                ComponentUtil.encryptConfigurationProperties(config.getConfigurationProperties(), this.cryptoService);
             }
         }
 
@@ -540,88 +510,34 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
     }
 
     @Override
-    public synchronized void rollback(long id) throws KuraException {
-        // load the snapshot we need to rollback to
-        XmlComponentConfigurations xmlConfigs = loadEncryptedSnapshotFileContent(id);
-
-        //
-        // restore configuration
+    public void rollback(long id) throws KuraException {
         logger.info("Rolling back to snapshot {}...", id);
 
-        Set<String> snapshotPids = new HashSet<>();
-        boolean snapshotOnConfirmation = false;
         List<Throwable> causes = new ArrayList<>();
-        List<ComponentConfiguration> configs = xmlConfigs.getConfigurations();
+        final Map<String, ComponentConfiguration> snapshotConfigs = getSnapshotConfigs(id);
+        final Map<String, Configuration> currentConfigs = getCurrentConfigs();
+        Iterator<Entry<String, Configuration>> currentConfigsIterator = currentConfigs.entrySet().iterator();
 
-        // remove all existing factory configurations
-        for (String pid : new ArrayList<>(this.factoryPidByPid.keySet())) {
-            try {
-                deleteFactoryConfiguration(pid, false);
-            } catch (Exception e) {
-                logger.warn("Failed to remove factory configuration for pid: " + pid, e);
-                causes.add(e);
-            }
+        while (currentConfigsIterator.hasNext()) {
+            manageCurrentConfigs(causes, snapshotConfigs, currentConfigsIterator);
         }
 
-        // create all factory configurations in snapshot
-        final Stream<ComponentConfiguration> factoryConfigurationsInSnapshot = configs.stream()
-                .filter(config -> config.getPid() != null
-                        && config.getConfigurationProperties().containsKey(ConfigurationAdmin.SERVICE_FACTORYPID));
-
-        factoryConfigurationsInSnapshot.forEach(config -> {
-            final String pid = config.getPid();
-            final Map<String, Object> properties = config.getConfigurationProperties();
-            final String factoryPid = properties.get(ConfigurationAdmin.SERVICE_FACTORYPID).toString();
-            try {
-                createFactoryConfiguration(factoryPid, pid, properties, false);
-            } catch (Exception e) {
-                logger.warn("Error during rollback for component " + pid, e);
-                causes.add(e);
-            }
-        });
-
-        for (ComponentConfiguration config : configs) {
-            if (config != null) {
-                try {
-                    rollbackConfigurationInternal(config.getPid(), config.getConfigurationProperties(),
-                            snapshotOnConfirmation);
-                } catch (Exception e) {
-                    logger.warn("Error during rollback for component " + config.getPid(), e);
-                    causes.add(e);
-                }
-                // Track the pid of the component
-                snapshotPids.add(config.getPid());
-            }
+        for (final ComponentConfiguration snapshotConfig : snapshotConfigs.values()) {
+            manageSnapshotConfigs(causes, currentConfigs, snapshotConfig);
         }
 
-        // rollback to the default configuration for those configurable
-        // components
-        // whose configuration is not present in the snapshot
-        Set<String> pids = new HashSet<>(this.allActivatedPids);
-        pids.removeAll(snapshotPids);
-
-        for (String pid : pids) {
-            logger.info("Rolling back to default configuration for component pid: '{}'", pid);
-            try {
-                rollbackConfigurationInternal(pid, Collections.emptyMap(), snapshotOnConfirmation);
-            } catch (Exception e) {
-                logger.warn("Error during rollback for component " + pid, e);
-                causes.add(e);
-            }
-        }
+        this.pendingDeletePids.clear();
 
         if (!causes.isEmpty()) {
             throw new KuraPartialSuccessException("Rollback", causes);
         }
 
-        // Do not call snapshot() here because it gets the configurations of
-        // SelfConfiguringComponents
-        // using SelfConfiguringComponent.getConfiguration() and the
-        // configuration returned
-        // might be the old one not the one just loaded from the snapshot and
-        // updated through
-        // the Configuration Admin. Instead just make a copy of the snapshot.
-        saveSnapshot(configs);
+        final SortedSet<Long> snapshotIds = getSnapshotsInternal();
+
+        if (snapshotIds.isEmpty() || id != snapshotIds.last()) {
+            saveSnapshot(snapshotConfigs.values());
+        }
+
     }
 
     @Override
@@ -994,67 +910,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         }
     }
 
-    private void encryptConfigurationProperties(Map<String, Object> propertiesToUpdate) {
-        if (propertiesToUpdate == null) {
-            return;
-        }
-
-        for (Entry<String, Object> property : propertiesToUpdate.entrySet()) {
-            Object configValue = property.getValue();
-            if (configValue instanceof Password || configValue instanceof Password[]) {
-                try {
-                    Object encryptedValue = encryptPasswordProperties(configValue);
-                    propertiesToUpdate.put(property.getKey(), encryptedValue);
-                } catch (KuraException e) {
-                    logger.warn("Failed to encrypt Password property: {}", property.getKey());
-                    propertiesToUpdate.remove(property.getKey());
-                }
-            }
-        }
-    }
-
-    private Object encryptPasswordProperties(Object configValue) throws KuraException {
-        Object encryptedValue = null;
-        if (configValue instanceof Password) {
-            encryptedValue = encryptPassword((Password) configValue);
-
-        } else if (configValue instanceof Password[]) {
-            Password[] passwordArray = (Password[]) configValue;
-            Password[] encryptedPasswords = new Password[passwordArray.length];
-
-            for (int i = 0; i < passwordArray.length; i++) {
-                encryptedPasswords[i] = encryptPassword(passwordArray[i]);
-            }
-            encryptedValue = encryptedPasswords;
-        }
-        return encryptedValue;
-    }
-
-    private boolean isEncrypted(Password configPassword) {
-        boolean result = false;
-        try {
-            this.cryptoService.decryptAes(configPassword.getPassword());
-            result = true;
-        } catch (Exception e1) {
-        }
-        return result;
-    }
-
-    private Password encryptPassword(Password password) throws KuraException {
-        if (!isEncrypted(password)) {
-            return new Password(this.cryptoService.encryptAes(password.getPassword()));
-        }
-        return password;
-    }
-
-    private void encryptConfigs(List<ComponentConfiguration> configs) {
-        if (configs != null) {
-            for (ComponentConfiguration config : configs) {
-                encryptConfigurationProperties(config.getConfigurationProperties());
-            }
-        }
-    }
-
     private boolean allSnapshotsUnencrypted() {
         try {
             Set<Long> snapshotIDs = getSnapshots();
@@ -1109,19 +964,15 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             final XmlComponentConfigurations xmlConfigs = unmarshal(readFully(fSnapshot),
                     XmlComponentConfigurations.class);
 
-            encryptConfigs(xmlConfigs.getConfigurations());
+            ComponentUtil.encryptConfigs(xmlConfigs.getConfigurations(), this.cryptoService);
 
             // Writes an encrypted snapshot with encrypted passwords.
             writeSnapshot(snapshot, xmlConfigs);
         }
     }
 
-    private synchronized long saveSnapshot(List<ComponentConfiguration> configs) throws KuraException {
-
-        List<ComponentConfiguration> configsToSave = configs;
-
-        // Remove definition from configurations
-        configsToSave = configs.stream()
+    private long saveSnapshot(Collection<? extends ComponentConfiguration> configs) throws KuraException {
+        List<ComponentConfiguration> configsToSave = configs.stream()
                 .map(cc -> new ComponentConfigurationImpl(cc.getPid(), null, cc.getConfigurationProperties()))
                 .collect(Collectors.toList());
 
@@ -1133,10 +984,9 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         long sid = new Date().getTime();
 
         // Do not save the snapshot in the past
-        Set<Long> snapshotIDs = getSnapshots();
+        SortedSet<Long> snapshotIDs = getSnapshotsInternal();
         if (snapshotIDs != null && !snapshotIDs.isEmpty()) {
-            Long[] snapshots = snapshotIDs.toArray(new Long[] {});
-            Long lastestID = snapshots[snapshotIDs.size() - 1];
+            Long lastestID = snapshotIDs.last();
 
             if (lastestID != null && sid <= lastestID) {
                 logger.warn("Snapshot ID: {} is in the past. Adjusting ID to: {} + 1", sid, lastestID);
@@ -1146,8 +996,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
 
         // Write snapshot
         writeSnapshot(sid, conf);
-
-        this.pendingDeletePids.clear();
 
         // Garbage Collector for number of Snapshots Saved
         garbageCollectionOldSnapshots();
@@ -1272,7 +1120,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         if (isNull(ocd) || isNull(ocd.getAD())) {
             return false;
         }
-        
+
         List<AD> ads = ocd.getAD();
 
         for (AD ad : ads) {
@@ -1336,9 +1184,8 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             File[] files = fConfigDir.listFiles();
             if (files != null) {
 
-                Pattern p = Pattern.compile("snapshot_([0-9]+)\\.xml");
                 for (File file : files) {
-                    Matcher m = p.matcher(file.getName());
+                    Matcher m = SNAPSHOT_FILENAME_PATTERN.matcher(file.getName());
                     if (m.matches()) {
                         ids.add(Long.parseLong(m.group(1)));
                     }
@@ -1547,44 +1394,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                 throw new KuraException(KuraErrorCode.CONFIGURATION_UPDATE, e, pid);
             }
         }
-
-        mergedProperties.putAll(properties);
-
-        if (!mergedProperties.containsKey(ConfigurationService.KURA_SERVICE_PID)) {
-            mergedProperties.put(ConfigurationService.KURA_SERVICE_PID, pid);
-        }
-
-        try {
-            updateComponentConfiguration(pid, mergedProperties, snapshotOnConfirmation);
-            logger.info("Updating Configuration of ConfigurableComponent {} ... Done.", pid);
-        } catch (IOException e) {
-            logger.warn("Error updating Configuration of ConfigurableComponent with pid {}", pid, e);
-            throw new KuraException(KuraErrorCode.CONFIGURATION_UPDATE, e, pid);
-        }
-    }
-
-    private void rollbackConfigurationInternal(String pid, Map<String, Object> properties,
-            boolean snapshotOnConfirmation) throws KuraException {
-        logger.debug("Attempting to rollback configuration for {}", pid);
-
-        if (!this.allActivatedPids.contains(pid)) {
-            logger.info("UpdatingConfiguration ignored as ConfigurableComponent {} is NOT tracked.", pid);
-            return;
-        }
-        if (properties == null) {
-            logger.info("UpdatingConfiguration ignored as properties for ConfigurableComponent {} are NULL.", pid);
-            return;
-        }
-
-        // get the OCD from the registered ConfigurableComponents
-        OCD registerdOCD = getRegisteredOCD(pid);
-        if (registerdOCD == null) {
-            logger.info("UpdatingConfiguration ignored as OCD for pid {} cannot be found.", pid);
-            return;
-        }
-
-        Map<String, Object> mergedProperties = new HashMap<>();
-        mergeWithDefaults(registerdOCD, mergedProperties);
 
         mergedProperties.putAll(properties);
 
@@ -1866,6 +1675,153 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         } catch (Exception e) {
             throw new KuraException(KuraErrorCode.ENCODE_ERROR, "configuration", e);
         }
+    }
+
+    private void manageSnapshotConfigs(List<Throwable> causes, final Map<String, Configuration> currentConfigs,
+            final ComponentConfiguration snapshotConfig) {
+        final Optional<Configuration> optionalCurrentConfig = Optional
+                .ofNullable(currentConfigs.get(snapshotConfig.getPid()));
+
+        try {
+            rollbackConfig(snapshotConfig, optionalCurrentConfig);
+        } catch (IOException | KuraException e) {
+            logger.warn("Failed to rollback configuration for pid {}", snapshotConfig.getPid(), e);
+            causes.add(e);
+        }
+    }
+
+    private void manageCurrentConfigs(List<Throwable> causes, final Map<String, ComponentConfiguration> snapshotConfigs,
+            Iterator<Entry<String, Configuration>> currentConfigsIterator) {
+        final Entry<String, Configuration> currentConfigEntry = currentConfigsIterator.next();
+        final Optional<ComponentConfiguration> optionalSnapshotConfig = Optional
+                .ofNullable(snapshotConfigs.get(currentConfigEntry.getKey()));
+
+        if (!isFactoryComponent(currentConfigEntry)) {
+
+            if (!optionalSnapshotConfig.isPresent() && this.allActivatedPids.contains(currentConfigEntry.getKey())) {
+                try {
+                    rollbackToDefaultConfig(currentConfigEntry);
+                } catch (IOException | KuraException e) {
+                    logger.warn("Failed to revert to factory configuration {}", currentConfigEntry.getKey(), e);
+                    causes.add(e);
+                }
+            }
+
+        } else if (!optionalSnapshotConfig.isPresent() || !Objects.equals(currentConfigEntry.getValue().getFactoryPid(),
+                optionalSnapshotConfig.get().getConfigurationProperties().get(ConfigurationAdmin.SERVICE_FACTORYPID))) {
+
+            try {
+                deleteFactoryComponent(currentConfigsIterator, currentConfigEntry);
+            } catch (IOException e) {
+                logger.warn("Failed to delete configuration {}", currentConfigEntry.getKey(), e);
+                causes.add(e);
+            }
+        }
+    }
+
+    private void rollbackConfigurationInternal(final ComponentConfiguration snapshotConfig,
+            final Optional<Configuration> existingConfig) throws IOException, KuraException {
+        final Optional<String> factoryPid = Optional
+                .ofNullable(snapshotConfig.getConfigurationProperties().get(ConfigurationAdmin.SERVICE_FACTORYPID))
+                .filter(String.class::isInstance).map(String.class::cast);
+
+        final Map<String, Object> result = snapshotConfig.getConfigurationProperties();
+
+        final Optional<OCD> ocd = Optional.ofNullable(getRegisteredOCD(snapshotConfig.getPid()));
+
+        if (ocd.isPresent()) {
+            mergeWithDefaults(ocd.get(), result);
+        }
+
+        final Dictionary<String, Object> resultAsDictionary = CollectionsUtil.mapToDictionary(result);
+
+        resultAsDictionary.put(KURA_SERVICE_PID, snapshotConfig.getPid());
+        resultAsDictionary.remove(Constants.SERVICE_PID);
+
+        final Configuration target;
+
+        if (existingConfig.isPresent()) {
+            target = existingConfig.get();
+        } else if (factoryPid.isPresent()) {
+            logger.info("creating new factory configuration for pid {} and factory pid {}", snapshotConfig.getPid(),
+                    factoryPid.get());
+            target = this.configurationAdmin.createFactoryConfiguration(factoryPid.get(), null);
+        } else {
+            logger.info("creating new configuration for pid {}", snapshotConfig.getPid());
+            target = this.configurationAdmin.getConfiguration(snapshotConfig.getPid());
+        }
+
+        final Dictionary<String, Object> currentProperties = target.getProperties();
+
+        if (currentProperties != null) {
+            currentProperties.remove(Constants.SERVICE_PID);
+        }
+
+        if (!CollectionsUtil.equals(resultAsDictionary, currentProperties)) {
+            logger.info("updating configuration for pid {}", snapshotConfig.getPid());
+            target.update(resultAsDictionary);
+            if (factoryPid.isPresent()) {
+                registerComponentConfiguration(snapshotConfig.getPid(), target.getPid(), factoryPid.get());
+            }
+        }
+    }
+
+    private void rollbackConfig(final ComponentConfiguration snapshotConfig,
+            final Optional<Configuration> optionalCurrentConfig) throws IOException, KuraException {
+        logger.info("Rolling back configuration for component with pid {}...", snapshotConfig.getPid());
+        rollbackConfigurationInternal(snapshotConfig, optionalCurrentConfig);
+    }
+
+    private void deleteFactoryComponent(Iterator<Entry<String, Configuration>> currentConfigsIterator,
+            final Entry<String, Configuration> currentConfigEntry) throws IOException {
+        logger.info("Deleting factory configuration for component with pid {}...", currentConfigEntry.getKey());
+        currentConfigEntry.getValue().delete();
+        currentConfigsIterator.remove();
+        unregisterComponentConfiguration(currentConfigEntry.getKey());
+    }
+
+    private void rollbackToDefaultConfig(final Entry<String, Configuration> currentConfigEntry)
+            throws IOException, KuraException {
+        logger.info("Rolling back to default configuration for component pid: '{}'", currentConfigEntry.getKey());
+        rollbackConfigurationInternal(
+                new ComponentConfigurationImpl(currentConfigEntry.getKey(), null, new HashMap<>()),
+                Optional.of(currentConfigEntry.getValue()));
+    }
+
+    private boolean isFactoryComponent(final Entry<String, Configuration> currentConfigEntry) {
+        return currentConfigEntry.getValue().getFactoryPid() != null;
+    }
+
+    private Map<String, Configuration> getCurrentConfigs() throws KuraException {
+        final Map<String, Configuration> currentConfigs;
+
+        try {
+            currentConfigs = Arrays.stream(this.configurationAdmin.listConfigurations(null))
+                    .collect(Collectors.toMap(c -> {
+                        final Dictionary<String, Object> properties = c.getProperties();
+
+                        if (properties != null) {
+                            final Object kuraServicePid = properties.get(KURA_SERVICE_PID);
+
+                            if (kuraServicePid instanceof String) {
+                                return (String) kuraServicePid;
+                            }
+                        }
+
+                        return c.getPid();
+                    }, Function.identity()));
+
+        } catch (final IOException | InvalidSyntaxException e) {
+            throw new KuraException(KuraErrorCode.IO_ERROR, e);
+        }
+        return currentConfigs;
+    }
+
+    private Map<String, ComponentConfiguration> getSnapshotConfigs(long id) throws KuraException {
+        XmlComponentConfigurations xmlConfigs = loadEncryptedSnapshotFileContent(id);
+        List<ComponentConfiguration> configs = xmlConfigs.getConfigurations();
+
+        return ComponentUtil.toMap(configs);
     }
 
     private static final class TrackedComponentFactory {

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -1251,8 +1251,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             cfg.update(CollectionsUtil.mapToDictionary(newProperties));
 
         } catch (IOException e) {
-            logger.warn("Error seeding initial properties to ConfigAdmin for pid: {}", config.getPid(),
-                    e);
+            logger.warn("Error seeding initial properties to ConfigAdmin for pid: {}", config.getPid(), e);
         }
     }
 
@@ -1263,8 +1262,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         try {
             createFactoryConfiguration(factoryPid, pid, props, false);
         } catch (KuraException e) {
-            logger.warn("Error creating configuration with pid: {} and factory pid: {}", pid,
-                    factoryPid, e);
+            logger.warn("Error creating configuration with pid: {} and factory pid: {}", pid, factoryPid, e);
         }
     }
 
@@ -1530,7 +1528,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             throws KuraException {
         // Merge the current configuration of registered components with the provided configurations.
         // It is assumed that the PIDs in the provided configurations is a subset of the registered PIDs.
-        
+
         List<ComponentConfiguration> currentConfigs = getComponentConfigurationsInternal();
         if (configsToUpdate == null || configsToUpdate.isEmpty()) {
             result.addAll(currentConfigs);
@@ -1671,7 +1669,8 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                 .ofNullable(currentConfigs.get(snapshotConfig.getPid()));
 
         try {
-            rollbackConfig(snapshotConfig, optionalCurrentConfig);
+            logger.info("Rolling back configuration for component with pid {}...", snapshotConfig.getPid());
+            rollbackConfigurationInternal(snapshotConfig, optionalCurrentConfig);
         } catch (IOException e) {
             logger.warn("Failed to rollback configuration for pid {}", snapshotConfig.getPid(), e);
             causes.add(e);
@@ -1752,12 +1751,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                 registerComponentConfiguration(snapshotConfig.getPid(), target.getPid(), factoryPid.get());
             }
         }
-    }
-
-    private void rollbackConfig(final ComponentConfiguration snapshotConfig,
-            final Optional<Configuration> optionalCurrentConfig) throws IOException {
-        logger.info("Rolling back configuration for component with pid {}...", snapshotConfig.getPid());
-        rollbackConfigurationInternal(snapshotConfig, optionalCurrentConfig);
     }
 
     private void deleteFactoryComponent(Iterator<Entry<String, Configuration>> currentConfigsIterator,

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -1669,7 +1669,7 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
                 .ofNullable(currentConfigs.get(snapshotConfig.getPid()));
 
         try {
-            logger.info("Rolling back configuration for component with pid {}...", snapshotConfig.getPid());
+            logger.info("Procession configuration rollback for component with pid {}...", snapshotConfig.getPid());
             rollbackConfigurationInternal(snapshotConfig, optionalCurrentConfig);
         } catch (IOException e) {
             logger.warn("Failed to rollback configuration for pid {}", snapshotConfig.getPid(), e);
@@ -1750,6 +1750,8 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             if (factoryPid.isPresent()) {
                 registerComponentConfiguration(snapshotConfig.getPid(), target.getPid(), factoryPid.get());
             }
+        } else {
+            logger.info("No need to update configuration for pid {}", snapshotConfig.getPid());
         }
     }
 

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/CollectionsUtil.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/CollectionsUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.configuration.metatype.AD;
@@ -101,5 +102,27 @@ public class CollectionsUtil {
             }
         }
         return dictionary;
+    }
+
+    public static boolean equals(final Dictionary<String, Object> first, final Dictionary<String, Object> second) {
+        if (first == null || second == null) {
+            return first == second;
+        }
+
+        if (first.size() != second.size()) {
+            return false;
+        }
+
+        final Enumeration<String> keys = first.keys();
+
+        while (keys.hasMoreElements()) {
+            final String key = keys.nextElement();
+
+            if (!Objects.deepEquals(first.get(key), second.get(key))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,12 +20,16 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLStreamException;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
+import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.Password;
 import org.eclipse.kura.configuration.metatype.AD;
 import org.eclipse.kura.configuration.metatype.Designate;
@@ -477,4 +481,107 @@ public class ComponentUtil {
         }
         return result;
     }
+
+    /*
+     * Encrypt a list of {@link org.eclipse.kura.ComponentConfiguration}s using the given CryptoService
+     */
+    public static void encryptConfigs(List<ComponentConfiguration> configs, final CryptoService cryptoService) {
+        if (configs != null) {
+            for (ComponentConfiguration config : configs) {
+                encryptConfigurationProperties(config.getConfigurationProperties(), cryptoService);
+            }
+        }
+    }
+
+    /*
+     * Encrypt a map of properties using the given CryptoService
+     */
+    public static void encryptConfigurationProperties(Map<String, Object> propertiesToUpdate,
+            final CryptoService cryptoService) {
+        if (propertiesToUpdate == null) {
+            return;
+        }
+
+        for (Entry<String, Object> property : propertiesToUpdate.entrySet()) {
+            Object configValue = property.getValue();
+            if (configValue instanceof Password || configValue instanceof Password[]) {
+                try {
+                    Object encryptedValue = encryptPasswordProperties(configValue, cryptoService);
+                    propertiesToUpdate.put(property.getKey(), encryptedValue);
+                } catch (KuraException e) {
+                    logger.warn("Failed to encrypt Password property: {}", property.getKey());
+                    propertiesToUpdate.remove(property.getKey());
+                }
+            }
+        }
+    }
+
+    private static Object encryptPasswordProperties(Object configValue, final CryptoService cryptoService)
+            throws KuraException {
+        Object encryptedValue = null;
+        if (configValue instanceof Password) {
+            encryptedValue = encryptPassword((Password) configValue, cryptoService);
+
+        } else if (configValue instanceof Password[]) {
+            Password[] passwordArray = (Password[]) configValue;
+            Password[] encryptedPasswords = new Password[passwordArray.length];
+
+            for (int i = 0; i < passwordArray.length; i++) {
+                encryptedPasswords[i] = encryptPassword(passwordArray[i], cryptoService);
+            }
+            encryptedValue = encryptedPasswords;
+        }
+        return encryptedValue;
+    }
+
+    private static boolean isEncrypted(Password configPassword, final CryptoService cryptoService) {
+        boolean result = false;
+        try {
+            cryptoService.decryptAes(configPassword.getPassword());
+            result = true;
+        } catch (Exception e1) {
+        }
+        return result;
+    }
+
+    private static Password encryptPassword(Password password, final CryptoService cryptoService) throws KuraException {
+        if (!isEncrypted(password, cryptoService)) {
+            return new Password(cryptoService.encryptAes(password.getPassword()));
+        }
+        return password;
+    }
+
+    /*
+     * Converts a list of {@link org.eclipse.kura.core.configuration.ComponentConfiguration}s to a map whose keys are
+     * the component pids.
+     */
+    public static Map<String, ComponentConfiguration> toMap(final List<ComponentConfiguration> configs) {
+        return configs.stream().collect(Collectors.toMap(ComponentConfiguration::getPid, Function.identity()));
+    }
+
+    // /*
+    // * Merge a collection of {@link org.eclipse.kura.core.configuration.ComponentConfiguration} properties with the
+    // * given configurations.
+    // */
+    // public static void merge(final Map<String, ComponentConfiguration> configs,
+    // final Collection<ComponentConfiguration> toBeMerged) {
+    // for (final ComponentConfiguration c : toBeMerged) {
+    // merge(configs, c);
+    // }
+    // }
+    //
+    // /*
+    // * Merge a {@link org.eclipse.kura.core.configuration.ComponentConfiguration} with the
+    // * given configurations.
+    // */
+    // public static void merge(final Map<String, ComponentConfiguration> configs, final ComponentConfiguration c) {
+    // configs.compute(c.getPid(), (k, v) -> {
+    // if (v == null) {
+    // return c;
+    // } else {
+    // v.getConfigurationProperties().putAll(c.getConfigurationProperties());
+    // return v;
+    // }
+    // });
+    // }
 }

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/util/ComponentUtil.java
@@ -539,7 +539,8 @@ public class ComponentUtil {
         try {
             cryptoService.decryptAes(configPassword.getPassword());
             result = true;
-        } catch (Exception e1) {
+        } catch (Exception e) {
+            // Do nothing...
         }
         return result;
     }
@@ -559,29 +560,4 @@ public class ComponentUtil {
         return configs.stream().collect(Collectors.toMap(ComponentConfiguration::getPid, Function.identity()));
     }
 
-    // /*
-    // * Merge a collection of {@link org.eclipse.kura.core.configuration.ComponentConfiguration} properties with the
-    // * given configurations.
-    // */
-    // public static void merge(final Map<String, ComponentConfiguration> configs,
-    // final Collection<ComponentConfiguration> toBeMerged) {
-    // for (final ComponentConfiguration c : toBeMerged) {
-    // merge(configs, c);
-    // }
-    // }
-    //
-    // /*
-    // * Merge a {@link org.eclipse.kura.core.configuration.ComponentConfiguration} with the
-    // * given configurations.
-    // */
-    // public static void merge(final Map<String, ComponentConfiguration> configs, final ComponentConfiguration c) {
-    // configs.compute(c.getPid(), (k, v) -> {
-    // if (v == null) {
-    // return c;
-    // } else {
-    // v.getConfigurationProperties().putAll(c.getConfigurationProperties());
-    // return v;
-    // }
-    // });
-    // }
 }

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,6 @@ import static org.osgi.framework.Constants.SERVICE_PID;
 
 import java.io.File;
 import java.io.FileReader;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Dictionary;
 import java.util.HashMap;
@@ -33,6 +32,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -131,8 +131,6 @@ public class ConfigurationServiceTest {
     private int kuraSnapshotsCount = 10;
     private String kuraSnapshotsDir = KURA_SNAPSHOTS_DIR;
 
-    // private BundleContext bundleContext;
-
     private Optional<Exception> exceptionOccurred;
 
     private Set<String> factoryComponentPids;
@@ -203,7 +201,7 @@ public class ConfigurationServiceTest {
     }
 
     @Test
-    public void testDeleteFactoryConfigurationNulls() throws KuraException {
+    public void testDeleteFactoryConfigurationNulls() {
         // negative test; null is given as pid
 
         whenDeleteFactoryConfiguration(null, false);
@@ -221,7 +219,7 @@ public class ConfigurationServiceTest {
     }
 
     @Test
-    public void testDeleteFactoryConfigurationWithSnapshot() throws KuraException, IOException, NoSuchFieldException {
+    public void testDeleteFactoryConfigurationWithSnapshot() {
         // positive test; pid registered in factory and service pids, configuration delete is expected, with snapshots
 
         givenCreateFactoryConfiguration("fpid_" + System.currentTimeMillis(), "spid-test1", this.exampleProperties,
@@ -544,6 +542,26 @@ public class ConfigurationServiceTest {
     }
 
     @Test
+    public void testRollbackShouldDeleteFactoryComponent() throws KuraException {
+        givenSnapshotBefore();
+        givenCreateFactoryConfiguration(DATA_SERVICE_FACTORY_PID, "pid_fc_rollback_create", null, true);
+
+        whenRollback();
+
+        thenFactoryComponentHasBeenDeleted("pid_fc_rollback_create");
+    }
+
+    @Test
+    public void testRollbackShouldCreateFactoryComponent() throws KuraException {
+        givenCreateFactoryConfiguration(DATA_SERVICE_FACTORY_PID, "pid_fc_rollback_delete", null, true);
+        givenDeleteFactoryConfiguration("pid_fc_rollback_delete", true);
+
+        whenRollback();
+
+        thenFactoryComponentHasBeenCreated("pid_fc_rollback_delete");
+    }
+
+    @Test
     public void testEncryptSnapshots() {
         givenCreateFactoryConfiguration(DATA_SERVICE_FACTORY_PID, "pid_rollback_1", null, true);
 
@@ -580,6 +598,18 @@ public class ConfigurationServiceTest {
         try {
             ConfigurationServiceTest.configurationService.createFactoryConfiguration(factoryPid, pid, properties,
                     takeSnapshot);
+
+            if (takeSnapshot) {
+                this.snapshotsBefore = ConfigurationServiceTest.configurationService.getSnapshots();
+            }
+        } catch (Exception e) {
+            this.exceptionOccurred = Optional.of(e);
+        }
+    }
+
+    private void givenDeleteFactoryConfiguration(String pid, boolean takeSnapshot) {
+        try {
+            ConfigurationServiceTest.configurationService.deleteFactoryConfiguration(pid, takeSnapshot);
 
             if (takeSnapshot) {
                 this.snapshotsBefore = ConfigurationServiceTest.configurationService.getSnapshots();
@@ -642,11 +672,7 @@ public class ConfigurationServiceTest {
     }
 
     private void givenNoSnapshotsInKuraDir() {
-        try {
-            cleanSnapshots();
-        } catch (KuraException e) {
-            this.exceptionOccurred = Optional.of(e);
-        }
+        cleanSnapshots();
     }
 
     /*
@@ -898,6 +924,22 @@ public class ConfigurationServiceTest {
         }
     }
 
+    private void thenFactoryComponentHasBeenDeleted(String pid) throws KuraException {
+        Long lastSnapshotId = ((TreeSet<Long>) ConfigurationServiceTest.configurationService.getSnapshots()).last();
+        List<ComponentConfiguration> lastSnapshot = ConfigurationServiceTest.configurationService
+                .getSnapshot(lastSnapshotId);
+
+        assertEquals(0, lastSnapshot.stream().filter(cc -> cc.getPid().equals(pid)).count());
+    }
+
+    private void thenFactoryComponentHasBeenCreated(String pid) throws KuraException {
+        Long lastSnapshotId = ((TreeSet<Long>) ConfigurationServiceTest.configurationService.getSnapshots()).last();
+        List<ComponentConfiguration> lastSnapshot = ConfigurationServiceTest.configurationService
+                .getSnapshot(lastSnapshotId);
+
+        assertEquals(1, lastSnapshot.stream().filter(cc -> cc.getPid().equals(pid)).count());
+    }
+
     private void thenConfigurableComponentPidsNotAssignable() {
         try {
             this.configurableComponentPids.add("should-be-unsupported");
@@ -1011,10 +1053,10 @@ public class ConfigurationServiceTest {
     }
 
     private void thenContainsWireComponentsDefinitions(List<ComponentConfiguration> configs, boolean includesAsset) {
-        final String[] PIDS = { "org.eclipse.kura.wire.CloudPublisher", "org.eclipse.kura.wire.CloudSubscriber",
+        final String[] pids = { "org.eclipse.kura.wire.CloudPublisher", "org.eclipse.kura.wire.CloudSubscriber",
                 "org.eclipse.kura.wire.Fifo", "org.eclipse.kura.wire.Logger", "org.eclipse.kura.wire.RegexFilter",
                 "org.eclipse.kura.wire.Timer" };
-        for (final String pid : PIDS) {
+        for (final String pid : pids) {
             assertTrue(configs.stream()
                     .filter(config -> config.getPid().equals(pid) && config.getDefinition().getId().equals(pid))
                     .findAny().isPresent());
@@ -1031,9 +1073,6 @@ public class ConfigurationServiceTest {
 
     @Before
     public void cleanUp() {
-        // this.bundleContext = null;
-        // this.bundleContext = FrameworkUtil.getBundle(ConfigurationServiceTest.class).getBundleContext();
-
         this.exceptionOccurred = Optional.empty();
 
         try {
@@ -1046,7 +1085,7 @@ public class ConfigurationServiceTest {
     }
 
     private boolean snapshotContains(List<ComponentConfiguration> snapshot, String pid,
-            Map<String, Object> expectedProperties) throws KuraException {
+            Map<String, Object> expectedProperties) {
         boolean found = false;
 
         for (ComponentConfiguration cc : snapshot) {
@@ -1070,7 +1109,7 @@ public class ConfigurationServiceTest {
         return found;
     }
 
-    private void cleanSnapshots() throws KuraException {
+    private void cleanSnapshots() {
         if (systemService != null) {
             this.kuraSnapshotsCount = systemService.getKuraSnapshotsCount();
             this.kuraSnapshotsDir = systemService.getKuraSnapshotsDirectory();

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceTest.java
@@ -45,17 +45,12 @@ import org.eclipse.kura.configuration.ComponentConfiguration;
 import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.configuration.SelfConfiguringComponent;
 import org.eclipse.kura.configuration.metatype.OCDService;
-import org.eclipse.kura.core.configuration.ComponentConfigurationImpl;
-import org.eclipse.kura.core.configuration.metatype.Tscalar;
 import org.eclipse.kura.system.SystemService;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.service.component.ComponentContext;
-import org.osgi.service.component.ComponentException;
 
 public class ConfigurationServiceTest {
 
@@ -396,7 +391,7 @@ public class ConfigurationServiceTest {
         // try it with a registered component and an existing PID with empty properties
         givenGetComponentConfiguration(TEST_COMPONENT_PID);
 
-        whenUpdateConfiguration(TEST_COMPONENT_PID, new HashMap<String, Object>());
+        whenUpdateConfiguration(TEST_COMPONENT_PID, new HashMap<>());
 
         thenConfigurationPropertiesHaveNotChanged();
     }

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
@@ -73,7 +73,7 @@ import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
 public class ConfigurationServiceJunitTest {
 
     @Test
-    public void testGetFactoryComponentPids() throws NoSuchFieldException, KuraException {
+    public void testGetFactoryComponentPids() throws KuraException {
         // test that the returned PIDs are the same as in the service and that they cannot be modified
 
         String[] expectedPIDs = { "pid1", "pid2", "pid3" };
@@ -124,7 +124,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testCreateFactoryExistingPid() throws KuraException, IOException, NoSuchFieldException {
+    public void testCreateFactoryExistingPid() throws KuraException, NoSuchFieldException {
         // negative test; what if existing PID is used
 
         final String factoryPid = "fpid";
@@ -348,7 +348,7 @@ public class ConfigurationServiceJunitTest {
 
     @Test
     public void testDeleteFactoryConfigurationNonFactoryComponent()
-            throws KuraException, NoSuchFieldException, IOException, InvalidSyntaxException {
+            throws KuraException, IOException, InvalidSyntaxException {
 
         ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
 
@@ -370,7 +370,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testDeleteFactoryConfigurationNonExistingServicePid() throws KuraException, NoSuchFieldException {
+    public void testDeleteFactoryConfigurationNonExistingServicePid() throws KuraException {
         ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
         cs.setConfigurationAdmin(mock(ConfigurationAdmin.class));
 
@@ -417,8 +417,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testDeleteFactoryConfigurationNoSnapshot()
-            throws KuraException, IOException, NoSuchFieldException, InvalidSyntaxException {
+    public void testDeleteFactoryConfigurationNoSnapshot() throws KuraException, IOException, InvalidSyntaxException {
         // positive test; pid registered in factory and service pids, configuration delete is expected, no snapshot
 
         String factoryPid = "fpid";
@@ -453,8 +452,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testDeleteFactoryConfigurationWithSnapshot()
-            throws KuraException, IOException, NoSuchFieldException, InvalidSyntaxException {
+    public void testDeleteFactoryConfigurationWithSnapshot() throws KuraException, IOException, InvalidSyntaxException {
         // positive test; pid registered in factory and service pids, configuration delete is expected, take a snapshot
 
         String factoryPid = "fpid";
@@ -1052,8 +1050,7 @@ public class ConfigurationServiceJunitTest {
 
             @Override
             XmlComponentConfigurations loadEncryptedSnapshotFileContent(long snapshotID) throws KuraException {
-                XmlComponentConfigurations cfgs = null;
-                return cfgs;
+                return null;
             }
         };
 
@@ -1238,7 +1235,7 @@ public class ConfigurationServiceJunitTest {
                 try {
                     return xmlMarshaller.marshal(object);
                 } catch (KuraException e) {
-
+                    // Do nothing...
                 }
                 return null;
             }
@@ -1538,7 +1535,7 @@ public class ConfigurationServiceJunitTest {
                 try {
                     return xmlMarshaller.marshal(object);
                 } catch (KuraException e) {
-
+                    // Do nothing...
                 }
                 return null;
             }
@@ -1637,7 +1634,7 @@ public class ConfigurationServiceJunitTest {
                 try {
                     return xmlMarshaller.marshal(object);
                 } catch (KuraException e) {
-
+                    // Do nothing...
                 }
                 return null;
             }
@@ -1697,7 +1694,7 @@ public class ConfigurationServiceJunitTest {
                 try {
                     return xmlMarshaller.marshal(object);
                 } catch (KuraException e) {
-
+                    // Do nothing...
                 }
                 return null;
             }
@@ -1993,7 +1990,7 @@ public class ConfigurationServiceJunitTest {
                 try {
                     return xmlMarshaller.marshal(object);
                 } catch (KuraException e) {
-
+                    // Do nothing...
                 }
                 return null;
             }
@@ -2074,7 +2071,7 @@ public class ConfigurationServiceJunitTest {
                 try {
                     return xmlMarshaller.marshal(object);
                 } catch (KuraException e) {
-
+                    // Do nothing...
                 }
                 return null;
             }
@@ -2159,7 +2156,7 @@ public class ConfigurationServiceJunitTest {
                 try {
                     return xmlMarshaller.marshal(object);
                 } catch (KuraException e) {
-
+                    // Do nothing...
                 }
                 return null;
             }
@@ -2220,7 +2217,7 @@ public class ConfigurationServiceJunitTest {
         snapshotsDir.deleteOnExit();
 
         final SystemService ssMock = mock(SystemService.class);
-        when(ssMock.getKuraSnapshotsDirectory()).thenReturn(snapshotsDir.getAbsolutePath().toString());
+        when(ssMock.getKuraSnapshotsDirectory()).thenReturn(snapshotsDir.getAbsolutePath());
 
         final Map<String, Object> expectedConfig = Collections.singletonMap("prop", "contains\nline\nbreaks\n");
 
@@ -2243,7 +2240,7 @@ public class ConfigurationServiceJunitTest {
 
             @Override
             String getSnapshotsDirectory() {
-                return snapshotsDir.getAbsolutePath().toString();
+                return snapshotsDir.getAbsolutePath();
             }
 
             @Override
@@ -2259,7 +2256,7 @@ public class ConfigurationServiceJunitTest {
                 try {
                     return xmlMarshaller.marshal(object);
                 } catch (KuraException e) {
-
+                    // Do nothing...
                 }
                 return null;
             }
@@ -2828,7 +2825,7 @@ public class ConfigurationServiceJunitTest {
                 try {
                     return xmlMarshaller.marshal(object);
                 } catch (KuraException e) {
-
+                    // Do nothing...
                 }
                 return null;
             }
@@ -3022,8 +3019,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     private OCDService createMockConfigurationServiceForOCDTests(List<String> registeredFactories,
-            List<Tocd> registeredOcds, List<ComponentDescriptionDTO> registeredComponents)
-            throws NoSuchFieldException, KuraException {
+            List<Tocd> registeredOcds, List<ComponentDescriptionDTO> registeredComponents) throws KuraException {
 
         assertEquals(registeredFactories.size(), registeredOcds.size());
         ServiceComponentRuntime scrService = mock(ServiceComponentRuntime.class);
@@ -3043,7 +3039,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testShouldReturnEmptyFactoryOCDList() throws NoSuchFieldException, KuraException {
+    public void testShouldReturnEmptyFactoryOCDList() throws KuraException {
         final OCDService ocdService = createMockConfigurationServiceForOCDTests(Arrays.asList(), Arrays.asList(),
                 Arrays.asList());
         final List<ComponentConfiguration> configs = ocdService.getFactoryComponentOCDs();
@@ -3051,7 +3047,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testShouldGetFactoryOCDList() throws NoSuchFieldException, KuraException {
+    public void testShouldGetFactoryOCDList() throws KuraException {
         final Tocd ocd1 = mock(Tocd.class);
         final Tocd ocd2 = mock(Tocd.class);
         final Tocd ocd3 = mock(Tocd.class);
@@ -3065,7 +3061,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testShouldReturnNullFactoryOCD() throws NoSuchFieldException, KuraException {
+    public void testShouldReturnNullFactoryOCD() throws KuraException {
         final OCDService ocdService = createMockConfigurationServiceForOCDTests(Arrays.asList(), Arrays.asList(),
                 Arrays.asList());
         assertNull(ocdService.getFactoryComponentOCD("bar"));
@@ -3073,7 +3069,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testShouldGetSingleFactoryOCD() throws NoSuchFieldException, KuraException {
+    public void testShouldGetSingleFactoryOCD() throws KuraException {
         final Tocd ocd1 = mock(Tocd.class);
         final Tocd ocd2 = mock(Tocd.class);
         final Tocd ocd3 = mock(Tocd.class);
@@ -3087,7 +3083,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testShouldReturnEmptyFactoryOCDListForServiceProvider() throws NoSuchFieldException, KuraException {
+    public void testShouldReturnEmptyFactoryOCDListForServiceProvider() throws KuraException {
         final OCDService ocdService = createMockConfigurationServiceForOCDTests(Arrays.asList(), Arrays.asList(),
                 Arrays.asList());
         assertTrue(ocdService.getServiceProviderOCDs(new Class<?>[0]).isEmpty());
@@ -3095,7 +3091,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testShouldReturnFactoryOCDListForServiceProvider() throws NoSuchFieldException, KuraException {
+    public void testShouldReturnFactoryOCDListForServiceProvider() throws KuraException {
         final Tocd fooOcd = mock(Tocd.class);
         final Tocd barOcd = mock(Tocd.class);
         final Tocd bazOcd = mock(Tocd.class);

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
@@ -2893,6 +2893,7 @@ public class ConfigurationServiceJunitTest {
         Configuration[] configurations = new Configuration[] {};
         ConfigurationAdmin cfgAdminMock = mock(ConfigurationAdmin.class);
         when(cfgAdminMock.listConfigurations(null)).thenReturn(configurations);
+        when(cfgAdminMock.getConfiguration(ppid)).thenThrow(IOException.class);
         cs.setConfigurationAdmin(cfgAdminMock);
 
         try {

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -786,134 +786,6 @@ public class ConfigurationServiceJunitTest {
         assertFalse("all pids don't contain pid", allPids.contains(pid));
         assertFalse("service pids don't contain pid", spbp.containsKey(pid));
         assertFalse("activated pids don't contain pid", asc.contains(pid));
-    }
-
-    @Test
-    public void testEncryptConfigsNull() throws NoSuchMethodException {
-        // test with null parameter
-
-        ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
-
-        List<? extends ComponentConfiguration> configs = null;
-
-        try {
-            TestUtil.invokePrivate(cs, "encryptConfigs", configs);
-        } catch (Throwable e) {
-            fail("Parameters not checked.");
-        }
-
-    }
-
-    @Test
-    public void testEncryptConfigsNoConfigs() {
-        // empty list
-        boolean exceptionCaught = false;
-        ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
-
-        List<? extends ComponentConfiguration> configs = new ArrayList<>();
-
-        try {
-            TestUtil.invokePrivate(cs, "encryptConfigs", configs);
-        } catch (Throwable t) {
-            exceptionCaught = true;
-        }
-        assertFalse(exceptionCaught);
-    }
-
-    @Test
-    public void testEncryptConfigsEncryptionException() throws Throwable {
-        // test failed encryption of a password: add a password and run; fail
-        ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
-
-        CryptoService cryptoServiceMock = mock(CryptoService.class);
-        cs.setCryptoService(cryptoServiceMock);
-
-        // first decryption must fail
-        when(cryptoServiceMock.decryptAes("pass".toCharArray()))
-                .thenThrow(new KuraException(KuraErrorCode.DECODER_ERROR, "password"));
-        // then also encryption can fail
-        when(cryptoServiceMock.encryptAes("pass".toCharArray()))
-                .thenThrow(new KuraException(KuraErrorCode.ENCODE_ERROR, "password"));
-
-        List<ComponentConfigurationImpl> configs = new ArrayList<>();
-
-        ComponentConfigurationImpl cfg = new ComponentConfigurationImpl();
-        Map<String, Object> props = new HashMap<>();
-        props.put("key1", new Password("pass"));
-        cfg.setProperties(props);
-
-        configs.add(cfg);
-
-        TestUtil.invokePrivate(cs, "encryptConfigs", configs);
-
-        verify(cryptoServiceMock, times(1)).decryptAes("pass".toCharArray());
-        verify(cryptoServiceMock, times(1)).encryptAes("pass".toCharArray());
-
-        assertEquals("property was deleted", 0, props.size());
-    }
-
-    @Test
-    public void testEncryptConfigs() throws Throwable {
-        // test encrypting a password: add a password and run
-        ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
-
-        CryptoService cryptoServiceMock = mock(CryptoService.class);
-        cs.setCryptoService(cryptoServiceMock);
-
-        // first decryption must fail
-        when(cryptoServiceMock.decryptAes("pass".toCharArray()))
-                .thenThrow(new KuraException(KuraErrorCode.DECODER_ERROR, "configuration"));
-        // so that encryption is attempted at all
-        when(cryptoServiceMock.encryptAes("pass".toCharArray())).thenReturn("encrypted".toCharArray());
-
-        List<ComponentConfigurationImpl> configs = new ArrayList<>();
-
-        ComponentConfigurationImpl cfg = new ComponentConfigurationImpl();
-        Map<String, Object> props = new HashMap<>();
-        props.put("key1", new Password("pass"));
-        cfg.setProperties(props);
-
-        configs.add(cfg);
-
-        TestUtil.invokePrivate(cs, "encryptConfigs", configs);
-
-        verify(cryptoServiceMock, times(1)).decryptAes("pass".toCharArray());
-        verify(cryptoServiceMock, times(1)).encryptAes("pass".toCharArray());
-
-        assertEquals("property was updated", 1, props.size());
-        assertTrue("key still exists", props.containsKey("key1"));
-        assertArrayEquals("key is encrypted", "encrypted".toCharArray(), ((Password) props.get("key1")).getPassword());
-    }
-
-    @Test
-    public void testEncryptConfigsPreencryptedPassword() throws Throwable {
-        // test encrypting a password when the password is already encrypted
-        ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
-
-        CryptoService cryptoServiceMock = mock(CryptoService.class);
-        cs.setCryptoService(cryptoServiceMock);
-
-        // decryption succeeds this time
-        when(cryptoServiceMock.decryptAes("pass".toCharArray())).thenReturn("pass".toCharArray());
-
-        List<ComponentConfigurationImpl> configs = new ArrayList<>();
-
-        ComponentConfigurationImpl cfg = new ComponentConfigurationImpl();
-        Map<String, Object> props = new HashMap<>();
-        props.put("key1", new Password("pass"));
-        cfg.setProperties(props);
-
-        configs.add(cfg);
-
-        TestUtil.invokePrivate(cs, "encryptConfigs", configs);
-
-        verify(cryptoServiceMock, times(1)).decryptAes("pass".toCharArray());
-        verify(cryptoServiceMock, times(0)).encryptAes((char[]) ArgumentMatchers.any());
-
-        assertEquals("property remains", 1, props.size());
-        assertTrue("key still exists", props.containsKey("key1"));
-        assertArrayEquals("key is already encrypted", "pass".toCharArray(),
-                ((Password) props.get("key1")).getPassword());
     }
 
     @Test
@@ -2987,7 +2859,7 @@ public class ConfigurationServiceJunitTest {
 
         when(systemServiceMock.getKuraSnapshotsCount()).thenReturn(5);
 
-        String pid = "pid";
+        String pid = "123";
         Set<String> allPids = (Set<String>) TestUtil.getFieldValue(cs, "allActivatedPids");
         allPids.add(pid);
 
@@ -3017,6 +2889,11 @@ public class ConfigurationServiceJunitTest {
         when(svcRefMock.getBundle()).thenReturn(bundleMock);
 
         when(bundleMock.getResource(ArgumentMatchers.anyString())).thenThrow(new NullPointerException("test"));
+
+        Configuration[] configurations = new Configuration[] {};
+        ConfigurationAdmin cfgAdminMock = mock(ConfigurationAdmin.class);
+        when(cfgAdminMock.listConfigurations(null)).thenReturn(configurations);
+        cs.setConfigurationAdmin(cfgAdminMock);
 
         try {
             cs.rollback(id);

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
@@ -596,7 +596,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void testMergeWithDefaultsNulls() throws KuraException {
+    public void testMergeWithDefaultsNulls() {
         // test with null parameters - null properties means error and NPE is expected
 
         ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
@@ -608,7 +608,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testMergeWithDefaultsEmpty() throws KuraException {
+    public void testMergeWithDefaultsEmpty() {
         // empty input
 
         ConfigurationServiceImpl cs = new ConfigurationServiceImpl();
@@ -623,7 +623,7 @@ public class ConfigurationServiceJunitTest {
     }
 
     @Test
-    public void testMergeWithDefaults() throws KuraException {
+    public void testMergeWithDefaults() {
         // a few default values, a few overrides, one ovelap
 
         final Map<String, Object> props = new HashMap<>();
@@ -635,7 +635,7 @@ public class ConfigurationServiceJunitTest {
         ConfigurationServiceImpl cs = new ConfigurationServiceImpl() {
 
             @Override
-            Map<String, Object> getDefaultProperties(OCD ocd) throws KuraException {
+            Map<String, Object> getDefaultProperties(OCD ocd) {
                 return props;
             }
         };
@@ -1302,7 +1302,7 @@ public class ConfigurationServiceJunitTest {
         List<ComponentConfigurationImpl> result = (List<ComponentConfigurationImpl>) TestUtil.invokePrivate(cs,
                 "loadLatestSnapshotConfigurations");
 
-        assertNull("null result", result);
+        assertTrue("empty result", result.isEmpty());
     }
 
     @Test
@@ -1322,7 +1322,7 @@ public class ConfigurationServiceJunitTest {
         List<ComponentConfigurationImpl> result = (List<ComponentConfigurationImpl>) TestUtil.invokePrivate(cs,
                 "loadLatestSnapshotConfigurations");
 
-        assertNull("null result", result);
+        assertTrue("empty result", result.isEmpty());
     }
 
     @Test
@@ -1451,7 +1451,7 @@ public class ConfigurationServiceJunitTest {
         List<ComponentConfigurationImpl> result = (List<ComponentConfigurationImpl>) TestUtil.invokePrivate(cs,
                 "loadLatestSnapshotConfigurations");
 
-        assertNull("xml config null", result);
+        assertTrue("xml config empty", result.isEmpty());
 
         assertEquals("call snapshots", 4, calls[0]);
         assertEquals("call load xml", 3, calls[1]);
@@ -1651,7 +1651,7 @@ public class ConfigurationServiceJunitTest {
             TestUtil.invokePrivate(cs, "writeSnapshot", sid, cfg);
             fail("Exception expected due to 'file' being directory.");
         } catch (KuraException e) {
-            assertEquals("Error code.", KuraErrorCode.INTERNAL_ERROR, e.getCode());
+            assertEquals("Error code.", KuraErrorCode.IO_ERROR, e.getCode());
         }
 
         verify(cryptoServiceMock, times(1)).encryptAes((char[]) ArgumentMatchers.any());
@@ -2362,7 +2362,7 @@ public class ConfigurationServiceJunitTest {
         ConfigurationServiceImpl cs = new ConfigurationServiceImpl() {
 
             @Override
-            boolean mergeWithDefaults(OCD ocd, Map<String, Object> properties) throws KuraException {
+            boolean mergeWithDefaults(OCD ocd, Map<String, Object> properties) {
                 assertEquals("size", 2, properties.size());
                 assertTrue("new property", properties.containsKey(ConfigurationService.KURA_SERVICE_PID));
                 assertEquals("property value", spid, properties.get(ConfigurationService.KURA_SERVICE_PID));
@@ -2401,7 +2401,7 @@ public class ConfigurationServiceJunitTest {
         ConfigurationServiceImpl cs = new ConfigurationServiceImpl() {
 
             @Override
-            boolean mergeWithDefaults(OCD ocd, Map<String, Object> properties) throws KuraException {
+            boolean mergeWithDefaults(OCD ocd, Map<String, Object> properties) {
                 assertEquals("size", 1, properties.size());
                 assertTrue("new property", properties.containsKey(ConfigurationService.KURA_SERVICE_PID));
                 assertEquals("property value", pid, properties.get(ConfigurationService.KURA_SERVICE_PID));

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/util/ComponentUtilTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/util/ComponentUtilTest.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ ******************************************************************************/
 package org.eclipse.kura.core.configuration.util;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/util/ComponentUtilTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/util/ComponentUtilTest.java
@@ -1,0 +1,143 @@
+package org.eclipse.kura.core.configuration.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.kura.KuraErrorCode;
+import org.eclipse.kura.KuraException;
+import org.eclipse.kura.configuration.ComponentConfiguration;
+import org.eclipse.kura.configuration.Password;
+import org.eclipse.kura.core.configuration.ComponentConfigurationImpl;
+import org.eclipse.kura.crypto.CryptoService;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+
+public class ComponentUtilTest {
+
+    @Test
+    public void testEncryptConfigsNull() throws NoSuchMethodException { // move
+        // test with null parameter
+        try {
+            ComponentUtil.encryptConfigs(null, null);
+        } catch (Throwable e) {
+            fail("Parameters not checked.");
+        }
+
+    }
+
+    @Test
+    public void testEncryptConfigsNoConfigs() { // move
+        // empty list
+        boolean exceptionCaught = false;
+
+        try {
+            ComponentUtil.encryptConfigs(new ArrayList<>(), null);
+        } catch (Throwable t) {
+            exceptionCaught = true;
+        }
+        assertFalse(exceptionCaught);
+    }
+
+    @Test
+    public void testEncryptConfigsEncryptionException() throws Throwable { // move
+        // test failed encryption of a password: add a password and run; fail
+
+        CryptoService cryptoServiceMock = mock(CryptoService.class);
+
+        // first decryption must fail
+        when(cryptoServiceMock.decryptAes("pass".toCharArray()))
+                .thenThrow(new KuraException(KuraErrorCode.DECODER_ERROR, "password"));
+        // then also encryption can fail
+        when(cryptoServiceMock.encryptAes("pass".toCharArray()))
+                .thenThrow(new KuraException(KuraErrorCode.ENCODE_ERROR, "password"));
+
+        List<ComponentConfiguration> configs = new ArrayList<>();
+
+        ComponentConfigurationImpl cfg = new ComponentConfigurationImpl();
+        Map<String, Object> props = new HashMap<>();
+        props.put("key1", new Password("pass"));
+        cfg.setProperties(props);
+
+        configs.add(cfg);
+
+        ComponentUtil.encryptConfigs(configs, cryptoServiceMock);
+
+        verify(cryptoServiceMock, times(1)).decryptAes("pass".toCharArray());
+        verify(cryptoServiceMock, times(1)).encryptAes("pass".toCharArray());
+
+        assertEquals("property was deleted", 0, props.size());
+    }
+
+    @Test
+    public void testEncryptConfigs() throws Throwable { // move
+        // test encrypting a password: add a password and run
+
+        CryptoService cryptoServiceMock = mock(CryptoService.class);
+
+        // first decryption must fail
+        when(cryptoServiceMock.decryptAes("pass".toCharArray()))
+                .thenThrow(new KuraException(KuraErrorCode.DECODER_ERROR, "configuration"));
+        // so that encryption is attempted at all
+        when(cryptoServiceMock.encryptAes("pass".toCharArray())).thenReturn("encrypted".toCharArray());
+
+        List<ComponentConfiguration> configs = new ArrayList<>();
+
+        ComponentConfigurationImpl cfg = new ComponentConfigurationImpl();
+        Map<String, Object> props = new HashMap<>();
+        props.put("key1", new Password("pass"));
+        cfg.setProperties(props);
+
+        configs.add(cfg);
+
+        ComponentUtil.encryptConfigs(configs, cryptoServiceMock);
+
+        verify(cryptoServiceMock, times(1)).decryptAes("pass".toCharArray());
+        verify(cryptoServiceMock, times(1)).encryptAes("pass".toCharArray());
+
+        assertEquals("property was updated", 1, props.size());
+        assertTrue("key still exists", props.containsKey("key1"));
+        assertArrayEquals("key is encrypted", "encrypted".toCharArray(), ((Password) props.get("key1")).getPassword());
+    }
+
+    @Test
+    public void testEncryptConfigsPreencryptedPassword() throws Throwable {
+        // test encrypting a password when the password is already encrypted
+
+        CryptoService cryptoServiceMock = mock(CryptoService.class);
+
+        // decryption succeeds this time
+        when(cryptoServiceMock.decryptAes("pass".toCharArray())).thenReturn("pass".toCharArray());
+
+        List<ComponentConfiguration> configs = new ArrayList<>();
+
+        ComponentConfigurationImpl cfg = new ComponentConfigurationImpl();
+        Map<String, Object> props = new HashMap<>();
+        props.put("key1", new Password("pass"));
+        cfg.setProperties(props);
+
+        configs.add(cfg);
+
+        ComponentUtil.encryptConfigs(configs, cryptoServiceMock);
+
+        verify(cryptoServiceMock, times(1)).decryptAes("pass".toCharArray());
+        verify(cryptoServiceMock, times(0)).encryptAes((char[]) ArgumentMatchers.any());
+
+        assertEquals("property remains", 1, props.size());
+        assertTrue("key still exists", props.containsKey("key1"));
+        assertArrayEquals("key is already encrypted", "pass".toCharArray(),
+                ((Password) props.get("key1")).getPassword());
+    }
+
+}


### PR DESCRIPTION
This PR updates the `rollback` method in the `ConfigurationServiceImpl` to make it simpler and avoid configuration updates if not really needed.

**Related Issue:** This PR fixes/closes N/A

**Description of the solution adopted:** The current implementation of the `rollback` method in the `ConfigurationServiceImpl` performs these operations:

- remove all existing factory configurations
- create all factory configurations in snapshot
- rollback configuration for all other components
- apply default configuration for components whose configuration is not in the snapshot

In order to simplify and speed up the process, this PR modifies the `rollback` method to perform these operations:

- if it's a factory component:
    - if it's present, but it is **not** in the snapshot to be applied, delete it
    - if it's **not** present, but it is in the snapshot to be applied, create it
    - if it's present and it is in the snapshot to be applied, check if the properties are different and updated it if needed
- if it's **not** a factory component:
    - if it's present, but it is **not** in the snapshot to be applied, apply the default configuration
    - if it's present and it is in the snapshot to be applied, check if the properties are different and updated it if needed

Moreover, several refactors have been done to the class following the suggestions by sonar.

