### PR TITLE
fix: missing version warning banner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mike==1.1.2
-mkdocs==1.5.3
+mkdocs==1.6.0
 mkdocs-material==9.6.2
 mkdocs-markdownextradata-plugin==0.2.5
 mkdocs-minify-plugin==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mike==1.1.2
 mkdocs==1.5.3
-mkdocs-material==9.5.17
+mkdocs-material==9.6.2
 mkdocs-markdownextradata-plugin==0.2.5
 mkdocs-minify-plugin==0.8.0
 mkdocs-jupyter==0.24.7


### PR DESCRIPTION
As reported in https://github.com/squidfunk/mkdocs-material/discussions/7947 after merging #5688 we realised that the version warning banner was no longer showing (more details about the issue [here](https://github.com/squidfunk/mkdocs-material/discussions/7947#discussioncomment-12039652)).

The behaviour was updated to cover our use case in https://github.com/squidfunk/mkdocs-material/pull/7959, and released in `mkdocs-material` [9.6.2](https://github.com/squidfunk/mkdocs-material/releases/tag/9.6.2).

This PR updates the `requirement.txt` file to use `mkdocs-material` [9.6.2](https://github.com/squidfunk/mkdocs-material/releases/tag/9.6.2) which contains the fix.
