### PR TITLE
ci(workflows): fix force merge shared workflow secrets inheriting

### DIFF
--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -13,4 +13,4 @@ permissions:
 jobs:
   call-workflow-in-public-repo:
     uses: eclipse-kura/.github/.github/workflows/_shared-force-merge.yml@main
-  secrets: inherit
+    secrets: inherit

--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -13,3 +13,4 @@ permissions:
 jobs:
   call-workflow-in-public-repo:
     uses: eclipse-kura/.github/.github/workflows/_shared-force-merge.yml@main
+  secrets: inherit


### PR DESCRIPTION
The force merge github action is currently failing to run, after being refactored as a shared workflow in #5936,  because it cannot see the org secrets required to perform the merge.

This is due to:
<img width="916" height="259" alt="image" src="https://github.com/user-attachments/assets/7fd086bb-ba5e-4479-8fb6-a50287909375" />

References:
- https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#using-secrets-in-a-workflow
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-of-jobsjob_idsecretsinherit

This PR explicitly inherits the secrets from the caller pipeline as described in https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#passing-inputs-and-secrets-to-a-reusable-workflow