### PR TITLE
fix: max number of log files not correctly enforced in high-volume logging circumstances

### DIFF
--- a/kura/distrib/src/main/resources/unfiltered/pkg/log4j/log4j.xml
+++ b/kura/distrib/src/main/resources/unfiltered/pkg/log4j/log4j.xml
@@ -27,7 +27,7 @@
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
         </Console>
-        <File name="RollingFile" fileName="${log_dir}/${log_name}.log">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
@@ -48,18 +48,18 @@
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
             <AppenderRef ref="Console" />
-            <AppenderRef ref="RollingFile" />
+            <AppenderRef ref="LoggingFile" />
         </Logger>
         <Logger name="org.glassfish.jersey.internal" level="error" additivity="false">
             <AppenderRef ref="Console" />
-            <AppenderRef ref="RollingFile" />
+            <AppenderRef ref="LoggingFile" />
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit" />
         </Logger>
         <Root level="info">
             <AppenderRef ref="Console" />
-            <AppenderRef ref="RollingFile" />
+            <AppenderRef ref="LoggingFile" />
         </Root>
     </Loggers>
 

--- a/kura/distrib/src/main/resources/unfiltered/pkg/log4j/log4j.xml
+++ b/kura/distrib/src/main/resources/unfiltered/pkg/log4j/log4j.xml
@@ -27,18 +27,12 @@
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
         </Console>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log"
-            filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="RollingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB" />
-            </Policies>
-            <DefaultRolloverStrategy max="10" />
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log"
-            filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext"
                 appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
@@ -48,11 +42,7 @@
                     <KeyValuePair key="exception" value="%ex" />
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB" />
-            </Policies>
-            <DefaultRolloverStrategy max="10" />
-        </RollingFile>
+        </File>
     </Appenders>
 
     <Loggers>


### PR DESCRIPTION
Fixes #5958

As described in #5958 log4j was not correctly enforcing log rotation due to a configuration error. To avoid flooding the filesystem with log files we decided to disable log4j-based rotation and only rely on `logrotate`.

This meant:
1. Switching to a [File appender](https://logging.apache.org/log4j/2.x/manual/appenders/file.html) instead of a [Rolling File appender](https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html).
2. Removing `filePattern` and log rotation-secific settings.

This solution has two drawbacks:
1. When Kura is logging a lot (i.e. >20MB in less than 5 minutes) the file size of the logs will be higher than before since `logrotate` only acts on time trigger.
3. As per log4j documentation (see [1][2]) this configuration is lossy: there is a very small time slice between `logrotate` copying the file and truncating it, so some logging data might be lost. We're fine with this limitation for now since it's been there since we started using `logrotate` for log rotation.

Given Kura 6.0.0 is on the horizon and is a major release, to improve on log handing, we might consider either:
1. Switch to journal for logging
2. Rely entirely on log4j for rotation (requires us to put `kura-gc` and `kura-console` under log4j responsibility).

This would solve both drawbacks mentioned above.

[1] https://logging.apache.org/log4j/2.x/manual/appenders/file.html
[2] https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html#logrotate-daily

---

Tested working correctly on Raspberry Pi. When replicating the high-volume logging circumstances described in #5958 we don't see log files flooding the filesystem even after a long time. The number of files maxes out at 7 as per our `logrotate` configuration.