### PR TITLE
ci(workflows): add label to PR when force-merging

### DIFF
--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -115,6 +115,13 @@ jobs:
         with:
           github-token: ${{ secrets.KURA_BOT_GITHUB_TOKEN }}
           script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['force-merged']
+            })
+
             await github.rest.pulls.merge({
               pull_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
This PR introduces a minor improvement to the force-merge github action. To keep track of use (and abuse :suspect:) of the force-merge action, the bot will add a label to the PR when it is force merged.