### PR TITLE
fix: check existance of parameter in modem

### DIFF
--- a/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/generic/QuectelGeneric.java
+++ b/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/generic/QuectelGeneric.java
@@ -212,9 +212,13 @@ public class QuectelGeneric extends HspaModem implements HspaCellularModem {
             sQnwinfo = sQnwinfo.substring("+QNWINFO:".length()).trim();
             logger.trace("getQueryNetworkInformation() :: +QNWINFO={}", sQnwinfo);
             this.asQnwinfo = sQnwinfo.split(",");
-            this.band = this.asQnwinfo[2].substring(1, this.asQnwinfo[2].length() - 1);
+            if (this.asQnwinfo.length > 2 && this.asQnwinfo[2] != null) {
+                this.band = this.asQnwinfo[2].substring(1, this.asQnwinfo[2].length() - 1);
+            }
             logger.trace("getBand() :: Band={}", this.band);
-            this.radio = this.asQnwinfo[0].substring(1, this.asQnwinfo[0].length() - 1);
+            if (this.asQnwinfo.length > 0 && this.asQnwinfo[0] != null) {
+                this.radio = this.asQnwinfo[0].substring(1, this.asQnwinfo[0].length() - 1);
+            }
             logger.info("getRadio() :: Radio={}", this.radio);
         }
         return this.asQnwinfo;


### PR DESCRIPTION
Problem comes from [here](https://github.com/eclipse-kura/kura/blob/ec0a4a4b5a37e77526911616b19c8dd967e7abdf/kura/org.eclipse.kura.net.admin/src/main/java/org/eclipse/kura/net/admin/modem/quectel/generic/QuectelGeneric.java#L215)  because the band info is not present until the modem has carriers.

We should put a check in the existance of the infos.

Old cause of the problem:
Enabled for WAN the modem with the card inserted and as soon as the cog disappear click on refresh in the modem tab.
A generic error should be logged in the WEBUI due to missing band in the trace logger.