### PR TITLE
chore: Updated netty bundles to 4.1.127

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -65,22 +65,22 @@ This project leverages the following third party content.
 * maven/mavencentral/io.grpc/grpc-protobuf-lite/1.56.1, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/io.grpc/grpc-protobuf/1.56.1, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/io.grpc/grpc-stub/1.56.1, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/io.netty/netty-all/4.1.121.Final, Apache-2.0 AND MIT AND BSD-3-Clause AND CC0-1.0 AND LicenseRef-Public-Domain, approved, CQ22582
-* maven/mavencentral/io.netty/netty-buffer/4.1.121.Final, Apache-2.0, approved, CQ21842
-* maven/mavencentral/io.netty/netty-codec-http/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-codec-mqtt/4.1.121.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
-* maven/mavencentral/io.netty/netty-codec/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-common/4.1.121.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
-* maven/mavencentral/io.netty/netty-handler/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-resolver/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.121.Final, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/io.netty/netty-transport-classes-kqueue/4.1.121.Final, Apache-2.0, approved, #4107
-* maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-transport-native-kqueue/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-transport/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-codec-socks/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-handler-proxy/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-all/4.1.127.Final, Apache-2.0 AND MIT AND BSD-3-Clause AND CC0-1.0 AND LicenseRef-Public-Domain, approved, CQ22582
+* maven/mavencentral/io.netty/netty-buffer/4.1.127.Final, Apache-2.0, approved, CQ21842
+* maven/mavencentral/io.netty/netty-codec-http/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-codec-mqtt/4.1.127.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
+* maven/mavencentral/io.netty/netty-codec/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-common/4.1.127.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
+* maven/mavencentral/io.netty/netty-handler/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-resolver/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.127.Final, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/io.netty/netty-transport-classes-kqueue/4.1.127.Final, Apache-2.0, approved, #4107
+* maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-transport-native-kqueue/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-transport/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-codec-socks/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-handler-proxy/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 * maven/mavencentral/io.perfmark/perfmark-api/0.26.0, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/jakarta.activation/jakarta.activation-api/1.2.2, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 * maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/2.3.3, BSD-3-Clause, approved, ee4j.jaxb

--- a/target-platform/target-platform-bom/pom.xml
+++ b/target-platform/target-platform-bom/pom.xml
@@ -73,7 +73,7 @@
         <guava.version>32.1.1-jre</guava.version>
         <hikaricp.version>2.7.9</hikaricp.version>
         <hk2.version>3.1.1</hk2.version>
-        <io.netty.version>4.1.121.Final</io.netty.version>
+        <io.netty.version>4.1.127.Final</io.netty.version>
         <javassist.version>3.30.2-GA</javassist.version>
         <jersey.version>3.1.9</jersey.version>
         <log4j.version>2.23.1</log4j.version>


### PR DESCRIPTION
This pull request updates the Netty library dependencies across the project from version 4.1.121.Final to 4.1.127.Final. This ensures the project benefits from any bug fixes, security patches, or improvements included in the newer Netty release.

Dependency version updates:

* Updated all Netty dependencies in the `NOTICE.md` file to reference version 4.1.127.Final instead of 4.1.121.Final.
* Changed the `io.netty.version` property in `target-platform/target-platform-bom/pom.xml` from 4.1.121.Final to 4.1.127.Final.