### PR TITLE
chore: Updated netty bundles to 4.1.127 [Backport 5.6.0]

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -73,20 +73,20 @@ This project leverages the following third party content.
 * maven/mavencentral/io.grpc/grpc-protobuf-lite/1.56.1, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/io.grpc/grpc-protobuf/1.56.1, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/io.grpc/grpc-stub/1.56.1, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/io.netty/netty-all/4.1.121.Final, Apache-2.0 AND MIT AND BSD-3-Clause AND CC0-1.0 AND LicenseRef-Public-Domain, approved, CQ22582
-* maven/mavencentral/io.netty/netty-buffer/4.1.121.Final, Apache-2.0, approved, CQ21842
-* maven/mavencentral/io.netty/netty-codec-http/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-codec-mqtt/4.1.121.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
-* maven/mavencentral/io.netty/netty-codec/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-common/4.1.121.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
-* maven/mavencentral/io.netty/netty-handler/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-resolver/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.121.Final, Apache-2.0, approved, clearlydefined
-* maven/mavencentral/io.netty/netty-transport-classes-kqueue/4.1.121.Final, Apache-2.0, approved, #4107
-* maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-transport-native-kqueue/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
-* maven/mavencentral/io.netty/netty-transport/4.1.121.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-all/4.1.127.Final, Apache-2.0 AND MIT AND BSD-3-Clause AND CC0-1.0 AND LicenseRef-Public-Domain, approved, CQ22582
+* maven/mavencentral/io.netty/netty-buffer/4.1.127.Final, Apache-2.0, approved, CQ21842
+* maven/mavencentral/io.netty/netty-codec-http/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-codec-mqtt/4.1.127.Final, Apache-2.0 OR LicenseRef-Public-Domain OR BSD-2-Clause OR MIT, approved, CQ15280
+* maven/mavencentral/io.netty/netty-codec/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-common/4.1.127.Final, Apache-2.0 AND MIT AND CC0-1.0, approved, CQ21843
+* maven/mavencentral/io.netty/netty-handler/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-resolver/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-transport-classes-epoll/4.1.127.Final, Apache-2.0, approved, clearlydefined
+* maven/mavencentral/io.netty/netty-transport-classes-kqueue/4.1.127.Final, Apache-2.0, approved, #4107
+* maven/mavencentral/io.netty/netty-transport-native-epoll/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-transport-native-kqueue/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-transport-native-unix-common/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
+* maven/mavencentral/io.netty/netty-transport/4.1.127.Final, Apache-2.0 AND BSD-3-Clause AND MIT, approved, CQ20926
 * maven/mavencentral/io.perfmark/perfmark-api/0.26.0, Apache-2.0, approved, clearlydefined
 * maven/mavencentral/jakarta.activation/jakarta.activation-api/1.2.2, EPL-2.0 OR BSD-3-Clause OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jaf
 * maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/2.3.3, BSD-3-Clause, approved, ee4j.jaxb

--- a/kura/org.eclipse.kura.ai.triton.server/pom.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/pom.xml
@@ -113,9 +113,9 @@
 				<artifactId>protobuf-maven-plugin</artifactId>
 				<version>${protobuf-maven-plugin.version}</version>
 				<configuration>
-					<protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:osx-x86_64</protocArtifact>
+					<protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
 					<pluginId>grpc-java</pluginId>
-					<pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</pluginArtifact>
+					<pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
 				</configuration>
 				<executions>
 					<execution>

--- a/kura/org.eclipse.kura.ai.triton.server/pom.xml
+++ b/kura/org.eclipse.kura.ai.triton.server/pom.xml
@@ -113,9 +113,9 @@
 				<artifactId>protobuf-maven-plugin</artifactId>
 				<version>${protobuf-maven-plugin.version}</version>
 				<configuration>
-					<protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
+					<protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:osx-x86_64</protocArtifact>
 					<pluginId>grpc-java</pluginId>
-					<pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+					<pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</pluginArtifact>
 				</configuration>
 				<executions>
 					<execution>

--- a/kura/org.eclipse.kura.driver.opcua.provider/pom.xml
+++ b/kura/org.eclipse.kura.driver.opcua.provider/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <kura.basedir>${project.basedir}/..</kura.basedir>
         <com.google.guava.version>32.1.1-jre</com.google.guava.version>
-        <io.netty.version>4.1.121.Final</io.netty.version>
+        <io.netty.version>4.1.127.Final</io.netty.version>
         <org.eclipse.milo.version>0.6.8</org.eclipse.milo.version>
         <com.digitalpetri.netty.netty-channel-fsm.version>0.8</com.digitalpetri.netty.netty-channel-fsm.version>
         <com.digitalpetri.fsm.strict-machine.version>0.6</com.digitalpetri.fsm.strict-machine.version>

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -71,7 +71,7 @@ org.apache.geronimo.specs.jms.version=1.0.0.alpha-2
 org.apache.geronimo.specs.jta.version=1.1.1
 guava.version=32.1.1-jre
 failureaccess.version=1.0.1
-io.netty.version=4.1.121.Final
+io.netty.version=4.1.127.Final
 org.jboss.logging.version=3.3.2.Final
 spring.version=4.3.20.RELEASE_1
 


### PR DESCRIPTION
This pull request updates the Netty dependency across the project from version 4.1.121.Final to 4.1.127.Final. This ensures the project uses the latest compatible version of Netty, which may include important bug fixes and security updates.

Dependency version updates:

* Updated all `io.netty` dependencies in `NOTICE.md` to version 4.1.127.Final to reflect the new Netty version in the third-party content list.
* Updated the Netty version property from 4.1.121.Final to 4.1.127.Final in `kura/org.eclipse.kura.driver.opcua.provider/pom.xml`.
* Updated the Netty version reference in `target-platform/config/kura.target-platform.build.properties` to 4.1.127.Final.