### PR TITLE
docs: add feedback widget

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+hide:
+  - feedback
+---
 <figure markdown>
   ![KuraLogo](./assets/kura_logo_400.png)
   <figcaption></figcaption>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,12 +239,12 @@ extra:
     feedback:
       title: Was this page helpful?
       ratings:
-        - icon: material/emoticon-happy-outline
+        - icon: material/thumb-up-outline
           name: This page was helpful
           data: 1
           note: >-
             Thanks for your feedback!
-        - icon: material/emoticon-sad-outline
+        - icon: material/thumb-down-outline
           name: This page could be improved
           data: 0
           note: >- 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -236,6 +236,20 @@ extra:
   analytics:
     provider: google
     property: G-B5KFDTHZMV
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: >- 
+            Thanks for your feedback! Help us improve this page by
+            using our <a href="https://github.com/eclipse-kura/kura/issues/new/?title=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">feedback form</a>.
   consent:
     title: Cookie consent
     description: >- 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,7 +249,7 @@ extra:
           data: 0
           note: >- 
             Thanks for your feedback! Help us improve this page by
-            using our <a href="https://github.com/eclipse-kura/kura/issues/new/?title=[Feedback]+{title}+-+{url}" target="_blank" rel="noopener">feedback form</a>.
+            using our <a href="https://github.com/eclipse-kura/kura/issues/new/?title=[Feedback]+{url}+-+" target="_blank" rel="noopener">feedback form</a>.
   consent:
     title: Cookie consent
     description: >- 


### PR DESCRIPTION
This PR adds the feedback widget for documentation pages. See https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/#was-this-page-helpful for details.

This feature leverages the Google Analytics setup introduced in #5673 and redirects user to our Github issues in case they need to provide feedback about the documentation pages.

Screenshots of the added feedback footer:
![image](https://github.com/user-attachments/assets/d2f86985-214e-46b0-abe3-f173f1429aa0)

Feedback form redirect:
![image](https://github.com/user-attachments/assets/8b75ea74-0c3b-464b-bdd8-ee42be4bff14)

Feedback is collected in our Google Analytics dashboard.