### PR TITLE
ci(workflows): fix Release notes github action

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options
-        java-version: '11' # Required by the git-changelog-command-line tool
+        java-version: '17'
 
     - name: Get version
       id: get-version
@@ -42,7 +42,6 @@ jobs:
           -Dexec.executable=echo
           -Dexec.args='${project.version}'
           --quiet exec:exec --non-recursive
-          -Pjava8
         )\" >> \"${GITHUB_OUTPUT}\""
       shell: bash
 
@@ -70,7 +69,7 @@ jobs:
         repository: 'maven2'
         groupId: 'se.bjurr.gitchangelog'
         artifactId: 'git-changelog-command-line'
-        version: '1.100.2'
+        version: '2.5.7'
         extension: 'jar'
 
     - name: Generate Release Notes


### PR DESCRIPTION
Release note action was failing when extracting the version due to JDK version incompatibilities. This PR fixes the issue.