### PR TITLE
feat(core.status): GPIO service as optional dependency

### DIFF
--- a/kura/org.eclipse.kura.core.status/OSGI-INF/status.xml
+++ b/kura/org.eclipse.kura.core.status/OSGI-INF/status.xml
@@ -26,8 +26,8 @@
               unbind="unsetSystemService"
               interface="org.eclipse.kura.system.SystemService"/>
    <reference name="GPIOService" 
-              cardinality="1..1" 
-              policy="static"
+              cardinality="0..1" 
+              policy="dynamic"
               bind="setGPIOService"
               unbind="unsetGPIOService"
               interface="org.eclipse.kura.gpio.GPIOService"/>

--- a/kura/org.eclipse.kura.core.status/OSGI-INF/status.xml
+++ b/kura/org.eclipse.kura.core.status/OSGI-INF/status.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-   Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
-  
-   This program and the accompanying materials are made
-   available under the terms of the Eclipse Public License 2.0
-   which is available at https://www.eclipse.org/legal/epl-2.0/
- 
-	SPDX-License-Identifier: EPL-2.0
-	
-	Contributors:
-	 Eurotech
+    Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+     Eurotech
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.eclipse.kura.status.CloudConnectionStatusService">

--- a/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@ package org.eclipse.kura.core.status;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -40,7 +41,7 @@ public class CloudConnectionStatusServiceImpl implements CloudConnectionStatusSe
     private static final Logger logger = LoggerFactory.getLogger(CloudConnectionStatusServiceImpl.class);
 
     private SystemService systemService;
-    private GPIOService gpioService;
+    private Optional<GPIOService> gpioService = Optional.empty();
 
     private final ExecutorService notificationExecutor;
     private Future<?> notificationWorker;
@@ -75,11 +76,11 @@ public class CloudConnectionStatusServiceImpl implements CloudConnectionStatusSe
     }
 
     public void setGPIOService(GPIOService gpioService) {
-        this.gpioService = gpioService;
+        this.gpioService = Optional.of(gpioService);
     }
 
     public void unsetGPIOService(GPIOService gpioService) {
-        this.gpioService = null;
+        this.gpioService = Optional.empty();
     }
 
     // ----------------------------------------------------------------
@@ -230,9 +231,12 @@ public class CloudConnectionStatusServiceImpl implements CloudConnectionStatusSe
     }
 
     private StatusRunnable getGpioStatusWorker(CloudConnectionStatusEnum status) {
+        if (!this.gpioService.isPresent()) {
+            return null;
+        }
         int gpioLed = (Integer) this.properties.get("led");
         boolean inverted = (Boolean) this.properties.get("inverted");
-        LedManager gpioLedManager = new GpioLedManager(this.gpioService, gpioLed, inverted);
+        LedManager gpioLedManager = new GpioLedManager(this.gpioService.get(), gpioLed, inverted);
 
         return createLedRunnable(status, gpioLedManager);
     }

--- a/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImpl.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.kura.core.status;
 
 import java.io.File;

--- a/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImplTest.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.kura.core.status;
 
 import static org.junit.Assert.assertEquals;

--- a/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImplTest.java
@@ -12,15 +12,25 @@
  *******************************************************************************/
 package org.eclipse.kura.core.status;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 
+import org.eclipse.kura.core.status.runnables.BlinkStatusRunnable;
+import org.eclipse.kura.core.status.runnables.HeartbeatStatusRunnable;
+import org.eclipse.kura.core.status.runnables.LogStatusRunnable;
+import org.eclipse.kura.core.status.runnables.OnOffStatusRunnable;
+import org.eclipse.kura.core.status.runnables.StatusRunnable;
 import org.eclipse.kura.core.testutil.TestUtil;
-
+import org.eclipse.kura.gpio.GPIOService;
 import org.eclipse.kura.status.CloudConnectionStatusComponent;
 import org.eclipse.kura.status.CloudConnectionStatusEnum;
 import org.eclipse.kura.status.CloudConnectionStatusService;
@@ -197,11 +207,50 @@ public class CloudConnectionStatusServiceImplTest {
 
             // Check if currentStatus is set correctly
             assertEquals(selectedStatus, getStatus(service));
+
+            // Check if the log statusRunnable is correctly selected
+            checkLogStatusRunnables(service);
         }
     }
 
     @Test
     public void testRegisterStatusesGpio() throws NoSuchFieldException {
+        CloudConnectionStatusEnum[] statuses = { CloudConnectionStatusEnum.OFF, CloudConnectionStatusEnum.FAST_BLINKING,
+                CloudConnectionStatusEnum.SLOW_BLINKING, CloudConnectionStatusEnum.HEARTBEAT,
+                CloudConnectionStatusEnum.ON };
+
+        for (CloudConnectionStatusEnum selectedStatus : statuses) {
+            // Prepare mock component with max priority with selected status
+            CloudConnectionStatusComponent mockComponent = createMockComponent(
+                    CloudConnectionStatusService.PRIORITY_MAX, selectedStatus);
+
+            // Create service
+            CloudConnectionStatusServiceImpl service = initCloudConnectionStatusService("ccs:led:44");
+            GPIOService gpioService = mock(GPIOService.class);
+            service.setGPIOService(gpioService);
+
+            ComponentContext componentContext = mock(ComponentContext.class);
+            service.activate(componentContext);
+
+            // Make sure mockComponent is initially not in componentRegistry
+            assertFalse(isInComponentRegistry(service, mockComponent));
+
+            // Register component
+            service.register(mockComponent);
+
+            // Check if mockComponent is now in componentRegistry
+            assertTrue(isInComponentRegistry(service, mockComponent));
+
+            // Check if currentStatus is set correctly
+            assertEquals(selectedStatus, getStatus(service));
+
+            // Check if the gpio statusRunnable is correctly selected
+            checkLedStatusRunnables(service);
+        }
+    }
+
+    @Test
+    public void testRegisterStatusesGpioWithoutGPIOService() throws NoSuchFieldException {
         CloudConnectionStatusEnum[] statuses = { CloudConnectionStatusEnum.OFF, CloudConnectionStatusEnum.FAST_BLINKING,
                 CloudConnectionStatusEnum.SLOW_BLINKING, CloudConnectionStatusEnum.HEARTBEAT,
                 CloudConnectionStatusEnum.ON };
@@ -228,6 +277,9 @@ public class CloudConnectionStatusServiceImplTest {
 
             // Check if currentStatus is set correctly
             assertEquals(selectedStatus, getStatus(service));
+
+            // Check if the log statusRunnable is correctly selected
+            checkLogStatusRunnables(service);
         }
     }
 
@@ -342,5 +394,19 @@ public class CloudConnectionStatusServiceImplTest {
 
     CloudConnectionStatusEnum getStatus(CloudConnectionStatusServiceImpl service) throws NoSuchFieldException {
         return (CloudConnectionStatusEnum) TestUtil.getFieldValue(service, "currentStatus");
+    }
+
+    private StatusRunnable getStatusRunnable(CloudConnectionStatusServiceImpl service) throws NoSuchFieldException {
+        return (StatusRunnable) TestUtil.getFieldValue(service, "statusRunnable");
+    }
+
+    private void checkLedStatusRunnables(CloudConnectionStatusServiceImpl service) throws NoSuchFieldException {
+        assertTrue(getStatusRunnable(service) instanceof OnOffStatusRunnable
+                || getStatusRunnable(service) instanceof BlinkStatusRunnable
+                || getStatusRunnable(service) instanceof HeartbeatStatusRunnable);
+    }
+
+    private void checkLogStatusRunnables(CloudConnectionStatusServiceImpl service) throws NoSuchFieldException {
+        assertTrue(getStatusRunnable(service) instanceof LogStatusRunnable);
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of the `GPIOService` dependency in the `CloudConnectionStatusServiceImpl` class and its associated tests. The updates include transitioning to an `Optional` for better null safety, modifying the service's cardinality and policy in the OSGi configuration, and enhancing test coverage to handle scenarios where the `GPIOService` is unavailable.

### Updates to `CloudConnectionStatusServiceImpl`:

* Transitioned `gpioService` to use `Optional` for safer null handling. Updated setter and unsetter methods accordingly. [[1]](diffhunk://#diff-43e442a4780110194cf2d6edf88dc27a5568e4ebd747dc40acbfbc3aa4fc684cL43-R44) [[2]](diffhunk://#diff-43e442a4780110194cf2d6edf88dc27a5568e4ebd747dc40acbfbc3aa4fc684cL78-R83)
* Added a null check in `getGpioStatusWorker` to handle cases where `gpioService` is not present, ensuring the method returns `null` if the service is unavailable.

### Changes to OSGi Configuration:

* Updated the `GPIOService` reference in `status.xml` to have a cardinality of `0..1` and a dynamic policy, allowing the service to be optional and dynamically bound.

### Enhancements to Unit Tests:

* Expanded test cases in `CloudConnectionStatusServiceImplTest` to include scenarios where `GPIOService` is unavailable, ensuring the application behaves correctly in such cases. [[1]](diffhunk://#diff-d2d641078279c727d30c6bf9c8eb906a05e3fe6730fcd0908923af8abd6b0000R222-R257) [[2]](diffhunk://#diff-d2d641078279c727d30c6bf9c8eb906a05e3fe6730fcd0908923af8abd6b0000R280-R282)
* Added helper methods to verify the correct selection of `StatusRunnables` based on the presence or absence of `GPIOService`.

### Minor Changes:

* Updated copyright year in `CloudConnectionStatusServiceImpl` to reflect 2025.
* Added missing imports in `CloudConnectionStatusServiceImplTest` for better readability and functionality.