### PR TITLE
fix(core.configuration): write snapshots with 600 permissions

### DIFF
--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -1011,14 +1011,37 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             throw new KuraException(KuraErrorCode.CONFIGURATION_SNAPSHOT_NOT_FOUND);
         }
 
-        File tempSnapshotFile;
-        try {
-            tempSnapshotFile = File.createTempFile(fSnapshot.getName(), null, new File(fSnapshot.getParent()));
-            tempSnapshotFile.deleteOnExit();
-        } catch (IOException ex) {
-            throw new KuraIOException(ex);
-        }
+        File tempSnapshotFile = getTempSnapshotFile(fSnapshot);
 
+        storeSnapshotData(conf, fSnapshot, tempSnapshotFile);
+
+        finalizeSnapshotWrite(fSnapshot, tempSnapshotFile);
+
+    }
+
+    private void finalizeSnapshotWrite(File fSnapshot, File tempSnapshotFile) throws KuraIOException {
+        try {
+            // Consolidate snapshot writing
+            Files.move(tempSnapshotFile.toPath(), fSnapshot.toPath(), StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE);
+
+            Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rw-------");
+            Files.setPosixFilePermissions(fSnapshot.toPath(), perms);
+        } catch (UnsupportedOperationException e1) {
+            // POSIX permissions not supported on this file system, log and continue
+            logger.warn("Unable to set POSIX file permissions for snapshot file: {}", fSnapshot.getAbsolutePath(), e1);
+        } catch (IOException e) {
+            try {
+                Files.delete(tempSnapshotFile.toPath());
+            } catch (IOException e1) {
+                throw new KuraIOException(e1);
+            }
+            throw new KuraIOException(e);
+        }
+    }
+
+    private void storeSnapshotData(XmlComponentConfigurations conf, File fSnapshot, File tempSnapshotFile)
+            throws KuraException {
         // Write the temporary snapshot
         try (FileOutputStream fos = new FileOutputStream(tempSnapshotFile);
                 OutputStream encryptedStream = this.cryptoService.aesEncryptingStream(fos)) {
@@ -1034,30 +1057,17 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         } catch (IOException e) {
             throw new KuraIOException(e);
         }
+    }
 
+    private File getTempSnapshotFile(File fSnapshot) throws KuraIOException {
+        File tempSnapshotFile;
         try {
-            // Consolidate snapshot writing
-            Files.move(tempSnapshotFile.toPath(), fSnapshot.toPath(), StandardCopyOption.REPLACE_EXISTING,
-                    StandardCopyOption.ATOMIC_MOVE);
-            
-            // Set file permissions to owner read/write only (600)
-            try {
-                Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rw-------");
-                Files.setPosixFilePermissions(fSnapshot.toPath(), perms);
-            } catch (UnsupportedOperationException e1) {
-                // POSIX permissions not supported on this file system, log and continue
-                logger.warn("Unable to set POSIX file permissions for snapshot file: {}", fSnapshot.getAbsolutePath(), e1);
-            }
-
-        } catch (IOException e) {
-            try {
-                Files.delete(tempSnapshotFile.toPath());
-            } catch (IOException e1) {
-                throw new KuraIOException(e1);
-            }
-            throw new KuraIOException(e);
+            tempSnapshotFile = File.createTempFile(fSnapshot.getName(), null, new File(fSnapshot.getParent()));
+            tempSnapshotFile.deleteOnExit();
+        } catch (IOException ex) {
+            throw new KuraIOException(ex);
         }
-
+        return tempSnapshotFile;
     }
 
     private ComponentConfiguration getConfigurableComponentConfiguration(String pid) {

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -1040,11 +1040,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             // POSIX permissions not supported on this file system, log and continue
             logger.warn("Unable to set POSIX file permissions for snapshot file: {}", fSnapshot.getAbsolutePath(), e1);
         } catch (IOException e) {
-            try {
-                Files.delete(tempSnapshotFile.toPath());
-            } catch (IOException e1) {
-                throw new KuraIOException(e1);
-            }
             throw new KuraIOException(e);
         }
     }

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -1013,9 +1013,18 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
 
         File tempSnapshotFile = getTempSnapshotFile(fSnapshot);
 
-        storeSnapshotData(conf, fSnapshot, tempSnapshotFile);
-
-        finalizeSnapshotWrite(fSnapshot, tempSnapshotFile);
+        try {
+            storeSnapshotData(conf, fSnapshot, tempSnapshotFile);
+            finalizeSnapshotWrite(fSnapshot, tempSnapshotFile);
+        } finally {
+            if (tempSnapshotFile.exists()) {
+                try {
+                    Files.delete(tempSnapshotFile.toPath());
+                } catch (IOException e) {
+                    logger.warn("Failed to delete temporary snapshot file: {}", tempSnapshotFile.getAbsolutePath(), e);
+                }
+            }
+        }
 
     }
 
@@ -1063,7 +1072,6 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
         File tempSnapshotFile;
         try {
             tempSnapshotFile = File.createTempFile(fSnapshot.getName(), null, new File(fSnapshot.getParent()));
-            tempSnapshotFile.deleteOnExit();
         } catch (IOException ex) {
             throw new KuraIOException(ex);
         }

--- a/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
+++ b/kura/org.eclipse.kura.core.configuration/src/main/java/org/eclipse/kura/core/configuration/ConfigurationServiceImpl.java
@@ -27,6 +27,9 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,7 +44,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.Function;
@@ -1037,6 +1039,15 @@ public class ConfigurationServiceImpl implements ConfigurationService, OCDServic
             // Consolidate snapshot writing
             Files.move(tempSnapshotFile.toPath(), fSnapshot.toPath(), StandardCopyOption.REPLACE_EXISTING,
                     StandardCopyOption.ATOMIC_MOVE);
+            
+            // Set file permissions to owner read/write only (600)
+            try {
+                Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rw-------");
+                Files.setPosixFilePermissions(fSnapshot.toPath(), perms);
+            } catch (UnsupportedOperationException e1) {
+                // POSIX permissions not supported on this file system, log and continue
+                logger.warn("Unable to set POSIX file permissions for snapshot file: {}", fSnapshot.getAbsolutePath(), e1);
+            }
 
         } catch (IOException e) {
             try {

--- a/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
+++ b/kura/test/org.eclipse.kura.core.configuration.test/src/test/java/org/eclipse/kura/core/configuration/ConfigurationServiceJunitTest.java
@@ -34,6 +34,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -3148,5 +3151,145 @@ public class ConfigurationServiceJunitTest {
         assertEquals(2, implementingDouble.size());
         assertTrue(implementingDouble.stream().filter(config -> isOCDFor(config, "bar", barOcd)).findAny().isPresent());
         assertTrue(implementingDouble.stream().filter(config -> isOCDFor(config, "baz", bazOcd)).findAny().isPresent());
+    }
+
+    @Test
+    public void testWriteSnapshotFilePermissions() throws Throwable {
+        // Test that snapshot files are created with secure 600 permissions (owner read/write only)
+        
+        long sid = 424L;
+        XmlComponentConfigurations cfg = prepareSnapshot();
+        final String dir = "snapshotDirPermissions";
+        
+        File d1 = new File(dir);
+        d1.mkdirs();
+        d1.deleteOnExit();
+        
+        ConfigurationServiceImpl cs = new ConfigurationServiceImpl() {
+            @Override
+            String getSnapshotsDirectory() {
+                return dir;
+            }
+            
+            @Override
+            protected <T> T unmarshal(InputStream xmlStream, Class<T> clazz) throws KuraException {
+                XmlMarshallUnmarshallImpl xmlMarshaller = new XmlMarshallUnmarshallImpl();
+                return xmlMarshaller.unmarshal(xmlStream, clazz);
+            }
+            
+            @Override
+            protected void marshal(OutputStream outStream, Object object) {
+                XmlMarshallUnmarshallImpl xmlMarshaller = new XmlMarshallUnmarshallImpl();
+                try {
+                    xmlMarshaller.marshal(outStream, object);
+                } catch (KuraException e) {
+                    // Do nothing...
+                }
+            }
+        };
+        
+        CryptoService cryptoServiceMock = mock(CryptoService.class);
+        cs.setCryptoService(cryptoServiceMock);
+        
+        when(cryptoServiceMock.aesEncryptingStream((OutputStream) ArgumentMatchers.any())).thenAnswer(answer -> {
+            return answer.getArgument(0, OutputStream.class);
+        });
+        
+        BundleContext bundleContext = mock(BundleContext.class);
+        TestUtil.setFieldValue(cs, "bundleContext", bundleContext);
+        
+        // Execute the writeSnapshot method
+        TestUtil.invokePrivate(cs, "writeSnapshot", sid, cfg);
+        
+        File f1 = new File(d1, "snapshot_" + sid + ".xml");
+        f1.deleteOnExit();
+        assertTrue("snapshot file was created", f1.exists());
+        
+        try {
+            // Verify file permissions are set to 600 (owner read/write only) on POSIX systems
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(f1.toPath());
+            Set<PosixFilePermission> expectedPerms = PosixFilePermissions.fromString("rw-------");
+            
+            assertEquals("File permissions should be 600 (owner read/write only)", expectedPerms, permissions);
+            
+            // Verify that group and others don't have any permissions
+            assertFalse("Group should not have read permission", permissions.contains(PosixFilePermission.GROUP_READ));
+            assertFalse("Group should not have write permission", permissions.contains(PosixFilePermission.GROUP_WRITE));
+            assertFalse("Others should not have read permission", permissions.contains(PosixFilePermission.OTHERS_READ));
+            assertFalse("Others should not have write permission", permissions.contains(PosixFilePermission.OTHERS_WRITE));
+            
+            // Verify that owner has both read and write permissions
+            assertTrue("Owner should have read permission", permissions.contains(PosixFilePermission.OWNER_READ));
+            assertTrue("Owner should have write permission", permissions.contains(PosixFilePermission.OWNER_WRITE));
+            assertFalse("Owner should not have execute permission", permissions.contains(PosixFilePermission.OWNER_EXECUTE));
+            
+        } catch (UnsupportedOperationException e) {
+            // This test is running on a non-POSIX filesystem (like Windows)
+            // In this case, we can't test the permissions, but we can verify the file was created
+            System.out.println("POSIX file permissions not supported on this filesystem - skipping permission verification");
+        }
+        
+        f1.delete();
+        d1.delete();
+    }
+    
+    @Test
+    public void testWriteSnapshotNonPosixFilesystem() throws Throwable {
+        // Test behavior on non-POSIX filesystems where setPosixFilePermissions is not supported
+        
+        long sid = 525L;
+        XmlComponentConfigurations cfg = prepareSnapshot();
+        final String dir = "snapshotDirNonPosix";
+        
+        File d1 = new File(dir);
+        d1.mkdirs();
+        d1.deleteOnExit();
+        
+        // Mock ConfigurationServiceImpl to simulate non-POSIX filesystem behavior
+        ConfigurationServiceImpl cs = new ConfigurationServiceImpl() {
+            @Override
+            String getSnapshotsDirectory() {
+                return dir;
+            }
+            
+            @Override
+            protected <T> T unmarshal(InputStream xmlStream, Class<T> clazz) throws KuraException {
+                XmlMarshallUnmarshallImpl xmlMarshaller = new XmlMarshallUnmarshallImpl();
+                return xmlMarshaller.unmarshal(xmlStream, clazz);
+            }
+            
+            @Override
+            protected void marshal(OutputStream outStream, Object object) {
+                XmlMarshallUnmarshallImpl xmlMarshaller = new XmlMarshallUnmarshallImpl();
+                try {
+                    xmlMarshaller.marshal(outStream, object);
+                } catch (KuraException e) {
+                    // Do nothing...
+                }
+            }
+        };
+        
+        CryptoService cryptoServiceMock = mock(CryptoService.class);
+        cs.setCryptoService(cryptoServiceMock);
+        
+        when(cryptoServiceMock.aesEncryptingStream((OutputStream) ArgumentMatchers.any())).thenAnswer(answer -> {
+            return answer.getArgument(0, OutputStream.class);
+        });
+        
+        BundleContext bundleContext = mock(BundleContext.class);
+        TestUtil.setFieldValue(cs, "bundleContext", bundleContext);
+        
+        // Execute the writeSnapshot method - should not throw exception even on non-POSIX systems
+        TestUtil.invokePrivate(cs, "writeSnapshot", sid, cfg);
+        
+        File f1 = new File(d1, "snapshot_" + sid + ".xml");
+        f1.deleteOnExit();
+        assertTrue("snapshot file was created", f1.exists());
+        
+        // On non-POSIX systems, the method should complete successfully even if permissions can't be set
+        // We can't easily mock the UnsupportedOperationException here, but this test verifies the method completes
+        
+        f1.delete();
+        d1.delete();
     }
 }


### PR DESCRIPTION
Set snapshot file permissions to owner read/write only (600) instead of the default permissions (644) to enhance security. Configuration snapshots may contain sensitive data and should not be readable by group or other users.

The change:
- Adds POSIX file permissions support to writeSnapshot method
- Sets permissions to rw------- after file creation
- Gracefully handles non-POSIX filesystems with warning log

