### PR TITLE
build: restored driver helper in kura-core

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -179,6 +179,7 @@
         <antcall target="rest-plugins" />
         <antcall target="util-plugins" />
         <antcall target="http.server.manager-plugin" />
+        <antcall target="driver-plugins" />
         
         <propertyfile
             file="${project.build.directory}/${build.output.name}/dpa.properties">


### PR DESCRIPTION
This PR restores the `org.eclipse.kura.driver.helper` in kura-core, to allow creating and managing driver instances