### PR TITLE
docs: stay on the same page when switching versions

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Eclipse Kura™ Documentation
-site_url: 'https://eclipse-kura.github.io/kura'
+site_url: 'https://eclipse-kura.github.io/kura/'
 
 nav:
     - Getting Started:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Eclipse Kura™ Documentation
+site_url: 'https://eclipse-kura.github.io/kura'
 
 nav:
     - Getting Started:


### PR DESCRIPTION
Improve version navigation following [Mkdocs-material documentation](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful)

> **Stay on the same page when switching versions**
> When the user chooses a version in the version selector, they usually want to go to the page corresponding to the page they were previously viewing. Material for MkDocs implements this behavior by default, but there are a few caveats:
>
> - the [site_url](https://www.mkdocs.org/user-guide/configuration/#site_url) must be set correctly in mkdocs.yml. See the ["Publishing a new version"](https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/#publishing-a-new-version) section for an example.
>- the redirect happens via JavaScript and there is no way to know which page you will be redirected to ahead of time.