### PR TITLE
refactor(distrib): added polkitd alternative dependency, installer net tools scripts moved to .data

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -81,8 +81,11 @@
         <deb.name>kura-core</deb.name>
         <deb.dependencies>
             setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
-            polkit | policykit-1, ssh | openssh, openssl, busybox, libpam-modules,
-            python3, gpsd, openjdk-17-jre-headless | temurin-17-jdk, dos2unix, libtirpc3, chrony, chronyc | chrony
+            polkit | policykit-1 | polkitd,
+            ssh | openssh, openssl, busybox, libpam-modules,
+            python3, gpsd,
+            openjdk-17-jre-headless | temurin-17-jdk,
+            dos2unix, libtirpc3, chrony, chronyc | chrony
         </deb.dependencies>
         <deb.recommendations></deb.recommendations>
         <deb.provides></deb.provides>

--- a/kura/distrib/src/main/resources/filtered/pkg/install/kura_install.sh
+++ b/kura/distrib/src/main/resources/filtered/pkg/install/kura_install.sh
@@ -58,6 +58,9 @@ bash "\${INSTALL_DIR}/kura/install/customize-installation.sh"
 # copy snapshot_0.xml
 cp \${INSTALL_DIR}/kura/user/snapshots/snapshot_0.xml \${INSTALL_DIR}/kura/.data/snapshot_0.xml
 
+# copy network_tools.py
+cp \${INSTALL_DIR}/kura/install/network_tools.py \${INSTALL_DIR}/kura/.data/network_tools.py
+
 # disable NTP service
 if command -v timedatectl > /dev/null ;
   then

--- a/kura/distrib/src/main/resources/unfiltered/pkg/install/customize_kura_properties.py
+++ b/kura/distrib/src/main/resources/unfiltered/pkg/install/customize_kura_properties.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2024 Eurotech and/or its affiliates and others
+# Copyright (c) 2024, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -13,8 +13,10 @@
 #
 import sys
 import logging
-import os
 import argparse
+
+sys.path.append("/opt/eclipse/kura/.data")
+
 from network_tools import get_eth_wlan_interfaces_names
 
 def main():

--- a/kura/distrib/src/main/resources/unfiltered/pkg/install/network_tools.py
+++ b/kura/distrib/src/main/resources/unfiltered/pkg/install/network_tools.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2024 Eurotech and/or its affiliates and others
+# Copyright (c) 2024, 2025 Eurotech and/or its affiliates and others
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
This PR adds `polkitd` alternative dependency and moves `network_tools.py` in `/opt/eclipse/kura/.data` so that it can be used by installers of other addons.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.