### PR TITLE
docs: Fix download URL to reference Github releases

### DIFF
--- a/docs/getting-started/install-kura.md
+++ b/docs/getting-started/install-kura.md
@@ -1,6 +1,6 @@
 # Install Kura
 
-Eclipse Kura&trade; is provided using a Debian Linux package. Visit the [Kura download page](https://github.com/eclipse-kura/kura/releases/latest) to find the correct installation file for the target system.
+Eclipse Kura&trade; is provided using a Debian Linux package. Visit the [Kura download page](https://github.com/eclipse-kura/kura/releases) to find the correct installation file for the target system.
 
 
 

--- a/docs/getting-started/install-kura.md
+++ b/docs/getting-started/install-kura.md
@@ -1,6 +1,6 @@
 # Install Kura
 
-Eclipse Kura&trade; is provided using a Debian Linux package. Visit the [Kura download page](https://www.eclipse.org/kura/downloads.php) to find the correct installation file for the target system.
+Eclipse Kura&trade; is provided using a Debian Linux package. Visit the [Kura download page](https://github.com/eclipse-kura/kura/releases/latest) to find the correct installation file for the target system.
 
 
 

--- a/docs/getting-started/raspberry-pi-raspberryos-quick-start.md
+++ b/docs/getting-started/raspberry-pi-raspberryos-quick-start.md
@@ -5,11 +5,11 @@
 This section provides Eclipse Kura&trade; quick installation procedures for the Raspberry Pi and the Kura development environment.
 
 !!! warning
-    This quickstart will install the version of Kura with the administrative web UI and network  configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://github.com/eclipse-kura/kura/releases/latest)
+    This quickstart will install the version of Kura with the administrative web UI and network  configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://github.com/eclipse-kura/kura/releases)
 
 This quickstart has been tested using the latest Raspberry Pi OS 64 bits images which are available for download through [the official Raspberry Pi foundation site](https://www.raspberrypi.com/software/operating-systems/) and the Raspberry Pi Imager.
 
-For additional details on OS compatibility refer to the [Kura&trade; release notes](https://github.com/eclipse-kura/kura/releases/latest).
+For additional details on OS compatibility refer to the [Kura&trade; release notes](https://github.com/eclipse-kura/kura/releases).
 
 ## Enable SSH Access
 

--- a/docs/getting-started/raspberry-pi-raspberryos-quick-start.md
+++ b/docs/getting-started/raspberry-pi-raspberryos-quick-start.md
@@ -5,11 +5,11 @@
 This section provides Eclipse Kura&trade; quick installation procedures for the Raspberry Pi and the Kura development environment.
 
 !!! warning
-    This quickstart will install the version of Kura with the administrative web UI and network  configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://websites.eclipseprojects.io/kura/downloads.php)
+    This quickstart will install the version of Kura with the administrative web UI and network  configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://github.com/eclipse-kura/kura/releases/latest)
 
 This quickstart has been tested using the latest Raspberry Pi OS 64 bits images which are available for download through [the official Raspberry Pi foundation site](https://www.raspberrypi.com/software/operating-systems/) and the Raspberry Pi Imager.
 
-For additional details on OS compatibility refer to the [Kura&trade; release notes](https://websites.eclipseprojects.io/kura/downloads.php).
+For additional details on OS compatibility refer to the [Kura&trade; release notes](https://github.com/eclipse-kura/kura/releases/latest).
 
 ## Enable SSH Access
 

--- a/docs/getting-started/raspberry-pi-ubuntu-20-quick-start.md
+++ b/docs/getting-started/raspberry-pi-ubuntu-20-quick-start.md
@@ -6,7 +6,7 @@ This section provides Eclipse Kura&trade; quick installation procedures for the
 Raspberry Pi.
 
 !!! warning
-    This quickstart will install the version of Kura with the administrative web UI and network configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://github.com/eclipse-kura/kura/releases/latest)
+    This quickstart will install the version of Kura with the administrative web UI and network configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://github.com/eclipse-kura/kura/releases)
 
 This quickstart has been tested using the latest Ubuntu 20.04.3 LTS Live Server for arm64 architecture flashed on the SD card through [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
 

--- a/docs/getting-started/raspberry-pi-ubuntu-20-quick-start.md
+++ b/docs/getting-started/raspberry-pi-ubuntu-20-quick-start.md
@@ -6,7 +6,7 @@ This section provides Eclipse Kura&trade; quick installation procedures for the
 Raspberry Pi.
 
 !!! warning
-    This quickstart will install the version of Kura with the administrative web UI and network configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://websites.eclipseprojects.io/kura/downloads.php)
+    This quickstart will install the version of Kura with the administrative web UI and network configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://github.com/eclipse-kura/kura/releases/latest)
 
 This quickstart has been tested using the latest Ubuntu 20.04.3 LTS Live Server for arm64 architecture flashed on the SD card through [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
 

--- a/docs/java-application-development/kura-workspace-setup.md
+++ b/docs/java-application-development/kura-workspace-setup.md
@@ -94,7 +94,7 @@ After the new workspace opens, click the Workbench icon to display the developme
 
 ### Importing the Eclipse Kura User Workspace
 
-To set up your Eclipse Kura project workspace, you will need to download the Eclipse Kura User Workspace archive from [Eclipse Kura Download Page](https://eclipse.dev/kura/downloads.php).
+To set up your Eclipse Kura project workspace, you will need to download the Eclipse Kura User Workspace archive from [Eclipse Kura Download Page](https://github.com/eclipse-kura/kura/releases/latest).
 
 From the Eclipse File menu, select the **Import** option.  In the Import dialog box, expand the **General** heading, select **Existing Projects into Workspace**, and then click **Next**.
 

--- a/docs/java-application-development/kura-workspace-setup.md
+++ b/docs/java-application-development/kura-workspace-setup.md
@@ -94,7 +94,7 @@ After the new workspace opens, click the Workbench icon to display the developme
 
 ### Importing the Eclipse Kura User Workspace
 
-To set up your Eclipse Kura project workspace, you will need to download the Eclipse Kura User Workspace archive from [Eclipse Kura Download Page](https://github.com/eclipse-kura/kura/releases/latest).
+To set up your Eclipse Kura project workspace, you will need to download the Eclipse Kura User Workspace archive from [Eclipse Kura Download Page](https://github.com/eclipse-kura/kura/releases).
 
 From the Eclipse File menu, select the **Import** option.  In the Import dialog box, expand the **General** heading, select **Existing Projects into Workspace**, and then click **Next**.
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-kura/kura/issues/5712
