### PR TITLE
revert: ci: build develop branch with mvn deploy (#5770)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,6 @@ def boolean onlyDocumentationFilesChangedIn(String workDirectory) {
 }
 
 node {
-
     properties([
         disableConcurrentBuilds(abortPrevious: true),
         buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2', daysToKeepStr: '', numToKeepStr: '5')),
@@ -37,16 +36,11 @@ node {
         return
     }
 
-    def buildType = 'install'
-    if ("${env.BRANCH_NAME}".equals('develop')) {
-        buildType = 'deploy'
-    }
-
     stage('Build target-platform') {
         timeout(time: 1, unit: 'HOURS') {
             dir("kura") {
                 withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6') {
-                    sh "mvn -f target-platform/pom.xml clean ${buildType} -Pno-mirror -Pcheck-exists-plugin"
+                    sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin"
                 }
             }
         }
@@ -56,7 +50,7 @@ node {
         timeout(time: 2, unit: 'HOURS') {
             dir("kura") {
                 withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6') {
-                    sh "mvn -f kura/pom.xml -Dsurefire.rerunFailingTestsCount=3 clean ${buildType} -Pcheck-exists-plugin"
+                    sh "mvn -f kura/pom.xml -Dsurefire.rerunFailingTestsCount=3 clean install -Pcheck-exists-plugin"
                 }
             }
         }
@@ -76,7 +70,7 @@ node {
         timeout(time: 1, unit: 'HOURS') {
             dir("kura") {
                 withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6') {
-                    sh "mvn -f kura/examples/pom.xml clean ${buildType} -Pcheck-exists-plugin"
+                    sh "mvn -f kura/examples/pom.xml clean install -Pcheck-exists-plugin"
                 }
             }
         }


### PR DESCRIPTION
This reverts commit 3819dffc42f3fc76b6bd614b77ea8c8e86a4b026.

> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Reverting as this is now handled by kura-nightly job