### PR TITLE
build: new versioning scheme support and build profiles for kura

### DIFF
--- a/kura/distrib/.gitignore
+++ b/kura/distrib/.gitignore
@@ -1,2 +1,3 @@
 build.properties
 /bin
+RELEASE_INFO

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -930,8 +930,8 @@
                                 </exec>
                                 <move file="RELEASE_INFO/${project.version}/p2-repo-common/pom_.xml" tofile="RELEASE_INFO/${project.version}/p2-repo-common/pom.xml" />
 
-                                <!-- Copy target-platform/p2-repo-equinoxpom.xml in distrib/RELEASE_INFO/${project.version}/p2-repo-equinox/pom.xml -->
-                                <copy file="${kura.basedir}/../../target-platform/p2-repo-equinoxpom.xml" tofile="RELEASE_INFO/${project.version}/p2-repo-equinox/pom.xml" overwrite="true" />
+                                <!-- Copy target-platform/p2-repo-equinox/pom.xml in distrib/RELEASE_INFO/${project.version}/p2-repo-equinox/pom.xml -->
+                                <copy file="${kura.basedir}/../../target-platform/p2-repo-equinox/pom.xml" tofile="RELEASE_INFO/${project.version}/p2-repo-equinox/pom.xml" overwrite="true" />
                                 <!-- replace artifactId -->
                                 <replace token="&lt;artifactId&gt;target-platform&lt;/artifactId&gt;" value="&lt;artifactId&gt;target-platform-previous&lt;/artifactId&gt;" dir="RELEASE_INFO/${project.version}/p2-repo-equinox">
                                     <include name="pom.xml" />

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -31,7 +31,7 @@
     <url>http://maven.apache.org</url>
     <properties>
         <tycho-version>4.0.11</tycho-version>
-        <jdeb-version>1.0</jdeb-version>
+        <jdeb-version>1.12</jdeb-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <kura.basedir>${project.basedir}</kura.basedir>
@@ -881,30 +881,13 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>verify-if-snapshot</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <exportAntProperties>true</exportAntProperties>
-                            <target name="is-snapshot-check">
-                                <condition property="is.not.snapshot">
-                                    <not>
-                                        <contains string="${project.version}" substring="-SNAPSHOT" />
-                                    </not>
-                                </condition>
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>release-copy</id>
                         <phase>install</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target name="distrib-store-files" if="${is.not.snapshot}">
+                            <target name="distrib-store-files">
                                 <!-- Copy distrib/config/kura.build.properties in distrib/RELEASE_INFO/${project.version}/config -->
                                 <copy file="config/kura.build.properties" todir="RELEASE_INFO/${project.version}/config" overwrite="true" />
 
@@ -1281,6 +1264,7 @@
                                     <snapshotExpand>true</snapshotExpand>
                                     <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/x86_64/deb/control</controlDir>
+                                    <skipPOMs>false</skipPOMs>
                                     <dataSet>
                                         <data>
                                             <src>${basedir}/target/kura_${project.version}_x86_64.zip</src>
@@ -1380,6 +1364,7 @@
                                     <snapshotExpand>true</snapshotExpand>
                                     <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/x86_64-nn/deb/control</controlDir>
+                                    <skipPOMs>false</skipPOMs>
                                     <dataSet>
                                         <data>
                                             <src>${basedir}/target/kura_${project.version}_x86_64-nn.zip</src>
@@ -1474,6 +1459,7 @@
                                     <snapshotExpand>true</snapshotExpand>
                                     <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/aarch64/deb/control</controlDir>
+                                    <skipPOMs>false</skipPOMs>
                                     <dataSet>
                                         <data>
                                             <src>${basedir}/target/kura_${project.version}_aarch64.zip</src>
@@ -1573,6 +1559,7 @@
                                     <snapshotExpand>true</snapshotExpand>
                                     <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/aarch64-nn/deb/control</controlDir>
+                                    <skipPOMs>false</skipPOMs>
                                     <dataSet>
                                         <data>
                                             <src>${basedir}/target/kura_${project.version}_aarch64-nn.zip</src>
@@ -1695,6 +1682,7 @@
                                     <snapshotExpand>true</snapshotExpand>
                                     <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/docker-x86_64-nn/deb/control</controlDir>
+                                    <skipPOMs>false</skipPOMs>
                                     <dataSet>
                                         <data>
                                             <src>${basedir}/target/kura_${project.version}_docker-x86_64-nn.zip</src>

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -881,13 +881,30 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>verify-if-snapshot</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <exportAntProperties>true</exportAntProperties>
+                            <target name="is-snapshot-check">
+                                <condition property="is.not.snapshot">
+                                    <not>
+                                        <contains string="${project.version}" substring="-SNAPSHOT" />
+                                    </not>
+                                </condition>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>release-copy</id>
                         <phase>install</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <target name="distrib-store-files">
+                            <target name="distrib-store-files" if="${is.not.snapshot}">
                                 <!-- Copy distrib/config/kura.build.properties in distrib/RELEASE_INFO/${project.version}/config -->
                                 <copy file="config/kura.build.properties" todir="RELEASE_INFO/${project.version}/config" overwrite="true" />
 

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -31,6 +31,7 @@
     <url>http://maven.apache.org</url>
     <properties>
         <tycho-version>4.0.11</tycho-version>
+        <jdeb-version>1.0</jdeb-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <kura.basedir>${project.basedir}</kura.basedir>
@@ -1266,7 +1267,7 @@
                     <plugin>
                         <groupId>org.vafer</groupId>
                         <artifactId>jdeb</artifactId>
-                        <version>1.0</version>
+                        <version>${jdeb-version}</version>
                         <executions>
                             <execution>
                                 <id>x86_64-deb</id>
@@ -1365,7 +1366,7 @@
                     <plugin>
                         <groupId>org.vafer</groupId>
                         <artifactId>jdeb</artifactId>
-                        <version>1.0</version>
+                        <version>${jdeb-version}</version>
                         <executions>
                             <execution>
                                 <id>x86_64-nn-deb</id>
@@ -1459,7 +1460,7 @@
                     <plugin>
                         <groupId>org.vafer</groupId>
                         <artifactId>jdeb</artifactId>
-                        <version>1.0</version>
+                        <version>${jdeb-version}</version>
                         <executions>
                             <execution>
                                 <id>aarch64-deb</id>
@@ -1558,7 +1559,7 @@
                     <plugin>
                         <groupId>org.vafer</groupId>
                         <artifactId>jdeb</artifactId>
-                        <version>1.0</version>
+                        <version>${jdeb-version}</version>
                         <executions>
                             <execution>
                                 <id>aarch64-nn-deb</id>
@@ -1680,7 +1681,7 @@
                     <plugin>
                         <groupId>org.vafer</groupId>
                         <artifactId>jdeb</artifactId>
-                        <version>1.0</version>
+                        <version>${jdeb-version}</version>
                         <executions>
                             <execution>
                                 <id>docker-x86_64-nn-deb</id>

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -44,6 +44,10 @@
 
         <!-- used for RPM uninstallation -->
         <kura.install.link>/opt/eclipse/kura</kura.install.link>
+
+        <!-- properties used for repository upload on artifactory -->
+        <kura.repo.distribution>kura-6</kura.repo.distribution>
+        <kura.repo.module>base</kura.repo.module>
     </properties>
 
     <organization>
@@ -88,7 +92,55 @@
                 <version>2.2</version>
             </extension>
         </extensions>
+
         <plugins>
+
+            <!-- Responsible for removing the "-SNAPSHOT" from the project.version -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>regex-property</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>release.version</name>
+                            <value>${project.version}</value>
+                            <regex>-SNAPSHOT</regex>
+                            <replacement></replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Responsible for retrieving the short git commit (defaults to length 7)-->
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>9.0.1</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <injectAllReactorProjects>true</injectAllReactorProjects>
+                    <generateGitPropertiesFile>false</generateGitPropertiesFile>
+                    <skipPoms>false</skipPoms>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
@@ -1097,6 +1149,60 @@
     </dependencies>
 
     <profiles>
+        <!-- Internal profile: FOR INTERNAL USE ONLY - active if -DreleaseBuild is *not* specified. -->
+        <profile>
+            <id>debugBuild</id>
+            <activation>
+                <property>
+                    <name>!releaseBuild</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
+                <package.snapshot>git${maven.build.timestamp}.${git.commit.id.abbrev}</package.snapshot>
+
+                <package.version>${release.version}~${package.snapshot}</package.version>
+                <package.revision>1</package.revision>
+            </properties>
+        </profile>
+        <!-- Internal profile: FOR INTERNAL USE ONLY - active if -DreleaseBuild *is* specified. -->
+        <profile>
+            <id>releaseBuild</id>
+            <activation>
+                <property>
+                    <name>releaseBuild</name>
+                </property>
+            </activation>
+            <properties>
+                <package.version>${release.version}</package.version>
+                <package.revision>1</package.revision>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseVersion>
+                                            <message>No snapshots allowed for release builds!</message>
+                                        </requireReleaseVersion>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
         <!-- x86_64 -->
         <profile>
@@ -1170,7 +1276,7 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/kura_${project.version}_amd64.deb</deb>
+                                    <deb>${basedir}/target/kura_${package.version}-${package.revision}_amd64.deb</deb>
                                     <controlDir>${basedir}/src/main/resources/x86_64/deb/control</controlDir>
                                     <dataSet>
                                         <data>
@@ -1267,7 +1373,7 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/kura-nn_${project.version}_amd64.deb</deb>
+                                    <deb>${basedir}/target/kura-nn_${package.version}-${package.revision}_amd64.deb</deb>
                                     <controlDir>${basedir}/src/main/resources/x86_64-nn/deb/control</controlDir>
                                     <dataSet>
                                         <data>
@@ -1359,7 +1465,7 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/kura_${project.version}_arm64.deb</deb>
+                                    <deb>${basedir}/target/kura_${package.version}-${package.revision}_arm64.deb</deb>
                                     <controlDir>${basedir}/src/main/resources/aarch64/deb/control</controlDir>
                                     <dataSet>
                                         <data>
@@ -1456,7 +1562,7 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/kura-nn_${project.version}_arm64.deb</deb>
+                                    <deb>${basedir}/target/kura-nn_${package.version}-${package.revision}_arm64.deb</deb>
                                     <controlDir>${basedir}/src/main/resources/aarch64-nn/deb/control</controlDir>
                                     <dataSet>
                                         <data>
@@ -1576,7 +1682,7 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/kura_${project.version}_docker-x86_64-nn_installer.deb</deb>
+                                    <deb>${basedir}/target/kura_${package.version}-${package.revision}_docker-x86_64-nn_installer.deb</deb>
                                     <controlDir>${basedir}/src/main/resources/docker-x86_64-nn/deb/control</controlDir>
                                     <dataSet>
                                         <data>

--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -1277,6 +1277,8 @@
                                 <configuration>
                                     <verbose>true</verbose>
                                     <deb>${basedir}/target/kura_${package.version}-${package.revision}_amd64.deb</deb>
+                                    <snapshotExpand>true</snapshotExpand>
+                                    <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/x86_64/deb/control</controlDir>
                                     <dataSet>
                                         <data>
@@ -1374,6 +1376,8 @@
                                 <configuration>
                                     <verbose>true</verbose>
                                     <deb>${basedir}/target/kura-nn_${package.version}-${package.revision}_amd64.deb</deb>
+                                    <snapshotExpand>true</snapshotExpand>
+                                    <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/x86_64-nn/deb/control</controlDir>
                                     <dataSet>
                                         <data>
@@ -1466,6 +1470,8 @@
                                 <configuration>
                                     <verbose>true</verbose>
                                     <deb>${basedir}/target/kura_${package.version}-${package.revision}_arm64.deb</deb>
+                                    <snapshotExpand>true</snapshotExpand>
+                                    <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/aarch64/deb/control</controlDir>
                                     <dataSet>
                                         <data>
@@ -1563,6 +1569,8 @@
                                 <configuration>
                                     <verbose>true</verbose>
                                     <deb>${basedir}/target/kura-nn_${package.version}-${package.revision}_arm64.deb</deb>
+                                    <snapshotExpand>true</snapshotExpand>
+                                    <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/aarch64-nn/deb/control</controlDir>
                                     <dataSet>
                                         <data>
@@ -1683,6 +1691,8 @@
                                 <configuration>
                                     <verbose>true</verbose>
                                     <deb>${basedir}/target/kura_${package.version}-${package.revision}_docker-x86_64-nn_installer.deb</deb>
+                                    <snapshotExpand>true</snapshotExpand>
+                                    <snapshotTemplate>${package.snapshot}</snapshotTemplate>
                                     <controlDir>${basedir}/src/main/resources/docker-x86_64-nn/deb/control</controlDir>
                                     <dataSet>
                                         <data>

--- a/kura/distrib/src/main/resources/aarch64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/aarch64-nn/deb/control/control
@@ -11,7 +11,7 @@
 #  Eurotech
 #
 Package: kura-nn
-Version: [[project.version]]
+Version: [[version]]-[[package.revision]]
 Section: admin
 Priority: optional
 Depends: openjdk-17-jre-headless | temurin-17-jdk,

--- a/kura/distrib/src/main/resources/aarch64/deb/control/control
+++ b/kura/distrib/src/main/resources/aarch64/deb/control/control
@@ -11,7 +11,7 @@
 #  Eurotech
 #
 Package: kura
-Version: [[project.version]]
+Version: [[version]]-[[package.revision]]
 Section: admin
 Priority: optional
 Depends: openjdk-17-jre-headless | temurin-17-jdk,

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
@@ -11,7 +11,7 @@
 #  Eurotech
 #
 Package: kura-nn
-Version: [[project.version]]
+Version: [[version]]-[[package.revision]]
 Section: admin
 Priority: optional
 Depends: dos2unix, unzip,

--- a/kura/distrib/src/main/resources/x86_64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/x86_64-nn/deb/control/control
@@ -11,7 +11,7 @@
 #  Eurotech
 #
 Package: kura-nn
-Version: [[project.version]]
+Version: [[version]]-[[package.revision]]
 Section: admin
 Priority: optional
 Depends: openjdk-17-jre-headless | temurin-17-jdk,

--- a/kura/distrib/src/main/resources/x86_64/deb/control/control
+++ b/kura/distrib/src/main/resources/x86_64/deb/control/control
@@ -11,7 +11,7 @@
 #  Eurotech
 #
 Package: kura
-Version: [[project.version]]
+Version: [[version]]-[[package.revision]]
 Section: admin
 Priority: optional
 Depends: openjdk-17-jre-headless | temurin-17-jdk,


### PR DESCRIPTION
This PR introduces the new versioning scheme support for debian packages and the new release build profile.

This PR adds the following:

- A Maven CLI parameter that allows us to select the build type:
    - Debug builds: which will produce the **CI build artifacts**. Versioning scheme: `X.X.X~gitYYYYMMDDHHMM.ZZZZZZZ-1`
    - Release builds: which will produce the **RC build artifacts**. Versioning scheme: `X.X.X-N`.
- Two new properties in the `distrib` POM that will drive the upload of the artifacts on Artifactory:
  - `kura.repo.distribution`: which sets the Kura distribution of the package (i.e. `kura-6`, `kura-7` etc)
  - `kura.repo.module`: which sets the Kura module of the package (i.e. `base`, `transportation`, `security` etc)

Additionally:
- It updates the `jdeb` plugin to version 1.12
- It fixes a typo in the distrib pom introduced in #5478 see 061ffee9b8af4580d69b918f46c01e6d88b06fd8

**Usage**

The build defaults to the `debugBuild` profile, if the `-DreleaseBuild` parameter is specified, the build selects the `releaseBuild` profile.

By default the `build.version` is set to `1`. It can be overridden via CLI using the `-Dpackage.revision=N` parameters.

### Examples

#### Debug build

```
mvn clean install -f kura/distrib/pom.xml -Paarch64
```

will produce:

```
ls kura/distrib/target
kura_6.0.0~git202505070911.c0687d8-1_arm64.deb
...
```

#### Release build

```
mvn clean install -f kura/distrib/pom.xml -Paarch64 -Dpackage.revision=6 -DreleaseBuild
```

will produce:

```
ls kura/distrib/target
kura_6.0.0-6_arm64.deb
```

---

### Notes about the implementation

This PR leverages the `snapshotExpand` and `snapshotTemplate` parameters of `jdeb` to correctly populate the Version field in the `control` file of the debian package.

References:
- Parameters documentation: https://github.com/tcurdt/jdeb/blob/master/docs/maven.md
- Implementation: https://github.com/tcurdt/jdeb/blob/8971c35ad0a0f939c342c76060b781aafb008561/src/main/java/org/vafer/jdeb/utils/Utils.java#L274

> [!WARNING]
> Limitation: due to how this functionality was implemented in `jdeb`, we cannot use it to **erase the `-SNAPSHOT` modifier in the release build**. An empty template would result in the timestamp being expanded instead. Therefore this implementation **assumes that the `-SNAPSHOT` modified is not present when performing a `releaseBuild`** and will fail the build (via `maven-enforcer-plugin`) if a snapshot is detected.
>
> This means that, to perform an actual `releaseBuild`, we need to:
> - perform the uptick from snapshot to release
> - run the build with `-DreleaseBuild`
>
> The `-DreleaseBuild` parameter on its own is not enough.

Release build without uptick:

![image](https://github.com/user-attachments/assets/6dce4fe6-6b7e-47b9-a455-768f5eb6f551)

---

### Third party content

This PR introduces three new maven plugins:
1. [`build-helper-maven-plugin`](https://github.com/mojohaus/build-helper-maven-plugin) [MIT License](https://github.com/mojohaus/build-helper-maven-plugin#MIT-1-ov-file)
    - [x] https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/21017
3. [`git-commit-id-maven-plugin`](https://github.com/git-commit-id/git-commit-id-maven-plugin) [LGPL-3.0](https://github.com/git-commit-id/git-commit-id-maven-plugin#LGPL-3.0-1-ov-file)
    - [x] https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/21018
5. [`maven-enforcer-plugin`](https://github.com/apache/maven-enforcer) [Apache 2.0 License](https://github.com/apache/maven-enforcer#Apache-2.0-1-ov-file)
    - [X] Vetted license information was found for all content. No further investigation is required.