### PR TITLE
fix: removing the starting of aries.spifly bundle because jvm crash

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -772,7 +772,7 @@ fi]]>
             <param name="bundle.name" value="org.apache.aries.spifly.dynamic.bundle" />
             <param name="bundle.version" value="${org.apache.aries.spifly.dynamic.bundle.version}" />
             <param name="start.level" value="2" />
-            <param name="start" value="s" />
+            <param name="start" value="" />
         </antcall>
         <antcall target="install-plugin">
             <param name="bundle.name" value="asm" />

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -550,7 +550,7 @@
                             <bundle>
                                 <id>org.apache.aries.spifly.dynamic.bundle</id>
                                 <level>4</level>
-                                <autoStart>true</autoStart>
+                                <autoStart>false</autoStart>
                             </bundle>
                             <bundle>
                                 <id>org.eclipse.osgitech.rest</id>


### PR DESCRIPTION
Starting the aries.spifly bundle causes jvm to crash if a security manager is installed.