### PR TITLE
test: fix failing CloudConnectionEndpointsTest.shouldConnectEndpoint

### DIFF
--- a/kura/test/org.eclipse.kura.rest.cloudconnection.provider.test/src/main/java/org/eclipse/kura/internal/rest/cloudconnection/provider/test/CloudConnectionEndpointsTest.java
+++ b/kura/test/org.eclipse.kura.rest.cloudconnection.provider.test/src/main/java/org/eclipse/kura/internal/rest/cloudconnection/provider/test/CloudConnectionEndpointsTest.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
- *******************************************************************************/
+ ******************************************************************************/
 package org.eclipse.kura.internal.rest.cloudconnection.provider.test;
 
 import static org.junit.Assert.fail;
@@ -42,7 +42,6 @@ import org.eclipse.kura.rest.configuration.api.PidAndFactoryPid;
 import org.eclipse.kura.rest.configuration.api.PidSet;
 import org.eclipse.kura.rest.configuration.api.UpdateComponentConfigurationRequest;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -233,7 +232,6 @@ public class CloudConnectionEndpointsTest extends AbstractRequestHandlerTest {
         thenRequestSucceeds();
     }
 
-    @Ignore
     @Test
     public void shouldConnectEndpoint() {
         givenCloudEndpointPidRequest(CLOUD_ENDPOINT_INSTANCE_TEST);

--- a/kura/test/org.eclipse.kura.rest.cloudconnection.provider.test/src/main/resources/updateConfigurationRequest.json
+++ b/kura/test/org.eclipse.kura.rest.cloudconnection.provider.test/src/main/resources/updateConfigurationRequest.json
@@ -5,7 +5,7 @@
             "properties": {
                 "broker-url": {
                     "type": "STRING",
-                    "value": "mqtt://mqtt.eclipseprojects.io:1883"
+                    "value": "mqtt://localhost:1883"
                 },
                 "topic.context.account-name": {
                     "type": "STRING",


### PR DESCRIPTION
This PR fixes the `CloudConnectionEndpointsTest.shouldConnectEndpoint` test by changing the endpoint from `mqtt.eclipseprojects.io` to `localhost` (where moquette broker is running).

The endpoint `mqtt.eclipseprojects.io` seems to be no longer maintained, see discussion on: https://github.com/eclipse-mosquitto/mosquitto/issues/3303.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
