### PR TITLE
ci: migrate workflows to shared

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,23 +10,5 @@ permissions:
   pull-requests: write
 
 jobs:
-  backport:
-    name: Backport
-    runs-on: ubuntu-latest
-    # Only react to merged PRs for security reasons.
-    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
-    if: >
-      github.event.pull_request.merged
-      && (
-        github.event.action == 'closed'
-        || (
-          github.event.action == 'labeled'
-          && contains(github.event.label.name, 'backport')
-        )
-      )
-    steps:
-      - uses: tibdex/backport@v2
-        with:
-          github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          title_template: "<%= title %> [backport <%= base %>]"
-
+  call-workflow-in-public-repo:
+    uses: eclipse-kura/.github/.github/workflows/_shared-backport.yml@main

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   call-workflow-in-public-repo:
     uses: eclipse-kura/.github/.github/workflows/_shared-pr-lint.yml@main

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,29 +7,6 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read
-
 jobs:
-  main:
-    name: Validate PR title
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            fix
-            feat
-            docs
-            refactor
-            test
-            style
-            chore
-            build
-            ci
-            revert
-            perf
-            deprecate
-          requireScope: false
+  call-workflow-in-public-repo:
+    uses: eclipse-kura/.github/.github/workflows/_shared-pr-lint.yml@main


### PR DESCRIPTION
This PR migrates the Kura github workflows the ones available in the https://github.com/eclipse-kura/.github repository.

Version uptick and Release notes workflows cannot be migrated to the shared ones since they were heavily customised for the Kura project.