### PR TITLE
ci(Jenkinsfile): fix load `nexusUtils` for package upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,7 @@ node {
             def repoDistribution = distribPom.properties['kura.repo.distribution']
             def repoModule = distribPom.properties['kura.repo.module']
 
+            def nexusUtils = load 'kura/.jenkins/nexusUtils.groovy'
             nexusUtils.uploadPackages(repoDistribution, repoModule)
         } else {
             echo "Skipping DEB upload"


### PR DESCRIPTION
Fix jenkins pipeline.

The load was mistakenly deleted in 9780713ab7c1b9f3f51b2edff7c92268b4115975