### PR TITLE
ci: fix deploy docs workflow permissions

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - 'docs-develop'
       - 'docs-release-*.*'
+
+permissions:
+  contents: write
+  pages: write
+
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix workflow for deploying docs. See: https://github.com/eclipse-kura/kura/actions/runs/13282289120