### PR TITLE
feat(archetype): new versioning scheme support and build profiles for kura-addon-archetype

### DIFF
--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/deb/control/control
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/deb/control/control
@@ -1,8 +1,8 @@
 Package: [[package.name]]
-Version: [[project.version]]
+Version: [[version]]-[[package.revision]]
 Section: admin
 Priority: optional
-Depends: kura
+Depends: kura-core (>= 6.0.0~), kura-core(<< 7.0.0~)
 Architecture: [[deb.architecture]]
 Maintainer: Eclipse Kura Developers <kura-dev@eclipse.org>
 Description: [[summary]]

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/pom.xml
@@ -59,13 +59,119 @@
         <!-- final name of the generated debian and rpm package -->
         <package.name>${artifactId}</package.name>
 
+        <!-- properties used for artifact upload on artifactory repository -->
+        <kura.repo.distribution>CHANGEME</kura.repo.distribution>
+        <kura.repo.module>CHANGEME</kura.repo.module>
+
         <!-- edit following fields and file deb/control/control -->
         <summary>Summary line (do not end this line with a dot, max 60 chars)</summary>
         <long.description>Here goes the long description of the packages, in this case this is an example addon for the Eclipse Kura Framework.</long.description>
     </properties>
 
+    <profiles>
+        <!-- Internal profile: FOR INTERNAL USE ONLY - active if -DreleaseBuild is *not* specified. -->
+        <profile>
+            <id>debugBuild</id>
+            <activation>
+                <property>
+                    <name>!releaseBuild</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+                <package.snapshot>git${maven.build.timestamp}.${git.commit.id.abbrev}</package.snapshot>
+
+                <package.version>${release.version}~${package.snapshot}</package.version>
+                <package.revision>1</package.revision>
+            </properties>
+        </profile>
+        <!-- Internal profile: FOR INTERNAL USE ONLY - active if -DreleaseBuild *is* specified. -->
+        <profile>
+            <id>releaseBuild</id>
+            <activation>
+                <property>
+                    <name>releaseBuild</name>
+                </property>
+            </activation>
+            <properties>
+                <package.version>${release.version}</package.version>
+                <package.revision>1</package.revision>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseVersion>
+                                            <message>No snapshots allowed for release builds!</message>
+                                        </requireReleaseVersion>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
+            <!-- Responsible for removing the "-SNAPSHOT" from the project.version -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>regex-property</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>release.version</name>
+                            <value>${project.version}</value>
+                            <regex>-SNAPSHOT</regex>
+                            <replacement></replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Responsible for retrieving the short git commit (defaults to length 7)-->
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>9.0.1</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <injectAllReactorProjects>true</injectAllReactorProjects>
+                    <generateGitPropertiesFile>false</generateGitPropertiesFile>
+                    <skipPoms>false</skipPoms>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.coderplus.maven.plugins</groupId>
                 <artifactId>copy-rename-maven-plugin</artifactId>
@@ -98,7 +204,9 @@
                         </goals>
                         <configuration>
                             <verbose>true</verbose>
-                            <deb>${basedir}/target/deb/${package.name}_${project.version}_${deb.architecture}.deb</deb>
+                            <deb>${basedir}/target/deb/${package.name}_${package.version}-${package.revision}_${deb.architecture}.deb</deb>
+                            <snapshotExpand>true</snapshotExpand>
+                            <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                             <controlDir>${project.basedir}/deb/control</controlDir>
                             <skipPOMs>false</skipPOMs>
                             <dataSet>
@@ -119,12 +227,12 @@
                                     </mapper>
                                 </data>
 
-                                <!-- 
-                                
+                                <!--
+
                                 If all the source file are managed in the same way, it is also
                                 possible to specify a 'directory' data type to include all the files
                                 present in the specify path
-                                
+
                                 <data>
                                     <src>${basedir}/target/input_files</src>
                                     <dst>${jar.name}_${project.version}.jar</dst>
@@ -137,7 +245,7 @@
                                         <filemode>600</filemode>
                                     </mapper>
                                 </data>
-                                
+
                                 -->
                             </dataSet>
                         </configuration>
@@ -166,6 +274,13 @@
                             <description>${long.description}</description>
                             <license>EPL 2.0 (https://www.eclipse.org/legal/epl-2.0/)</license>
 
+                            <projversion>${package.version}</projversion>
+                            <release>${package.revision}</release>
+
+                            <requires>
+                                <require>kura-core &gt;= 6.0.0~, kura-core &lt; 7.0.0~</require>
+                            </requires>
+
                             <mappings>
                                 <!-- Repeate the 'mapping' schema multiple time if you want to
                                 manage different files indipendentely, specifying for each one the
@@ -188,11 +303,11 @@
                                     </sources>
                                 </mapping>
 
-                                <!-- 
-                                
+                                <!--
+
                                 If all the source file are managed in the same way, it is also possible to specify the path to a
                                 directory to include all the files present in that
-                                
+
                                 <mapping>
                                     <directory>${addon.installation.dir}</directory>
                                     <filemode>600</filemode>
@@ -205,7 +320,7 @@
                                         </source>
                                     </sources>
                                 </mapping>
-                                
+
                                 -->
                             </mappings>
 


### PR DESCRIPTION
This PR updates the build of kura-addon-archetype to support the new versioning scheme.

This PR adds the following to the Kura add-ons archetype:

- A Maven CLI parameter that allows us to select the build type:
    - Debug builds: which will produce the **CI build artifacts**. Versioning scheme: `X.X.X~gitYYYYMMDDHHMM.ZZZZZZZ-1`
    - Release builds: which will produce the **RC build artifacts**. Versioning scheme: `X.X.X-N`.
- Two new properties in the `distrib` POM that will drive the upload of the artifacts on Artifactory:
  - `kura.repo.distribution`: which sets the Kura distribution of the package (i.e. `kura-6`, `kura-7` etc)
  - `kura.repo.module`: which sets the Kura module of the package (i.e. `base`, `transportation`, `security` etc)

**Usage**

The build defaults to the `debugBuild` profile, if the `-DreleaseBuild` parameter is specified, the build selects the `releaseBuild` profile.

By default the `build.version` is set to `1`. It can be overridden via CLI using the `-Dpackage.revision=N` parameters.

### Examples

#### Debug build

```
mvn clean install
```

will produce:

```
ls distrib/target/deb
kura-example_2.0.0~git202504291452.4c8a852-1_amd64.deb kura-example_2.0.0~git202504291452.4c8a852-1_arm64.deb
```

```
ls distrib/target/rpm/aarch64/kura-example/RPMS/aarch64
kura-example-2.0.0~git202504291452.4c8a852-1.aarch64.rpm
```

```
ls distrib/target/rpm/x86_64/kura-example/RPMS/x86_64
kura-example-2.0.0~git202504291452.4c8a852-1.x86_64.rpm
```

#### Release build

```
mvn clean install -Dpackage.revision=6 -DreleaseBuild
```

will produce:

```
ls distrib/target/deb                                                        
kura-example_2.0.0-6_amd64.deb kura-example_2.0.0-6_arm64.deb
```
```
ls distrib/target/rpm/x86_64/kura-example/RPMS/x86_64                           
kura-example-2.0.0-6.x86_64.rpm
```
```
ls distrib/target/rpm/aarch64/kura-example/RPMS/aarch64                         
kura-example-2.0.0-6.aarch64.rpm
```

---

### Notes about the implementation

This PR leverages the `snapshotExpand` and `snapshotTemplate` parameters of `jdeb` to correctly populate the Version field in the `control` file of the debian package.

References:
- Parameters documentation: https://github.com/tcurdt/jdeb/blob/master/docs/maven.md
- Implementation: https://github.com/tcurdt/jdeb/blob/8971c35ad0a0f939c342c76060b781aafb008561/src/main/java/org/vafer/jdeb/utils/Utils.java#L274

> [!WARNING]
> Limitation: due to how this functionality was implemented in `jdeb`, we cannot use it to **erase the `-SNAPSHOT` modifier in the release build**. An empty template would result in the timestamp being expanded instead. Therefore this implementation **assumes that the `-SNAPSHOT` modified is not present when performing a `releaseBuild`** and will fail the build (via `maven-enforcer-plugin`) if a snapshot is detected.
>
> This means that, to perform an actual `releaseBuild`, we need to:
> - perform the uptick from snapshot to release
> - run the build with `-DreleaseBuild`
>
> The `-DreleaseBuild` parameter on its own is not enough.

---

### Third party content

This PR introduces three new maven plugins:
1. [`build-helper-maven-plugin`](https://github.com/mojohaus/build-helper-maven-plugin) [MIT License](https://github.com/mojohaus/build-helper-maven-plugin#MIT-1-ov-file)
    - [x] https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/21017
3. [`git-commit-id-maven-plugin`](https://github.com/git-commit-id/git-commit-id-maven-plugin) [LGPL-3.0](https://github.com/git-commit-id/git-commit-id-maven-plugin#LGPL-3.0-1-ov-file)
    - [x] https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/21018
5. [`maven-enforcer-plugin`](https://github.com/apache/maven-enforcer) [Apache 2.0 License](https://github.com/apache/maven-enforcer#Apache-2.0-1-ov-file)
    - [X] Vetted license information was found for all content. No further investigation is required.