### PR TITLE
revert: Reverted Java compiler version in pom file

### DIFF
--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -150,10 +150,9 @@
         <check.plugins.exist.remote>false</check.plugins.exist.remote>
         <kura.addons.url>https://raw.github.com/eurotech/kura_addons/mvn-repo/</kura.addons.url>
 
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
 
-        <!-- plugins versions common to Java 8 and Java 17 builds -->
         <bnd.baseline.version>6.3.1</bnd.baseline.version>
         <exists-maven-plugin.version>0.0.3</exists-maven-plugin.version>
         <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>


### PR DESCRIPTION
This pull request includes an important update to the `kura/pom.xml` file, which involves upgrading the Java compiler version. This change ensures that the project is compatible with the latest Java features and improvements.

Key change:

* Upgraded the Maven compiler source and target versions from 1.8 to 17 in the `kura/pom.xml` file to support the latest Java features and improvements.