### PR TITLE
fix: max number of log files not correctly enforced in high-volume logging circumstances [backport #5961]

### DIFF
--- a/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
 
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/log4j.xml
@@ -27,16 +27,12 @@
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
         </Console>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -45,24 +41,20 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
 
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
             <AppenderRef ref="Console"/>
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
             <AppenderRef ref="Console"/>
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
   </Loggers>
 

--- a/kura/distrib/src/main/resources/generic-aarch64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-aarch64-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/generic-aarch64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-aarch64-nn/log4j.xml
@@ -20,16 +20,12 @@
     </Properties>
     <Filter type="ThresholdFilter" level="trace"/>
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -38,21 +34,17 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/kura/distrib/src/main/resources/generic-aarch64/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-aarch64/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/generic-aarch64/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-aarch64/log4j.xml
@@ -20,16 +20,12 @@
     </Properties>
     <Filter type="ThresholdFilter" level="trace"/>
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -38,21 +34,17 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/kura/distrib/src/main/resources/generic-arm32-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-arm32-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/generic-arm32-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-arm32-nn/log4j.xml
@@ -20,16 +20,12 @@
     </Properties>
     <Filter type="ThresholdFilter" level="trace"/>
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -38,21 +34,17 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/kura/distrib/src/main/resources/generic-arm32/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-arm32/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/generic-arm32/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-arm32/log4j.xml
@@ -20,16 +20,12 @@
     </Properties>
     <Filter type="ThresholdFilter" level="trace"/>
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -38,21 +34,17 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/kura/distrib/src/main/resources/generic-x86_64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-x86_64-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/generic-x86_64-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-x86_64-nn/log4j.xml
@@ -20,16 +20,12 @@
     </Properties>
     <Filter type="ThresholdFilter" level="trace"/>
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -38,21 +34,17 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/kura/distrib/src/main/resources/generic-x86_64/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-x86_64/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2023 Eurotech and/or its affiliates and others
+    Copyright (c) 2023, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/generic-x86_64/log4j.xml
+++ b/kura/distrib/src/main/resources/generic-x86_64/log4j.xml
@@ -20,16 +20,12 @@
     </Properties>
     <Filter type="ThresholdFilter" level="trace"/>
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -38,21 +34,17 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/log4j.xml
@@ -22,16 +22,12 @@
     <Filter type="ThresholdFilter" level="trace"/>
  
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -40,22 +36,18 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
  
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
   </Loggers>
  

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/log4j.xml
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/log4j.xml
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/log4j.xml
@@ -22,16 +22,12 @@
     <Filter type="ThresholdFilter" level="trace"/>
  
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -40,22 +36,18 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
  
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
   </Loggers>
  

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/log4j.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/log4j.xml
@@ -22,16 +22,12 @@
     <Filter type="ThresholdFilter" level="trace"/>
  
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -40,22 +36,18 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
  
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
   </Loggers>
  

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/log4j.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/log4j.xml
@@ -20,16 +20,12 @@
     </Properties>
     <Filter type="ThresholdFilter" level="trace"/>
     <Appenders>
-        <RollingFile name="RollingFile" fileName="${log_dir}/${log_name}.log" filePattern="${log_dir}/${log_name}-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
             </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-        <RollingFile name="audit" fileName="${log_dir}/${log_name}-audit.log" filePattern="${log_dir}/${log_name}-audit-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz">
+        </File>
+        <File name="audit" fileName="${log_dir}/${log_name}-audit.log">
             <RFC5424Layout enterpriseNumber="28392" includeMDC="true" mdcId="RequestContext" appName="EclipseKura" mdcPrefix="" newLine="true">
                 <LoggerFields>
                     <KeyValuePair key="thread" value="%t"/>
@@ -38,21 +34,17 @@
                     <KeyValuePair key="exception" value="%ex"/>
                 </LoggerFields>
             </RFC5424Layout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="20 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
+        </File>
     </Appenders>
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit"/>
         </Logger>
         <Root level="info">
-            <AppenderRef ref="RollingFile"/>
+            <AppenderRef ref="LoggingFile"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/log4j.xml
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2025 Eurotech and/or its affiliates and others
   
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
Backport of #5961 