### PR TITLE
perf(http.server.manager): Start Jetty in a separate thread

### DIFF
--- a/kura/org.eclipse.kura.http.server.manager/OSGI-INF/httpService.xml
+++ b/kura/org.eclipse.kura.http.server.manager/OSGI-INF/httpService.xml
@@ -21,11 +21,6 @@
        <provide interface="org.osgi.service.event.EventHandler"/>
    </service>
 
-   <reference name="SystemService"
-              bind="setSystemService"
-              cardinality="1..1"
-              policy="static"
-              interface="org.eclipse.kura.system.SystemService"/>
    <reference name="KeystoreService"
            policy="static"
            policy-option="greedy"

--- a/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/HttpService.java
+++ b/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/HttpService.java
@@ -15,6 +15,9 @@ package org.eclipse.kura.http.server.manager;
 import java.util.EventListener;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.kura.configuration.ConfigurableComponent;
 import org.eclipse.kura.configuration.ConfigurationService;
@@ -42,6 +45,7 @@ public class HttpService implements ConfigurableComponent, EventHandler {
     private String keystoreServicePid;
 
     private JettyServerHolder jettyServerHolder;
+    private ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     public void setSystemService(SystemService systemService) {
         this.systemService = systemService;
@@ -97,22 +101,33 @@ public class HttpService implements ConfigurableComponent, EventHandler {
     }
 
     private synchronized void activateHttpService() {
-        try {
-            logger.info("starting Jetty instance...");
-            this.jettyServerHolder = new JettyServerHolder(this.options, Optional.ofNullable(this.keystoreService),
-                    this.dispatcherServlet, this.eventListener);
-            logger.info("starting Jetty instance...done");
-        } catch (final Exception e) {
-            logger.error("Could not start Jetty Web server", e);
-        }
+        this.executorService.submit(() -> {
+            try {
+                logger.info("starting Jetty instance...");
+                this.jettyServerHolder = new JettyServerHolder(this.options, Optional.ofNullable(this.keystoreService),
+                        this.dispatcherServlet, this.eventListener);
+                logger.info("starting Jetty instance...done");
+            } catch (final Exception e) {
+                logger.error("Could not start Jetty Web server", e);
+            }
+        });
     }
 
     private synchronized void deactivateHttpService() {
         try {
             logger.info("stopping Jetty instance...");
-            this.jettyServerHolder.stop();
+            if (this.jettyServerHolder != null) {
+                this.jettyServerHolder.stop();
+            }
+            this.executorService.shutdown();
+            this.executorService.awaitTermination(30, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Could not stop Jetty Web server", e);
         } catch (final Exception e) {
             logger.error("Could not stop Jetty Web server", e);
+        } finally {
+            this.executorService.shutdownNow();
         }
     }
 

--- a/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/HttpService.java
+++ b/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/HttpService.java
@@ -23,7 +23,6 @@ import org.eclipse.kura.configuration.ConfigurableComponent;
 import org.eclipse.kura.configuration.ConfigurationService;
 import org.eclipse.kura.security.keystore.KeystoreChangedEvent;
 import org.eclipse.kura.security.keystore.KeystoreService;
-import org.eclipse.kura.system.SystemService;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventHandler;
 import org.slf4j.Logger;
@@ -37,7 +36,6 @@ public class HttpService implements ConfigurableComponent, EventHandler {
 
     private HttpServiceOptions options;
 
-    private SystemService systemService;
     private KeystoreService keystoreService;
     private HttpServlet dispatcherServlet;
     private EventListener eventListener;
@@ -46,10 +44,6 @@ public class HttpService implements ConfigurableComponent, EventHandler {
 
     private JettyServerHolder jettyServerHolder;
     private ExecutorService executorService = Executors.newSingleThreadExecutor();
-
-    public void setSystemService(SystemService systemService) {
-        this.systemService = systemService;
-    }
 
     public void setKeystoreService(KeystoreService keystoreService, final Map<String, Object> properties) {
         this.keystoreService = keystoreService;
@@ -67,9 +61,9 @@ public class HttpService implements ConfigurableComponent, EventHandler {
     public void activate(Map<String, Object> properties) {
         logger.info("Activating {}", this.getClass().getSimpleName());
 
-        this.options = new HttpServiceOptions(properties, this.systemService.getKuraHome());
+        this.options = new HttpServiceOptions(properties);
 
-        activateHttpService();
+        startHttpService(this.options);
 
         logger.info("Activating... Done.");
     }
@@ -77,7 +71,7 @@ public class HttpService implements ConfigurableComponent, EventHandler {
     public void updated(Map<String, Object> properties) {
         logger.info("Updating {}", this.getClass().getSimpleName());
 
-        HttpServiceOptions updatedOptions = new HttpServiceOptions(properties, this.systemService.getKuraHome());
+        HttpServiceOptions updatedOptions = new HttpServiceOptions(properties);
 
         if (!this.options.equals(updatedOptions)) {
             logger.debug("Updating, new props");
@@ -92,19 +86,20 @@ public class HttpService implements ConfigurableComponent, EventHandler {
     public void deactivate() {
         logger.info("Deactivating {}", this.getClass().getSimpleName());
 
-        deactivateHttpService();
+        stopHttpService();
+        shutdownExecutor();
     }
 
     private synchronized void restartHttpService() {
-        deactivateHttpService();
-        activateHttpService();
+        stopHttpService();
+        startHttpService(this.options);
     }
 
-    private synchronized void activateHttpService() {
+    private synchronized void startHttpService(final HttpServiceOptions options) {
         this.executorService.submit(() -> {
             try {
                 logger.info("starting Jetty instance...");
-                this.jettyServerHolder = new JettyServerHolder(this.options, Optional.ofNullable(this.keystoreService),
+                this.jettyServerHolder = new JettyServerHolder(options, Optional.ofNullable(this.keystoreService),
                         this.dispatcherServlet, this.eventListener);
                 logger.info("starting Jetty instance...done");
             } catch (final Exception e) {
@@ -113,19 +108,26 @@ public class HttpService implements ConfigurableComponent, EventHandler {
         });
     }
 
-    private synchronized void deactivateHttpService() {
-        try {
-            logger.info("stopping Jetty instance...");
-            if (this.jettyServerHolder != null) {
-                this.jettyServerHolder.stop();
+    private synchronized void stopHttpService() {
+        this.executorService.submit(() -> {
+            try {
+                logger.info("stopping Jetty instance...");
+                if (this.jettyServerHolder != null) {
+                    this.jettyServerHolder.stop();
+                }
+            } catch (final Exception e) {
+                logger.error("Could not stop Jetty Web server", e);
             }
+        });
+    }
+
+    private synchronized void shutdownExecutor() {
+        try {
             this.executorService.shutdown();
             this.executorService.awaitTermination(30, TimeUnit.SECONDS);
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.error("Could not stop Jetty Web server", e);
-        } catch (final Exception e) {
-            logger.error("Could not stop Jetty Web server", e);
+            logger.error("Could not stop executor", e);
         } finally {
             this.executorService.shutdownNow();
         }

--- a/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/HttpServiceOptions.java
+++ b/kura/org.eclipse.kura.http.server.manager/src/main/java/org/eclipse/kura/http/server/manager/HttpServiceOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -58,7 +58,7 @@ public class HttpServiceOptions {
     private final boolean isRevocationSoftFailEnabled;
     private final String keystoreServicePid;
 
-    public HttpServiceOptions(final Map<String, Object> properties, final String kuraHome) {
+    public HttpServiceOptions(final Map<String, Object> properties) {
         this.httpPorts = loadIntArrayProperty(HTTP_PORTS.get(properties));
         this.httpsPorts = loadIntArrayProperty(HTTPS_PORTS.get(properties));
         this.httpsWithClientAuthPorts = loadIntArrayProperty(HTTPS_CLIENT_AUTH_PORTS.get(properties));
@@ -110,7 +110,7 @@ public class HttpServiceOptions {
             }
         }
 
-        return result;
+        return Collections.unmodifiableSet(result);
     }
 
     @Override

--- a/kura/test/org.eclipse.kura.http.server.manager.test/src/main/java/org/eclipse/kura/https/server/manager/test/HttpServiceTest.java
+++ b/kura/test/org.eclipse.kura.http.server.manager.test/src/main/java/org/eclipse/kura/https/server/manager/test/HttpServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -19,9 +19,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.KeyManagementException;
 import java.security.KeyPair;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -132,8 +130,8 @@ public class HttpServiceTest {
     }
 
     @Test
-    public void shouldNotOpenAnyPortWithDefaultConfig() throws KuraException, InvalidSyntaxException,
-            InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+    public void shouldNotOpenAnyPortWithDefaultConfig()
+            throws InvalidSyntaxException, InterruptedException, ExecutionException, TimeoutException {
         final ConfigurationService configService = configurationService.get(5, TimeUnit.MINUTES);
 
         updateComponentConfiguration(configService, HTTP_SERVER_MANAGER_PID,
@@ -147,8 +145,8 @@ public class HttpServiceTest {
     }
 
     @Test
-    public void shouldOpenHttpPorts() throws KuraException, InvalidSyntaxException, InterruptedException,
-            ExecutionException, TimeoutException, MalformedURLException {
+    public void shouldOpenHttpPorts()
+            throws InvalidSyntaxException, InterruptedException, ExecutionException, TimeoutException {
         final ConfigurationService configService = configurationService.get(5, TimeUnit.MINUTES);
 
         updateComponentConfiguration(configService, HTTP_SERVER_MANAGER_PID,
@@ -163,8 +161,8 @@ public class HttpServiceTest {
     }
 
     @Test
-    public void shouldOpenMultipleHttpPorts() throws KuraException, InvalidSyntaxException, InterruptedException,
-            ExecutionException, TimeoutException, MalformedURLException {
+    public void shouldOpenMultipleHttpPorts()
+            throws InvalidSyntaxException, InterruptedException, ExecutionException, TimeoutException {
         final ConfigurationService configService = configurationService.get(5, TimeUnit.MINUTES);
 
         updateComponentConfiguration(configService, HTTP_SERVER_MANAGER_PID,
@@ -178,8 +176,8 @@ public class HttpServiceTest {
     }
 
     @Test
-    public void shouldNotSupportHttpsWithoutKeystore() throws KuraException, InvalidSyntaxException,
-            InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+    public void shouldNotSupportHttpsWithoutKeystore()
+            throws InvalidSyntaxException, InterruptedException, ExecutionException, TimeoutException {
         final ConfigurationService configService = configurationService.get(5, TimeUnit.MINUTES);
 
         updateComponentConfiguration(configService, HTTP_SERVER_MANAGER_PID, HttpServiceOptions.defaultConfiguration()
@@ -198,6 +196,8 @@ public class HttpServiceTest {
 
         try (final TestKeystore testKeystore = new TestKeystore(configSvc, cryptoSvc, TEST_KEYSTORE_PID,
                 HttpsKeystoreServiceOptions.defaultConfiguration())) {
+
+            Thread.sleep(30000);
             updateComponentConfiguration(configSvc, HTTP_SERVER_MANAGER_PID,
                     HttpServiceOptions.defaultConfiguration().withHttpsPorts(4442)
                             .withKeystoreServiceTarget(testKeystore.getTargetFilter()).toProperties()).get(30,
@@ -377,7 +377,7 @@ public class HttpServiceTest {
 
         public TestKeystore(final ConfigurationService configSvc, final CryptoService cryptoSvc, final String pid,
                 final HttpsKeystoreServiceOptions options)
-                throws InterruptedException, ExecutionException, TimeoutException, IOException, KuraException {
+                throws InterruptedException, ExecutionException, TimeoutException, KuraException {
             this.configSvc = configSvc;
             this.pid = pid;
 
@@ -615,7 +615,7 @@ public class HttpServiceTest {
     }
 
     static CompletableFuture<Void> updateComponentConfiguration(final ConfigurationService configurationService,
-            final String pid, final Map<String, Object> properties) throws KuraException, InvalidSyntaxException {
+            final String pid, final Map<String, Object> properties) throws InvalidSyntaxException {
 
         final CompletableFuture<Void> result = new CompletableFuture<>();
         final BundleContext context = FrameworkUtil.getBundle(WireTestUtil.class).getBundleContext();
@@ -667,7 +667,7 @@ public class HttpServiceTest {
     }
 
     private static KeyManager[] buildClientKeyManagers() throws KeyStoreException, NoSuchAlgorithmException,
-            CertificateException, IOException, UnrecoverableKeyException, KeyManagementException {
+            CertificateException, IOException, UnrecoverableKeyException {
         final KeyStore keystore = KeyStore.getInstance("JKS");
         try (final FileInputStream in = new FileInputStream(clientKeystore)) {
             keystore.load(in, "changeit".toCharArray());

--- a/kura/test/org.eclipse.kura.http.server.manager.test/src/main/java/org/eclipse/kura/https/server/manager/test/HttpServiceTest.java
+++ b/kura/test/org.eclipse.kura.http.server.manager.test/src/main/java/org/eclipse/kura/https/server/manager/test/HttpServiceTest.java
@@ -197,7 +197,6 @@ public class HttpServiceTest {
         try (final TestKeystore testKeystore = new TestKeystore(configSvc, cryptoSvc, TEST_KEYSTORE_PID,
                 HttpsKeystoreServiceOptions.defaultConfiguration())) {
 
-            Thread.sleep(30000);
             updateComponentConfiguration(configSvc, HTTP_SERVER_MANAGER_PID,
                     HttpServiceOptions.defaultConfiguration().withHttpsPorts(4442)
                             .withKeystoreServiceTarget(testKeystore.getTargetFilter()).toProperties()).get(30,


### PR DESCRIPTION
In order to speed up the Kura start, this PR adds an `Executor` to start the Jetty HTTP Server.

