### PR TITLE
feat(RED-DA): new password strength policy

### DIFF
--- a/kura/org.eclipse.kura.core.identity/src/main/java/org/eclipse/kura/core/identity/PasswordStrengthVerificationServiceOptions.java
+++ b/kura/org.eclipse.kura.core.identity/src/main/java/org/eclipse/kura/core/identity/PasswordStrengthVerificationServiceOptions.java
@@ -26,19 +26,19 @@ public @interface PasswordStrengthVerificationServiceOptions {
     @AttributeDefinition(name = "Minimum password length", //
             min = "0", //
             description = "The minimum length to be enforced for new passwords. Set to 0 to disable.")
-    public int new_password_min_length() default 8;
+    public int new_password_min_length() default 12;
 
     @AttributeDefinition(name = "Require digits in new password", //
             description = "If set to true, new passwords will be accepted only if containing at least one digit.")
-    public boolean new_password_require_digits() default false;
+    public boolean new_password_require_digits() default true;
 
     @AttributeDefinition(name = "Require special characters in new password", //
             description = "If set to true, new passwords will be accepted only if containing at least one non alphanumeric character.")
-    public boolean new_password_require_special_characters() default false;
+    public boolean new_password_require_special_characters() default true;
 
     @AttributeDefinition(name = "Require uppercase and lowercase characters in new passwords", //
             description = "If set to true, new passwords will be accepted only if containing both"
                     + " uppercase and lowercase alphanumeric characters.")
-    public boolean new_password_require_both_cases() default false;
+    public boolean new_password_require_both_cases() default true;
 
 }

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityV2EndpointsTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityV2EndpointsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2024, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityV2EndpointsTest.java
+++ b/kura/test/org.eclipse.kura.rest.identity.provider.test/src/main/java/org/eclipse/kura/internal/rest/identity/provider/test/IdentityV2EndpointsTest.java
@@ -145,7 +145,7 @@ public class IdentityV2EndpointsTest extends AbstractRequestHandlerTest {
         givenMockIdentityConfigurationExtension("test2.extension");
 
         givenPermissionConfiguration(this.testPermissionName);
-        givenPasswordConfiguration("abcdef1234567", true, false);
+        givenPasswordConfiguration("Abcdef1234567@", true, false);
         givenAdditionalConfigurations(TestComponentConfiguration.forPid("test.extension"),
                 TestComponentConfiguration.forPid("test2.extension"));
 


### PR DESCRIPTION
Following the need to make Kura 6.0.0 compatible to the RED-DA requirements, this PR modifies the default Kura password configuration to match the requirements set by RED-DA.

Requirements:
- Minimum 12 characters
- Enable digits, special characters, upper and lower

Tested working on RPi:

![image](https://github.com/user-attachments/assets/150e54ce-22fb-4040-98a2-3eec36027d11)
