### PR TITLE
fix(distrib): `kura.log` and `kura-console.log` log duplication

### DIFF
--- a/kura/distrib/src/main/resources/unfiltered/pkg/log4j/log4j.xml
+++ b/kura/distrib/src/main/resources/unfiltered/pkg/log4j/log4j.xml
@@ -22,11 +22,6 @@
     <Filter type="ThresholdFilter" level="trace" />
 
     <Appenders>
-        <Console name="Console" target="SYSTEM_OUT" follow="true">
-            <PatternLayout>
-                <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
-            </PatternLayout>
-        </Console>
         <File name="LoggingFile" fileName="${log_dir}/${log_name}.log">
             <PatternLayout>
                 <Pattern>%d{ISO8601} [%t] %-5p %c{1.} - %m%n%throwable{full}</Pattern>
@@ -47,18 +42,15 @@
 
     <Loggers>
         <Logger name="org.eclipse" level="info" additivity="false">
-            <AppenderRef ref="Console" />
             <AppenderRef ref="LoggingFile" />
         </Logger>
         <Logger name="org.glassfish.jersey.internal" level="error" additivity="false">
-            <AppenderRef ref="Console" />
             <AppenderRef ref="LoggingFile" />
         </Logger>
         <Logger name="AuditLogger" level="trace" additivity="false">
             <AppenderRef ref="audit" />
         </Logger>
         <Root level="info">
-            <AppenderRef ref="Console" />
             <AppenderRef ref="LoggingFile" />
         </Root>
     </Loggers>


### PR DESCRIPTION
Currently, the log entries in `kura.log` (Kura application log) are being duplicated in the `kura-console.log` file (Equinox console log). This PR fixes the issue.

The problem was probably introduced when we removed the old installer profiles in #5872 and used the Docker `log4j.xml` configuration for all our installers. The Docker configuration, though, outputs all its log to STDOUT (as it should) while the standard installer should not.

Therefore we had two sources logging to console:

1. The Equinox console (as intended): https://github.com/eclipse-kura/kura/blob/c99807e953f0eeb0c7dc0725db389e4f073447d6/kura/distrib/src/main/resources/filtered/pkg/bin/start_kura_background.sh#L37
2. The Kura application: https://github.com/eclipse-kura/kura/blob/c99807e953f0eeb0c7dc0725db389e4f073447d6/kura/distrib/src/main/resources/unfiltered/pkg/log4j/log4j.xml#L25-L29

This PR removes the "Console" appender from our `log4j.xml` configuration so that logfiles behave as intended.

**Note**: this is the same configuration as in Kura 5.6.0  https://github.com/eclipse-kura/kura/blob/release-5.6.0/kura/distrib/src/main/resources/generic-aarch64/log4j.xml