### PR TITLE
feat: prevent upgrades

### DIFF
--- a/kura/distrib/src/main/resources/aarch64-nn/deb/control/postinst
+++ b/kura/distrib/src/main/resources/aarch64-nn/deb/control/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -93,6 +93,13 @@ function postInstall {
 ##############################################
 # POST INSTALL SCRIPT
 ##############################################
+
+# Handle abort-upgrade case
+if [ "$1" = "abort-upgrade" ]; then
+    echo "postinst called with abort-upgrade: nothing to do."
+    exit 0
+fi
+
 runPostInstall
 exit 0
 #############################################

--- a/kura/distrib/src/main/resources/aarch64-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/aarch64-nn/deb/control/prerm
@@ -114,7 +114,22 @@ function preRemove {
 ##############################################
 
 # Fail if the first argument is 'upgrade' or 'failed-upgrade'
-if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
+if [ "$1" == "upgrade" ]; then
+    echo ""
+    echo "#####################################################################"
+    echo "#                                                                   #"
+    echo "#  ERROR: KURA upgrade is NOT supported!                            #"
+    echo "#  Please uninstall the existing version before upgrading.          #"
+    echo "#                                                                   #"
+    echo "#  To prevent accidental upgrades, you can hold this package with:  #"
+    echo "#      sudo apt-mark hold kura                                      #"
+    echo "#                                                                   #"
+    echo "#####################################################################"
+    echo ""
+    exit 1
+fi
+
+if [ "$1" == "failed-upgrade" ]; then
     echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
     exit 1
 fi

--- a/kura/distrib/src/main/resources/aarch64-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/aarch64-nn/deb/control/prerm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -112,6 +112,13 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
+
+# Fail if the first argument is 'upgrade' or 'failed-upgrade'
+if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
+    echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
+    exit 1
+fi
+
 echo ""
 echo "Uninstalling KURA..."
 

--- a/kura/distrib/src/main/resources/aarch64/deb/control/postinst
+++ b/kura/distrib/src/main/resources/aarch64/deb/control/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -93,6 +93,13 @@ function postInstall {
 ##############################################
 # POST INSTALL SCRIPT
 ##############################################
+
+# Handle abort-upgrade case
+if [ "$1" = "abort-upgrade" ]; then
+    echo "postinst called with abort-upgrade: nothing to do."
+    exit 0
+fi
+
 runPostInstall
 exit 0
 #############################################

--- a/kura/distrib/src/main/resources/aarch64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/aarch64/deb/control/prerm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -140,6 +140,13 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
+
+# Fail if the first argument is 'upgrade' or 'failed-upgrade'
+if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
+    echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
+    exit 1
+fi
+
 echo ""
 echo "Uninstalling KURA..."
 

--- a/kura/distrib/src/main/resources/aarch64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/aarch64/deb/control/prerm
@@ -142,7 +142,22 @@ function preRemove {
 ##############################################
 
 # Fail if the first argument is 'upgrade' or 'failed-upgrade'
-if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
+if [ "$1" == "upgrade" ]; then
+    echo ""
+    echo "#####################################################################"
+    echo "#                                                                   #"
+    echo "#  ERROR: KURA upgrade is NOT supported!                            #"
+    echo "#  Please uninstall the existing version before upgrading.          #"
+    echo "#                                                                   #"
+    echo "#  To prevent accidental upgrades, you can hold this package with:  #"
+    echo "#      sudo apt-mark hold kura                                      #"
+    echo "#                                                                   #"
+    echo "#####################################################################"
+    echo ""
+    exit 1
+fi
+
+if [ "$1" == "failed-upgrade" ]; then
     echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
     exit 1
 fi

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/postinst
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/postinst
@@ -1,4 +1,16 @@
 #!/bin/bash
+#
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#  Eurotech
+#
 
 INSTALL_DIR=/opt/eclipse
 TIMESTAMP=`date +%Y%m%d%H%M%S`
@@ -81,6 +93,13 @@ function postInstall {
 ##############################################
 # POST INSTALL SCRIPT
 ##############################################
+
+# Handle abort-upgrade case
+if [ "$1" = "abort-upgrade" ]; then
+    echo "postinst called with abort-upgrade: nothing to do."
+    exit 0
+fi
+
 runPostInstall
 exit 0
 #############################################

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/prerm
@@ -1,4 +1,16 @@
 #!/bin/bash
+#
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#  Eurotech
+#
 
 INSTALL_DIR=/opt/eclipse
 WD_TMP_FILE=/tmp/watchdog
@@ -95,6 +107,14 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
+
+# Fail if the first argument is 'upgrade' or 'failed-upgrade'
+if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
+    echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
+    exit 1
+fi
+
+
 echo ""
 echo "Uninstalling KURA..."
 

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/prerm
@@ -109,11 +109,25 @@ function preRemove {
 ##############################################
 
 # Fail if the first argument is 'upgrade' or 'failed-upgrade'
-if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
-    echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
+if [ "$1" == "upgrade" ]; then
+    echo ""
+    echo "#####################################################################"
+    echo "#                                                                   #"
+    echo "#  ERROR: KURA upgrade is NOT supported!                            #"
+    echo "#  Please uninstall the existing version before upgrading.          #"
+    echo "#                                                                   #"
+    echo "#  To prevent accidental upgrades, you can hold this package with:  #"
+    echo "#      sudo apt-mark hold kura                                      #"
+    echo "#                                                                   #"
+    echo "#####################################################################"
+    echo ""
     exit 1
 fi
 
+if [ "$1" == "failed-upgrade" ]; then
+    echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
+    exit 1
+fi
 
 echo ""
 echo "Uninstalling KURA..."

--- a/kura/distrib/src/main/resources/x86_64-nn/deb/control/postinst
+++ b/kura/distrib/src/main/resources/x86_64-nn/deb/control/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -93,6 +93,13 @@ function postInstall {
 ##############################################
 # POST INSTALL SCRIPT
 ##############################################
+
+# Handle abort-upgrade case
+if [ "$1" = "abort-upgrade" ]; then
+    echo "postinst called with abort-upgrade: nothing to do."
+    exit 0
+fi
+
 runPostInstall
 exit 0
 #############################################

--- a/kura/distrib/src/main/resources/x86_64-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/x86_64-nn/deb/control/prerm
@@ -114,7 +114,22 @@ function preRemove {
 ##############################################
 
 # Fail if the first argument is 'upgrade' or 'failed-upgrade'
-if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
+if [ "$1" == "upgrade" ]; then
+    echo ""
+    echo "#####################################################################"
+    echo "#                                                                   #"
+    echo "#  ERROR: KURA upgrade is NOT supported!                            #"
+    echo "#  Please uninstall the existing version before upgrading.          #"
+    echo "#                                                                   #"
+    echo "#  To prevent accidental upgrades, you can hold this package with:  #"
+    echo "#      sudo apt-mark hold kura                                      #"
+    echo "#                                                                   #"
+    echo "#####################################################################"
+    echo ""
+    exit 1
+fi
+
+if [ "$1" == "failed-upgrade" ]; then
     echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
     exit 1
 fi

--- a/kura/distrib/src/main/resources/x86_64-nn/deb/control/prerm
+++ b/kura/distrib/src/main/resources/x86_64-nn/deb/control/prerm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -112,6 +112,13 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
+
+# Fail if the first argument is 'upgrade' or 'failed-upgrade'
+if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
+    echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
+    exit 1
+fi
+
 echo ""
 echo "Uninstalling KURA..."
 

--- a/kura/distrib/src/main/resources/x86_64/deb/control/postinst
+++ b/kura/distrib/src/main/resources/x86_64/deb/control/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -93,6 +93,13 @@ function postInstall {
 ##############################################
 # POST INSTALL SCRIPT
 ##############################################
+
+# Handle abort-upgrade case
+if [ "$1" = "abort-upgrade" ]; then
+    echo "postinst called with abort-upgrade: nothing to do."
+    exit 0
+fi
+
 runPostInstall
 exit 0
 #############################################

--- a/kura/distrib/src/main/resources/x86_64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/x86_64/deb/control/prerm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+# Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -140,6 +140,13 @@ function preRemove {
 ##############################################
 # PRE-REMOVE SCRIPT
 ##############################################
+
+# Fail if the first argument is 'upgrade' or 'failed-upgrade'
+if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
+    echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
+    exit 1
+fi
+
 echo ""
 echo "Uninstalling KURA..."
 

--- a/kura/distrib/src/main/resources/x86_64/deb/control/prerm
+++ b/kura/distrib/src/main/resources/x86_64/deb/control/prerm
@@ -142,7 +142,22 @@ function preRemove {
 ##############################################
 
 # Fail if the first argument is 'upgrade' or 'failed-upgrade'
-if [ "$1" == "upgrade" ] || [ "$1" == "failed-upgrade" ]; then
+if [ "$1" == "upgrade" ]; then
+    echo ""
+    echo "#####################################################################"
+    echo "#                                                                   #"
+    echo "#  ERROR: KURA upgrade is NOT supported!                            #"
+    echo "#  Please uninstall the existing version before upgrading.          #"
+    echo "#                                                                   #"
+    echo "#  To prevent accidental upgrades, you can hold this package with:  #"
+    echo "#      sudo apt-mark hold kura                                      #"
+    echo "#                                                                   #"
+    echo "#####################################################################"
+    echo ""
+    exit 1
+fi
+
+if [ "$1" == "failed-upgrade" ]; then
     echo "This package cannot be upgraded. Please uninstall the existing version before installing a new one."
     exit 1
 fi


### PR DESCRIPTION
Once we’ll have the Kura repositories in place, user might be tempted to update Kura packages via `apt update && apt dist-upgrade`. Given that we don’t support upgrades for Kura packages we want to prevent users from breaking their installation running the above mentioned command.

This PR introduces a check in the `prerm` script so that, if the script is ran during an upgrade, it will fail leaving the Kura installation intact.

![image](https://github.com/user-attachments/assets/d35b8bc3-d080-4b26-aa9b-f1390b7e3d53)

Tested on RPi 4:

```
pi@raspberrypi:~ $ sudo apt install ./kura_6.0.0~git202506090923.f86000e4-2_arm64.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'kura' instead of './kura_6.0.0~git202506090923.f86000e4-2_arm64.deb'
The following packages were automatically installed and are no longer required:
  libcamera0.3 ntpdate ntpsec-ntpdate ntpsec-ntpdig python3-ntp
Use 'sudo apt autoremove' to remove them.
The following packages will be upgraded:
  kura
1 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/101 MB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 /home/pi/kura_6.0.0~git202506090923.f86000e4-2_arm64.deb kura arm64 6.0.0~git202506090923.f86000e4-2 [101 MB]
Reading changelogs... Done
(Reading database ... 78582 files and directories currently installed.)
Preparing to unpack .../kura_6.0.0~git202506090923.f86000e4-2_arm64.deb ...

#####################################################################
#                                                                   #
#  ERROR: KURA upgrade is NOT supported!                            #
#  Please uninstall the existing version before upgrading.          #
#                                                                   #
#  To prevent accidental upgrades, you can hold this package with:  #
#      sudo apt-mark hold kura                                      #
#                                                                   #
#####################################################################

dpkg: warning: old kura package pre-removal script subprocess returned error exit status 1
dpkg: trying script from the new package instead ...
This package cannot be upgraded. Please uninstall the existing version before installing a new one.
dpkg: error processing archive /home/pi/kura_6.0.0~git202506090923.f86000e4-2_arm64.deb (--unpack):
 new kura package pre-removal script subprocess returned error exit status 1
postinst called with abort-upgrade: nothing to do.
Errors were encountered while processing:
 /home/pi/kura_6.0.0~git202506090923.f86000e4-2_arm64.deb
N: Download is performed unsandboxed as root as file '/home/pi/kura_6.0.0~git202506090923.f86000e4-2_arm64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

---

### Alternatives to this approach

1. Configure a repository in such a way that apt won’t consider upgrading packages shipped there by default (see: https://wiki.debian.org/DebianRepository/Format#NotAutomatic_and_ButAutomaticUpgrades)
2. Package name containing the version

---

Additional resources:
- https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
- https://wiki.debian.org/MaintainerScripts