### PR TITLE
fix(distrib): added jre 17 and 21 as alternative virtual package dependencies

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -84,7 +84,7 @@
             polkit | policykit-1 | polkitd,
             ssh | openssh, openssl, busybox, libpam-modules,
             python3, gpsd,
-            openjdk-17-jre-headless | temurin-17-jdk,
+            openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
             dos2unix, libtirpc3, chrony, chronyc | chrony
         </deb.dependencies>
         <deb.recommendations></deb.recommendations>


### PR DESCRIPTION
This PR adds virtual package dependencies to support other JRE concrete packages that do not match the defaults `openjdk-17-jre-headless` or `temurin-17-jdk`.

This PR will allow Kura to run on Java 21.

**Related Issue:** Superseds https://github.com/eclipse-kura/kura/pull/5999.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
