### PR TITLE
fix(distrib): restore log output

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -1077,7 +1077,7 @@ fi]]>
             <entry key="osgi.bundles" operation="+"
                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.quartz-scheduler.quartz_${quartz.version}.jar@3" />
             <entry key="osgi.bundles" operation="+"
-                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.equinox.permission.cache.fix_${org.eclipse.kura.equinox.permission.cache.fix.version}.jar@1:start" />
+                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.equinox.permission.cache.fix_${org.eclipse.kura.equinox.permission.cache.fix.version}.jar@3:start" />
         </propertyfile>
     </target>
 


### PR DESCRIPTION
While working on #5975 I found out a bug that was preventing log to appear and log files to be created. This bug seems to have been introduced in #5966.

```
WARNING: Using incubator modules: jdk.incubator.foreign, jdk.incubator.vector
2025-09-17T13:25:34.924967367Z main ERROR Unable to load OSGI services: The bundle has no valid BundleContext for serviceType = class org.apache.logging.log4j.spi.Provider, lookup = org.apache.logging.log4j.util.ProviderUtil, lookupClass = class org.apache.logging.log4j.util.ProviderUtil, bundle = org.apache.logging.log4j.api_2.23.1 [39]
2025-09-17T13:25:34.944090886Z main ERROR Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...
```

To fix it I set the start level of the `permission.cache.fix` to `3` instead of `1`.

Looking at #5966 code, it starts before the log4j stuff is up & running and tries to log. I assume this could be the issue.

@salvatore-coppola does `permission.cache.fix` needs to be at start level `1`?

---

**Note**: to test the fix I edited the `config.ini` file on the device since, due to the issue we're having with Github, I cannot currently perform a build reliably. To be tested again with a proper installer before merging.