### PR TITLE
docs: added new Temurin JRE installation steps for debian Trixie

### DIFF
--- a/docs/getting-started/raspberry-pi-raspberryos-quick-start.md
+++ b/docs/getting-started/raspberry-pi-raspberryos-quick-start.md
@@ -11,6 +11,9 @@ This quickstart has been tested using the latest Raspberry Pi OS 64 bits images 
 
 For additional details on OS compatibility refer to the [Kura&trade; release notes](https://github.com/eclipse-kura/kura/releases).
 
+!!! warning
+    Please note that, at the time of this writing, only 64 bit OS image is supported.
+
 ## Enable SSH Access
 
 The ssh server is disabled by default on Raspbian images released after November 2016,
@@ -41,6 +44,8 @@ following steps:
     !!! tip
         **Optional**: Since version 5.3.0 Kura also supports [Eclipse Temurin&trade;](https://adoptium.net/en-GB/) as an alternative JVM. To install it you need to perform these additional steps:
 
+        <details><summary>Raspbian Bookworm and earlier</summary>
+
         ```bash
         sudo apt-get install -y wget apt-transport-https gnupg
         ```
@@ -52,10 +57,31 @@ following steps:
         ```
         ```bash
         sudo apt-get update
-        ```
-        ```bash
         sudo apt-get install temurin-17-jdk
         ```
+
+        </details>
+
+        <details><summary>Raspbian Trixie and later</summary>
+
+        ```bash
+        sudo mkdir /usr/local/share/keyrings
+        ```
+
+        ```bash
+        curl https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | dd of=/usr/local/share/keyrings/adoptium-keyring.gpg
+        ```
+
+        ```bash
+        echo "deb [signed-by=/usr/local/share/keyrings/adoptium-keyring.gpg] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee -a /etc/apt/sources.list.d/adoptium.list
+        ```
+
+        ```bash
+        sudo apt-get update
+        sudo apt-get install temurin-17-jdk
+        ```
+
+        </details>
 
 4. Download the Kura package with:
 

--- a/docs/getting-started/raspberry-pi-ubuntu-20-quick-start.md
+++ b/docs/getting-started/raspberry-pi-ubuntu-20-quick-start.md
@@ -40,6 +40,8 @@ following steps:
     !!! tip
         **Optional**: Since version 5.3.0 Kura also supports [Eclipse Temurin&trade;](https://adoptium.net/en-GB/) as an alternative JVM. To install it you need to perform these additional steps:
 
+        <details><summary>Debian Bookworm and earlier</summary>
+
         ```bash
         sudo apt-get install -y wget apt-transport-https gnupg
         ```
@@ -51,10 +53,31 @@ following steps:
         ```
         ```bash
         sudo apt-get update
-        ```
-        ```bash
         sudo apt-get install temurin-17-jdk
         ```
+
+        </details>
+
+        <details><summary>Debian Trixie and later</summary>
+
+        ```bash
+        sudo mkdir /usr/local/share/keyrings
+        ```
+
+        ```bash
+        curl https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | dd of=/usr/local/share/keyrings/adoptium-keyring.gpg
+        ```
+
+        ```bash
+        echo "deb [signed-by=/usr/local/share/keyrings/adoptium-keyring.gpg] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee -a /etc/apt/sources.list.d/adoptium.list
+        ```
+
+        ```bash
+        sudo apt-get update
+        sudo apt-get install temurin-17-jdk
+        ```
+
+        </details>
 
 4. Download the Kura package with:
 


### PR DESCRIPTION
`apt-key` is deprecated on Debian Trixie, so a new installation method for the Eclipse Temurin JRE is given.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** Added collapsible sections depending on the OS

<img width="1002" height="696" alt="Screenshot 2025-09-29 at 14 38 35" src="https://github.com/user-attachments/assets/d9fd2ec2-3323-4f04-91f7-8eb986b6b61c" />

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
