### PR TITLE
chore: Updated Apache commons-io

### DIFF
--- a/target-platform/target-platform-bom/pom.xml
+++ b/target-platform/target-platform-bom/pom.xml
@@ -62,7 +62,7 @@
         <mimepull.version>1.10.0</mimepull.version>
         <org.apache.aries.spifly.dynamic.bundle.version>1.3.7</org.apache.aries.spifly.dynamic.bundle.version>
         <org.apache.camel.version>2.25.3</org.apache.camel.version>
-        <org.apache.commons.commons-io.version>2.18.0</org.apache.commons.commons-io.version>
+        <org.apache.commons.commons-io.version>2.19.0</org.apache.commons.commons-io.version>
         <org.apache.commons.commons-net.version>3.8.0</org.apache.commons.commons-net.version>
         <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>
         <org.apache.felix.dependencymanager.version>3.0.0</org.apache.felix.dependencymanager.version>


### PR DESCRIPTION
This PR updates the `org.apache.commons.commons-io` to 2.19.0, since the `org.apache.commons.commons-fileupload 2.0.0.M4` requires it (see [here](https://github.com/apache/commons-fileupload/blob/95a65ecc354de53273f9d269ebd7bc97887871d6/pom.xml#L77)).  