### PR TITLE
ci(workflows): add Target Platform SBOM upload action

### DIFF
--- a/.github/workflows/target-platform-sbom.yml
+++ b/.github/workflows/target-platform-sbom.yml
@@ -1,12 +1,19 @@
 name: Target Platform SBOM upload
 
 on:
+  schedule:
+    # At 00:00 on Saturday
+    - cron: "0 0 * * 6"
   workflow_dispatch:
     inputs:
         target_branch:
           type: string
           default: 'develop'
           required: true
+  workflow_run:
+    workflows: ["Release Notes automation"]
+    types:
+      - completed
 
 # Product specific settings
 env:
@@ -20,6 +27,7 @@ permissions:
 jobs:
   generate-sbom:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       project-version: ${{ steps.version.outputs.PROJECT_VERSION }} # required for DependencyTrack upload
     steps:
@@ -27,7 +35,14 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event.inputs.target_branch }}
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.event.inputs.target_branch || github.ref_name }}
+
+      - name: Debug branch information
+        run: |
+          echo "=== Debug Branch Information ==="
+          echo "Event name: ${{ github.event_name }}"
+          echo "Current branch (git): $(git branch --show-current)"
+          echo "==============================="
 
       - name: Setup Java SDK
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0

--- a/.github/workflows/target-platform-sbom.yml
+++ b/.github/workflows/target-platform-sbom.yml
@@ -43,18 +43,26 @@ jobs:
         id: version
         shell: bash
         run: |
-          event="${{ github.event_name }}"
-          ref="${{ github.ref }}"
-          input="${{ github.event.inputs.version }}"
           VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/target/bom.json)"
-          if [[ "$event" == "push" && "$ref" == refs/heads/* ]] || \
-            [[ "$event" == "workflow_dispatch" && ! "$input" =~ ^v ]]; then
-            VERSION="${VERSION}@dev"
-          fi
-          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
 
-#       - name: Upload sbom
-#         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-#         with:
-#           name: target-platform-sbom
-#           path: ${{ env.PRODUCT_PATH }}/target/bom.json
+          # Substitute "-SNAPSHOT" suffix with "@dev" if present
+          VERSION="${VERSION/-SNAPSHOT/@dev}"
+
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Product version: $VERSION"
+
+      - name: Upload sbom
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: target-platform-sbom
+          path: ${{ env.PRODUCT_PATH }}/target/bom.json
+
+  store-sbom-data:
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'kura-target-platform'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'target-platform-sbom'
+      bomFilename: 'bom.json'
+      parentProject: '100d803b-679b-40c2-8e73-101e0bf363ba'

--- a/.github/workflows/target-platform-sbom.yml
+++ b/.github/workflows/target-platform-sbom.yml
@@ -1,0 +1,60 @@
+name: Target Platform SBOM upload
+
+on:
+  workflow_dispatch:
+    inputs:
+        target_branch:
+          type: string
+          default: 'develop'
+          required: true
+
+# Product specific settings
+env:
+  JAVA_VERSION: '17' # java version used by the product
+  JAVA_DISTRO: 'temurin' # java distro used by the product
+  PRODUCT_PATH: 'target-platform/target-platform-bom' # path within project repository for SBOM source
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }} # required for DependencyTrack upload
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.target_branch }}
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate sbom
+        run: |
+          mvn -f target-platform/pom.xml clean install
+
+      - name: Extract product version
+        id: version
+        shell: bash
+        run: |
+          event="${{ github.event_name }}"
+          ref="${{ github.ref }}"
+          input="${{ github.event.inputs.version }}"
+          VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/target/bom.json)"
+          if [[ "$event" == "push" && "$ref" == refs/heads/* ]] || \
+            [[ "$event" == "workflow_dispatch" && ! "$input" =~ ^v ]]; then
+            VERSION="${VERSION}@dev"
+          fi
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+#       - name: Upload sbom
+#         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+#         with:
+#           name: target-platform-sbom
+#           path: ${{ env.PRODUCT_PATH }}/target/bom.json

--- a/.github/workflows/target-platform-sbom.yml
+++ b/.github/workflows/target-platform-sbom.yml
@@ -20,6 +20,10 @@ env:
   JAVA_VERSION: '17' # java version used by the product
   JAVA_DISTRO: 'temurin' # java distro used by the product
   PRODUCT_PATH: 'target-platform/target-platform-bom' # path within project repository for SBOM source
+  WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+  INPUT_TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
+  EVENT_NAME: ${{ github.event_name }}
+  GITHUB_REF_NAME: ${{ github.ref_name }}
 
 permissions:
   contents: read
@@ -35,12 +39,12 @@ jobs:
         id: set-checkout-ref
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            echo "CHECKOUT_REF=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "CHECKOUT_REF=${{ github.event.inputs.target_branch }}" >> $GITHUB_ENV
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            echo "CHECKOUT_REF=$WORKFLOW_HEAD_BRANCH" >> $GITHUB_ENV
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "CHECKOUT_REF=$INPUT_TARGET_BRANCH" >> $GITHUB_ENV
           else
-            echo "CHECKOUT_REF=${{ github.ref_name }}" >> $GITHUB_ENV
+            echo "CHECKOUT_REF=$GITHUB_REF_NAME" >> $GITHUB_ENV
           fi
 
       - name: Checkout repository
@@ -52,7 +56,7 @@ jobs:
       - name: Debug branch information
         run: |
           echo "=== Debug Branch Information ==="
-          echo "Event name: ${{ github.event_name }}"
+          echo "Event name: $EVENT_NAME"
           echo "Current branch (git): $(git branch --show-current)"
           echo "==============================="
 

--- a/.github/workflows/target-platform-sbom.yml
+++ b/.github/workflows/target-platform-sbom.yml
@@ -31,11 +31,23 @@ jobs:
     outputs:
       project-version: ${{ steps.version.outputs.PROJECT_VERSION }} # required for DependencyTrack upload
     steps:
+      - name: Set checkout ref
+        id: set-checkout-ref
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            echo "CHECKOUT_REF=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "CHECKOUT_REF=${{ github.event.inputs.target_branch }}" >> $GITHUB_ENV
+          else
+            echo "CHECKOUT_REF=${{ github.ref_name }}" >> $GITHUB_ENV
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.event.inputs.target_branch || github.ref_name }}
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Debug branch information
         run: |


### PR DESCRIPTION
Follow up on https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6454. This PR leverages the changes introduced in #5886 to upload the SBOM to the Eclipse Foundation's Dependency Track instance.

I followed the template available in https://eclipse-csi.github.io/security-handbook/sbom/howto.html#example-workflow-maven but introduced the following changes:
 
1. Instead of relying on Github events to detect whether the version is a `@dev` one, I simply substitute the `-SNAPSHOT` suffix with the `@dev` one. This suit our workflow better and is simpler to maintain.
2. Build trigger: the action is triggered by
   1. Manual trigger
   2. Schedule at 00:00 UTC every Saturday (it will always run on the `develop` branch)
   3. When the "Release notes automation" workflow completes successfully (the job will run on the same branch as the "Release notes automation" workflow)

Secure best practices references:
- https://docs.github.com/en/actions/concepts/security/script-injections
- https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks