### PR TITLE
fix(kura-addon-archetype): Set start level for log bundles

### DIFF
--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/pom.xml
@@ -187,6 +187,18 @@
                             <level>4</level>
                             <autoStart>true</autoStart>
                         </defaultStartLevel>
+                        <bundleStartLevel>
+                            <bundle>
+                                <id>org.apache.logging.log4j.slf4j2.impl</id>
+                                <level>2</level>
+                                <autoStart>true</autoStart>
+                            </bundle>
+                            <bundle>
+                                <id>org.apache.aries.spifly.dynamic.bundle</id>
+                                <level>2</level>
+                                <autoStart>true</autoStart>
+                            </bundle>
+                        </bundleStartLevel>
                     </configuration>
                 </plugin>
                 


### PR DESCRIPTION
This pull request adds a new configuration section to the `pom.xml` file for managing bundle start levels. It introduces two bundles with specific start levels and auto-start settings.

Configuration updates:

* [`kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/pom.xml`](diffhunk://#diff-f04db3c7e98ea789169091d693423458aaad2b971291d05115452e56661edbe0R190-R201): Added a `bundleStartLevel` section to configure the start levels and auto-start settings for the `org.apache.logging.log4j.slf4j2.impl` and `org.apache.aries.spifly.dynamic.bundle` bundles.