### PR TITLE
docs(triton.server): New TritonServer metrics documentation

### DIFF
--- a/docs/core-services/nvidia-triton-server-inference-engine.md
+++ b/docs/core-services/nvidia-triton-server-inference-engine.md
@@ -90,6 +90,7 @@ The parameters used to configure the Triton Service are the following:
 - **Optional configuration for the local backends**: A semi-colon separated list of configuration for the backends. i.e. tensorflow,version=2;tensorflow,allow-soft-placement=false 
 - **Timeout (in seconds) for time consuming tasks**: Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout, the operation will be terminated with an error.
 - **Max. GRPC message size (bytes)**: this field controls the maximum allowed size for the GRPC calls to the server instance.
+- **Enable Triton Server Metrics**: Enables the [Triton Server Metrics and Statistics support](#triton-server-metrics-and-statistics-support)
 
 !!! note
     Pay attention on the ports used for communicating with the Triton Server. The default ports are the 8000-8002, but these are tipically used by Kura for debug purposes.
@@ -122,6 +123,7 @@ The parameters used to configure the Triton Service are the following:
 - **Devices**: A comma-separated list of device paths passed to the Triton server container (e.g. `/dev/video0`).
 - **Timeout (in seconds) for time consuming tasks**: Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout, the operation will be terminated with an error.
 - **Max. GRPC message size (bytes)**: this field controls the maximum allowed size for the GRPC calls to the server instance.
+- **Enable Triton Server Metrics**: Enables the [Triton Server Metrics and Statistics support](#triton-server-metrics-and-statistics-support)
 
 !!! note
     Pay attention on the ports used for communicating with the Triton Server. The default ports are the 8000-8002, but these are typically used by Kura for debug purposes.
@@ -200,7 +202,7 @@ More in details, the following GPU metrics are supported:
 The metrics are provided as key-value pairs, whose key is in the format `gpu.metrics.<GPU uuid>` where the `GPU uuid` is an unique identifier of the GPU. The value is in JSON format.
 An example of GPU metrics is the following:
 
-```
+```json
 key : gpu.metrics.GPU-340cec52-80ba-c0df-8511-5f9680aae0ff 
 value : 
 {
@@ -218,7 +220,7 @@ value :
 The format of the model statistic key is `model.metrics.<model name>.<model version>`. The value is in JSON format.
 An example of model statistics is reported below:
 
-```
+```json
 key : model.metrics.preprocessor.1
 value : 
 {

--- a/docs/core-services/nvidia-triton-server-inference-engine.md
+++ b/docs/core-services/nvidia-triton-server-inference-engine.md
@@ -186,7 +186,7 @@ The resulting archive `tf_autoencoder_fp32.zip.asc` can be transferred to the _L
 
 Since version 6.0.0, Eclipse Kura supports metrics and statistics reporting from a generic Inference Engine, leveraging the [InferenceEngineMetricsService](https://github.com/eclipse-kura/kura/blob/develop/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/ai/inference/InferenceEngineMetricsService.java) APIs.
 
-The implementation for the Triton Server allows to retrieve relevant metrics regarding GPU and models from the engine. It is based on the [Nvidia Triton Server Metrics feature](https://github.com/triton-inference-server/server/blob/r24.08/docs/user_guide/metrics.md) and the [Model Statistics Extension](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_statistics.md). The feature is enabled using the `Enable Triton Server Metrics` parameter from the Eclipse Kura webUI or the `enable.metrics` property in the snapshot configuration. This property is available only for the Triton Server Native Service and Triton Server Container Service components. In the case of the Triton Server Remote Service, the metrics reporting cannot be configured but it can be available depending on the Triton Server setup.
+The implementation for the Triton Server allows to retrieve relevant metrics regarding GPU and models from the engine. It is based on the [Nvidia Triton Server Metrics feature](https://github.com/triton-inference-server/server/blob/r24.08/docs/user_guide/metrics.md) and the [Model Statistics Extension](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_statistics.md). The feature is enabled using the `Enable Triton Server Metrics` parameter from the Eclipse Kura webUI or the `enable.metrics` property in the snapshot configuration. This property is available only for the Triton Server Native Service and Triton Server Container Service components. In the case of the Triton Server Remote Service, the metrics reporting cannot be configured but it can be available depending on the remote Triton Server setup.
 
 More in details, the following GPU metrics are supported:
 
@@ -197,7 +197,7 @@ More in details, the following GPU metrics are supported:
 - GPU Total Memory
 - GPU Used Memory
 
-The metrics are provided in a key-value pairs, whose key is in the format `gpu.metrics.<GPU uuid>` where the `GPU uuid` is an unique identifier of the GPU. The value is in JSON format.
+The metrics are provided as key-value pairs, whose key is in the format `gpu.metrics.<GPU uuid>` where the `GPU uuid` is an unique identifier of the GPU. The value is in JSON format.
 An example of GPU metrics is the following:
 
 ```

--- a/docs/core-services/nvidia-triton-server-inference-engine.md
+++ b/docs/core-services/nvidia-triton-server-inference-engine.md
@@ -126,6 +126,8 @@ The parameters used to configure the Triton Service are the following:
 !!! note
     Pay attention on the ports used for communicating with the Triton Server. The default ports are the 8000-8002, but these are typically used by Kura for debug purposes.
 
+
+
 ## AI Model Encryption Support
 
 For ensuring inference integrity and providing copyright protection of deep-learning models on edge devices, Kura provides decryption capabilities for trained models to be served through the Triton Server.
@@ -179,3 +181,104 @@ gpg --armor --symmetric --cipher-algo AES256 tf_autoencoder_fp32.zip
 ```
 
 The resulting archive `tf_autoencoder_fp32.zip.asc` can be transferred to the _Local Model Repository Path_ on the target machine and will be decrypted by Kura.
+
+## Triton Server Metrics and Statistics support
+
+Since version 6.0.0, Eclipse Kura supports metrics and statistics reporting from a generic Inference Engine, leveraging the [InferenceEngineMetricsService](https://github.com/eclipse-kura/kura/blob/develop/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/ai/inference/InferenceEngineMetricsService.java) APIs.
+
+The implementation for the Triton Server allows to retrieve relevant metrics regarding GPU and models from the engine. It is based on the [Nvidia Triton Server Metrics feature](https://github.com/triton-inference-server/server/blob/r24.08/docs/user_guide/metrics.md) and the [Model Statistics Extension](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_statistics.md). The feature is enabled using the `Enable Triton Server Metrics` parameter from the Eclipse Kura webUI or the `enable.metrics` property in the snapshot configuration. This property is available only for the Triton Server Native Service and Triton Server Container Service components. In the case of the Triton Server Remote Service, the metrics reporting cannot be configured but it can be available depending on the Triton Server setup.
+
+More in details, the following GPU metrics are supported:
+
+- Power Usage
+- Power Limit
+- Energy Consumption
+- GPU Utilization
+- GPU Total Memory
+- GPU Used Memory
+
+The metrics are provided in a key-value pairs, whose key is in the format `gpu.metrics.<GPU uuid>` where the `GPU uuid` is an unique identifier of the GPU. The value is in JSON format.
+An example of GPU metrics is the following:
+
+```
+key : gpu.metrics.GPU-340cec52-80ba-c0df-8511-5f9680aae0ff 
+value : 
+{
+    "gpuUuid" : "GPU-340cec52-80ba-c0df-8511-5f9680aae0ff",
+    "gpuStats" : {
+        "nvGpuMemoryTotalBytes" : "16101933056.000000",
+        "nvGpuPowerUsage" : "20.085000",
+        "nvGpuUtilization" : "0.000000",
+        "nvGpuPowerLimit" : "60.000000",
+        "nvGpuMemoryUsedBytes" : "617611264.000000"
+    }
+}
+```
+
+The format of the model statistic key is `model.metrics.<model name>.<model version>`. The value is in JSON format.
+An example of model statistics is reported below:
+
+```
+key : model.metrics.preprocessor.1
+value : 
+{
+    "name" : "preprocessor",
+    "version" : "1",
+    "lastInference" : "1740037894861",
+    "inferenceCount" : "20",
+    "executionCount" : "20",
+    "inferenceStats" : {
+        "success" : {
+            "count" : "20",
+            "ns" : "143434240"
+        },
+        "fail" : {
+            "count" : "0",
+            "ns" : "0"
+        },
+        "queue" : {
+            "count" : "20",
+            "ns" : "4805536"
+        },
+        "computeInput" : {
+            "count" : "20",
+            "ns" : "5873920"
+        },
+        "computeInfer" : {
+            "count" : "20",
+            "ns" : "119049856"
+        },
+        "computeOutput" : {
+            "count" : "20",
+            "ns" : "13182208"
+        },
+        "cacheHit" : {
+            "count" : "0",
+            "ns" : "0"
+        },
+        "cacheMiss" : {
+            "count" : "0",
+            "ns" : "0"
+        }
+    },
+    "batchStats" : [
+        {
+            "batchSize" : "1",
+            "computeInput" : {
+                "count" : "20",
+                "ns" : "5873920"
+            },
+            "computeInfer" : {
+                "count" : "20",
+                "ns" : "119049856"
+            },
+            "computeOutput" : {
+                "count" : "20",
+                "ns" : "13182208"
+            }
+        }
+    ],
+    "memoryUsage" : [],
+    "responseStats" : {}
+}
+```

--- a/docs/core-services/nvidia-triton-server-inference-engine.md
+++ b/docs/core-services/nvidia-triton-server-inference-engine.md
@@ -7,7 +7,6 @@ Kura provides three components for exposing the Triton Server service functional
 - **TritonServerRemoteService**: provides methods for interacting with a remote Nvidia™ Triton Server without managing the server lifecycle. Can be used both for connecting to a remote instance or a local non-managed instance. It exposes a simpler but more limited configuration.
 - **TritonServerNativeService**: provides methods for interacting with a local native Nvidia™ Triton Server. Requires the Triton Server executable to be already available on the device and offers more options and features (like AI Model Encryption).
 - **TritonServerContainerService**: provides methods for interacting with a local container running Nvidia™ Triton Server. Requires the Triton Server container image to be already available on the device and offers more options and features (like AI Model Encryption).
-- **TritonServerService**: provides methods for interacting with a local or remote Nvidia™ Triton Server within the same component. **Note**: _deprecated since 5.2.0_ 
 
 
 
@@ -126,90 +125,6 @@ The parameters used to configure the Triton Service are the following:
 
 !!! note
     Pay attention on the ports used for communicating with the Triton Server. The default ports are the 8000-8002, but these are typically used by Kura for debug purposes.
-
-
-
-## Triton Server Service component [deprecated since 5.2.0]
-
-The Kura Triton Server component is the implementation of the inference engine APIs and provides methods for interacting with a local or remote Nvidia™ Triton Server. As presented below, the component enables the user to configure a local server running on the gateway or to communicate to an external server to load specific models.
-
-The parameters used to configure the Triton Service are the following:
-
-- **Local Nvidia Triton Server**: If enabled, a local native Nvidia Triton Server is started on the gateway. In this case, the model repository and backends path are mandatory. Moreover, the server address property is overridden and set to localhost. Be aware that the Triton Server has to be already installed on the system.
-- **Nvidia Triton Server address**: the address of the Nvidia Triton Server.
-- **Nvidia Triton Server ports**: the ports used to connect to the server for HTTP, GRPC, and Metrics services.
-- **Local model repository path**: Only for a local instance, specify the path on the filesystem where the models are stored.
-- **Local model decryption password**: Only for local instance, specify the password to be used for decrypting models stored in the model repository. If none is specified, models are supposed to be plaintext.
-- **Inference Models**: a comma-separated list of inference model names that the server will load. The models have to be already present in the filesystem where the server is running. This option simply tells the server to load the given models from a local or remote repository.
-- **Local backends path**: Only for a local instance, specify the path on the filesystem where the backends are stored.
-- **Optional configuration for the local backends**: Only for local instance, a semi-colon separated list of configuration for the backends. i.e. tensorflow,version=2;tensorflow,allow-soft-placement=false 
-- **Timeout (in seconds) for time consuming tasks**: Timeout (in seconds) for time consuming tasks like server startup, shutdown or model load. If the task exceeds the timeout, the operation will be terminated with an error.
-- **Max. GRPC message size (bytes)**: this field controls the maximum allowed size for the GRPC calls to the server instance.
-
-!!! note
-    Pay attention on the ports used for communicating with the Triton Server. The default ports are the 8000-8002, but these are tipically used by Kura for debug purposes.
-
-### Configuration for a local native Triton Server with Triton Server Service component [deprecated since 5.2.0]
-
-!!! note
-    **Requirement**: `tritonserver` executable needs to be available in the path to the `kurad` user. Be sure to have a working Triton Server installation before configuring the local native Triton Server instance through Kura UI.
-
-When the **Local Nvidia Triton Server** option is set to true, a local instance of the Nvidia™ Triton Server is started on the gateway. The following configuration is required:
-
-- **Local Nvidia Triton Server**: true
-- **Nvidia Triton Server address**: localhost
-- **Nvidia Triton Server ports**: mandatory
-- **Local model repository path**: mandatory
-- **Inference Models**: mandatory. Note that the models have to be already present on the filesystem.
-- **Local backends path**: mandatory
-
-The typical command used to start the Triton Server is like this:
-
-```shell
-tritonserver --model-repository=<model_repository_path> \
---backend-directory=<backend_repository_path> \
---backend-config=<backend_config> \
---http-port=<http_port> \
---grpc-port=<grpc_port> \
---metrics-port=<metrics_port> \
---model-control-mode=explicit \
---load-model=<model_name_1> \
---load-model=<model_name_2> \
-...
-```
-
-### Configuration for a local Triton Server running in a Docker container with Triton Server Service component [deprecated since 5.2.0]
-
-If the Nvidia™ Triton Server is running as a Docker container in the gateway, the following configuration is required:
-
-- **Local Nvidia Triton Server**: false
-- **Nvidia Triton Server address**: localhost
-- **Nvidia Triton Server ports**: \<mandatory\>
-- **Inference Models**: \<mandatory\>. The models have to be already present on the filesystem.
-
-In order to correctly load the models at runtime, configure the server with the `--model-control-mode=explicit` option. The typical command used for running the docker container is as follows. Note the forward of the ports to not interfere with Kura.
-
-```shell
-docker run --rm \
--p4000:8000 \
--p4001:8001 \
--p4002:8002 \
---shm-size=150m \
--v path/to/models:/models \
-nvcr.io/nvidia/tritonserver:[version] \
-tritonserver --model-repository=/models --model-control-mode=explicit
-```
-
-### Configuration for a remote Triton Server with Triton Server Service component [deprecated since 5.2.0]
-
-When the Nvidia™ Triton Server is running on a remote server, the following configuration is needed:
-
- - **Local Nvidia Triton Server**: false
- - **Nvidia Triton Server address**: mandatory
- - **Nvidia Triton Server ports**: mandatory
- - ** Inference Models**: mandatory. The models have to be already present on the filesystem.
-
-
 
 ## AI Model Encryption Support
 


### PR DESCRIPTION
This pull request includes updates to the documentation for the Nvidia Triton Server Inference Engine in Eclipse Kura. The most important changes involve the removal of deprecated components and the addition of new metrics and statistics support.

Deprecation and Removal of Components:

* Removed references to the deprecated `TritonServerService` component and its configuration details from the documentation. [[1]](diffhunk://#diff-061d888a0c9c95e0c814281fb5937b200d31054b391299935bcf7ba9eacc7d34L10) [[2]](diffhunk://#diff-061d888a0c9c95e0c814281fb5937b200d31054b391299935bcf7ba9eacc7d34L132-L213)

Addition of Metrics and Statistics Support:

* Added a new section detailing the support for metrics and statistics reporting from the Triton Server, including GPU and model metrics. This feature is enabled via the `Enable Triton Server Metrics` parameter or `enable.metrics` property.