### PR TITLE
ci(Jenkinsfile): upload DEP packages on Kura APT repository

### DIFF
--- a/.jenkins/nexusUtils.groovy
+++ b/.jenkins/nexusUtils.groovy
@@ -1,0 +1,39 @@
+def uploadPackages(String repoDistribution, String repoModule, Boolean setupPromotion = false) {
+    stage ("Upload packages parameters check") {
+        echo "Distribution: ${repoDistribution}"
+        echo "Module: ${repoModule}"
+
+        // Check "distribution" parameter is set and valid
+        assert repoDistribution instanceof String
+        assert repoDistribution ==~ /kura-\d+/
+
+        // Check "module" parameter is set and valid
+        def valid_modules = [
+            "base"
+        ]
+
+        assert repoModule instanceof String
+        assert valid_modules.contains(repoModule)
+    }
+
+    stage("Upload .deb packages to Artifactory") {
+        def debFilesOutput = sh(script: "find kura -type f -name '*.deb'", returnStdout: true).trim()
+        def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
+
+        debFiles.each {
+            withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
+                sh(
+                    script: "curl -u \"\$USERPASS\" -H \"Content-Type: multipart/form-data\" --data-binary \"@./${it}\" \"https://repo3.eclipse.org/repository/kura-apt/\"",
+                    returnStatus: true
+                )
+            }
+        }
+
+        if (setupPromotion) {
+            // TODO
+        }
+
+    }
+}
+
+return this

--- a/.jenkins/nexusUtils.groovy
+++ b/.jenkins/nexusUtils.groovy
@@ -16,7 +16,7 @@ def uploadPackages(String repoDistribution, String repoModule, Boolean setupProm
         assert valid_modules.contains(repoModule)
     }
 
-    stage("Upload .deb packages to Artifactory") {
+    stage("Upload .deb packages to Nexus") {
         def debFiles = findFiles(glob: 'kura/**/*.deb')
 
         if (debFiles.size() == 0) {

--- a/.jenkins/nexusUtils.groovy
+++ b/.jenkins/nexusUtils.groovy
@@ -30,7 +30,7 @@ def uploadPackages(String repoDistribution, String repoModule, Boolean setupProm
                         curl -u \"\$USERPASS\" \
                         -H \"Content-Type: multipart/form-data\" \
                         --data-binary \"@./${it}\" \
-                        \"https://repo3.eclipse.org/repository/kura-apt/\"
+                        \"https://repo3.eclipse.org/repository/kura-apt-dev/\"
                     """,
                     returnStatus: true
                 )

--- a/.jenkins/nexusUtils.groovy
+++ b/.jenkins/nexusUtils.groovy
@@ -25,15 +25,21 @@ def uploadPackages(String repoDistribution, String repoModule, Boolean setupProm
 
         debFiles.each {
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
-                sh(
+                def status = sh(
                     script: """
                         curl -u \"\$USERPASS\" \
+                        -w '%{http_code}' \
                         -H \"Content-Type: multipart/form-data\" \
                         --data-binary \"@./${it}\" \
-                        \"https://repo3.eclipse.org/repository/kura-apt-dev/\"
+                        \"https://repo3.eclipse.org/repository/kura-apt-dev/\" \
+                        -o /dev/null
                     """,
                     returnStatus: true
                 )
+
+                if (status != "201") {
+                    error("Returned status code = $status")
+                }
             }
         }
 

--- a/.jenkins/nexusUtils.groovy
+++ b/.jenkins/nexusUtils.groovy
@@ -17,13 +17,21 @@ def uploadPackages(String repoDistribution, String repoModule, Boolean setupProm
     }
 
     stage("Upload .deb packages to Artifactory") {
-        def debFilesOutput = sh(script: "find kura -type f -name '*.deb'", returnStdout: true).trim()
-        def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
+        def debFiles = findFiles(glob: 'kura/**/*.deb')
+
+        if (debFiles.size() == 0) {
+            error("No .deb files found to upload")
+        }
 
         debFiles.each {
             withCredentials([usernameColonPassword(credentialsId: 'repo.eclipse.org-bot-account', variable: 'USERPASS')]) {
                 sh(
-                    script: "curl -u \"\$USERPASS\" -H \"Content-Type: multipart/form-data\" --data-binary \"@./${it}\" \"https://repo3.eclipse.org/repository/kura-apt/\"",
+                    script: """
+                        curl -u \"\$USERPASS\" \
+                        -H \"Content-Type: multipart/form-data\" \
+                        --data-binary \"@./${it}\" \
+                        \"https://repo3.eclipse.org/repository/kura-apt/\"
+                    """,
                     returnStatus: true
                 )
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+
 def boolean onlyDocumentationFilesChangedIn(String workDirectory) {
     if (!env.CHANGE_TARGET) {
         echo "CHANGE_TARGET not set. Skipping check"
@@ -69,6 +71,27 @@ node {
     stage('Generate test reports') {
         dir("kura") {
             junit 'kura/test/*/target/surefire-reports/*.xml'
+        }
+    }
+
+    stage ("Deploy on Nexus") {
+        def debFilesOutput = sh(script: "find kura -type f -name '*.deb'", returnStdout: true).trim()
+        def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
+
+        // Call uploadPackages only if we are on the default branch,
+        // if we have DEB packages to upload and if the user has set the pushArtifacts parameter to true
+        // if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
+        if (debFiles && debFiles.size() > 0) {
+            echo "Found DEB packages, uploading..."
+
+            // FIXME read pom to extract distribution and module
+            def repoDistribution = "kura-6"
+            def repoModule = "base"
+
+            uploadPackages(repoDistribution, repoModule)
+        } else {
+            echo "Skipping DEB upload"
+            Utils.markStageSkippedForConditional(STAGE_NAME)
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,8 +77,7 @@ node {
     stage ("Deploy on Nexus") {
         // Call uploadPackages only if we are on the default branch,
         // if we have DEB packages to upload and if the user has set the pushArtifacts parameter to true
-        // if (env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
-        if (true) {
+        if (env.BRANCH_IS_PRIMARY) {
             echo "Uploading DEB packages..."
 
             def distribPom = readMavenPom file: 'kura/kura/distrib/pom.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,20 +75,17 @@ node {
     }
 
     stage ("Deploy on Nexus") {
-        def debFilesOutput = sh(script: "find kura -type f -name '*.deb'", returnStdout: true).trim()
-        def debFiles = debFilesOutput ? debFilesOutput.split("\n") : []
-
         // Call uploadPackages only if we are on the default branch,
         // if we have DEB packages to upload and if the user has set the pushArtifacts parameter to true
-        // if (debFiles && env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
-        if (debFiles && debFiles.size() > 0) {
-            echo "Found DEB packages, uploading..."
+        // if (env.BRANCH_IS_PRIMARY && pipelineParams.pushArtifacts) {
+        if (true) {
+            echo "Uploading DEB packages..."
 
-            // FIXME read pom to extract distribution and module
-            def repoDistribution = "kura-6"
-            def repoModule = "base"
+            def distribPom = readMavenPom file: 'kura/kura/distrib/pom.xml'
 
-            def nexusUtils = load 'kura/.jenkins/nexusUtils.groovy'
+            def repoDistribution = distribPom.properties['kura.repo.distribution']
+            def repoModule = distribPom.properties['kura.repo.module']
+
             nexusUtils.uploadPackages(repoDistribution, repoModule)
         } else {
             echo "Skipping DEB upload"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,8 @@ node {
             def repoDistribution = "kura-6"
             def repoModule = "base"
 
-            uploadPackages(repoDistribution, repoModule)
+            def nexusUtils = load 'kura/.jenkins/nexusUtils.groovy'
+            nexusUtils.uploadPackages(repoDistribution, repoModule)
         } else {
             echo "Skipping DEB upload"
             Utils.markStageSkippedForConditional(STAGE_NAME)


### PR DESCRIPTION
This PR adds the necessary step to perform the DEP packages upload on our recently introduced Kura APT repository. See https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5706

Tested working on https://ci.eclipse.org/kura/job/kura-base/job/kura-metapackage/view/change-requests/job/PR-5/

Promotion setup will be introduced in a later PR

Checklist
- [x] Dynamically detect `kura.repo.distribution` and `kura.repo.module`
- [x] Only upload when on main branch
- [x] Use final repository (`kura-apt-dev`)

Please note that `kura.repo.distribution` and `kura.repo.module` are not used at this point given the limited Nexus3 repository structure support.