### PR TITLE
docs: Fix download URL to reference Github releases (#5713)

### DIFF
--- a/docs/getting-started/install-kura.md
+++ b/docs/getting-started/install-kura.md
@@ -1,6 +1,6 @@
 # Install Kura
 
-Kura is provided using a DEB Linux package. Visit the [Kura download page](https://www.eclipse.org/kura/downloads.php) to find the correct installation file for the target system.
+Eclipse Kura&trade; is provided using a Debian Linux package. Visit the [Kura download page](https://github.com/eclipse-kura/kura/releases) to find the correct installation file for the target system.
 
 
 

--- a/docs/getting-started/raspberry-pi-raspberryos-quick-start.md
+++ b/docs/getting-started/raspberry-pi-raspberryos-quick-start.md
@@ -5,14 +5,14 @@
 This section provides Eclipse Kura&trade; quick installation procedures for the Raspberry Pi and the Kura development environment.
 
 !!! warning
-    This quickstart will install the version of Kura with the administrative web UI and network  configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://websites.eclipseprojects.io/kura/downloads.php)
+    This quickstart will install the version of Kura with the administrative web UI and network  configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://github.com/eclipse-kura/kura/releases)
 
 This quickstart has been tested using the latest Raspberry Pi OS 32 and 64 bits images which are available for download through [the official Raspberry Pi foundation site](https://www.raspberrypi.com/software/operating-systems/) and the Raspberry Pi Imager.
 
 !!! warning
     Recent versions of Raspberry Pi OS 32 bit on Raspberry PI 4 will use by default a 64 bit kernel with a 32 bit userspace. This can cause issues to applications that use the result of `uname -m` to decide which native libraries to load (see https://github.com/raspberrypi/firmware/issues/1795). This currently affects for example the Kura SQLite database connector. It should be possible to solve by switching to the 32 bit kernel setting `arm_64bit=0` in `/boot/config.txt` and restarting the device.
 
-For additional details on OS compatibility refer to the [Kura&trade; release notes](https://websites.eclipseprojects.io/kura/downloads.php).
+For additional details on OS compatibility refer to the [Kura&trade; release notes](https://github.com/eclipse-kura/kura/releases).
 
 ## Enable SSH Access
 

--- a/docs/getting-started/raspberry-pi-ubuntu-20-quick-start.md
+++ b/docs/getting-started/raspberry-pi-ubuntu-20-quick-start.md
@@ -6,7 +6,7 @@ This section provides Eclipse Kura&trade; quick installation procedures for the
 Raspberry Pi.
 
 !!! warning
-    This quickstart will install the version of Kura with the administrative web UI and network  configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://websites.eclipseprojects.io/kura/downloads.php)
+    This quickstart will install the version of Kura with the administrative web UI and network configuration support but not [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) support. For more information on this please visit the [Eclipse Kura download page](https://github.com/eclipse-kura/kura/releases)
 
 This quickstart has been tested using the latest Ubuntu 20.04.3 LTS Live Server for arm64 architecture flashed on the SD card through [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
 

--- a/docs/java-application-development/kura-workspace-setup.md
+++ b/docs/java-application-development/kura-workspace-setup.md
@@ -94,7 +94,7 @@ After the new workspace opens, click the Workbench icon to display the developme
 
 ### Importing the Eclipse Kura User Workspace
 
-To set up your Eclipse Kura project workspace, you will need to download the Eclipse Kura User Workspace archive from [Eclipse Kura Download Page](https://eclipse.dev/kura/downloads.php).
+To set up your Eclipse Kura project workspace, you will need to download the Eclipse Kura User Workspace archive from [Eclipse Kura Download Page](https://github.com/eclipse-kura/kura/releases).
 
 From the Eclipse File menu, select the **Import** option.  In the Import dialog box, expand the **General** heading, select **Existing Projects into Workspace**, and then click **Next**.
 


### PR DESCRIPTION
* docs: Fix download URL to reference Github releases

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>

* docs: Implemented the suggested change

---------

Signed-off-by: MMaiero <matteo.maiero@eurotech.com>
(cherry picked from commit d28aa4b03cf85c2e266bd310636df7289a55c0b2)

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

**Related Issue:** This PR fixes/closes {issue number}

**Description of the solution adopted:** A more detailed description of the changes made to solve/close one or more issues. If the PR is simple and easy to understand this section can be skipped

**Screenshots:** If applicable, add screenshots to help explain your solution

**Manual Tests**: Optional description of the tests performed to check correct functioning of changes, useful for an efficient review

**Any side note on the changes made:** Description of any other change that has been made, which is not directly linked to the issue resolution [e.g. Code clean up/Sonar issue resolution]
