### PR TITLE
ci(workflows): add Kura core SBOM generate & upload action

### DIFF
--- a/.github/workflows/kura-core-sbom.yml
+++ b/.github/workflows/kura-core-sbom.yml
@@ -77,6 +77,17 @@ jobs:
         run: |
           mvn -f kura/pom.xml clean install -Dmaven.test.skip=true
 
+      - name: Get version
+        id: get-version
+        run: "echo \"resolved-version=\
+          $(mvn
+            --file ./kura/pom.xml
+            -Dexec.executable=echo
+            -Dexec.args='${project.version}'
+            --quiet exec:exec --non-recursive
+          )\" >> \"${GITHUB_OUTPUT}\""
+        shell: bash
+
       - name: Setup Node SDK
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
@@ -98,6 +109,8 @@ jobs:
             --exclude "**/target/**" \
             --exclude "**/distrib/**" \
             --filter "kura" \
+            --project-version "${{ steps.get-version.outputs.resolved-version }}" \
+            --project-name "kura-core" \
             --deep
 
       - name: Extract product version

--- a/.github/workflows/kura-core-sbom.yml
+++ b/.github/workflows/kura-core-sbom.yml
@@ -1,0 +1,133 @@
+name: Kura core SBOM upload
+
+on:
+  schedule:
+    # At 00:00 on Saturday
+    - cron: "0 0 * * 6"
+  workflow_dispatch:
+    inputs:
+        target_branch:
+          type: string
+          default: 'develop'
+          required: true
+  workflow_run:
+    workflows: ["Release Notes automation"]
+    types:
+      - completed
+
+env:
+  JAVA_VERSION: '17' # java version used by the product
+  JAVA_DISTRO: 'temurin' # java distro used by the product
+  NODE_VERSION: "20.x"
+  REGISTRY_URL: "https://registry.npmjs.org"
+  PRODUCT_PATH: "./kura"
+  WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+  INPUT_TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
+  EVENT_NAME: ${{ github.event_name }}
+  GITHUB_REF_NAME: ${{ github.ref_name }}
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-22.04
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
+    permissions:
+      packages: read
+    steps:
+      - name: Set checkout ref
+        id: set-checkout-ref
+        shell: bash
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            echo "CHECKOUT_REF=$WORKFLOW_HEAD_BRANCH" >> $GITHUB_ENV
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "CHECKOUT_REF=$INPUT_TARGET_BRANCH" >> $GITHUB_ENV
+          else
+            echo "CHECKOUT_REF=$GITHUB_REF_NAME" >> $GITHUB_ENV
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Debug branch information
+        run: |
+          echo "=== Debug Branch Information ==="
+          echo "Event name: $EVENT_NAME"
+          echo "Current branch (git): $(git branch --show-current)"
+          echo "==============================="
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Build target platform
+        run: |
+          mvn -f target-platform/pom.xml clean install
+
+      - name: Build Kura core
+        run: |
+          mvn -f kura/pom.xml clean install -Dmaven.test.skip=true
+
+      - name: Setup Node SDK
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: ${{ env.REGISTRY_URL }}
+
+      - name: Install dependencies
+        run: |
+          npm ci
+
+      - name: Install cdxgen
+        run: |
+          npm install -g @cyclonedx/cdxgen
+
+      - name: Generate SBOM
+        run: |
+          FETCH_LICENSE=1 cdxgen
+            -r ${{ env.PRODUCT_PATH }} \
+            -o ${{ env.PRODUCT_PATH }}/bom.json \
+            -t jar \
+            --exclude "**/test/**" \
+            --exclude "**/target-definition/**" \
+            --exclude "**/target/**" \
+            --exclude "**/distrib/**" \
+            --filter "kura" \
+            --deep
+
+      - name: Extract product version
+        id: version
+        shell: bash
+        run: |
+          VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/bom.json)"
+
+          # Substitute "-SNAPSHOT" suffix with "@dev" if present
+          VERSION="${VERSION/-SNAPSHOT/@dev}"
+
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Product version: $VERSION"
+
+      # - name: Upload sbom
+      #   uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      #   with:
+      #     name: kura-core-sbom
+      #     path: ${{ env.PRODUCT_PATH }}/bom.json
+
+#   store-sbom-data:
+#     needs: ['generate-sbom']
+#     uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+#     with:
+#       projectName: 'kura-core'
+#       projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+#       bomArtifact: 'kura-core-sbom'
+#       bomFilename: 'bom.json'
+#       parentProject: 'f295fa60-24df-44d9-83ff-00b3ff8d6131'

--- a/.github/workflows/kura-core-sbom.yml
+++ b/.github/workflows/kura-core-sbom.yml
@@ -83,19 +83,15 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.REGISTRY_URL }}
 
-      - name: Install dependencies
-        run: |
-          npm ci
-
       - name: Install cdxgen
         run: |
           npm install -g @cyclonedx/cdxgen
 
       - name: Generate SBOM
+        working-directory: ${{ env.PRODUCT_PATH }}
         run: |
-          FETCH_LICENSE=1 cdxgen
-            -r ${{ env.PRODUCT_PATH }} \
-            -o ${{ env.PRODUCT_PATH }}/bom.json \
+          FETCH_LICENSE=1 CDXGEN_DEBUG_MODE=debug cdxgen \
+            -r -o ./bom.json \
             -t jar \
             --exclude "**/test/**" \
             --exclude "**/target-definition/**" \
@@ -116,18 +112,18 @@ jobs:
           echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "Product version: $VERSION"
 
-      # - name: Upload sbom
-      #   uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-      #   with:
-      #     name: kura-core-sbom
-      #     path: ${{ env.PRODUCT_PATH }}/bom.json
+      - name: Upload sbom
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: kura-core-sbom
+          path: ${{ env.PRODUCT_PATH }}/bom.json
 
-#   store-sbom-data:
-#     needs: ['generate-sbom']
-#     uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
-#     with:
-#       projectName: 'kura-core'
-#       projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
-#       bomArtifact: 'kura-core-sbom'
-#       bomFilename: 'bom.json'
-#       parentProject: 'f295fa60-24df-44d9-83ff-00b3ff8d6131'
+  store-sbom-data:
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'kura-core'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'kura-core-sbom'
+      bomFilename: 'bom.json'
+      parentProject: 'f295fa60-24df-44d9-83ff-00b3ff8d6131'


### PR DESCRIPTION
Follow-up on #5886 and #5920 leveraging https://github.com/OtterdogTest/theia/blob/sbom-testing/.github/workflows/generate-sbom.yml (see: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6454)

This workflow uses [`cdxgen`](https://github.com/CycloneDX/cdxgen) to scan the `.jar` downloaded by the Kura modules. 