### PR TITLE
chore: Use gpsd provider by default in PositionService

### DIFF
--- a/kura/org.eclipse.kura.linux.position/OSGI-INF/metatype/org.eclipse.kura.position.PositionService.xml
+++ b/kura/org.eclipse.kura.linux.position/OSGI-INF/metatype/org.eclipse.kura.position.PositionService.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
@@ -41,7 +41,7 @@
             type="String"
             cardinality="0"
             required="true"
-            default="serial"
+            default="gpsd"
             description="Source for setting the position provider. Verify the availabiliy of the selected provider before activate it.">
             
             <Option label="serial" value="serial" />

--- a/kura/org.eclipse.kura.linux.position/OSGI-INF/metatype/org.eclipse.kura.position.PositionService.xml
+++ b/kura/org.eclipse.kura.linux.position/OSGI-INF/metatype/org.eclipse.kura.position.PositionService.xml
@@ -2,15 +2,15 @@
 <!--
 
     Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
-  
+
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/
- 
-	SPDX-License-Identifier: EPL-2.0
-	
-	Contributors:
-	 Eurotech
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
 
 -->
 <MetaData xmlns="http://www.osgi.org/xmlns/metatype/v1.2.0" localization="en_us">


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

