### PR TITLE
chore(distrib): Removed FloodingProtectionConfigurator from snapshot_0.xml

### DIFF
--- a/kura/distrib/distrib-extra/distrib-nm/src/main/resources/unfiltered/pkg/install/snapshot_0.xml
+++ b/kura/distrib/distrib-extra/distrib-nm/src/main/resources/unfiltered/pkg/install/snapshot_0.xml
@@ -363,14 +363,4 @@ NETWORK_CONFIGURATION
             </esf:property>
         </esf:properties>
     </esf:configuration>
-    <esf:configuration pid="org.eclipse.kura.internal.floodingprotection.FloodingProtectionConfigurator">
-        <esf:properties>
-            <esf:property array="false" encrypted="false" name="flooding.protection.enabled.ipv6" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-            <esf:property array="false" encrypted="false" name="flooding.protection.enabled" type="Boolean">
-                <esf:value>true</esf:value>
-            </esf:property>
-        </esf:properties>
-    </esf:configuration>
 </esf:configurations>


### PR DESCRIPTION
Removed `FloodingProtectionConfigurator` from `snapshot_0.xml`. It is now in `kura-networking`