### PR TITLE
fix(web2): avoid password validation in 802.1x config for station mode

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/server/net2/configuration/NetworkConfigurationServicePropertiesBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -286,7 +286,6 @@ public class NetworkConfigurationServicePropertiesBuilder {
 
                 this.properties.set8021xPassword(this.ifname, gwt8021xConfig.getPassword());
             } else {
-                GwtServerUtil.validateUserPassword(password8021x);
                 this.properties.set8021xPassword(this.ifname, password8021x);
             }
         }


### PR DESCRIPTION
This PR disables the usage of the `PasswordStrengthVerificationService` for the password field in the wireless 802.1x configuration.

Like for the standard station mode, this station mode should not check password requirements since decided by the system administrator.

**Related Issue:** Backport of https://github.com/eclipse-kura/kura-management-ui/pull/8. Resolves the issue:

1. Setup a device with a `wlan` interface, edit a `snapshot_0.xml` that does not contain the configuration for the `wlan` interface
2. Start Kura, from Security section set the PasswordStrength to 12 min characters
3. Configure the WiFi interface to be in station mode, WAN, DHCP enabled. Do not configure the 802.1x tab
4. Apply the changes, logs show that the password does not meet requirements

The error is not relative to the password configured from the Wireless tab, but it is the one of the 802.1x that by default is set to `Placeholder`. Like for the other station modes, there should be no verification on the password requirements.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: Set log level to debug for the `org.eclipse.kura.web.server.net2` logger from the log4j configuration file. Perform the following tests:

Test 1 (connect to AP)

1. Setup a device with a WiFi interface and edit the snapshot 0 to not contain any wireless configuration
2. Start Kura and from Security -> PasswordStrength set min password length to 12
3. From Network, configure the wireless interface in station mode to connect to an AP
4. Apply, no errors appear in log, device is connected

Test 2 (connect to AP with WPA enterprise security)

1. Setup a device with a WiFi interface and edit the snapshot 0 to not contain any wireless configuration
2. Start Kura and from Security -> PasswordStrength set min password length to 12
3. From Network, configure the wireless interface in station mode to connect to an AP with WPA3-enterprise security
4. Configure the 802.1x tab accordingly
5. Apply, no errors appear in log, device is connected

**Any side note on the changes made:** N/A.

**Workaround**: before starting Kura, edit the snapshot 0 by adding the wireless interface name to the property `net.interfaces` of the `org.eclipse.kura.net.admin.NetworkConfigurationService`.