### PR TITLE
docs: added target platform documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Advanced software frameworks, which abstract and isolate the developer from the 
 
 Eclipse Kura is an Eclipse IoT project that provides a platform for building IoT gateways. It is a smart application container that enables remote management of such gateways and provides a wide range of APIs for allowing you to write and deploy your own IoT application.
 
-Kura runs on top of the Java Virtual Machine (JVM) and leverages OSGi, a dynamic component system for Java, to simplify the process of writing reusable software building blocks. Kura APIs offer  easy access to the underlying hardware including serial ports, GPS, watchdog, USB, GPIOs, I2C, etc. It also offer OSGI bundle to simplify the management of network configurations, the communication with IoT servers, and the remote management of the gateway.
+Kura runs on top of the Java Virtual Machine (JVM) and leverages OSGi, a dynamic component system for Java, to simplify the process of writing reusable software building blocks. Kura APIs offer easy access to the underlying hardware including serial ports, GPS, watchdog, USB, GPIOs, I2C, etc. It also offer OSGI bundle to simplify the management of network configurations, the communication with IoT servers, and the remote management of the gateway.
 
 Kura components are designed as configurable OSGi Declarative Service exposing service API and raising events. While several Kura components are in pure Java, others are invoked through JNI and have a dependency on the Linux operating system.
 

--- a/docs/java-application-development/target-platform-dependencies.md
+++ b/docs/java-application-development/target-platform-dependencies.md
@@ -1,0 +1,22 @@
+# Target platform dependencies
+
+Eclipse Kura is distributed with a well-defined set of [Java APIs](https://download.eclipse.org/kura/docs/api/) and components that provide implementations of such APIs. Being based on OSGi, it extensively leverages its modularity by interconnecting each Kura service (or bundle) through the explicit description of required imports and provided exports in the MANIFEST file, following the [semantic versioning](https://github.com/eclipse-kura/kura/wiki/Kura-Semantic-Versioning) standard.
+
+An Eclipse Kura installation is composed of:
+
+- Kura APIs
+- Core components that provide implementations of key APIs
+- Core components that provide consumers of key APIs
+- Optionally, additional components that implement advanced functionalities
+- External dependencies
+
+The focus of this section is on the **set of distributed external dependencies**.
+
+Dependencies are usually required by multiple bundles. Instead of embedding the dependency artifacts in each bundle that is requiring it, causing lots of duplications, the JAR of the dependency is usually made available to the whole framework by either embedding it directly in the target platform (if it is already a OSGi bundle), or by [wrapping it as a OSGi bundle](https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html).
+
+The set of external target platform bundles is built in the [Kura Target Platform project](https://github.com/eclipse-kura/kura/tree/develop/target-platform) and embedded in the final installation through the [Kura distrib project](https://github.com/eclipse-kura/kura/tree/develop/kura/distrib).
+
+The Kura target platform artifacts that are not core Kura components must not be assumed to be stable across Kura versions. Read the following box.
+
+!!! tip "Target platform stability"
+    The artifacts that are distributed in Eclipse Kura through its target platform **are not API**. This means that, although a custom component could leverage these dependencies (like `guava`), it is not guaranteed that the next Kura version will maintain compatibility with the installed dependencies. For instance, a dependency `example` in version `1.2.3` can be available in Kura 5.6.0, but be missing or with a major version bump (like `2.0.0`, making the old APIs break) in the next Kura release.

--- a/docs/java-application-development/target-platform-dependencies.md
+++ b/docs/java-application-development/target-platform-dependencies.md
@@ -16,7 +16,7 @@ Dependencies are usually required by multiple bundles. Instead of embedding the 
 
 The set of external target platform bundles is built in the [Kura Target Platform project](https://github.com/eclipse-kura/kura/tree/develop/target-platform) and embedded in the final installation through the [Kura distrib project](https://github.com/eclipse-kura/kura/tree/develop/kura/distrib).
 
-The Kura target platform artifacts that are not core Kura components must not be assumed to be stable across Kura versions. Read the following box.
+The Kura target platform artifacts that are not core Kura components must not be assumed to be stable across Kura versions. Read the following box before consuming them in your project.
 
 !!! tip "Target platform stability"
     The artifacts that are distributed in Eclipse Kura through its target platform **are not API**. This means that, although a custom component could leverage these dependencies (like `guava`), it is not guaranteed that the next Kura version will maintain compatibility with the installed dependencies. For instance, a dependency `example` in version `1.2.3` can be available in Kura 5.6.0, but be missing or with a major version bump (like `2.0.0`, making the old APIs break) in the next Kura release.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - References: kura-wires/wire-service-references.md
     - Java Application Development:
       - Kura Development Environment Setup: java-application-development/development-environment-setup.md
+      - Target platform dependencies: java-application-development/target-platform-dependencies.md
       - Kura Addon Archetype: java-application-development/kura-addon-archetype.md
       - Hello World Application: java-application-development/hello-world-application.md
       - Deploy and Debug Applications: java-application-development/deploy-and-debug-applications.md


### PR DESCRIPTION
This PR adds a section that describes the stability of the distributed target platform dependencies across different Kura versions.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
