### PR TITLE
docs(5.3): correctly document supported parameters

### DIFF
--- a/docs/gateway-configuration/cellular-configuration.md
+++ b/docs/gateway-configuration/cellular-configuration.md
@@ -46,11 +46,11 @@ The **Cellular** tab contains the following configuration parameters:
 
 - **Active Filter**[^1]: sets the _active-filter_ option of the PPP daemon. This option specifies a packet filter _(filter-expression)_ to be applied to data packets in order to determine which packets are regarded as link activity, and thereby, reset the idle timer. The _filter-expression_ syntax is as described for tcpdump(1); however, qualifiers that do not apply to a PPP link, such as _ether_ and _arp_, are not permitted. The default value is _inbound_. To disable the _active-filter_ option, leave it blank.
 
-- **LCP Echo Interval**[^1]: sets the _lcp-echo-interval_ option of the PPP daemon. If set to a positive number, the modem sends LCP echo request to the peer at the specified number of seconds. To disable this option, set it to zero. This option may be used with the _lcp-echo-failure_ option to detect that the peer is no longer connected.
+- **LCP Echo Interval**: sets the _lcp-echo-interval_ option of the PPP daemon. If set to a positive number, the modem sends LCP echo request to the peer at the specified number of seconds. To disable this option, set it to zero. This option may be used with the _lcp-echo-failure_ option to detect that the peer is no longer connected.
 
-- **LCP Echo Failure**[^1]: sets the _lcp-echo-failure_ option of the PPP daemon. If set to a positive number, the modem presumes the peer to be dead if a specified number of LCP echo-requests are sent without receiving a valid LCP echo-reply. To disable this option, set it to zero.
+- **LCP Echo Failure**: sets the _lcp-echo-failure_ option of the PPP daemon. If set to a positive number, the modem presumes the peer to be dead if a specified number of LCP echo-requests are sent without receiving a valid LCP echo-reply. To disable this option, set it to zero.
 
-- **Enable GPS**[^1]: enables GPS with the following conditions:
+- **Enable GPS**: enables GPS with the following conditions:
     - One modem port will be dedicated to NMEA data stream.
     - This port may not be used to send AT commands to the modem.
     - _PositionService_ should be enabled. Serial settings of _PositionService_ should not be changed; it will be redirected to the modem GPS port automatically.

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -176,13 +176,13 @@ Name                                                   | Type     | Description
 `net.interface.<interface>.config.password`            | Password | The password used for the connection
 `net.interface.<interface>.config.pdpType`[^1]         | String   | The PdP type; possible values are IP, PPP and IPv6
 `net.interface.<interface>.config.maxFail`[^1]         | Integer  | The maxfail option of the PPP daemon
-`net.interface.<interface>.config.authType`[^1]        | String   | The authentication type; possible values are None, Auto, CHAP and PAP
-`net.interface.<interface>.config.lpcEchoInterval`[^1] | Integer  | The lcp-echo-interval option of the PPP daemon
+`net.interface.<interface>.config.authType`            | String   | The authentication type; possible values are None, Auto, CHAP and PAP
+`net.interface.<interface>.config.lpcEchoInterval`     | Integer  | The lcp-echo-interval option of the PPP daemon
 `net.interface.<interface>.config.activeFilter`[^1]    | String   | The active-filter option of the PPP daemon
-`net.interface.<interface>.config.lpcEchoFailure`[^1]  | Integer  | The lcp-echo-failure option of the PPP daemon
+`net.interface.<interface>.config.lpcEchoFailure`      | Integer  | The lcp-echo-failure option of the PPP daemon
 `net.interface.<interface>.config.diversityEnabled`[^1]|Boolean  | Enable the LTE diversity antenna
 `net.interface.<interface>.config.resetTimeout`        | Integer  | The modem reset timeout in minutes
-`net.interface.<interface>.config.gpsEnabled`[^1]      | Boolean  | Enable the GPS device in the modem if available
+`net.interface.<interface>.config.gpsEnabled`          | Boolean  | Enable the GPS device in the modem if available
 `net.interface.<interface>.config.persist`[^1]         | Boolean  | The persist option of the PPP daemon
 `net.interface.<interface>.config.apn`                 | String   | The modem Access Point Name
 `net.interface.<interface>.config.dialString`[^1]      | String   | The dial string used for connecting to the APN


### PR DESCRIPTION
This PR performs a correction on #5650: some parameter are actually supported.