### PR TITLE
refactor(distrib): disable log4j2 JMX logging

### DIFF
--- a/kura/distrib/src/main/resources/filtered/pkg/bin/start_kura.sh
+++ b/kura/distrib/src/main/resources/filtered/pkg/bin/start_kura.sh
@@ -27,6 +27,7 @@ if [ -z "$KURA_RUNNING" ] ; then
         -Dkura.custom.configuration=file:\${DIR}/user/kura_custom.properties \
         -Ddpa.configuration=\${DIR}/packages/dpa.properties \
         -Dlog4j.configurationFile=file:\${DIR}/log4j/log4j.xml \
+        -Dlog4j2.disable.jmx=true \
         -Djava.security.policy=\${DIR}/framework/jdk.dio.policy \
         -Djdk.dio.registry=\${DIR}/framework/jdk.dio.properties \
         -Djdk.tls.trustNameService=true \

--- a/kura/distrib/src/main/resources/filtered/pkg/bin/start_kura_background.sh
+++ b/kura/distrib/src/main/resources/filtered/pkg/bin/start_kura_background.sh
@@ -28,6 +28,7 @@ if [ -z "$KURA_RUNNING" ] ; then
         -Dkura.custom.configuration=file:\${DIR}/user/kura_custom.properties \
         -Ddpa.configuration=\${DIR}/packages/dpa.properties \
         -Dlog4j.configurationFile=file:\${DIR}/log4j/log4j.xml \
+        -Dlog4j2.disable.jmx=true \
         -Djava.security.policy=\${DIR}/framework/jdk.dio.policy \
         -Djdk.dio.registry=\${DIR}/framework/jdk.dio.properties \
         -Djdk.tls.trustNameService=true \

--- a/kura/distrib/src/main/resources/filtered/pkg/bin/start_kura_debug.sh
+++ b/kura/distrib/src/main/resources/filtered/pkg/bin/start_kura_debug.sh
@@ -32,6 +32,7 @@ if [ -z "$KURA_RUNNING" ] ; then
         -Dkura.custom.configuration=file:\${DIR}/user/kura_custom.properties \
         -Ddpa.configuration=\${DIR}/packages/dpa.properties \
         -Dlog4j.configurationFile=file:\${DIR}/log4j/log4j.xml \
+        -Dlog4j2.disable.jmx=true \
         -Djava.security.policy=\${DIR}/framework/jdk.dio.policy \
         -Djdk.dio.registry=\${DIR}/framework/jdk.dio.properties \
         -Djdk.tls.trustNameService=true \


### PR DESCRIPTION
This PR disables JMX logging feature of log4j2, which is enabled by default [1]. It solves the following intermittent error stacktrace:

```
2025-09-26T09:55:07.297096301Z pool-25-thread-1 ERROR Could not register mbeans javax.management.InstanceAlreadyExistsException: org.apache.logging.log4j2:type=org.eclipse.kura.http.server.manager,component=Loggers,name=org.glassfish.jersey.internal
Sep 26 11:55:07 raspberry sh[5844]:         at java.management/com.sun.jmx.mbeanserver.Repository.addMBean(Repository.java:322)
Sep 26 11:55:07 raspberry sh[5844]:         at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerWithRepository(DefaultMBeanServerInterceptor.java:1848)
Sep 26 11:55:07 raspberry sh[5844]:         at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerDynamicMBean(DefaultMBeanServerInterceptor.java:945)
Sep 26 11:55:07 raspberry sh[5844]:         at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerObject(DefaultMBeanServerInterceptor.java:880)

...
```

[1] https://logging.apache.org/log4j/2.3.x/manual/jmx.html

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
