### PR TITLE
fix: multiple cookie consent pop-up when switching version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -233,6 +233,7 @@ extra:
       link: https://github.com/eclipse-kura/kura
     - icon: fontawesome/brands/docker
       link: https://hub.docker.com/r/eclipse/kura
+  scope: "/kura/"
   analytics:
     provider: google
     property: G-B5KFDTHZMV


### PR DESCRIPTION
As discussed in https://github.com/squidfunk/mkdocs-material/discussions/7947 currently Kura documentation asks users for cookie consent for **each published version** which is kind of awkward.

This PR sets the project `scope` as per https://squidfunk.github.io/mkdocs-material/setup/building-an-optimized-site/#scope

> There might be a use case, where you want to share user-level settings like the selected [color palette](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette), or [cookie consent](https://squidfunk.github.io/mkdocs-material/setup/ensuring-data-privacy/#cookie-consent) across all projects. To do so, add the following lines to mkdocs.yml:

Doing so should fix both the cookie consent issue **and** the color palette being separate for each published version.

From my local testing this seems to be working correctly. Upon switching version the user is no longer asked for cookie consent (and color palette preferences are preserved).

<img width="695" alt="immagine" src="https://github.com/user-attachments/assets/290172c8-af26-4f45-994d-3917c9bff21a" />

Thanks to @kamilkrzyskow and @alexvoss for the help!

**Note**: This PR is intended to be backported to all documentation versions supporting Google Analytics.
