### PR TITLE
feat(cloudconnection): Made NetworkService optional for cloudconnections

### DIFF
--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/cloud.xml
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/cloud.xml
@@ -42,8 +42,8 @@
               unbind="unsetSystemAdminService"
               interface="org.eclipse.kura.system.SystemAdminService"/>
    <reference name="NetworkService" 
-              policy="static" 
-              cardinality="1..1" 
+              policy="dynamic" 
+              cardinality="0..1" 
               bind="setNetworkService" 
               unbind="unsetNetworkService"
               interface="org.eclipse.kura.net.NetworkService"/>

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/cloud.xml
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/OSGI-INF/cloud.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
 
-   This program and the accompanying materials are made
-   available under the terms of the Eclipse Public License 2.0
-   which is available at https://www.eclipse.org/legal/epl-2.0/
- 
-	SPDX-License-Identifier: EPL-2.0
-	
-	Contributors:
-	 Eurotech
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="true" modified="updated" name="org.eclipse.kura.cloudconnection.eclipseiot.mqtt.ConnectionManager">

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -119,7 +119,7 @@ public class CloudConnectionManagerImpl
     private DataService dataService;
     private SystemService systemService;
     private SystemAdminService systemAdminService;
-    private NetworkService networkService;
+    private Optional<NetworkService> networkService;
     private Optional<PositionService> positionService = Optional.empty();
     private EventAdmin eventAdmin;
     private CertificatesService certificatesService;
@@ -206,16 +206,16 @@ public class CloudConnectionManagerImpl
     }
 
     public void setNetworkService(NetworkService networkService) {
-        this.networkService = networkService;
+        this.networkService = Optional.of(networkService);
     }
 
     public void unsetNetworkService(NetworkService networkService) {
-        if (this.networkService.equals(networkService)) {
-            this.networkService = null;
+        if (this.networkService.isPresent() && this.networkService.get().equals(networkService)) {
+            this.networkService = Optional.empty();
         }
     }
 
-    public NetworkService getNetworkService() {
+    public Optional<NetworkService> getNetworkService() {
         return this.networkService;
     }
 

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -119,7 +119,7 @@ public class CloudConnectionManagerImpl
     private DataService dataService;
     private SystemService systemService;
     private SystemAdminService systemAdminService;
-    private Optional<NetworkService> networkService;
+    private Optional<NetworkService> networkService = Optional.empty();
     private Optional<PositionService> positionService = Optional.empty();
     private EventAdmin eventAdmin;
     private CertificatesService certificatesService;

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/CloudConnectionManagerImpl.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.kura.internal.cloudconnection.eclipseiot.mqtt.cloud;
 
 import static java.util.Objects.nonNull;

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.kura.internal.cloudconnection.eclipseiot.mqtt.cloud;
 
 import java.util.List;

--- a/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider/src/main/java/org/eclipse/kura/internal/cloudconnection/eclipseiot/mqtt/cloud/LifeCyclePayloadBuilder.java
@@ -135,37 +135,36 @@ public class LifeCyclePayloadBuilder {
     public KuraDeviceProfile buildDeviceProfile() {
         SystemService systemService = this.cloudConnectionManagerImpl.getSystemService();
         SystemAdminService sysAdminService = this.cloudConnectionManagerImpl.getSystemAdminService();
-        NetworkService networkService = this.cloudConnectionManagerImpl.getNetworkService();
+        Optional<NetworkService> networkService = this.cloudConnectionManagerImpl.getNetworkService();
         Optional<PositionService> positionService = this.cloudConnectionManagerImpl.getPositionService();
 
         //
         // get the network information
-        StringBuilder sbConnectionIp = null;
-        StringBuilder sbConnectionInterface = null;
-        try {
-            List<NetInterface<? extends NetInterfaceAddress>> nis = networkService.getActiveNetworkInterfaces();
-            if (!nis.isEmpty()) {
-                sbConnectionIp = new StringBuilder();
-                sbConnectionInterface = new StringBuilder();
-
-                for (NetInterface<? extends NetInterfaceAddress> ni : nis) {
-                    List<? extends NetInterfaceAddress> nias = ni.getNetInterfaceAddresses();
-                    if (nias != null && !nias.isEmpty()) {
-                        sbConnectionInterface.append(buildConnectionInterface(ni)).append(",");
-                        sbConnectionIp.append(buildConnectionIp(ni)).append(",");
+        StringBuilder sbConnectionIp = new StringBuilder();
+        StringBuilder sbConnectionInterface = new StringBuilder();
+        networkService.ifPresent(ns -> {
+            try {
+                List<NetInterface<? extends NetInterfaceAddress>> nis = ns.getActiveNetworkInterfaces();
+                if (!nis.isEmpty()) {
+                    for (NetInterface<? extends NetInterfaceAddress> ni : nis) {
+                        List<? extends NetInterfaceAddress> nias = ni.getNetInterfaceAddresses();
+                        if (nias != null && !nias.isEmpty()) {
+                            sbConnectionInterface.append(buildConnectionInterface(ni)).append(",");
+                            sbConnectionIp.append(buildConnectionIp(ni)).append(",");
+                        }
                     }
+
+                    // Remove trailing comma
+                    sbConnectionIp.deleteCharAt(sbConnectionIp.length() - 1);
+                    sbConnectionInterface.deleteCharAt(sbConnectionInterface.length() - 1);
                 }
-
-                // Remove trailing comma
-                sbConnectionIp.deleteCharAt(sbConnectionIp.length() - 1);
-                sbConnectionInterface.deleteCharAt(sbConnectionInterface.length() - 1);
+            } catch (Exception se) {
+                logger.warn("Error while getting ConnetionIP and ConnectionInterface", se);
             }
-        } catch (Exception se) {
-            logger.warn("Error while getting ConnetionIP and ConnectionInterface", se);
-        }
+        });
 
-        String connectionIp = sbConnectionIp != null ? sbConnectionIp.toString() : UNKNOWN;
-        String connectionInterface = sbConnectionInterface != null ? sbConnectionInterface.toString() : UNKNOWN;
+        String connectionIp = !sbConnectionIp.isEmpty() ? sbConnectionIp.toString() : UNKNOWN;
+        String connectionInterface = !sbConnectionInterface.isEmpty() ? sbConnectionInterface.toString() : UNKNOWN;
 
         //
         // get the position information

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/OSGI-INF/cloud.xml
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/OSGI-INF/cloud.xml
@@ -43,8 +43,8 @@
               unbind="unsetSystemAdminService"
               interface="org.eclipse.kura.system.SystemAdminService"/>
    <reference name="NetworkService" 
-              policy="static" 
-              cardinality="1..1" 
+              policy="dynamic" 
+              cardinality="0..1" 
               bind="setNetworkService" 
               unbind="unsetNetworkService"
               interface="org.eclipse.kura.net.NetworkService"/>

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/OSGI-INF/cloud.xml
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/OSGI-INF/cloud.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
 
-   This program and the accompanying materials are made
-   available under the terms of the Eclipse Public License 2.0
-   which is available at https://www.eclipse.org/legal/epl-2.0/
- 
-	SPDX-License-Identifier: EPL-2.0
-	
-	Contributors:
-	 Eurotech
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" configuration-policy="require" deactivate="deactivate" enabled="true" immediate="false" modified="updated" name="org.eclipse.kura.cloud.CloudService">

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -137,7 +137,7 @@ public class CloudServiceImpl
     private DataService dataService;
     private SystemService systemService;
     private SystemAdminService systemAdminService;
-    private Optional<NetworkService> networkService;
+    private Optional<NetworkService> networkService = Optional.empty();
     private Optional<PositionService> positionService = Optional.empty();
     private EventAdmin eventAdmin;
     private CertificatesService certificatesService;

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/CloudServiceImpl.java
@@ -137,7 +137,7 @@ public class CloudServiceImpl
     private DataService dataService;
     private SystemService systemService;
     private SystemAdminService systemAdminService;
-    private NetworkService networkService;
+    private Optional<NetworkService> networkService;
     private Optional<PositionService> positionService = Optional.empty();
     private EventAdmin eventAdmin;
     private CertificatesService certificatesService;
@@ -238,16 +238,16 @@ public class CloudServiceImpl
     }
 
     public void setNetworkService(NetworkService networkService) {
-        this.networkService = networkService;
+        this.networkService = Optional.of(networkService);
     }
 
     public void unsetNetworkService(NetworkService networkService) {
-        if (this.networkService != null && this.networkService.equals(networkService)) {
-            this.networkService = null;
+        if (this.networkService.isPresent() && this.networkService.get().equals(networkService)) {
+            this.networkService = Optional.empty();
         }
     }
 
-    public NetworkService getNetworkService() {
+    public Optional<NetworkService> getNetworkService() {
         return this.networkService;
     }
 

--- a/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
+++ b/kura/org.eclipse.kura.cloudconnection.kapua.mqtt.provider/src/main/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilder.java
@@ -183,37 +183,36 @@ public class LifeCyclePayloadBuilder {
     public KuraDeviceProfile buildDeviceProfile() {
         SystemService systemService = this.cloudServiceImpl.getSystemService();
         SystemAdminService sysAdminService = this.cloudServiceImpl.getSystemAdminService();
-        NetworkService networkService = this.cloudServiceImpl.getNetworkService();
+        Optional<NetworkService> networkService = this.cloudServiceImpl.getNetworkService();
         Optional<PositionService> positionService = this.cloudServiceImpl.getPositionService();
 
         //
-        // get the network information
-        StringBuilder sbConnectionIp = null;
-        StringBuilder sbConnectionInterface = null;
-        try {
-            List<NetInterface<? extends NetInterfaceAddress>> nis = networkService.getActiveNetworkInterfaces();
-            if (!nis.isEmpty()) {
-                sbConnectionIp = new StringBuilder();
-                sbConnectionInterface = new StringBuilder();
-
-                for (NetInterface<? extends NetInterfaceAddress> ni : nis) {
-                    List<? extends NetInterfaceAddress> nias = ni.getNetInterfaceAddresses();
-                    if (nias != null && !nias.isEmpty()) {
-                        sbConnectionInterface.append(buildConnectionInterface(ni)).append(",");
-                        sbConnectionIp.append(buildConnectionIp(ni)).append(",");
+        // get the network information if available
+        StringBuilder sbConnectionIp = new StringBuilder();
+        StringBuilder sbConnectionInterface = new StringBuilder();
+        networkService.ifPresent(ns -> {
+            try {
+                List<NetInterface<? extends NetInterfaceAddress>> nis = ns.getActiveNetworkInterfaces();
+                if (!nis.isEmpty()) {
+                    for (NetInterface<? extends NetInterfaceAddress> ni : nis) {
+                        List<? extends NetInterfaceAddress> nias = ni.getNetInterfaceAddresses();
+                        if (nias != null && !nias.isEmpty()) {
+                            sbConnectionInterface.append(buildConnectionInterface(ni)).append(",");
+                            sbConnectionIp.append(buildConnectionIp(ni)).append(",");
+                        }
                     }
+
+                    // Remove trailing comma
+                    sbConnectionIp.deleteCharAt(sbConnectionIp.length() - 1);
+                    sbConnectionInterface.deleteCharAt(sbConnectionInterface.length() - 1);
                 }
-
-                // Remove trailing comma
-                sbConnectionIp.deleteCharAt(sbConnectionIp.length() - 1);
-                sbConnectionInterface.deleteCharAt(sbConnectionInterface.length() - 1);
+            } catch (Exception se) {
+                logger.warn("Error while getting ConnectionIP and ConnectionInterface", se);
             }
-        } catch (Exception se) {
-            logger.warn("Error while getting ConnetionIP and ConnectionInterface", se);
-        }
+        });
 
-        String connectionIp = sbConnectionIp != null ? sbConnectionIp.toString() : UNKNOWN;
-        String connectionInterface = sbConnectionInterface != null ? sbConnectionInterface.toString() : UNKNOWN;
+        String connectionIp = !sbConnectionIp.isEmpty() ? sbConnectionIp.toString() : UNKNOWN;
+        String connectionInterface = !sbConnectionInterface.isEmpty() ? sbConnectionInterface.toString() : UNKNOWN;
 
         //
         // get the position information

--- a/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/BirthMessagesTest.java
@@ -429,7 +429,7 @@ public class BirthMessagesTest {
                         out.write(object.toString().getBytes(StandardCharsets.UTF_8));
                     }
                 } catch (IOException ex) {
-                    //do nothing
+                    // do nothing
                 }
             }
         };

--- a/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
@@ -38,7 +38,7 @@ public class LifeCyclePayloadBuilderTest {
 
     private SystemService systemService;
     private SystemAdminService sysAdminService;
-    private NetworkService networkService;
+    private Optional<NetworkService> networkService;
     private Optional<PositionService> positionService;
     private CloudServiceImpl cloudServiceImpl;
     private LifeCyclePayloadBuilder lifeCyclePayloadBuilder;
@@ -119,8 +119,8 @@ public class LifeCyclePayloadBuilderTest {
 
     private void givenNetworkService(List<NetInterface<? extends NetInterfaceAddress>> netInterfaces)
             throws KuraException {
-        this.networkService = mock(NetworkService.class);
-        when(this.networkService.getActiveNetworkInterfaces()).thenReturn(netInterfaces);
+        this.networkService = Optional.of(mock(NetworkService.class));
+        when(this.networkService.get().getActiveNetworkInterfaces()).thenReturn(netInterfaces);
     }
 
     private void givenPositionService() {

--- a/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
+++ b/kura/test/org.eclipse.kura.cloudconnection.kapua.mqtt.provider.test/src/test/java/org/eclipse/kura/core/cloud/LifeCyclePayloadBuilderTest.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2025 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.kura.core.cloud;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
This PR makes the dependency from the `NetworkService` optional for the following cloudconnections:

- `org.eclipse.kura.cloudconnection.kapua.mqtt.provider`
- `org.eclipse.kura.cloudconnection.eclipseiot.mqtt.provider`