### PR TITLE
fix: Return 404 in CONF-V2/GET/snapshots/byId if snapshot does not exist

### DIFF
--- a/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/internal/rest/configuration/ConfigurationRestService.java
+++ b/kura/org.eclipse.kura.rest.configuration.provider/src/main/java/org/eclipse/kura/internal/rest/configuration/ConfigurationRestService.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
 import org.eclipse.kura.cloudconnection.request.RequestHandler;
 import org.eclipse.kura.cloudconnection.request.RequestHandlerRegistry;
@@ -61,6 +62,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 @Path("/configuration/v2")
 public class ConfigurationRestService {
@@ -491,10 +493,19 @@ public class ConfigurationRestService {
         id.validate();
 
         try {
+            if (!this.configurationService.getSnapshots().contains(id.getId())) {
+                throw new KuraException(KuraErrorCode.CONFIGURATION_SNAPSHOT_NOT_FOUND);
+            }
+
             List<ComponentConfiguration> configs = this.configurationService.getSnapshot(id.getId());
 
             return DTOUtil.toComponentConfigurationList(configs, this.cryptoService, false);
         } catch (KuraException e) {
+            if (e.getCode() == KuraErrorCode.CONFIGURATION_SNAPSHOT_NOT_FOUND) {
+                throw DefaultExceptionHandler.buildWebApplicationException(Status.NOT_FOUND,
+                        "The requested snapshot cannot be found.");
+            }
+
             throw DefaultExceptionHandler.toWebApplicationException(e);
         }
     }

--- a/kura/test/org.eclipse.kura.rest.configuration.provider.test/src/main/java/org/eclipse/kura/rest/configuration/provider/test/ConfigurationRestServiceTest.java
+++ b/kura/test/org.eclipse.kura.rest.configuration.provider.test/src/main/java/org/eclipse/kura/rest/configuration/provider/test/ConfigurationRestServiceTest.java
@@ -307,7 +307,7 @@ public class ConfigurationRestServiceTest extends AbstractRequestHandlerTest {
     public void testGetSnapshotReturnsUnencryptedPassword() throws KuraException {
         givenATestConfigurationPropertyWithAdTypeAndValue(Scalar.PASSWORD, new Password("foobar".toCharArray()));
 
-        whenRequestIsPerformed(new MethodSpec("POST"), "/snapshots/byId", "{\"id\":1}");
+        whenRequestIsPerformed(new MethodSpec("POST"), "/snapshots/byId", "{\"id\":10000}");
 
         thenRequestSucceeds();
         thenTestPropertyTypeIs(Json.value("PASSWORD"));
@@ -854,22 +854,34 @@ public class ConfigurationRestServiceTest extends AbstractRequestHandlerTest {
 
     @Test
     public void testGetSnapshotException() throws KuraException {
-        givenMockGetSnapshotReturnException();
+        givenMockGetSnapshotsReturnSome(5);
+        givenMockGetSnapshotReturnException(10000);
 
-        whenRequestIsPerformed(new MethodSpec("POST"), "/snapshots/byId", "{\"id\":12345}");
+        whenRequestIsPerformed(new MethodSpec("POST"), "/snapshots/byId", "{\"id\":10000}");
 
         thenResponseCodeIs(400);
     }
 
     @Test
     public void testGetSnapshot() throws KuraException {
-        givenMockGetSnapshotReturnSome(12345, 5);
+        givenMockGetSnapshotsReturnSome(5);
+        givenMockGetSnapshotReturnSome(10000, 5);
 
-        whenRequestIsPerformed(new MethodSpec("POST"), "/snapshots/byId", "{\"id\":12345}");
+        whenRequestIsPerformed(new MethodSpec("POST"), "/snapshots/byId", "{\"id\":10000}");
 
         thenRequestSucceeds();
         thenResponseBodyEqualsJson("{\"configs\":[" + "{\"pid\":\"pid0\"}," + "{\"pid\":\"pid1\"},"
                 + "{\"pid\":\"pid2\"}," + "{\"pid\":\"pid3\"}," + "{\"pid\":\"pid4\"}]" + "}");
+    }
+
+    @Test
+    public void testGetSnapshotNotFound() throws KuraException {
+        givenMockGetSnapshotsReturnSome(5);
+        givenMockGetSnapshotReturnSome(10000, 5);
+
+        whenRequestIsPerformed(new MethodSpec("POST"), "/snapshots/byId", "{\"id\":12346}");
+
+        thenResponseCodeIs(404);
     }
 
     @Test
@@ -1395,8 +1407,8 @@ public class ConfigurationRestServiceTest extends AbstractRequestHandlerTest {
         when(configurationService.getDefaultComponentConfiguration(ArgumentMatchers.any())).thenReturn(config);
     }
 
-    private void givenMockGetSnapshotReturnException() throws KuraException {
-        when(configurationService.getSnapshot(12345)).thenThrow(new KuraException(KuraErrorCode.BAD_REQUEST));
+    private void givenMockGetSnapshotReturnException(int snapshotId) throws KuraException {
+        when(configurationService.getSnapshot(snapshotId)).thenThrow(new KuraException(KuraErrorCode.BAD_REQUEST));
     }
 
     private void givenMockGetSnapshotReturnSome(long snapshotId, int howManyConfigurations) throws KuraException {
@@ -1464,6 +1476,8 @@ public class ConfigurationRestServiceTest extends AbstractRequestHandlerTest {
             final String pid = i.getArgument(0, String.class);
             return byPid.get(pid);
         });
+
+        givenMockGetSnapshotsReturnSome(5);
 
         Mockito.when(configurationService.getSnapshot(Mockito.anyLong()))
                 .thenReturn(byPid.values().stream().collect(Collectors.toList()));


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Fixes incorrect behaviour of `CONF-V2/GET/snapshots/byId` returning 200 with an empty configuration list instead of 404 if the requested snapshot does not exist