### PR TITLE
docs: Removed appadmin and netadmin users documentation

### DIFF
--- a/docs/gateway-configuration/gateway-administration-console-authentication.md
+++ b/docs/gateway-configuration/gateway-administration-console-authentication.md
@@ -31,7 +31,11 @@ Kura provides the following identities by default:
 
 It is possible to modify/remove the default identity configuration.
 
+Starting from Kura 5.6.1, the `appadmin` and `netadmin` default identities have been removed. The default identity is:
 
+| Name | Password | Permissions |
+| ---- | -------- | ----------- |
+| admin | admin | kura.admin |
 
 ## Login
 


### PR DESCRIPTION
This pull request updates the documentation for Kura's default identities to reflect recent changes in version 5.6.1. The most important change is the removal of the `appadmin` and `netadmin` default identities, leaving only the `admin` identity by default.

Documentation update:

* Updated the section on default identities to state that, starting from Kura 5.6.1, only the `admin` identity is provided by default, and both `appadmin` and `netadmin` have been removed.