### PR TITLE
build: added kura-snapshot repository in kura/pom.xml

### DIFF
--- a/kura/pom.xml
+++ b/kura/pom.xml
@@ -272,9 +272,15 @@
             https://github.com/bndtools/bnd/issues/1755
         -->
         <repository>
-            <id>repo.eclipse.org</id>
+            <id>repo.eclipse.org.releases</id>
             <name>Eclipse Kura Repository - Releases</name>
             <url>https://repo.eclipse.org/content/repositories/kura-releases/</url>
+        </repository>
+
+        <repository>
+            <id>repo.eclipse.org.snapshot</id>
+            <name>Eclipse Kura Repository - Releases</name>
+            <url>https://repo.eclipse.org/content/repositories/kura-snapshots/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This PR adds the https://repo.eclipse.org/content/repositories/kura-snapshots/ repository in the kura/pom.xml in order to be able to download also migrated dependencies deployed
