### PR TITLE
build(archetype): changed archetype to leverage BOM POMs in target definition

### DIFF
--- a/kura/tools/kura-addon-archetype/pom.xml
+++ b/kura/tools/kura-addon-archetype/pom.xml
@@ -28,11 +28,26 @@
     <artifactId>kura-addon-archetype</artifactId>
     <packaging>maven-archetype</packaging>
 
-    <properties>
-        <kura_eth.basedir>${project.basedir}/../..</kura_eth.basedir>
-    </properties>
-
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>archetype-resources/test/test-env/framework/kura.properties</include>
+                    <include>META-INF/maven/archetype-metadata.xml</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>archetype-resources/test/test-env/framework/kura.properties</exclude>
+                    <exclude>META-INF/maven/archetype-metadata.xml</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
         <extensions>
             <extension>
                 <groupId>org.apache.maven.archetype</groupId>
@@ -40,20 +55,6 @@
                 <version>3.3.1</version>
             </extension>
         </extensions>
-
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>false</filtering>
-            </resource>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-                <includes>
-                    <include>archetype-resources/bundles/pom.xml</include>
-                </includes>
-            </resource>
-        </resources>
 
         <plugins>
             <plugin>
@@ -64,7 +65,6 @@
                     <includeEmptyDirs>true</includeEmptyDirs>
                     <!-- needed to include .gitignore -->
                     <useDefaultExcludes>false</useDefaultExcludes>
-                    <escapeString>\</escapeString>
                 </configuration>
             </plugin>
 

--- a/kura/tools/kura-addon-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -23,9 +23,15 @@
         <requiredProperty key="version">
             <defaultValue>1.0.0-SNAPSHOT</defaultValue>
         </requiredProperty>
+        <requiredProperty key="kuraVersion">
+            <defaultValue>${project.version}</defaultValue>
+        </requiredProperty>
     </requiredProperties>
 
     <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>target-definition</directory>
+        </fileSet>
         <fileSet filtered="true" encoding="UTF-8">
             <directory>distrib</directory>
         </fileSet>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/.gitignore
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/.gitignore
@@ -11,4 +11,3 @@ RemoteSystemsTempFiles
 .settings
 .vscode
 OSGI-INF
-target-definition

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/bundles/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/bundles/pom.xml
@@ -313,6 +313,11 @@
             <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
         </repository>
         <repository>
+            <id>kura-addons</id>
+            <name>Kura Addons Maven Repository</name>
+            <url>https://raw.github.com/eurotech/kura_addons/mvn-repo/</url>
+        </repository>
+        <repository>
             <id>central</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/bundles/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/bundles/pom.xml
@@ -19,12 +19,12 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>\${groupId}</groupId>
-    <artifactId>\${artifactId}.parent</artifactId>
-    <version>\${version}</version>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}.parent</artifactId>
+    <version>${version}</version>
     <packaging>pom</packaging>
 
-    <name>Parent POM for \${artifactId}</name>
+    <name>Parent POM for ${artifactId}</name>
 
     <pluginRepositories>
         <pluginRepository>
@@ -37,20 +37,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tycho-version>4.0.11</tycho-version>
         <bnd-version>7.1.0</bnd-version>
-        <maven-resources-version>3.1.0</maven-resources-version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven-deploy-version>2.8.2</maven-deploy-version>
-        <antrun-version>1.8</antrun-version>
-        <exists-version>0.0.6</exists-version>
-        <eclipse.jarsigner.version>1.1.5</eclipse.jarsigner.version>
         <maven.jarsigner.plugin.version>1.4</maven.jarsigner.plugin.version>
-        <target-definition-version>\${project.version}</target-definition-version>
-        <kura-workdir>\${project.build.directory}/kura</kura-workdir>
-        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-        <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
         <skip.artifact.signing>true</skip.artifact.signing>
         <keystore.type>JKS</keystore.type>
-        <kura.target.definition.version>${project.version}</kura.target.definition.version>
     </properties>
 
     <build>
@@ -59,7 +48,7 @@
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-compiler-plugin</artifactId>
-                    <version>\${tycho-version}</version>
+                    <version>${tycho-version}</version>
                     <configuration>
                         <source>17</source>
                         <target>17</target>
@@ -72,20 +61,20 @@
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-maven-plugin</artifactId>
-                    <version>\${tycho-version}</version>
+                    <version>${tycho-version}</version>
                     <extensions>true</extensions>
                 </plugin>
 
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>target-platform-configuration</artifactId>
-                    <version>\${tycho-version}</version>
+                    <version>${tycho-version}</version>
                     <configuration>
                         <target>
                             <artifact>
-                                <groupId>org.eclipse.kura</groupId>
-                                <artifactId>kura-target-definition.target</artifactId>
-                                <version>\${kura.target.definition.version}</version>
+                                <groupId>${groupId}</groupId>
+                                <artifactId>${artifactId}-target-definition</artifactId>
+                                <version>${version}</version>
                             </artifact>
                         </target>
                     </configuration>
@@ -94,7 +83,7 @@
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-packaging-plugin</artifactId>
-                    <version>\${tycho-version}</version>
+                    <version>${tycho-version}</version>
                     <configuration>
                         <strictVersions>true</strictVersions>
                         <deriveHeaderFromSource>false</deriveHeaderFromSource>
@@ -104,7 +93,7 @@
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-source-plugin</artifactId>
-                    <version>\${tycho-version}</version>
+                    <version>${tycho-version}</version>
                     <executions>
                         <execution>
                             <id>plugin-source</id>
@@ -118,7 +107,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
-                    <version>\${antrun-version}</version>
+                    <version>1.8</version>
                 </plugin>
 
                 <plugin>
@@ -126,7 +115,7 @@
                     Incremental builds as well -->
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-maven-plugin</artifactId>
-                    <version>\${bnd-version}</version>
+                    <version>${bnd-version}</version>
                     <executions>
                         <execution>
                             <goals>
@@ -142,7 +131,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jarsigner-plugin</artifactId>
-                    <version>\${maven.jarsigner.plugin.version}</version>
+                    <version>${maven.jarsigner.plugin.version}</version>
                     <executions>
                         <execution>
                             <id>sign</id>
@@ -152,12 +141,12 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <skip>\${skip.artifact.signing}</skip>
-                        <storetype>\${keystore.type}</storetype>
-                        <keystore>\${addon.keystore.path}</keystore>
-                        <alias>\${addon.key.alias}</alias>
-                        <storepass>\${addon.keystore.password}</storepass>
-                        <keypass>\${addon.key.password}</keypass>
+                        <skip>${skip.artifact.signing}</skip>
+                        <storetype>${keystore.type}</storetype>
+                        <keystore>${addon.keystore.path}</keystore>
+                        <alias>${addon.key.alias}</alias>
+                        <storepass>${addon.keystore.password}</storepass>
+                        <keypass>${addon.key.password}</keypass>
                         <arguments>
                             <argument>-tsa</argument>
                             <argument>http://timestamp.digicert.com</argument>
@@ -175,7 +164,7 @@
                 <plugin>
                     <groupId>org.eclipse.cbi.maven.plugins</groupId>
                     <artifactId>eclipse-jarsigner-plugin</artifactId>
-                    <version>\${eclipse.jarsigner.version}</version>
+                    <version>1.1.5</version>
                     <executions>
                         <execution>
                             <id>sign</id>
@@ -193,20 +182,20 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>\${maven-deploy-version}</version>
+                    <version>2.8.2</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.honton.chas</groupId>
                     <artifactId>exists-maven-plugin</artifactId>
-                    <version>\${exists-version}</version>
+                    <version>0.0.6</version>
                     <executions>
                         <execution>
                             <goals>
                                 <goal>remote</goal>
                             </goals>
                             <configuration>
-                                <artifact>\${project.artifactId}-\${project.version}.jar</artifact>
+                                <artifact>${project.artifactId}-${project.version}.jar</artifact>
                                 <skipIfSnapshot>true</skipIfSnapshot>
                                 <failIfExists>true</failIfExists>
                             </configuration>
@@ -217,7 +206,7 @@
                 <plugin>
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-baseline-maven-plugin</artifactId>
-                    <version>\${bnd-version}</version>
+                    <version>${bnd-version}</version>
                     <configuration>
                         <failOnMissing>false</failOnMissing>
                     </configuration>
@@ -236,7 +225,7 @@
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
-                    <version>\${lifecycle.mapping.version}</version>
+                    <version>1.0.0</version>
                     <configuration>
                         <lifecycleMappingFilters>
                             <lifecycleMappingFilter>
@@ -300,33 +289,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jarsigner-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
-                <executions>
-                    <execution>
-                        <id>copy-local-target-definition</id>
-                        <phase>generate-resources</phase>
-                        <inherited>false</inherited>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.eclipse.kura</groupId>
-                                    <artifactId>kura-target-definition.target</artifactId>
-                                    <version>\${kura.target.definition.version}</version>
-                                    <type>target</type>
-                                    <outputDirectory>\${project.basedir}/../target-definition</outputDirectory>
-                                    <destFileName>kura-target-definition.target</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -350,9 +312,31 @@
             <name>Eclipse Kura Repository - Snapshots</name>
             <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
         </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
+        </repository>
+        <repository>
+            <!-- moquette-broker -->
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
+    <distributionManagement>
+        <repository>
+            <id>repo.eclipse.org</id>
+            <name>Kura Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/kura-releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>repo.eclipse.org</id>
+            <name>Kura Repository - Snapshots</name>
+            <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <modules>
-        <module>\${artifactId}.bundle</module>
+        <module>${artifactId}.bundle</module>
     </modules>
 </project>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/pom.xml
@@ -29,6 +29,15 @@
     <artifactId>${artifactId}.distrib</artifactId>
     <packaging>pom</packaging>
 
+    <!-- Insert your bundles as dependencies -->
+    <dependencies>
+        <dependency>
+            <groupId>${groupId}</groupId>
+            <artifactId>${artifactId}.bundle</artifactId>
+            <version>${version}</version>
+        </dependency>
+    </dependencies>
+
     <!-- Change this if your org is different -->
     <organization>
         <name>Eclipse Kura</name>
@@ -45,7 +54,7 @@
         <addon.installation.dir>/opt/eclipse/kura/plugins/6s</addon.installation.dir>
 
         <!-- name of the JAR produced in bundles/target -->
-        <jar.name>${artifactId}.bundle</jar.name>
+        <jar.name>${artifactId}.bundle-${version}.jar</jar.name>
 
         <!--
             Available DEB architectures:
@@ -146,7 +155,7 @@
                 </executions>
             </plugin>
 
-            <!-- Responsible for retrieving the short git commit (defaults to length 7)-->
+            <!-- Responsible for retrieving the short git commit (defaults to length 7) -->
             <plugin>
                 <groupId>io.github.git-commit-id</groupId>
                 <artifactId>git-commit-id-maven-plugin</artifactId>
@@ -169,20 +178,22 @@
                     </includeOnlyProperties>
                 </configuration>
             </plugin>
+            
+            <!-- Responsible for copying the dependencies into a known location -->
             <plugin>
-                <groupId>com.coderplus.maven.plugins</groupId>
-                <artifactId>copy-rename-maven-plugin</artifactId>
-                <version>1.0.1</version>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-and-rename-jar</id>
-                        <phase>generate-sources</phase>
+                        <id>get-bundles-to-distrib</id>
+                        <phase>generate-resources</phase>
                         <goals>
-                            <goal>copy</goal>
+                            <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <sourceFile>${project.basedir}/../bundles/${jar.name}/target/${jar.name}-${project.version}.jar</sourceFile>
-                            <destinationFile>target/input_files/${jar.name}_${project.version}.jar</destinationFile>
+                            <excludeTypes>pom</excludeTypes>
+                            <excludeClassifiers>sources</excludeClassifiers>
+                            <excludeTransitive>true</excludeTransitive>
+                            <outputDirectory>${project.build.directory}/plugins</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -207,13 +218,14 @@
                             <controlDir>${project.basedir}/deb/control</controlDir>
                             <skipPOMs>false</skipPOMs>
                             <dataSet>
-                                <!-- Repeate the 'data' schema multiple time if you want to manage
+                                <!--
+                                Repeate the 'data' schema multiple time if you want to manage
                                 different files indipendentely, specifying for each one the mapper:
                                 it is usefull if different files require different prefix (aka:
-                                different destination location) or specific user, group and filemode -->
+                                different destination location) or specific user, group and filemode
+                                -->
                                 <data>
-                                    <src>${basedir}/target/input_files/${jar.name}_${project.version}.jar</src>
-                                    <dst>${jar.name}_${project.version}.jar</dst>
+                                    <src>${project.build.directory}/plugins/${jar.name}</src>
                                     <type>file</type>
                                     <mapper>
                                         <type>perm</type>
@@ -225,14 +237,13 @@
                                 </data>
 
                                 <!--
-
                                 If all the source file are managed in the same way, it is also
                                 possible to specify a 'directory' data type to include all the files
                                 present in the specify path
-
+                                -->
+                                <!--
                                 <data>
-                                    <src>${basedir}/target/input_files</src>
-                                    <dst>${jar.name}_${project.version}.jar</dst>
+                                    <src>${project.build.directory}/plugins</src>
                                     <type>directory</type>
                                     <mapper>
                                         <type>perm</type>
@@ -242,7 +253,6 @@
                                         <filemode>600</filemode>
                                     </mapper>
                                 </data>
-
                                 -->
                             </dataSet>
                         </configuration>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/pom.xml
@@ -37,6 +37,7 @@
     </build>
 
     <modules>
+        <module>target-definition</module>
         <module>bundles</module>
         <module>distrib</module>
         <module>tests</module>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/target-definition/__artifactId__.target
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/target-definition/__artifactId__.target
@@ -46,6 +46,11 @@
                     <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
                 </repository>
                 <repository>
+                    <id>kura-addons</id>
+                    <name>Kura Addons Maven Repository</name>
+                    <url>https://raw.github.com/eurotech/kura_addons/mvn-repo/</url>
+                </repository>
+                <repository>
                     <id>central</id>
                     <url>https://repo1.maven.org/maven2/</url>
                 </repository>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/target-definition/__artifactId__.target
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/target-definition/__artifactId__.target
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<!--
+
+    Copyright (c) 2025 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
+
+-->
+<target name="${artifactId} Target Definition" sequenceNumber="75">
+    <locations>
+        <location includeDependencyDepth="direct" includeDependencyScopes="compile,test"
+            missingManifest="ignore" type="Maven">
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.eclipse.kura</groupId>
+                    <artifactId>target-platform-bom</artifactId>
+                    <version>${kuraVersion}</version>
+                    <type>pom</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.eclipse.kura</groupId>
+                    <artifactId>kura-bom</artifactId>
+                    <version>${kuraVersion}</version>
+                    <type>pom</type>
+                </dependency>
+            </dependencies>
+
+            <repositories>
+                <repository>
+                    <id>kura-releases</id>
+                    <name>Eclipse Kura Repository - Releases</name>
+                    <url>https://repo.eclipse.org/content/repositories/kura-releases/</url>
+                </repository>
+                <repository>
+                    <id>kura-snapshots</id>
+                    <name>Eclipse Kura Repository - Snapshots</name>
+                    <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
+                </repository>
+                <repository>
+                    <id>central</id>
+                    <url>https://repo1.maven.org/maven2/</url>
+                </repository>
+                <repository>
+                    <!-- moquette-broker -->
+                    <id>jitpack.io</id>
+                    <url>https://jitpack.io</url>
+                </repository>
+            </repositories>
+        </location>
+    </locations>
+</target>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/target-definition/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/target-definition/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
+
+-->
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>${groupId}</groupId>
+        <artifactId>${artifactId}.parent</artifactId>
+        <version>${version}</version>
+        <relativePath>../bundles/pom.xml</relativePath>
+    </parent>
+
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}-target-definition</artifactId>
+    <version>${version}</version>
+    <packaging>eclipse-target-definition</packaging>
+    <name>Target definition for ${artifactId}</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-maven-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/__artifactId__.bundle.test/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/__artifactId__.bundle.test/pom.xml
@@ -51,10 +51,6 @@
             
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <testSourceDirectory>${basedir}/src/test/java/</testSourceDirectory>
-                    <testClassesDirectory>${project.build.directory}/classes/</testClassesDirectory>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/pom.xml
@@ -29,11 +29,29 @@
     <packaging>pom</packaging>
 
     <properties>
-        <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
-        <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
-        <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
         <kura.workdir>${project.build.directory}/test-env</kura.workdir>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <pluginManagement>
@@ -120,7 +138,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>${jacoco.maven.plugin.version}</version>
+                    <version>0.8.12</version>
                     <executions>
                         <execution>
                             <goals>
@@ -174,7 +192,7 @@
                 
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire-plugin.version}</version>
+                    <version>2.22.2</version>
                     <executions>
                         <execution>
                             <id>default-test</id>
@@ -196,9 +214,9 @@
                     <configuration>
                         <target>
                             <artifact>
-                                <groupId>org.eclipse.kura</groupId>
-                                <version>${kura.target.definition.version}</version>
-                                <artifactId>kura-target-definition.target</artifactId>
+                                <groupId>${groupId}</groupId>
+                                <artifactId>${artifactId}-target-definition</artifactId>
+                                <version>${version}</version>
                             </artifact>
                         </target>
                         <!--

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/framework/kura.properties
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/framework/kura.properties
@@ -13,7 +13,7 @@
 
 kura.name=Kura
 kura.version=${project.version}
-kura.marketplace.compatibility.version=KURA_${kura.version}
+kura.marketplace.compatibility.version=KURA_${project.version}
 kura.company=Eurotech
 kura.project=Dev
 kura.platform=Development


### PR DESCRIPTION
This PR adds support for the BOM POMs as target definition.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
