### PR TITLE
fix: Fixed drivers not shown in drivers and assets section

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtDriverAndAssetServiceImpl.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/GwtDriverAndAssetServiceImpl.java
@@ -421,13 +421,21 @@ public class GwtDriverAndAssetServiceImpl extends OsgiRemoteServiceServlet imple
             }
         });
 
-        final List<GwtConfigComponent> componentConfigurations = GwtComponentServiceInternal
-                .findComponentConfigurations(
-                        "(|(objectClass=" + Driver.class.getName() + ")(objectClass=" + Asset.class.getName() + "))");
+        final List<GwtConfigComponent> componentConfigurations = new ArrayList<>();
+
+        final List<GwtConfigComponent> driverConfigurations = GwtComponentServiceInternal
+                .findComponentConfigurations("(objectClass=" + Driver.class.getName() + ")");
+
+        driverConfigurations.forEach(c -> c.setIsDriver(true));
+        componentConfigurations.addAll(driverConfigurations);
 
         if (supportedFeatures.isAssetAvailable()) {
             result.setBaseChannelDescriptor(GwtWireAssetConstants.WIRE_ASSET_CHANNEL_DESCRIPTOR);
             componentDefinitions.add(GwtWireAssetConstants.WIRE_ASSET_OCD);
+
+            final List<GwtConfigComponent> assetConfigurations = GwtComponentServiceInternal
+                    .findComponentConfigurations("(objectClass=" + Asset.class.getName() + ")");
+            componentConfigurations.addAll(assetConfigurations);
         }
 
         result.setComponentDefinitions(componentDefinitions);


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Fixes Driver instances not being shown in the Drivers and Assets section due to the fact that their configuration is not marked with the `isDriver` flag
