### PR TITLE
fix(distrib): added polkitd, ntpdate, jre 17, jre 21 alternative deps [backport release-5.6]

### DIFF
--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate, 
- openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21)
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/docker-x86_64-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate, 
- openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21)
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/generic-aarch64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64-nn/deb/control/control
@@ -14,7 +14,7 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk,
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
  polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,

--- a/kura/distrib/src/main/resources/generic-aarch64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64-nn/deb/control/control
@@ -14,11 +14,11 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk,
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
- polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
+ polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
- ntpdate, chrony, chronyc | chrony, gpsd, python3
+ ntpdate | ntpsec-ntpdate, chrony, chronyc | chrony, gpsd, python3
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
@@ -14,11 +14,11 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk,
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
- polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
+ polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
- ntpdate, chrony, chronyc | chrony,
+ ntpdate | ntpsec-ntpdate, chrony, chronyc | chrony,
  network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, isc-dhcp-client | dhcpcd, iw, iptables, modemmanager,
  gpsd, python3
 Architecture: all

--- a/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-aarch64/deb/control/control
@@ -14,7 +14,7 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk,
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
  polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,

--- a/kura/distrib/src/main/resources/generic-arm32-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-arm32-nn/deb/control/control
@@ -14,7 +14,7 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk,
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
  polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,

--- a/kura/distrib/src/main/resources/generic-arm32-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-arm32-nn/deb/control/control
@@ -14,11 +14,11 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk,
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
- polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
+ polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
- ntpdate, chrony, chronyc | chrony, gpsd, python3
+ ntpdate | ntpsec-ntpdate, chrony, chronyc | chrony, gpsd, python3
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/control
@@ -14,11 +14,11 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk,
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
- polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
+ polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
- ntpdate, chrony, chronyc | chrony,
+ ntpdate | ntpsec-ntpdate, chrony, chronyc | chrony,
  network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, isc-dhcp-client | dhcpcd, iw, iptables, modemmanager,
  gpsd, python3
 Architecture: all

--- a/kura/distrib/src/main/resources/generic-arm32/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-arm32/deb/control/control
@@ -14,7 +14,7 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk,
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
  polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,

--- a/kura/distrib/src/main/resources/generic-x86_64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-x86_64-nn/deb/control/control
@@ -14,7 +14,7 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk,
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
  polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,

--- a/kura/distrib/src/main/resources/generic-x86_64-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-x86_64-nn/deb/control/control
@@ -14,11 +14,11 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk,
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
- polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
+ polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
- ntpdate, chrony, chronyc | chrony, gpsd, python3
+ ntpdate | ntpsec-ntpdate, chrony, chronyc | chrony, gpsd, python3
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
@@ -14,11 +14,11 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk,
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
- polkit | policykit-1, ssh | openssh, openssl, busybox, openvpn,
+ polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,
- ntpdate, chrony, chronyc | chrony,
+ ntpdate | ntpsec-ntpdate, chrony, chronyc | chrony,
  network-manager | networkmanager, bind9 | bind, dnsmasq | isc-dhcp-server, isc-dhcp-client | dhcpcd, iw, iptables, modemmanager,
  gpsd, python3
 Architecture: all

--- a/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
+++ b/kura/distrib/src/main/resources/generic-x86_64/deb/control/control
@@ -14,7 +14,7 @@ Package: kura
 Version: [[project.version]]
 Section: misc
 Priority: low
-Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
+Depends: openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk,
  setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
  polkit | policykit-1 | polkitd, ssh | openssh, openssl, busybox, openvpn,
  bluez | bluez5, bluez-hcidump | bluez5-noinst-tools,

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
@@ -5,7 +5,7 @@ Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
  bluez, chrony, ntpdate | ntpsec-ntpdate, 
- openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21)
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20-nn/deb/control/control
@@ -4,8 +4,8 @@ Section: misc
 Priority: low
 Depends: dos2unix, unzip, 
  telnet, bluez-hcidump, 
- bluez, chrony, ntpdate, 
- openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk
+ bluez, chrony, ntpdate | ntpsec-ntpdate, 
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21)
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
@@ -6,9 +6,9 @@ Depends: hostapd, isc-dhcp-server, iw,
  dos2unix, bind9, unzip, 
  ethtool, telnet, bluez-hcidump, 
  bluez, wireless-tools, net-tools, 
- iptables, chrony, ntpdate, 
+ iptables, chrony, ntpdate | ntpsec-ntpdate, 
  ifupdown,
- openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk, 
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
  dmidecode
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/deb/control/control
@@ -8,7 +8,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  bluez, wireless-tools, net-tools, 
  iptables, chrony, ntpdate | ntpsec-ntpdate, 
  ifupdown,
- openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk,
  dmidecode
 Architecture: all
 Maintainer: support@eurotech.com

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
@@ -4,7 +4,7 @@ Section: misc
 Priority: low
 Depends: dos2unix, unzip, telnet, 
  bluez-hcidump, chrony, ntpdate | ntpsec-ntpdate, 
- openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21)
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano-nn/deb/control/control
@@ -3,8 +3,8 @@ Version: [[project.version]]
 Section: misc
 Priority: low
 Depends: dos2unix, unzip, telnet, 
- bluez-hcidump, chrony, ntpdate, 
- openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk
+ bluez-hcidump, chrony, ntpdate | ntpsec-ntpdate, 
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21)
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
@@ -7,7 +7,7 @@ Depends: hostapd, isc-dhcp-server, iw,
  ethtool, telnet, ifupdown, 
  net-tools, iptables, chrony, 
  dmidecode, ntpdate | ntpsec-ntpdate,
- openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21)
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21) | openjdk-8-jre-headless | temurin-8-jdk
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/deb/control/control
@@ -6,8 +6,8 @@ Depends: hostapd, isc-dhcp-server, iw,
  dos2unix, bind9, unzip, 
  ethtool, telnet, ifupdown, 
  net-tools, iptables, chrony, 
- dmidecode, ntpdate,
- openjdk-17-jre-headless | temurin-17-jdk | openjdk-8-jre-headless | temurin-8-jdk
+ dmidecode, ntpdate | ntpsec-ntpdate,
+ openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21)
 Architecture: all
 Maintainer: support@eurotech.com
 Description: Kura is an inclusive software framework that puts a layer


### PR DESCRIPTION
This PR adds alternative dependencies for polkit, ntpdate, and java to support Debian Trixie.

Java alternatives updated following https://github.com/eclipse-kura/kura/pull/6006.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.