### PR TITLE
fix: fixed parsing of byte array in channel descriptor

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/LegacyChannelModel.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/LegacyChannelModel.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2024 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2024, 2025 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
- *******************************************************************************/
+ ******************************************************************************/
 
 package org.eclipse.kura.web.client.ui.drivers.assets;
 

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/LegacyChannelModel.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/drivers/assets/LegacyChannelModel.java
@@ -78,13 +78,18 @@ public class LegacyChannelModel implements AssetModel.ChannelModel {
             }
         }
 
-        if (scaleOffsetType != null && valueType != null) {
+        if (isScalarType(valueType) && scaleOffsetType != null && valueType != null) {
             subType = scaleOffsetType == ScaleOffsetType.DEFINED_BY_VALUE_TYPE
                     ? GwtConfigParameterType.valueOf(valueType.name())
                     : GwtConfigParameterType.valueOf(scaleOffsetType.name());
         }
 
         this.subtype = subType;
+    }
+
+    private boolean isScalarType(DataType valueType) {
+        return valueType != null && valueType != DataType.BOOLEAN && valueType != DataType.STRING
+                && valueType != DataType.BYTE_ARRAY;
     }
 
     private String getId(AssetConstants assetConstant) {


### PR DESCRIPTION
This PR fixes a problem that occurs in the channel descriptors, when parsing old xml snapshot files that don't contain the scaleOffsetType parameters.

If some channels were of type `STRING`, `BOOLEAN` or `BYTE_ARRAY` the framework tried to apply on them a scaleOffsetParameter and failed, while the correct behaviour should be to not trying to do that and just ignore the scaleOffesetType applying the default `DEFINED_BY_VALUE_TYPE`.

Tested on Pi5 Esf 8.0.0
