### PR TITLE
chore: Updated commons-fileupload to 2.0.0.M4

### DIFF
--- a/target-platform/target-platform-bom/pom.xml
+++ b/target-platform/target-platform-bom/pom.xml
@@ -50,7 +50,7 @@
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-csv.version>1.4</commons-csv.version>
         <commons-exec.version>1.3</commons-exec.version>
-        <commons-fileupload.version>2.0.0-M2</commons-fileupload.version>
+        <commons-fileupload.version>2.0.0-M4</commons-fileupload.version>
         <failureaccess.version>1.0.1</failureaccess.version>
         <guava.version>32.1.1-jre</guava.version>
         <hikaricp.version>2.7.9</hikaricp.version>


### PR DESCRIPTION
This PR updates the `commons-fileupload` to version 2.0.0.M4.