### PR TITLE
fix(kura_addon_archetype): Added database config in archetype snapshot

### DIFF
--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/user/snapshots/snapshot_0.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/user/snapshots/snapshot_0.xml
@@ -204,4 +204,26 @@
             </esf:property>
         </esf:properties>
     </esf:configuration>
+    <esf:configuration pid="org.eclipse.kura.db.H2DbService">
+        <esf:properties>
+            <esf:property array="false" encrypted="false" name="db.user" type="String">
+                <esf:value>SA</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="db.connection.pool.max.size" type="Integer">
+                <esf:value>10</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="db.connector.url" type="String">
+                <esf:value>jdbc:h2:mem:kuradb</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="service.factoryPid" type="String">
+                <esf:value>org.eclipse.kura.core.db.H2DbService</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="db.checkpoint.interval.seconds" type="Integer">
+                <esf:value>900</esf:value>
+            </esf:property>
+            <esf:property array="false" encrypted="false" name="kura.service.pid" type="String">
+                <esf:value>org.eclipse.kura.db.H2DbService</esf:value>
+            </esf:property>
+        </esf:properties>
+    </esf:configuration>
 </esf:configurations>


### PR DESCRIPTION
This pull request adds a new configuration for the H2 database service in the `snapshot_0.xml` file. The changes define properties such as database user, connection pool size, and connector URL.

### Added H2 database service configuration:

* [`kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/user/snapshots/snapshot_0.xml`](diffhunk://#diff-b5fe912a8007b4d6320185132916e472ab89d82ad2e879ce0b7aa76b747ff8c4R207-R228): Introduced a new `<esf:configuration>` block for `org.eclipse.kura.db.H2DbService` with properties including `db.user`, `db.connection.pool.max.size`, `db.connector.url`, `service.factoryPid`, `db.checkpoint.interval.seconds`, and `kura.service.pid`.