### PR TITLE
fix(container.provider): removed useless unset method

### DIFF
--- a/kura/org.eclipse.kura.container.provider/OSGI-INF/containerinstance.xml
+++ b/kura/org.eclipse.kura.container.provider/OSGI-INF/containerinstance.xml
@@ -18,5 +18,5 @@
    <property name="service.pid" value="org.eclipse.kura.container.provider.ContainerInstance"/>
    <reference bind="setContainerOrchestrationService" cardinality="1..1" interface="org.eclipse.kura.container.orchestration.ContainerOrchestrationService" name="ContainerOrchestrationService" policy="static"/>
    <reference bind="setContainerSignatureValidationService" cardinality="0..n" interface="org.eclipse.kura.container.signature.ContainerSignatureValidationService" name="ContainerSignatureValidationService" policy="dynamic" unbind="unsetContainerSignatureValidationService"/>
-   <reference bind="setConfigurationService" cardinality="1..1" interface="org.eclipse.kura.configuration.ConfigurationService" name="ConfigurationService" policy="static" unbind="unsetConfigurationService"/>
+   <reference bind="setConfigurationService" cardinality="1..1" interface="org.eclipse.kura.configuration.ConfigurationService" name="ConfigurationService" policy="static"/>
 </scr:component>

--- a/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
+++ b/kura/org.eclipse.kura.container.provider/src/main/java/org/eclipse/kura/container/provider/ContainerInstance.java
@@ -76,10 +76,6 @@ public class ContainerInstance implements ConfigurableComponent, ContainerOrches
         this.configurationService = confService;
     }
 
-    public synchronized void unsetConfigurationService() {
-        this.configurationService = null;
-    }
-
     // ----------------------------------------------------------------
     //
     // Activation APIs
@@ -294,7 +290,8 @@ public class ContainerInstance implements ConfigurableComponent, ContainerOrches
             final boolean isInstanceEnabled = newOptions.isEnabled();
 
             try {
-                existingContainer = getExistingContainerByName(newOptions.getContainerConfiguration().getContainerName());
+                existingContainer = getExistingContainerByName(
+                        newOptions.getContainerConfiguration().getContainerName());
             } catch (final Exception e) {
                 logger.warn("failed to get existing container state", e);
                 return new Disabled(newOptions);


### PR DESCRIPTION
This PR removes the useless method to unbind the configurationService from a ContainerInstance, when the latter is deleted from the webUI.

That method was wrong, as the signature didn't contain the required parameter (eg: `final ConfigurationService confService`):

`public synchronized void unsetConfigurationService() {`
`    this.configurationService = null;`
`}`

This caused an error, visible also in the logger:
>   deactivate...done
 !ENTRY org.eclipse.kura.container.provider 4 0 2025-02-11 12:47:54.264
 !MESSAGE bundle org.eclipse.kura.container.provider:2.0.0.202502050814 (169)[org.eclipse.kura.container.provider.ContainerInstance(120)] : unbind method [unsetConfigurationService] not found; Component will fail
 !ENTRY org.eclipse.kura.container.provider 4 0 2025-02-11 12:47:54.265
 !MESSAGE bundle org.eclipse.kura.container.provider:2.0.0.202502050814 (169)[org.eclipse.kura.container.provider.ContainerInstance(120)] : unbind method [unsetConfigurationService] not found
 Container signature validation service class com.eurotech.framework.container.signature.validation.cosign.provider.CosignContainerValidationService removed.

Adding the parameter would already fix the problem, but being that method pretty useless, it is better to just remove it.
