### PR TITLE
docs(network): Added note for network connection timeout property

### DIFF
--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -8,6 +8,9 @@ Since the network configuration shown on the screen may not be synchronized with
 !!! tip
     It is recommended that the **IPv4** or **IPv6** tab is configured first since it defines how the interface is going to be used.
 
+!!! note
+    When the **Apply** button is clicked, the network configuration is submitted and the configuration process starts. If some network interfaces are configured to connect, NetworkManager will setup and start the connection. The default timeout for the connection attempt is **30s**, but this can be changed with the `kura.network.configuration.timeout` property in the `kura_custom.properties` file.
+
 ## TCP/IP Configuration
 
 The **IPv4** and **IPv6** tabs contain the following configuration parameters:

--- a/docs/gateway-configuration/network-configuration.md
+++ b/docs/gateway-configuration/network-configuration.md
@@ -93,10 +93,10 @@ The rules shown above create an *Overloaded* (i.e., many-to-one) NAT. This type 
 
 ## Network Linux Configuration
 
-When applying a new network configuration, Kura changes the configuration files of the Linux networking subsystem. Please read the following note before proceeding with manual changes of the Linux networking configuration.
+When applying a new network configuration, Kura configures NetworkManager and ModemManager to apply the desidered system configuration. Moreover, it changes some configuration files of the Linux networking subsystem. Please read the following note before proceeding with manual changes of the Linux networking configuration.
 
 !!! warning
-    It is **NOT** recommended performing manual editing of the Linux networking configuration files when the gateway configuration is being managed through Kura. While Linux may correctly accept manual changes, Kura may not be able to interpret the new configuration resulting in an inconsistent state.
+    It is **NOT** recommended performing manual editing of the Linux networking configuration files or manually configuring  NetworkManager or ModemManager when the gateway configuration is being managed through Kura. Kura will be notified by NM/MM and it will roll-back the configuration.
 
 ## Network Configuration properties
 


### PR DESCRIPTION
This pull request updates the `network-configuration.md` documentation to clarify the behavior of network configuration management in Kura and provide additional guidance on configuration processes. The most important changes include adding a note about the network configuration submission process and updating the description of how Kura interacts with Linux networking subsystems.

### Documentation Enhancements:

* Added a note explaining the behavior when the **Apply** button is clicked, including details about the default timeout for connection attempts and how it can be configured using the `kura.network.configuration.timeout` property in the `kura_custom.properties` file. (`docs/gateway-configuration/network-configuration.md`, [docs/gateway-configuration/network-configuration.mdR11-R13](diffhunk://#diff-a214e38353ecde08a7c5d3d8eaf58ea33d2e62ba2498f7643ef777d406438c7aR11-R13))
* Updated the description of Kura's interaction with Linux networking configuration, specifying that Kura configures `NetworkManager` and `ModemManager` and adjusts Linux networking subsystem files. Also clarified that manual changes to `NetworkManager` or `ModemManager` settings are not recommended, as Kura will roll back such changes. (`docs/gateway-configuration/network-configuration.md`, [docs/gateway-configuration/network-configuration.mdL96-R102](diffhunk://#diff-a214e38353ecde08a7c5d3d8eaf58ea33d2e62ba2498f7643ef777d406438c7aL96-R102))