### PR TITLE
fix(distrib): update start level of `permission.cache.fix`

### DIFF
--- a/kura/distrib/src/main/ant/build_equinox_distrib.xml
+++ b/kura/distrib/src/main/ant/build_equinox_distrib.xml
@@ -1070,7 +1070,7 @@ fi]]>
             <entry key="osgi.bundles" operation="+"
                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.quartz-scheduler.quartz_${quartz.version}.jar@3" />
             <entry key="osgi.bundles" operation="+"
-                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.equinox.permission.cache.fix_${org.eclipse.kura.equinox.permission.cache.fix.version}.jar@3:start" />
+                 value=", reference:file:${kura.install.dir}/${kura.symlink}/${plugins.folder}/org.eclipse.kura.equinox.permission.cache.fix_${org.eclipse.kura.equinox.permission.cache.fix.version}.jar@6:start" />
         </propertyfile>
     </target>
 


### PR DESCRIPTION
As discussed in https://github.com/eclipse-kura/kura/pull/5976#issuecomment-3305746239 we updated the start level of `permission.cache.fix` from `3` to `6`.