### PR TITLE
fix: Updated m2e config to ignore bnd-maven-plugin

### DIFF
--- a/kura/examples/pom.xml
+++ b/kura/examples/pom.xml
@@ -7,10 +7,10 @@
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
 
-	SPDX-License-Identifier: EPL-2.0
+    SPDX-License-Identifier: EPL-2.0
 
-	Contributors:
-	 Eurotech
+    Contributors:
+     Eurotech
      Red Hat Inc
 
 -->

--- a/kura/examples/pom.xml
+++ b/kura/examples/pom.xml
@@ -471,7 +471,7 @@
                             <goal>bnd-process</goal>
                             </goals>
                             <configuration>
-                                <packagingTypes>eclipse-plugin, eclipse-test-plugin</packagingTypes>
+                                <packagingTypes>eclipse-plugin,eclipse-test-plugin</packagingTypes>
                             </configuration>
                         </execution>
                     </executions>
@@ -495,6 +495,19 @@
                     <configuration>
                         <lifecycleMappingMetadata>
                             <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>biz.aQute.bnd</groupId>
+                                        <artifactId>bnd-maven-plugin</artifactId>
+                                        <versionRange>[0.0.0,)</versionRange>
+                                        <goals>
+                                            <goal>bnd-process</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
+
+    Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
 
-	SPDX-License-Identifier: EPL-2.0
+    SPDX-License-Identifier: EPL-2.0
 
-	Contributors:
-	 Eurotech
+    Contributors:
+     Eurotech
      Red Hat Inc
      Cavium
 

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -640,7 +640,7 @@
                             <goal>bnd-process</goal>
                             </goals>
                             <configuration>
-                                <packagingTypes>eclipse-plugin, eclipse-test-plugin</packagingTypes>
+                                <packagingTypes>eclipse-plugin,eclipse-test-plugin</packagingTypes>
                             </configuration>
                         </execution>
                     </executions>
@@ -691,6 +691,19 @@
                     <configuration>
                         <lifecycleMappingMetadata>
                             <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>biz.aQute.bnd</groupId>
+                                        <artifactId>bnd-maven-plugin</artifactId>
+                                        <versionRange>[0.0.0,)</versionRange>
+                                        <goals>
+                                            <goal>bnd-process</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Updates m2e config to ignore bnd-maven-plugin execution, to solve new project import issues in Eclipse IDE
