### PR TITLE
fix(distrib): Fixed packages dir permissions

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -819,6 +819,17 @@
                                 </mapper>
                             </data>
                             <data>
+                                <src>${project.build.directory}/pkg/packages/</src>
+                                <type>directory</type>
+                                <mapper>
+                                    <type>perm</type>
+                                    <prefix>${kura.install.dir}/${kura.symlink}/packages</prefix>
+                                    <user>root</user>
+                                    <group>root</group>
+                                    <filemode>600</filemode>
+                                </mapper>
+                            </data>
+                            <data>
                                 <src>${project.build.directory}/pkg/plugins/</src>
                                 <type>directory</type>
                                 <mapper>

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -97,6 +100,9 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
     private static final String READ_TIMEOUT_PROPNAME = "dpa.read.timeout";
 
     private static final long THREAD_TERMINATION_TOUT = 1; // in seconds
+
+    private static final Set<PosixFilePermission> DEFAULT_PACKAGES_DIR_PERMMISION = PosixFilePermissions
+            .fromString("rwx------");
 
     private DeploymentAdmin deploymentAdmin;
     private EventAdmin eventAdmin;
@@ -172,8 +178,13 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         }
 
         File packagesDir = new File(this.packagesPath);
-        if (!packagesDir.exists() && !packagesDir.mkdirs()) {
-            throw new ComponentException("Cannot create packages directory");
+        if (!packagesDir.exists()) {
+            try {
+                Files.createDirectories(Path.of(this.packagesPath),
+                        PosixFilePermissions.asFileAttribute(DEFAULT_PACKAGES_DIR_PERMMISION));
+            } catch (Exception e) {
+                throw new ComponentException("Cannot create packages directory", e);
+            }
         }
 
         installPackagesFromConfFile();

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -181,7 +181,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
         if (!packagesDir.exists()) {
             try {
                 Files.createDirectories(Path.of(this.packagesPath),
-                        PosixFilePermissions.asFileAttribute(DEFAULT_PACKAGES_DIR_PERMMISION));
+                        PosixFilePermissions.asFileAttribute(DEFAULT_PACKAGES_DIR_PERMISSIONS));
             } catch (Exception e) {
                 throw new ComponentException("Cannot create packages directory", e);
             }

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -101,7 +101,7 @@ public class DeploymentAgent implements DeploymentAgentService, ConfigurableComp
 
     private static final long THREAD_TERMINATION_TOUT = 1; // in seconds
 
-    private static final Set<PosixFilePermission> DEFAULT_PACKAGES_DIR_PERMMISION = PosixFilePermissions
+    private static final Set<PosixFilePermission> DEFAULT_PACKAGES_DIR_PERMISSIONS = PosixFilePermissions
             .fromString("rwx------");
 
     private DeploymentAdmin deploymentAdmin;

--- a/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
+++ b/kura/org.eclipse.kura.deployment.agent/src/main/java/org/eclipse/kura/deployment/agent/impl/DeploymentAgent.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *  Red Hat Inc


### PR DESCRIPTION
Fixed packages directory permissions, the package directory now is managed by the installer, if it doesn't exist it's created with permission `600`