### PR TITLE
fix(distrib): remove gpsd debian dependency (moved to kura-position)

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -83,7 +83,7 @@
             setserial, zip, gzip, unzip, procps, usbutils, socat, gawk, sed, inetutils-telnet,
             polkit | policykit-1 | polkitd,
             ssh | openssh, openssl, busybox, libpam-modules,
-            python3, gpsd,
+            python3,
             openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
             dos2unix, libtirpc3, chrony, chronyc | chrony
         </deb.dependencies>


### PR DESCRIPTION
This PR removed the `gpsd` dependency from the debian package since it has been moved to `kura-position` installer.

**Related Issue:** https://github.com/eclipse-kura/kura-position/pull/22, https://github.com/eclipse-kura/kura/pull/6044.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
