### PR TITLE
fix: fixed verifyCRL ignored by CRLManagerOptions.equals()

### DIFF
--- a/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/crl/CRLManagerOptions.java
+++ b/kura/org.eclipse.kura.core.keystore/src/main/java/org/eclipse/kura/core/keystore/crl/CRLManagerOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021, 2025 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -110,7 +110,8 @@ public class CRLManagerOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hash(crlCheckIntervalMs, crlManagementEnabled, crlStore, crlURIs, crlUpdateIntervalMs);
+        return Objects.hash(crlCheckIntervalMs, crlManagementEnabled, crlStore, crlURIs, crlUpdateIntervalMs,
+                verifyCRL);
     }
 
     @Override
@@ -124,7 +125,7 @@ public class CRLManagerOptions {
         CRLManagerOptions other = (CRLManagerOptions) obj;
         return crlCheckIntervalMs == other.crlCheckIntervalMs && crlManagementEnabled == other.crlManagementEnabled
                 && Objects.equals(crlStore, other.crlStore) && Objects.equals(crlURIs, other.crlURIs)
-                && crlUpdateIntervalMs == other.crlUpdateIntervalMs;
+                && crlUpdateIntervalMs == other.crlUpdateIntervalMs && verifyCRL == other.verifyCRL;
     }
 
 }

--- a/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/crl/test/FilesystemKeystoreServiceImplCrlTest.java
+++ b/kura/test/org.eclipse.kura.core.keystore.test/src/test/java/org/eclipse/kura/core/keystore/crl/test/FilesystemKeystoreServiceImplCrlTest.java
@@ -414,6 +414,47 @@ public class FilesystemKeystoreServiceImplCrlTest {
         }
     }
 
+    @Test
+    public void shouldSupportDisablingCRLVerificationWithUpdate() throws Exception {
+        final X500Name name = new X500Name("cn=Test CA, dc=bar.com");
+
+        try (final Fixture fixture = new Fixture()) {
+
+            final TestCA ca = new TestCA(CertificateCreationOptions.builder(name)
+                    .withCRLDownloadURI(new URI(fixture.getCrlDownloadURL("/foo.crl"))).build());
+
+            CompletableFuture<String> nextDownload = fixture.nextDownloadRelativeURI();
+
+            fixture.setOptions(fixture.getOptions().setCrlManagerEnabled(true).setCrlUpdateInterval(1)
+                    .setCrlUpdateIntervalTimeUnit(TimeUnit.SECONDS));
+            fixture.activate();
+            fixture.update(fixture.getOptions().setCrlVerificationEnabled(false));
+
+            final X509CRL crl = ca.generateCRL(CRLCreationOptions.builder().build());
+            fixture.setCrl("/foo.crl", crl);
+
+            fixture.keystoreService.setEntry("foo", new TrustedCertificateEntry(ca.getCertificate()));
+
+            assertEquals("/foo.crl", nextDownload.get(1, TimeUnit.MINUTES));
+            assertEquals(DEFAULT_KEYSTORE_PID,
+                    ((KeystoreChangedEvent) fixture.expectNextEventAdminEvent(1, TimeUnit.MINUTES)).getSenderPid());
+            assertEquals(DEFAULT_KEYSTORE_PID,
+                    ((KeystoreChangedEvent) fixture.expectNextEventAdminEvent(1, TimeUnit.MINUTES)).getSenderPid());
+
+            final TestCA otherCA = new TestCA(CertificateCreationOptions.builder(name).build());
+            fixture.setCrl("/foo.crl", otherCA.generateCRL(CRLCreationOptions.builder().build()));
+
+            nextDownload = fixture.nextDownloadRelativeURI();
+            nextDownload.get(1, TimeUnit.MINUTES);
+
+            nextDownload = fixture.nextDownloadRelativeURI();
+            nextDownload.get(1, TimeUnit.MINUTES);
+
+            assertEquals(true, fixture.nextEventAdminEvent(10, TimeUnit.SECONDS).isPresent());
+
+        }
+    }
+
     private static class Fixture implements AutoCloseable {
 
         private final FilesystemKeystoreServiceImpl keystoreService = new FilesystemKeystoreServiceImpl();


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

Adds the missing `verifyCRL` field to the `hashCode` and `equals` methods of `CRLManagerOptions`
