### PR TITLE
build(deps): updated usb4java from 1.2.0 to 1.3.0

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -137,9 +137,9 @@ This project leverages the following third party content.
 * maven/mavencentral/org.slf4j/jcl-over-slf4j/2.0.17, MIT AND Apache-2.0, approved, #11889
 * maven/mavencentral/org.slf4j/slf4j-api/2.0.17, MIT, approved, #5915
 * maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.17, MIT, approved, #7698
-* maven/mavencentral/org.usb4java/libusb4java/1.2.0, MIT, approved, #3088
-* maven/mavencentral/org.usb4java/usb4java-javax/1.2.0, MIT, approved, #3090
-* maven/mavencentral/org.usb4java/usb4java/1.2.0, MIT, approved, #3089
+* maven/mavencentral/org.usb4java/libusb4java/1.3.0, MIT, approved, #3087
+* maven/mavencentral/org.usb4java/usb4java-javax/1.3.0, MIT, approved, #22528
+* maven/mavencentral/org.usb4java/usb4java/1.3.0, MIT, approved, clearlydefined
 * maven/mavencentral/org.apache.servicemix.bundles/org.apache.servicemix.bundles.c3p0/0.9.5.5_1, Apache-2.0, approved, #3761
 * maven/mavencentral/com.zaxxer/HikariCP/2.7.9, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/org.gwtproject/gwt-servlet-jakarta/2.12.1, Apache-2.0, approved, #18538

--- a/target-platform/org.usb4java/pom.xml
+++ b/target-platform/org.usb4java/pom.xml
@@ -16,7 +16,7 @@
     <url>usb4java.org/</url>
 
     <properties>
-        <usb4java.version>1.2.0</usb4java.version>
+        <usb4java.version>1.3.0</usb4java.version>
     </properties>
 
     <dependencies>
@@ -29,13 +29,13 @@
             <groupId>org.usb4java</groupId>
             <artifactId>libusb4java</artifactId>
             <version>${usb4java.version}</version>
-            <classifier>linux-arm</classifier>
+            <classifier>linux-aarch64</classifier>
         </dependency>
         <dependency>
             <groupId>org.usb4java</groupId>
             <artifactId>libusb4java</artifactId>
             <version>${usb4java.version}</version>
-            <classifier>linux-x86_64</classifier>
+            <classifier>linux-x86-64</classifier>
         </dependency>
     </dependencies>
 
@@ -66,7 +66,7 @@
                         <configuration>
                             <outputDirectory>${project.basedir}/lib</outputDirectory>
                             <excludeClassifiers>
-                                sources,osx-x86_64,osx-x86,osx-aarch_64,windows-x86,windows-x86_64,linux-x86
+                                sources,osx-x86_64,osx-x86,osx-aarch_64,windows-x86,windows-x86_64,linux-x86,linux-arm
                             </excludeClassifiers>
                             <excludeTransitive>true</excludeTransitive>
                             <stripVersion>true</stripVersion>
@@ -87,16 +87,16 @@
                         <Bundle-Name>${project.name}</Bundle-Name>
                         <Bundle-Version>${project.version}</Bundle-Version>
                         <Bundle-ClassPath>
-                            .,libusb4java-linux-arm.jar,libusb4java-linux-x86_64.jar,usb4java.jar</Bundle-ClassPath>
+                            .,libusb4java-linux-aarch64.jar,libusb4java-linux-x86-64.jar,usb4java.jar</Bundle-ClassPath>
                         <Include-Resource>
                             ${project.basedir}/lib,
                             ${project.basedir}/about.html,
                             about_files=${project.basedir}/about_files/
                         </Include-Resource>
                         <Export-Package>
-                            org.usb4java.linux-x86_64;version="1.2.0",
-                            org.usb4java;uses:="org.apache.commons.lang3.builder,org.apache.commons.lang3.tuple";version="1.2.0",
-                            org.usb4java.linux-arm;version="1.2.0"
+                            org.usb4java.linux-aarch64;version="${usb4java.version}",
+                            org.usb4java.linux-x86-64;version="${usb4java.version}",
+                            org.usb4java;uses:="org.apache.commons.lang3.builder,org.apache.commons.lang3.tuple";version="${usb4java.version}"
                         </Export-Package>
                         <Require-Capability>
                             osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"

--- a/target-platform/usb4java-javax/pom.xml
+++ b/target-platform/usb4java-javax/pom.xml
@@ -12,18 +12,22 @@
     <version>2.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>usb4java-javax</name>
-    <description>javax.usb 1.0.2 API using usb4java</description>
+    <description>javax.usb API using usb4java</description>
+
+    <properties>
+        <usb-api.version>1.0.2</usb-api.version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>javax.usb</groupId>
             <artifactId>usb-api</artifactId>
-            <version>1.0.2</version>
+            <version>${usb-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.usb4java</groupId>
             <artifactId>usb4java-javax</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
     </dependencies>
 
@@ -79,9 +83,9 @@
                             about_files=${project.basedir}/about_files/
                         </Include-Resource>
                         <Export-Package>
-                            javax.usb;version="1.0.2",
-                            javax.usb.event;version="1.0.2",
-                            javax.usb.util;version="1.0.2"
+                            javax.usb;version="${usb-api.version}",
+                            javax.usb.event;version="${usb-api.version}",
+                            javax.usb.util;version="${usb-api.version}"
                         </Export-Package>
                         <Require-Capability>
                             osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"


### PR DESCRIPTION
This PR updates the following dependencies:

- org.usb4java:libusb4java:1.3.0
- org.usb4java:usb4java-javax:1.3.0
- org.usb4java:usb4java:1.3.0

Indirectly, this PR adds support now for the `aarch64` profiles, that was previously missing because of missing libraries.

**Related Issue:** IP lab review https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/22528

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.