### PR TITLE
docs(RED-DA): remove `appadmin` and `netadmin` from docs

### DIFF
--- a/docs/gateway-configuration/gateway-administration-console-authentication.md
+++ b/docs/gateway-configuration/gateway-administration-console-authentication.md
@@ -26,12 +26,8 @@ Kura provides the following identities by default:
 | Name | Password | Permissions |
 | ---- | -------- | ----------- |
 | admin | admin | kura.admin |
-| appadmin | appadmin | kura.cloud.connection.admin, kura.packages.admin, kura.wires.admin |
-| netadmin | netadmin | kura.cloud.connection.admin, kura.device, kura.network.admin |
 
 It is possible to modify/remove the default identity configuration.
-
-
 
 ## Login
 


### PR DESCRIPTION
Documentation update following #5834 