### PR TITLE
ci(workflows): fix force merge action indentation

### DIFF
--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -13,7 +13,4 @@ permissions:
 jobs:
   call-workflow-in-public-repo:
     uses: eclipse-kura/.github/.github/workflows/_shared-force-merge.yml@main
-<<<<<<< Updated upstream
-=======
     secrets: inherit
->>>>>>> Stashed changes

--- a/.github/workflows/force-merge.yml
+++ b/.github/workflows/force-merge.yml
@@ -13,3 +13,7 @@ permissions:
 jobs:
   call-workflow-in-public-repo:
     uses: eclipse-kura/.github/.github/workflows/_shared-force-merge.yml@main
+<<<<<<< Updated upstream
+=======
+    secrets: inherit
+>>>>>>> Stashed changes


### PR DESCRIPTION
Fix indentation error introduced in #5950 see https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-of-jobsjob_idsecretsinherit