### PR TITLE
ci: add `copyright-check` github action

### DIFF
--- a/.github/copyright-config.yml
+++ b/.github/copyright-config.yml
@@ -1,0 +1,31 @@
+# Enable or disable the copyright date check
+bypass_year_check: false
+# In the template the user can specify two variables: {years} and {holder}
+# - {years} will match the copyright years (regex: `\d{4}(,\s\d{4})?`)
+# - {holder} will match the copyright holder (regex: `[\w\s\.]+`)
+template_java: |
+  ******************************************************************************
+   * Copyright (c) {years} {holder} and/or its affiliates and others
+   *
+   * This program and the accompanying materials are made
+   * available under the terms of the Eclipse Public License 2.0
+   * which is available at https://www.eclipse.org/legal/epl-2.0/
+   *
+   * SPDX-License-Identifier: EPL-2.0
+   *
+   * Contributors:
+   *  {holder}
+template_xml: |2
+      Copyright (c) {years} {holder} and/or its affiliates and others
+
+      This program and the accompanying materials are made
+      available under the terms of the Eclipse Public License 2.0
+      which is available at https://www.eclipse.org/legal/epl-2.0/
+
+      SPDX-License-Identifier: EPL-2.0
+
+      Contributors:
+       {holder}
+# Ignore specific files and paths. The syntax and semantics are the same as in the .gitignore file.
+ignore:
+  - target-platform/

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,0 +1,15 @@
+name: Copyright check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - 'develop'
+      - 'release-*'
+
+jobs:
+  call-workflow-in-public-repo:
+    uses: eclipse-kura/.github/.github/workflows/_shared-copyright-check.yml@main
+    with:
+      config-path: '.github/copyright-config.yml'
+


### PR DESCRIPTION
This PR introduces a new re-usable github action to perform copyright headers check automatically. 

- The tool we're using was contributed here: https://github.com/eclipse-kura/copyright-check
- The re-usable workflow is defined here: https://github.com/eclipse-kura/.github