### PR TITLE
fix: Allowed to get GPIO by name in CloudConnectionStatusService

### DIFF
--- a/kura/distrib/src/main/resources/filtered/pkg/framework/kura.properties
+++ b/kura/distrib/src/main/resources/filtered/pkg/framework/kura.properties
@@ -93,8 +93,12 @@ ccs.status.notification.url=ccs:log
 
 #2. Cloud Connection Status on LED
 #The Cloud Connection Status will be indicated by a blinking LED connected to the system GPIOs
-#The URL should indicate the GPIO logic index of the GPIO Pin used for the LED
+#The URL should identify the GPIO to be used, either by name or by terminal index as defined by Kura GpioService.
+# Syntax for using GPIO terminal index:
 #ccs.status.notification.url=ccs:led:16
+#ccs.status.notification.url=ccs:led:terminal:16
+# Syntax for using GPIO name:
+#ccs.status.notification.url=ccs:led:name:LED_1
 
 #3. Cloud Connection Status disabled
 #Disables the Cloud Connection Status service

--- a/kura/emulator/org.eclipse.kura.emulator/src/main/resources/kura.properties
+++ b/kura/emulator/org.eclipse.kura.emulator/src/main/resources/kura.properties
@@ -84,8 +84,12 @@ ccs.status.notification.url=ccs:log
 
 #2. Cloud Connection Status on LED
 #The Cloud Connection Status will be indicated by a blinking LED connected to the system GPIOs
-#The URL should indicate the GPIO logic index of the GPIO Pin used for the LED
+#The URL should identify the GPIO to be used, either by name or by terminal index as defined by Kura GpioService.
+# Syntax for using GPIO terminal index:
 #ccs.status.notification.url=ccs:led:16
+#ccs.status.notification.url=ccs:led:terminal:16
+# Syntax for using GPIO name:
+#ccs.status.notification.url=ccs:led:name:LED_1
 
 #3. Cloud Connection Status disabled
 #Disables the Cloud Connection Status service

--- a/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImpl.java
+++ b/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImpl.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.eclipse.kura.core.status.GpioLedManager.GpioIdentifier;
 import org.eclipse.kura.core.status.runnables.BlinkStatusRunnable;
 import org.eclipse.kura.core.status.runnables.HeartbeatStatusRunnable;
 import org.eclipse.kura.core.status.runnables.LogStatusRunnable;
@@ -176,15 +177,21 @@ public class CloudConnectionStatusServiceImpl implements CloudConnectionStatusSe
     private StatusRunnable getRunnable(CloudConnectionStatusEnum status) {
         StatusRunnable runnable = null;
 
-        StatusNotificationTypeEnum notificationType = (StatusNotificationTypeEnum) this.properties
-                .get(CloudConnectionStatusURL.NOTIFICATION_TYPE);
+        StatusNotificationTypeEnum notificationType = Optional
+                .ofNullable(this.properties.get(CloudConnectionStatusURL.NOTIFICATION_TYPE))
+                .filter(StatusNotificationTypeEnum.class::isInstance).map(StatusNotificationTypeEnum.class::cast)
+                .orElseGet(() -> {
+                    logger.warn("Invalid {} property, disabiling cloud connection status notifications",
+                            STATUS_NOTIFICATION_URL);
+                    return StatusNotificationTypeEnum.NONE;
+                });
 
         switch (notificationType) {
         case LED:
-            if (this.properties.get("linux_led") != null) {
+            if (this.properties.get("linux_led") instanceof String) {
                 runnable = getLinuxStatusWorker(status);
             }
-            if (runnable == null && this.properties.get("led") != null) {
+            if (runnable == null && this.properties.get("led") instanceof GpioIdentifier) {
                 runnable = getGpioStatusWorker(status);
             }
             if (runnable == null) {
@@ -234,9 +241,18 @@ public class CloudConnectionStatusServiceImpl implements CloudConnectionStatusSe
         if (!this.gpioService.isPresent()) {
             return null;
         }
-        int gpioLed = (Integer) this.properties.get("led");
-        boolean inverted = (Boolean) this.properties.get("inverted");
-        LedManager gpioLedManager = new GpioLedManager(this.gpioService.get(), gpioLed, inverted);
+
+        final Object rawIdentifier = this.properties.get("led");
+        final GpioIdentifier identifier;
+
+        if (rawIdentifier instanceof GpioIdentifier) {
+            identifier = (GpioIdentifier) rawIdentifier;
+        } else {
+            throw new IllegalStateException("invaild gpio identifier: " + rawIdentifier);
+        }
+
+        final boolean inverted = Boolean.TRUE.equals(this.properties.get("inverted"));
+        LedManager gpioLedManager = new GpioLedManager(this.gpioService.get(), identifier, inverted);
 
         return createLedRunnable(status, gpioLedManager);
     }

--- a/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusURL.java
+++ b/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusURL.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/

--- a/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusURL.java
+++ b/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/CloudConnectionStatusURL.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,11 +17,17 @@ import static java.util.Objects.requireNonNull;
 import java.util.Locale;
 import java.util.Properties;
 
+import org.eclipse.kura.core.status.GpioLedManager.GpioIdentifier;
+import org.eclipse.kura.core.status.GpioLedManager.GpioName;
+import org.eclipse.kura.core.status.GpioLedManager.GpioTerminal;
+
 public class CloudConnectionStatusURL {
 
     public static final String NOTIFICATION_TYPE = "notification_type";
     public static final String CCS = "ccs:";
     public static final String LED = "led:";
+    public static final String LED_NAME_PREFIX = "name:";
+    public static final String LED_TERMINAL_PREFIX = "terminal:";
     public static final String LINUX_LED = "linux_led:";
     public static final String LOG = "log";
     public static final String NONE = "none";
@@ -61,21 +67,21 @@ public class CloudConnectionStatusURL {
         String urlLowerCase = urlImage.toLowerCase(Locale.ENGLISH);
         if (urlLowerCase.startsWith(LED)) {
             // Cloud Connection Status on LED
-            String ledString = urlLowerCase.replace(LED, "").trim();
+            String ledString = urlImage.substring(4);
             try {
-                if (ledString.endsWith(INVERTED)) {
-                    props.put("inverted", true);
-                } else {
-                    props.put("inverted", false);
+
+                final boolean inverted = urlLowerCase.endsWith(INVERTED);
+
+                if (inverted) {
+                    ledString = ledString.substring(0, ledString.length() - INVERTED.length());
                 }
 
-                // in case of typo
-                if (ledString.contains(":")) {
-                    ledString = ledString.substring(0, ledString.indexOf(":"));
-                }
-                int ledPin = Integer.parseInt(ledString.trim());
+                props.put("inverted", inverted);
+
+                final GpioIdentifier identifier = parseLedIdentifier(ledString);
+
                 props.put(NOTIFICATION_TYPE, StatusNotificationTypeEnum.LED);
-                props.put("led", ledPin);
+                props.put("led", identifier);
             } catch (Exception ex) {
                 // Do nothing
             }
@@ -89,5 +95,27 @@ public class CloudConnectionStatusURL {
             props.put(NOTIFICATION_TYPE, StatusNotificationTypeEnum.NONE);
         }
         return props;
+    }
+
+    private static GpioIdentifier parseLedIdentifier(final String identifier) {
+        if (identifier.toLowerCase().startsWith(LED_NAME_PREFIX)) {
+            final String name = identifier.substring(LED_NAME_PREFIX.length());
+
+            if (!name.isEmpty()) {
+                return new GpioName(name);
+            }
+        } else {
+            final String number;
+
+            if (identifier.toLowerCase().startsWith(LED_TERMINAL_PREFIX)) {
+                number = identifier.substring(LED_TERMINAL_PREFIX.length());
+            } else {
+                number = identifier;
+            }
+
+            return new GpioTerminal(Integer.parseInt(number.trim()));
+        }
+
+        throw new IllegalArgumentException("invalid GPIO identifier " + identifier);
     }
 }

--- a/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/GpioLedManager.java
+++ b/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/GpioLedManager.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/

--- a/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/GpioLedManager.java
+++ b/kura/org.eclipse.kura.core.status/src/main/java/org/eclipse/kura/core/status/GpioLedManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
 package org.eclipse.kura.core.status;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.eclipse.kura.KuraErrorCode;
 import org.eclipse.kura.KuraException;
@@ -31,28 +32,35 @@ public class GpioLedManager implements LedManager {
 
     private static final Logger logger = LoggerFactory.getLogger(GpioLedManager.class);
 
-    private int ledId;
-    private GPIOService gpioService;
-    private boolean inverted;
+    private final GpioIdentifier identifier;
+    private final GPIOService gpioService;
+    private final boolean inverted;
 
-    public GpioLedManager(GPIOService gpioService, int led) {
-        this(gpioService, led, false);
+    public GpioLedManager(GPIOService gpioService, GpioIdentifier identifier) {
+        this(gpioService, identifier, false);
     }
 
-    public GpioLedManager(GPIOService gpioService, int led, boolean inverted) {
-        this.ledId = led;
+    public GpioLedManager(GPIOService gpioService, GpioIdentifier identifier, boolean inverted) {
+        this.identifier = identifier;
         this.gpioService = gpioService;
         this.inverted = inverted;
     }
-    
+
     public void writeLed(boolean enabled) throws KuraException {
-        KuraGPIOPin notificationLED = this.gpioService.getPinByTerminal(ledId, KuraGPIODirection.OUTPUT,
-                KuraGPIOMode.OUTPUT_OPEN_DRAIN, KuraGPIOTrigger.NONE);
+        final KuraGPIOPin notificationLED;
+
+        if (identifier instanceof GpioTerminal) {
+            notificationLED = this.gpioService.getPinByTerminal(((GpioTerminal) identifier).getNumber(),
+                    KuraGPIODirection.OUTPUT, KuraGPIOMode.OUTPUT_OPEN_DRAIN, KuraGPIOTrigger.NONE);
+        } else {
+            notificationLED = this.gpioService.getPinByName(((GpioName) identifier).getName(), KuraGPIODirection.OUTPUT,
+                    KuraGPIOMode.OUTPUT_OPEN_DRAIN, KuraGPIOTrigger.NONE);
+        }
 
         try {
             if (!notificationLED.isOpen()) {
                 notificationLED.open();
-                logger.info("CloudConnectionStatus active on LED {}.", ledId);
+                logger.info("CloudConnectionStatus active on LED {}.", identifier);
             }
             notificationLED.setValue(enabled ^ inverted);
 
@@ -63,6 +71,81 @@ public class GpioLedManager implements LedManager {
             logger.error("Error accessing to the specified LED!");
             throw new KuraException(KuraErrorCode.UNAVAILABLE_DEVICE);
         }
+    }
+
+    public interface GpioIdentifier {
+    }
+
+    public static class GpioTerminal implements GpioIdentifier {
+
+        private final int number;
+
+        public GpioTerminal(final int number) {
+            this.number = number;
+        }
+
+        public int getNumber() {
+            return number;
+        }
+
+        @Override
+        public String toString() {
+            return Integer.toString(number);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(number);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof GpioTerminal)) {
+                return false;
+            }
+            GpioTerminal other = (GpioTerminal) obj;
+            return number == other.number;
+        }
+
+    }
+
+    public static class GpioName implements GpioIdentifier {
+
+        private final String name;
+
+        public GpioName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof GpioName)) {
+                return false;
+            }
+            GpioName other = (GpioName) obj;
+            return Objects.equals(name, other.name);
+        }
+
     }
 
 }

--- a/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImplTest.java
+++ b/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusServiceImplTest.java
@@ -44,6 +44,34 @@ public class CloudConnectionStatusServiceImplTest {
     private static final String STATUS_NOTIFICATION_URL = "ccs.status.notification.url";
 
     @Test
+    public void testActivateEmptyProperty() throws NoSuchFieldException {
+        CloudConnectionStatusServiceImpl service = initCloudConnectionStatusService("");
+
+        ComponentContext componentContext = mock(ComponentContext.class);
+        service.activate(componentContext);
+
+        assertNotNull(TestUtil.getFieldValue(service, "properties"));
+        assertNotNull(TestUtil.getFieldValue(service, "idleComponent"));
+        HashSet<CloudConnectionStatusComponent> componentRegistry = (HashSet) TestUtil.getFieldValue(service,
+                "componentRegistry");
+        assertEquals(1, componentRegistry.size());
+    }
+
+    @Test
+    public void testActivateInvalidProperty() throws NoSuchFieldException {
+        CloudConnectionStatusServiceImpl service = initCloudConnectionStatusService("ccs:foo");
+
+        ComponentContext componentContext = mock(ComponentContext.class);
+        service.activate(componentContext);
+
+        assertNotNull(TestUtil.getFieldValue(service, "properties"));
+        assertNotNull(TestUtil.getFieldValue(service, "idleComponent"));
+        HashSet<CloudConnectionStatusComponent> componentRegistry = (HashSet) TestUtil.getFieldValue(service,
+                "componentRegistry");
+        assertEquals(1, componentRegistry.size());
+    }
+
+    @Test
     public void testActivateNone() throws NoSuchFieldException {
         CloudConnectionStatusServiceImpl service = initCloudConnectionStatusService("ccs:none");
 

--- a/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusURLTest.java
+++ b/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusURLTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
- * 
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/

--- a/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusURLTest.java
+++ b/kura/test/org.eclipse.kura.core.status.test/src/test/java/org/eclipse/kura/core/status/CloudConnectionStatusURLTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2025 Eurotech and/or its affiliates and others
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -16,8 +16,11 @@ import static org.eclipse.kura.core.status.CloudConnectionStatusURL.NOTIFICATION
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
 import java.util.Properties;
 
+import org.eclipse.kura.core.status.GpioLedManager.GpioName;
+import org.eclipse.kura.core.status.GpioLedManager.GpioTerminal;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -73,7 +76,7 @@ public class CloudConnectionStatusURLTest {
         Properties props = CloudConnectionStatusURL.parseURL(CCS_PREFIX + LED_44);
         assertNotNull(props);
         assertEquals(StatusNotificationTypeEnum.LED, props.get(NOTIFICATION_TYPE));
-        assertEquals(44, props.get("led"));
+        assertEquals(new GpioTerminal(44), props.get("led"));
         assertEquals(false, props.get("inverted"));
         assertEquals(4, props.size());
     }
@@ -83,11 +86,11 @@ public class CloudConnectionStatusURLTest {
         Properties props = CloudConnectionStatusURL.parseURL(CCS_PREFIX + LED_44 + INVERTED);
         assertNotNull(props);
         assertEquals(StatusNotificationTypeEnum.LED, props.get(NOTIFICATION_TYPE));
-        assertEquals(44, props.get("led"));
+        assertEquals(new GpioTerminal(44), props.get("led"));
         assertEquals(4, props.size());
         assertEquals(true, props.get("inverted"));
     }
-    
+
     @Test
     public void testParseUrlCcsLinuxLed() {
         Properties props = CloudConnectionStatusURL.parseURL(CCS_PREFIX + LINUX_LED_LED1_GREEN);
@@ -104,12 +107,12 @@ public class CloudConnectionStatusURLTest {
                 .parseURL(CCS_PREFIX + LINUX_LED_LED1_GREEN + ";" + CCS_PREFIX + LED_44);
         assertNotNull(props);
         assertEquals(StatusNotificationTypeEnum.LED, props.get(NOTIFICATION_TYPE));
-        assertEquals(44, props.get("led"));
+        assertEquals(new GpioTerminal(44), props.get("led"));
         assertEquals(LINUX_LED_LED1_GREEN_PATH, props.get("linux_led"));
         assertEquals(false, props.get("inverted"));
         assertEquals(5, props.size());
     }
-    
+
     @Test
     public void testParseUrlCcsLinuxWrongGpioLed() {
         Properties props = CloudConnectionStatusURL
@@ -121,17 +124,39 @@ public class CloudConnectionStatusURLTest {
     }
 
     @Test
+    public void testParseUrlCcsGpioLedName() {
+        Properties props = CloudConnectionStatusURL
+                .parseURL(CCS_PREFIX + LINUX_LED_LED1_GREEN + ";" + CCS_PREFIX + "led:name:test");
+        assertNotNull(props);
+        assertEquals(StatusNotificationTypeEnum.LED, props.get(NOTIFICATION_TYPE));
+        assertEquals(LINUX_LED_LED1_GREEN_PATH, props.get("linux_led"));
+        assertEquals(new GpioName("test"), props.get("led"));
+        assertEquals(5, props.size());
+    }
+
+    @Test
+    public void testParseUrlCcsGpioLedWithTerminalPrefix() {
+        Properties props = CloudConnectionStatusURL
+                .parseURL(CCS_PREFIX + LINUX_LED_LED1_GREEN + ";" + CCS_PREFIX + "led:terminal:12");
+        assertNotNull(props);
+        assertEquals(StatusNotificationTypeEnum.LED, props.get(NOTIFICATION_TYPE));
+        assertEquals(LINUX_LED_LED1_GREEN_PATH, props.get("linux_led"));
+        assertEquals(new GpioTerminal(12), props.get("led"));
+        assertEquals(5, props.size());
+    }
+
+    @Test
     public void testParseUrlCcsGpioLinuxLed() {
         Properties props = CloudConnectionStatusURL
                 .parseURL(CCS_PREFIX + LED_44 + ";" + CCS_PREFIX + LINUX_LED_LED1_GREEN);
         assertNotNull(props);
         assertEquals(StatusNotificationTypeEnum.LED, props.get(NOTIFICATION_TYPE));
-        assertEquals(44, props.get("led"));
+        assertEquals(new GpioTerminal(44), props.get("led"));
         assertEquals(LINUX_LED_LED1_GREEN_PATH, props.get("linux_led"));
         assertEquals(false, props.get("inverted"));
         assertEquals(5, props.size());
     }
-    
+
     @Test
     public void testParseUrlCcsLinuxLedUpperCasePath() {
         Properties props = CloudConnectionStatusURL.parseURL(CCS_PREFIX + LINUX_LED_TEST_UPPER_CASE);

--- a/kura/test/org.eclipse.kura.core.test/src/main/resources/kura.properties
+++ b/kura/test/org.eclipse.kura.core.test/src/main/resources/kura.properties
@@ -84,7 +84,12 @@ dpa.read.timeout = 60000
 
 #2. Cloud Connection Status on LED
 #The Cloud Connection Status will be indicated by a blinking LED connected to the system GPIOs
-#The URL should indicate the GPIO logic index of the GPIO Pin used for the LED
+#The URL should identify the GPIO to be used, either by name or by terminal index as defined by Kura GpioService.
+# Syntax for using GPIO terminal index:
+#ccs.status.notification.url=ccs:led:16
+#ccs.status.notification.url=ccs:led:terminal:16
+# Syntax for using GPIO name:
+#ccs.status.notification.url=ccs:led:name:LED_1
 ccs.status.notification.url=ccs:led:16
 
 #3. Cloud Connection Status disabled

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/framework/kura.properties
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/test-env/framework/kura.properties
@@ -76,8 +76,13 @@ ccs.status.notification.url=ccs:log
 
 #2. Cloud Connection Status on LED
 #The Cloud Connection Status will be indicated by a blinking LED connected to the system GPIOs
-#The URL should indicate the GPIO logic index of the GPIO Pin used for the LED
+#The URL should identify the GPIO to be used, either by name or by terminal index as defined by Kura GpioService.
+# Syntax for using GPIO terminal index:
 #ccs.status.notification.url=ccs:led:16
+#ccs.status.notification.url=ccs:led:terminal:16
+# Syntax for using GPIO name:
+#ccs.status.notification.url=ccs:led:name:LED_1
+ccs.status.notification.url=ccs:led:16
 
 #3. Cloud Connection Status disabled
 #Disables the Cloud Connection Status service


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

See https://github.com/eclipse-kura/kura/pull/6039
