### PR TITLE
fix: change cookie settings in copyright notice

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,8 +221,8 @@ markdown_extensions:
   - footnotes
 
 copyright: >
-  Copyright &copy; 2025 Eurotech and/or its affiliates and others –
-  <a href="#__consent">Change cookie settings</a>
+  Copyright &copy; Eclipse Foundation AISBL. All Rights Reserved. –
+  <a href="#__consent"><b>Change cookie settings<b></a>
 
 extra:
   version:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,6 +220,10 @@ markdown_extensions:
   - pymdownx.superfences
   - footnotes
 
+copyright: >
+  Copyright &copy; 2025 Eurotech and/or its affiliates and others –
+  <a href="#__consent">Change cookie settings</a>
+
 extra:
   version:
     provider: mike


### PR DESCRIPTION
In order to comply with GDPR, users must be able to change their cookie settings at any time.

This PR adds a simple link to our newly introduced [copyright notice](https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#copyright-notice) in the `mkdocs.yml`