### PR TITLE
fix(rest.provider): Avoid JakartarsServletWhiteboardRuntimeComponent restart triggered by configuration rollback

### DIFF
--- a/kura/org.eclipse.kura.rest.provider/src/main/java/org/eclipse/kura/internal/rest/provider/RestService.java
+++ b/kura/org.eclipse.kura.rest.provider/src/main/java/org/eclipse/kura/internal/rest/provider/RestService.java
@@ -58,6 +58,8 @@ import jakarta.ws.rs.ext.Provider;
 @SuppressWarnings("restriction")
 public class RestService implements ConfigurableComponent {
 
+    private static final String KURA_DEFAULT_JAKARTARS_WHITEBOARD_NAME = "KuraDefaultJakartarsWhiteboard";
+
     static {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
@@ -150,14 +152,14 @@ public class RestService implements ConfigurableComponent {
 
     private void configureDefaultWhiteboard() throws IOException, InvalidSyntaxException {
 
-        final Configuration[] configs = this.configurationAdmin
-                .listConfigurations("(kura.service.pid=kura.jakartars.whiteboard)");
+        final Configuration[] configs = this.configurationAdmin.listConfigurations(
+                "(jersey.jakartars.whiteboard.name=" + KURA_DEFAULT_JAKARTARS_WHITEBOARD_NAME + ")");
 
         if (configs == null) {
             final Dictionary<String, Object> properties = new Hashtable<>();
 
             properties.put("jersey.context.path", "/services");
-            properties.put("kura.service.pid", "kura.jakartars.whiteboard");
+            properties.put("jersey.jakartars.whiteboard.name", KURA_DEFAULT_JAKARTARS_WHITEBOARD_NAME);
 
             final Configuration newConfiguration = this.configurationAdmin
                     .createFactoryConfiguration("JakartarsServletWhiteboardRuntimeComponent", null);

--- a/kura/test/org.eclipse.kura.asset.provider.test/src/main/java/org/eclipse/kura/asset/provider/test/AssetTest.java
+++ b/kura/test/org.eclipse.kura.asset.provider.test/src/main/java/org/eclipse/kura/asset/provider/test/AssetTest.java
@@ -77,8 +77,6 @@ public final class AssetTest {
     /** A latch to be initialized with the no of OSGi dependencies it needs */
     private static CountDownLatch dependencyLatch = new CountDownLatch(1);
 
-    private static int channelNumber;
-
     /**
      * JUnit Callback to be triggered before creating the instance of this suite
      *
@@ -230,8 +228,6 @@ public final class AssetTest {
         channels.put("13.CH#+offset", "4.3");
         channels.put("13.CH#DRIVER.modbus.register", "sample.channel2.modbus.register");
         channels.put("13.CH#DRIVER.modbus.DUMMY.NN", "sample.channel2.modbus.FC");
-
-        channelNumber = channels.size();
 
         ((BaseAsset) asset).updated(channels);
         sync(asset);

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -143,7 +143,7 @@
                             ${tycho.surefire.testenv.args}
                             -Dlog4j.configurationFile=file:${kura.basedir}/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml
                         </argLine>
-                        <appArgLine>-consoleLog -console 5002 -noExit</appArgLine>
+                        <!-- <appArgLine>-consoleLog -console 5002 -noExit</appArgLine> -->
                         <dependencies>
                             <dependency>
                                 <type>p2-installable-unit</type>

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -143,7 +143,7 @@
                             ${tycho.surefire.testenv.args}
                             -Dlog4j.configurationFile=file:${kura.basedir}/emulator/org.eclipse.kura.emulator/src/main/resources/log4j.xml
                         </argLine>
-                        <!-- <appArgLine>-consoleLog -console 5002 -noExit</appArgLine> -->
+                        <appArgLine>-consoleLog -console 5002 -noExit</appArgLine>
                         <dependencies>
                             <dependency>
                                 <type>p2-installable-unit</type>


### PR DESCRIPTION
Removed `kura.service.pid` property from `JakartarsServletWhiteboardRuntimeComponent` to avoid component restart in case of rollback

