### PR TITLE
docs: update VSCode setup documentation

### DIFF
--- a/docs/java-application-development/development-environment-setup.md
+++ b/docs/java-application-development/development-environment-setup.md
@@ -118,7 +118,7 @@ cd kura/
 and then run the tool with the following command
 
 ```bash
-kura-gen
+kura-gen -t target-definition/kura-equinox.target
 ```
 
 #### 4. Open VSCode in the `kura` directory


### PR DESCRIPTION
Follow-up of #5866

The instructions provided in #5866 were not generating a javaConfig.json file.
