### PR TITLE
docs(6.0): add GoogleAnalytics and cookie consent banner

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -228,3 +228,13 @@ extra:
       link: https://github.com/eclipse-kura/kura
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com/r/eclipse/kura
+  analytics:
+    provider: google
+    property: G-B5KFDTHZMV
+  consent:
+    title: Cookie consent
+    description: >- 
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. With your consent, you're helping us to
+      make our documentation better.


### PR DESCRIPTION
This PR adds Google Analytics and a cookie consent banner to the `docs-develop` version of the documentation.

<img width="875" alt="image" src="https://github.com/user-attachments/assets/dc4c5d10-ae70-40ae-8902-ee4a02bf7616" />
