### PR TITLE
fix(nm): Fixed typo in NMSettingsConverter

### DIFF
--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -619,10 +619,12 @@ public class NMSettingsConverter {
     public static Map<String, Variant<?>> buildPPPSettings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
-        Optional<Integer> lcpEchoInterval = props.getOpt(Integer.class, "net.interface.%s.config.lcpEchoInterval",
+        // The property is wrongly named in Kura, it should be "net.interface.%s.config.lcpEchoInterval"
+        Optional<Integer> lcpEchoInterval = props.getOpt(Integer.class, "net.interface.%s.config.lpcEchoInterval",
                 deviceId);
         lcpEchoInterval.ifPresent(interval -> settings.put("lcp-echo-interval", new Variant<>(interval)));
-        Optional<Integer> lcpEchoFailure = props.getOpt(Integer.class, "net.interface.%s.config.lcpEchoFailure",
+        // The property is wrongly named in Kura, it should be "net.interface.%s.config.lcpEchoFailure"
+        Optional<Integer> lcpEchoFailure = props.getOpt(Integer.class, "net.interface.%s.config.lpcEchoFailure",
                 deviceId);
         lcpEchoFailure.ifPresent(failure -> settings.put("lcp-echo-failure", new Variant<>(failure)));
 

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -623,7 +623,8 @@ public class NMSettingsConverter {
         Optional<Integer> lcpEchoInterval = props.getOpt(Integer.class, "net.interface.%s.config.lpcEchoInterval",
                 deviceId);
         lcpEchoInterval.ifPresent(interval -> settings.put("lcp-echo-interval", new Variant<>(interval)));
-        // The property is wrongly named in Kura, it should be "net.interface.%s.config.lcpEchoFailure"
+        // The property is wrongly named in Kura's snapshot, it should be "net.interface.%s.config.lcpEchoFailure"
+        // we're keeping the typo for backward compatibility reasons.
         Optional<Integer> lcpEchoFailure = props.getOpt(Integer.class, "net.interface.%s.config.lpcEchoFailure",
                 deviceId);
         lcpEchoFailure.ifPresent(failure -> settings.put("lcp-echo-failure", new Variant<>(failure)));

--- a/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
+++ b/kura/org.eclipse.kura.nm/src/main/java/org/eclipse/kura/nm/configuration/NMSettingsConverter.java
@@ -619,7 +619,8 @@ public class NMSettingsConverter {
     public static Map<String, Variant<?>> buildPPPSettings(NetworkProperties props, String deviceId) {
         Map<String, Variant<?>> settings = new HashMap<>();
 
-        // The property is wrongly named in Kura, it should be "net.interface.%s.config.lcpEchoInterval"
+        // The property is wrongly named in Kura's snapshot, it should be "net.interface.%s.config.lcpEchoInterval"
+        // we're keeping the typo for backward compatibility reasons.
         Optional<Integer> lcpEchoInterval = props.getOpt(Integer.class, "net.interface.%s.config.lpcEchoInterval",
                 deviceId);
         lcpEchoInterval.ifPresent(interval -> settings.put("lcp-echo-interval", new Variant<>(interval)));

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
+++ b/kura/test/org.eclipse.kura.nm.test/src/test/java/org/eclipse/kura/nm/configuration/NMSettingsConverterTest.java
@@ -1250,8 +1250,8 @@ public class NMSettingsConverterTest {
 
     @Test
     public void buildPPPSettingsShouldWorkWhenGivenOptionalLcpParameters() {
-        givenMapWith("net.interface.ttyACM0.config.lcpEchoInterval", 30);
-        givenMapWith("net.interface.ttyACM0.config.lcpEchoFailure", 5);
+        givenMapWith("net.interface.ttyACM0.config.lpcEchoInterval", 30);
+        givenMapWith("net.interface.ttyACM0.config.lpcEchoFailure", 5);
         givenNetworkPropsCreatedWithTheMap(this.internetNetworkPropertiesInstanciationMap);
 
         whenBuildPPPSettingsIsRunWith(this.networkProperties, "ttyACM0");


### PR DESCRIPTION
This pull request includes a fix for a typo in the property names used in the `buildPPPSettings` method within the `NMSettingsConverter.java` file. The typo correction ensures that the correct property names are used when retrieving configuration settings.

Fixes to property names:

* Corrected the property name from "net.interface.%s.config.l**cp**EchoInterval" to "net.interface.%s.config.l**pc**EchoInterval"
* Corrected the property name from "net.interface.%s.config.l**cp**EchoFailure" to "net.interface.%s.config.l**pc**EchoFailure"

The correct names are **lcp**-echo-failure and **lcp**-echo-interval. However, we keep the wrong names for compatibility.