### PR TITLE
fix(ui): initialize unconfigured wireless interface to resolve NPE, fix channel selection on hardware tab, fix validation message on empty password [backport release-5.6.0]

### DIFF
--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/network/TabWirelessUi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -1820,7 +1820,7 @@ public class TabWirelessUi extends Composite implements NetworkTab {
         if (this.activeConfig != null && this.activeConfig.getChannels() != null
                 && !this.activeConfig.getChannels().isEmpty()) {
             this.netTabs.hardwareTab.channel
-                    .setText(this.channelList.getItemText(this.activeConfig.getChannels().get(0)));
+                    .setText(this.channelList.getItemText(selectedChannelValue));
 
             this.channelList.setSelectedIndex(selectedChannelValue);
         }

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/GwtValidators.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/client/ui/validator/GwtValidators.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -51,9 +51,9 @@ public class GwtValidators {
     public static List<Validator<String>> newPassword(final GwtConsoleUserOptions userOptions) {
 
         final List<Validator<String>> defaultValidators = Arrays.asList(
+                nonEmpty(MSGS.pwdEmpty()),
                 stringLength(255, MSGS.pwdMaxLength()),
-                noWhitespaceCharacters(MSGS.pwdWhitespaceCharacters()),
-                nonEmpty(MSGS.pwdEmpty()));
+                noWhitespaceCharacters(MSGS.pwdWhitespaceCharacters()));
 
         return Stream
                 .concat(PasswordStrengthValidators.fromConfig(userOptions, new PasswordStrengthValidators.Messages() {

--- a/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtWifiNetInterfaceConfig.java
+++ b/kura/org.eclipse.kura.web2/src/main/java/org/eclipse/kura/web/shared/model/GwtWifiNetInterfaceConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -110,7 +110,8 @@ public class GwtWifiNetInterfaceConfig extends GwtNetInterfaceConfig {
 
     public GwtWifiConfig getActiveWifiConfig() {
         GwtWifiWirelessMode wifiMode = getWirelessModeEnum();
-        GwtWifiConfig activeConfig = null;
+        GwtWifiConfig activeConfig = new GwtWifiConfig();
+        activeConfig.setWirelessMode(wifiMode.name());
 
         if (wifiMode.equals(GwtWifiWirelessMode.netWifiWirelessModeAccessPoint)) {
             activeConfig = this.m_accessPointWifiConfig;


### PR DESCRIPTION
Backport of PR https://github.com/eclipse-kura/kura-management-ui/pull/11.

**Related Issue:** https://github.com/eclipse-kura/kura-management-ui/pull/11.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
