### PR TITLE
style(distrib): fixed warning on regexp during kura startup

### DIFF
--- a/kura/distrib/src/main/resources/common/gen_config_ini.sh
+++ b/kura/distrib/src/main/resources/common/gen_config_ini.sh
@@ -41,7 +41,7 @@ do
         continue
     fi
 
-    if ! expr "${DIR_NAME}" : '^[0-9]\{1,\}s\{0,1\}$' > /dev/null
+    if ! expr "${DIR_NAME}" : '[0-9]\{1,\}s\{0,1\}$' > /dev/null
     then
         continue
     fi


### PR DESCRIPTION
Removed unsupported `^`