### PR TITLE
ci(Jenkinsfile): fix return status handling in `nexusUtils.groovy`

### DIFF
--- a/.jenkins/nexusUtils.groovy
+++ b/.jenkins/nexusUtils.groovy
@@ -34,8 +34,8 @@ def uploadPackages(String repoDistribution, String repoModule, Boolean setupProm
                         \"https://repo3.eclipse.org/repository/kura-apt-dev/\" \
                         -o /dev/null
                     """,
-                    returnStatus: true
-                )
+                    returnStdout: true
+                ).trim()
 
                 if (status != "201") {
                     error("Returned status code = $status")


### PR DESCRIPTION
🤦 This is what happens when you code too fast.

Hopefully this is the last issue