### PR TITLE
build: Updated tycho to version 4

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -30,7 +30,7 @@
     <name>distrib</name>
     <url>http://maven.apache.org</url>
     <properties>
-        <tycho-version>3.0.5</tycho-version>
+        <tycho-version>4.0.11</tycho-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <zip_workspace.prefix>user_workspace_archive_${project.version}</zip_workspace.prefix>
 
@@ -964,7 +964,8 @@
                     <configuration>
                         <strictVersions>true</strictVersions>
                         <format>${kura.build.version}</format>
-                        <skipPomGeneration>true</skipPomGeneration> 
+                        <skipPomGeneration>true</skipPomGeneration>
+                        <deriveHeaderFromSource>false</deriveHeaderFromSource>
                     </configuration>
                 </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings

--- a/kura/examples/pom.xml
+++ b/kura/examples/pom.xml
@@ -29,7 +29,7 @@
         <tycho.scmUrl>scm:git:ssh://github.com/eclipse/kura/kura</tycho.scmUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <osgi-dp-plugin-version>0.3.0</osgi-dp-plugin-version>
-        <tycho-version>3.0.5</tycho-version>
+        <tycho-version>4.0.11</tycho-version>
         <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
         <kura.basedir>${project.basedir}/..</kura.basedir>
         <kura.build.version>${maven.build.timestamp}</kura.build.version>

--- a/kura/org.eclipse.kura.core.configuration/OSGI-INF/configuration.xml
+++ b/kura/org.eclipse.kura.core.configuration/OSGI-INF/configuration.xml
@@ -1,80 +1,95 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2011, 2021 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
 
-   This program and the accompanying materials are made
-   available under the terms of the Eclipse Public License 2.0
-   which is available at https://www.eclipse.org/legal/epl-2.0/
- 
-	SPDX-License-Identifier: EPL-2.0
-	
-	Contributors:
-	 Eurotech
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" enabled="true" immediate="true" name="org.eclipse.kura.configuration.ConfigurationService">
-   <implementation class="org.eclipse.kura.core.configuration.ConfigurationServiceAuditFacade"/>
-   <service>
-      <provide interface="org.eclipse.kura.configuration.ConfigurationService"/>
-      <provide interface="org.eclipse.kura.configuration.metatype.OCDService"/>
-   </service>
-   <property name="service.pid" value="org.eclipse.kura.configuration.ConfigurationService"/>
-   <reference bind="setEventAdmin" cardinality="1..1" interface="org.osgi.service.event.EventAdmin" name="EventAdmin" policy="static" unbind="unsetEventAdmin"/>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" 
+    activate="activate" 
+    deactivate="deactivate" 
+    enabled="true" 
+    immediate="true" 
+    name="org.eclipse.kura.configuration.ConfigurationService">
+
+    <implementation class="org.eclipse.kura.core.configuration.ConfigurationServiceAuditFacade"/>
+
+    <service>
+        <provide interface="org.eclipse.kura.configuration.ConfigurationService"/>
+        <provide interface="org.eclipse.kura.configuration.metatype.OCDService"/>
+    </service>
+
+    <property name="service.pid" value="org.eclipse.kura.configuration.ConfigurationService"/>
+
+    <reference  name="EventAdmin" 
+                bind="setEventAdmin" 
+                cardinality="1..1" 
+                interface="org.osgi.service.event.EventAdmin"
+                policy="static" />
+
    <reference name="ConfigurationAdmin"
               bind="setConfigurationAdmin"
-              unbind="unsetConfigurationAdmin"
               cardinality="1..1"
               policy="static"
-              interface="org.osgi.service.cm.ConfigurationAdmin"/>
+              interface="org.osgi.service.cm.ConfigurationAdmin" />
+
    <reference name="MetaTypeService"
               bind="setMetaTypeService"
-              unbind="unsetMetaTypeService"
               cardinality="1..1"
               policy="static"
-              interface="org.osgi.service.metatype.MetaTypeService"/>
+              interface="org.osgi.service.metatype.MetaTypeService" />
+
    <reference name="SystemService"
               bind="setSystemService"
-              unbind="unsetSystemService"
               cardinality="1..1"
               policy="static"
-              interface="org.eclipse.kura.system.SystemService"/>
+              interface="org.eclipse.kura.system.SystemService" />
+
    <reference name="CryptoService"
               interface="org.eclipse.kura.crypto.CryptoService"
               bind="setCryptoService"
-              unbind="unsetCryptoService"
               cardinality="1..1"
-              policy="static"/>
+              policy="static" />
+
    <reference bind="setScrService"
               cardinality="1..1"
               interface="org.osgi.service.component.runtime.ServiceComponentRuntime"
               name="ScrService"
-              policy="static"
-              unbind="unsetScrService"/>
-   <reference bind="addConfigurableComponent"
+              policy="static" />
+
+   <reference name="ConfigurableComponent"
+              bind="addConfigurableComponent"
               cardinality="0..n"
               interface="org.eclipse.kura.configuration.ConfigurableComponent"
-              name="ConfigurableComponent"
               policy="dynamic"
-              unbind="removeConfigurableComponent"/>
+              unbind="removeConfigurableComponent" />
+
    <reference bind="addSelfConfiguringComponent"
               cardinality="0..n"
               interface="org.eclipse.kura.configuration.SelfConfiguringComponent"
               name="SelfConfiguringComponent"
               policy="dynamic"
-              unbind="removeSelfConfiguringComponent"/>
+              unbind="removeSelfConfiguringComponent" />
+
    <reference bind="setXmlUnmarshaller"
               cardinality="1..1"
               interface="org.eclipse.kura.marshalling.Unmarshaller"
               name="Unmarshaller"
               policy="static"
-              target="(kura.service.pid=org.eclipse.kura.xml.marshaller.unmarshaller.provider)"
-              unbind="unsetXmlUnmarshaller"/>
+              target="(kura.service.pid=org.eclipse.kura.xml.marshaller.unmarshaller.provider)" />
+
    <reference bind="setXmlMarshaller"
               cardinality="1..1"
               interface="org.eclipse.kura.marshalling.Marshaller"
               name="Marshaller"
               policy="static"
-              target="(kura.service.pid=org.eclipse.kura.xml.marshaller.unmarshaller.provider)"
-              unbind="unsetXmlMarshaller"/>
+              target="(kura.service.pid=org.eclipse.kura.xml.marshaller.unmarshaller.provider)" />
 </scr:component>

--- a/kura/org.eclipse.kura.rest.identity.provider/OSGI-INF/IdentityRestServiceV1.xml
+++ b/kura/org.eclipse.kura.rest.identity.provider/OSGI-INF/IdentityRestServiceV1.xml
@@ -13,7 +13,7 @@
      Eurotech
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" 
     activate="activate" 
     immediate="true" 
     name="org.eclipse.kura.internal.rest.identity.provider.IdentityRestServiceV1">
@@ -47,7 +47,7 @@
                
     <reference interface="org.eclipse.kura.internal.rest.identity.provider.LegacyIdentityService" 
                bind="bindLegacyIdentityService" 
-               cardinality="0..1"  
+               cardinality="1..1"  
                name="LegacyIdentityService" 
                policy="static" />
 

--- a/kura/org.eclipse.kura.rest.identity.provider/OSGI-INF/IdentityRestServiceV1.xml
+++ b/kura/org.eclipse.kura.rest.identity.provider/OSGI-INF/IdentityRestServiceV1.xml
@@ -2,13 +2,13 @@
 <!--
 
     Copyright (c) 2024, 2025 Eurotech and/or its affiliates and others
-  
+
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
- 
+
     SPDX-License-Identifier: EPL-2.0
-    
+
     Contributors:
      Eurotech
 

--- a/kura/org.eclipse.kura.rest.identity.provider/OSGI-INF/IdentityRestServiceV2.xml
+++ b/kura/org.eclipse.kura.rest.identity.provider/OSGI-INF/IdentityRestServiceV2.xml
@@ -13,7 +13,7 @@
      Eurotech
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" 
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" 
     immediate="true" 
     name="org.eclipse.kura.internal.rest.identity.provider.IdentityRestServiceV2">
     
@@ -40,7 +40,7 @@
                
     <reference interface="org.eclipse.kura.identity.IdentityService" 
                bind="bindIdentityService" 
-               cardinality="0..1"  
+               cardinality="1..1"  
                name="IdentityService" 
                policy="static" />
 

--- a/kura/org.eclipse.kura.rest.identity.provider/OSGI-INF/IdentityRestServiceV2.xml
+++ b/kura/org.eclipse.kura.rest.identity.provider/OSGI-INF/IdentityRestServiceV2.xml
@@ -2,13 +2,13 @@
 <!--
 
     Copyright (c) 2024, 2025 Eurotech and/or its affiliates and others
-  
+
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
- 
+
     SPDX-License-Identifier: EPL-2.0
-    
+
     Contributors:
      Eurotech
 

--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -138,7 +138,7 @@
     <properties>
         <!-- SCM: Note that we are in the "kura" sub-dir here already -->
         <tycho.scmUrl>scm:git:ssh://github.com/eclipse/kura/kura</tycho.scmUrl>
-        <tycho-version>3.0.5</tycho-version>
+        <tycho-version>4.0.11</tycho-version>
         <osgi-dp-plugin-version>0.3.0</osgi-dp-plugin-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -575,6 +575,7 @@
                         <strictVersions>true</strictVersions>
                         <format>${kura.build.version}</format>
                         <skipPomGeneration>true</skipPomGeneration>
+                        <deriveHeaderFromSource>false</deriveHeaderFromSource>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityRestServiceV2DependenciesTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityRestServiceV2DependenciesTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2024, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -99,9 +99,10 @@ public class IdentityRestServiceV2DependenciesTest {
     }
 
     @Test
-    public void shouldBindRestIdentityServiceDependencies() throws KuraException {
+    public void shouldBindRestIdentityServiceDependencies() {
         givenUserAdminMock();
         givenIdentityServiceMock();
+        givenRequestHandlerRegistryMock();
 
         whenBindDependencies();
 

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceV1Test.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/test/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityServiceV1Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -287,7 +287,7 @@ public class IdentityServiceV1Test {
         }
     }
 
-    private void thenUserIsCreated() throws KuraException {
+    private void thenUserIsCreated() {
         verify(this.userAdmin, times(1)).createRole(USER_ROLE_NAME_PREFIX + this.newUser.getUserName(), Role.USER);
     }
 

--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -116,7 +116,6 @@
                             </configuration>
                         </execution>
                     </executions>
-                    <configuration />
                 </plugin>
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
@@ -130,7 +129,7 @@
                             ${tycho.testArgLine}
                             ${tycho.surefire.testenv.args}
                         </argLine>
-                        <!-- <appArgLine>-consoleLog -console 5002 -noExit</appArgLine> -->
+ <!--                       <appArgLine>-consoleLog -console 5002 -noExit</appArgLine>-->
                         <dependencies>
                             <dependency>
                                 <type>p2-installable-unit</type>
@@ -203,6 +202,10 @@
                             <dependency>
                                 <type>p2-installable-unit</type>
                                 <artifactId>org.eclipse.kura.core</artifactId>
+                            </dependency>
+                            <dependency>
+                                <type>p2-installable-unit</type>
+                                <artifactId>org.eclipse.kura.core.identity</artifactId>
                             </dependency>
                             <dependency>
                                 <type>p2-installable-unit</type>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/bundles/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/bundles/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tycho-version>3.0.5</tycho-version>
+        <tycho-version>4.0.11</tycho-version>
         <bnd-version>7.1.0</bnd-version>
         <maven-resources-version>3.1.0</maven-resources-version>
         <maven-deploy-version>2.8.2</maven-deploy-version>
@@ -96,6 +96,7 @@
                     <version>${tycho-version}</version>
                     <configuration>
                         <strictVersions>true</strictVersions>
+                        <deriveHeaderFromSource>false</deriveHeaderFromSource>
                     </configuration>
                 </plugin>
 

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/target-definition/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/target-definition/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-maven-plugin</artifactId>
-                <version>3.0.5</version>
+                <version>4.0.11</version>
                 <extensions>true</extensions>
             </plugin>
             <plugin>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -43,7 +43,7 @@
         <maven-site-plugin.version>3.3</maven-site-plugin.version>
         <maven-surefire-plugin.version>2.7.2</maven-surefire-plugin.version>
         <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
-        <tycho-p2-extras-plugin.version>3.0.5</tycho-p2-extras-plugin.version>
+        <tycho-p2-extras-plugin.version>4.0.11</tycho-p2-extras-plugin.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Updated tycho to version 4.
The setting `<deriveHeaderFromSource>false</deriveHeaderFromSource>` is required to avoid strict tycho check on service referencens.
