### PR TITLE
docs: update VSCode setup documentation

### DIFF
--- a/docs/java-application-development/development-environment-setup.md
+++ b/docs/java-application-development/development-environment-setup.md
@@ -118,7 +118,7 @@ cd kura/
 and then run the tool with the following command
 
 ```bash
-kura-gen --patch-target-platform -t target-definition/kura-equinox.target
+kura-gen
 ```
 
 #### 4. Open VSCode in the `kura` directory


### PR DESCRIPTION
Following https://github.com/eclipse-kura/kura/pull/5850 it is no longer required to patch the target platform for VSCode to correctly pick it up. This PR reflects this changes.