### PR TITLE
ci(Jenkinsfile): reduce disk usage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ spec:
         stage('Build target-platform') {
             timeout(time: 1, unit: 'HOURS') {
                 dir("kura") {
-                    withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6') {
+                    withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6', options: [artifactsPublisher(disabled: true)]) {
                         sh "mvn -f target-platform/pom.xml clean install -Pno-mirror -Pcheck-exists-plugin"
                     }
                 }
@@ -62,7 +62,7 @@ spec:
         stage('Build core') {
             timeout(time: 2, unit: 'HOURS') {
                 dir("kura") {
-                    withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6') {
+                    withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6', options: [artifactsPublisher(disabled: true)]) {
                         sh "mvn -f kura/pom.xml -Dsurefire.rerunFailingTestsCount=3 clean install -Pcheck-exists-plugin"
                     }
                 }
@@ -72,16 +72,10 @@ spec:
         stage('Build distrib') {
             timeout(time: 1, unit: 'HOURS') {
                 dir("kura") {
-                    withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6') {
+                    withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6', options: [artifactsPublisher(disabled: true)]) {
                         sh "mvn -f kura/distrib/pom.xml clean install -DbuildAll"
                     }
                 }
-            }
-        }
-
-        stage('Archive .deb artifacts') {
-            dir("kura") {
-                archiveArtifacts artifacts: 'kura/distrib/target/*.deb', excludes: '**/*.jar', onlyIfSuccessful: true
             }
         }
 
@@ -91,12 +85,16 @@ spec:
             }
         }
 
-
+        stage('Archive .deb artifacts') {
+            dir("kura") {
+                archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
+            }
+        }
 
         stage('Sonar') {
             timeout(time: 2, unit: 'HOURS') {
                 dir("kura") {
-                    withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6') {
+                    withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.6', options: [artifactsPublisher(disabled: true)]) {
                         withCredentials([string(credentialsId: 'sonarcloud-token', variable: 'SONARCLOUD_TOKEN')]) {
                             withSonarQubeEnv {
                                 sh '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ spec:
 
         properties([
             disableConcurrentBuilds(abortPrevious: true),
-            buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '2', daysToKeepStr: '', numToKeepStr: '5')),
+            buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '1', daysToKeepStr: '', numToKeepStr: '3')),
             gitLabConnection('gitlab.eclipse.org'),
             [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
             [$class: 'JobLocalConfiguration', changeReasonComment: '']
@@ -79,17 +79,19 @@ spec:
             }
         }
 
+        stage('Archive .deb artifacts') {
+            dir("kura") {
+                archiveArtifacts artifacts: 'kura/distrib/target/*.deb', excludes: '**/*.jar', onlyIfSuccessful: true
+            }
+        }
+
         stage('Generate test reports') {
             dir("kura") {
                 junit 'kura/test/*/target/surefire-reports/*.xml'
             }
         }
 
-        stage('Archive .deb artifacts') {
-            dir("kura") {
-                archiveArtifacts artifacts: 'kura/distrib/target/*.deb', onlyIfSuccessful: true
-            }
-        }
+
 
         stage('Sonar') {
             timeout(time: 2, unit: 'HOURS') {


### PR DESCRIPTION
See:
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5880
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6061

This PR:
- Reduces the number of artifact to keep upon successfully buidling the project (from 2 -> 1). This means that only the latest successful build artifacts will be stored on Jenkins.
- Reduces the number of builds to keep (from 5 -> 3)
- Avoid storing the `*.jar` files as artifacts and only archives the `*.deb` installers

Build results:
![image](https://github.com/user-attachments/assets/48d5419a-7ed8-48fa-a6c3-7400b63293c1)
