### PR TITLE
chore: Removed systemd-hostnamed disabling [backport-release-5.6.0]

### DIFF
--- a/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
+++ b/kura/distrib/src/main/resources/intel-up2-ubuntu-20/kura_install.sh
@@ -177,10 +177,6 @@ systemctl disable resolvconf.service
 systemctl stop ModemManager
 systemctl disable ModemManager
 
-#disable systemd-hostnamed
-systemctl stop systemd-hostnamed
-systemctl disable systemd-hostnamed
-
 #disable wpa_supplicant
 systemctl stop wpa_supplicant
 systemctl disable wpa_supplicant

--- a/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
+++ b/kura/distrib/src/main/resources/nvidia-jetson-nano/kura_install.sh
@@ -178,10 +178,6 @@ systemctl disable resolvconf.service
 systemctl stop ModemManager
 systemctl disable ModemManager
 
-#disable systemd-hostnamed
-systemctl stop systemd-hostnamed
-systemctl disable systemd-hostnamed
-
 #disable wpa_supplicant
 systemctl stop wpa_supplicant
 systemctl disable wpa_supplicant


### PR DESCRIPTION
Removed `systemd-hostnamed` disabling