### PR TITLE
feat(RED-DA): default enable flooding protection

### DIFF
--- a/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml
+++ b/kura/distrib/src/main/resources/common/snapshots/snapshot_0.xml
@@ -391,4 +391,14 @@ NETWORK_CONFIGURATION
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.internal.floodingprotection.FloodingProtectionConfigurator">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="flooding.protection.enabled.ipv6" type="Boolean">
+                <esf:value>true</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="flooding.protection.enabled" type="Boolean">
+                <esf:value>true</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>

--- a/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
+++ b/kura/org.eclipse.kura.network.threat.manager/src/main/java/org/eclipse/kura/internal/floodingprotection/FloodingProtectionOptions.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  ******************************************************************************/
@@ -86,8 +86,8 @@ public class FloodingProtectionOptions {
             + "If the device does not support IPv6, this property will be ignored. "
             + "In kernel versions less than 6.x, after disabling the feature by setting this field to false, "
             + "a reboot may be needed to completely disable the filtering.";
-    private static final boolean FP_ENABLED_DEFAULT_IPV4 = false;
-    private static final boolean FP_ENABLED_DEFAULT_IPV6 = false;
+    private static final boolean FP_ENABLED_DEFAULT_IPV4 = true;
+    private static final boolean FP_ENABLED_DEFAULT_IPV6 = true;
 
     private Map<String, Object> properties = new HashMap<>();
 


### PR DESCRIPTION
Following the need to make Kura 6.0.0 compatible to the RED-DA requirements, this PR modifies the default Kura configuration for flooding protection.

Therefore this PR:
- Always enable the flooding protection for ipv4 and ipv6

Tested working on RPi:

![image](https://github.com/user-attachments/assets/8c27796d-1de4-4072-befb-55bb3587d25f)
