### PR TITLE
docs: Documented systemd-credentials support in CryptoService page

### DIFF
--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -7,18 +7,47 @@ The interface centralizes cryptographic operations and keystore password managem
 The interface is implemented by the `CryptoServiceImpl` class that provides a baseline reference for users to generate their own versions of the CryptoService if needed.
 A notable use of the `CryptoService` is encrypting the configuration snapshot files and the configuration properties of PASSWORD type.
 
-!!! note
-    The default `CryptoServiceImpl` bundled with Kura uses a well-known, default encryption key when no secret is provided. This default is intended only for development and testing purposes. For production deployments, users MUST replace the default secret by setting the Java environment variable:
+## Encryption key
 
-    - org.eclipse.kura.core.crypto.secretKey
+The default `CryptoServiceImpl` bundled with Kura perfmorms encryption with a configurable encryption key. A well-known, default encryption key is used when no secret is provided. This default is intended only for development and testing purposes. For production deployments, users **MUST** replace the default encryption key.
 
-    The secret key must be either 16, 24, or 32 bytes (characters) long. Example (set as JVM argument or environment variable depending on your runtime):
-
-    - As JVM system property: -Dorg.eclipse.kura.core.crypto.secretKey=your-16+char-secret
+!!! warning
 
     Failing to replace the default secret leaves encrypted data vulnerable. Ensure secrets are stored and managed securely in your environment.
 
-    To implement an alternative mechanism for storing the key it is possible to replace the `org.eclipse.kura.core.crypto` bundle with a custom implementation.
+The secret key must be either 16, 24, or 32 bytes (characters) long, it can be specified in the following ways:
+
+### Using a Java system property
+
+The encryption key can be configured with the following Java system property:
+
+- `org.eclipse.kura.core.crypto.secretKey`
+
+Kura default start scripts will set the system property above to the content of the `KURA_CRYPTO_SECRET_KEY` environment variable.
+
+### Using systemd-credentials
+
+Strating from Eclipse Kura 6.0, the default `CryptoService` implementation supports loading the encryption key from a [systemd credential](https://systemd.io/CREDENTIALS/) named `kura_encryption_key`.
+
+It can be speficied using any of the methods supported by systemd. For example it can be stored in encrypted form in a configuration dropin of the `kura.service` unit, as shown below (adapted from Example 2 in [systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) man page)
+
+```
+mkdir -p /etc/systemd/system/kura.service.d
+systemd-ask-password -n | ( echo "[Service]" && systemd-creds encrypt --name=kura_encryption_key -p - - ) >/etc/systemd/system/kura.service.d/50-encryption-key.conf
+```
+
+### Using a custom storage implementation
+
+To implement an alternative mechanism for storing the key it is possible to replace the `org.eclipse.kura.core.crypto` bundle with a custom implementation.
+
+!!! note
+
+    The default CryptoService implementation will load the encryption key from the supported sources in the following order (higher priority first), falling back to the next one if the key cannot be loaded:
+
+    1. Systemd credential
+    2. Java system property
+    3. Default well-known key
+
 
 ## Key Functional Areas
 

--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -67,7 +67,7 @@ SetCredentialEncrypted=kura_encryption_key: \
 
     The setup above is just an example, systemd offers different ways to pass credentials to services. Please review systemd documentation to understand the different options and chose the most appropriate for your case.
 
-### Using a Java system property
+### Option 2: Using a Java system property
 
 The encryption key can be configured with the following Java system property:
 

--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -124,7 +124,7 @@ kura.service content
 EnvironmentFile=/etc/kura-key.conf
 ```
 
-#### Contanier based deployments
+#### Container based deployments
 
 Specify the environment variable using the `--env` or `--env-file` command line option of the `docker`/`podman` `run` or `create` commands.
 

--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -128,6 +128,8 @@ EnvironmentFile=/etc/kura-key.conf
 
 Specify the environment variable using the `--env` or `--env-file` command line option of the `docker`/`podman` `run` or `create` commands.
 
+For additional information about Eclipse Kura containers see: https://hub.docker.com/r/eclipse/kura/
+
 ### Option 3: Using a custom storage implementation
 
 To implement an alternative mechanism for key storage, you can replace the `org.eclipse.kura.core.crypto` bundle with a custom implementation.

--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -38,7 +38,7 @@ systemd-ask-password -n | ( echo "[Service]" && systemd-creds encrypt --name=kur
 
 ### Using a custom storage implementation
 
-To implement an alternative mechanism for storing the key it is possible to replace the `org.eclipse.kura.core.crypto` bundle with a custom implementation.
+To implement an alternative mechanism for key storage, you can replace the `org.eclipse.kura.core.crypto` bundle with a custom implementation.
 
 !!! note
 

--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -128,7 +128,7 @@ EnvironmentFile=/etc/kura-key.conf
 
 Specify the environment variable using the `--env` or `--env-file` command line option of the `docker`/`podman` `run` or `create` commands.
 
-### Using a custom storage implementation
+### Option 3: Using a custom storage implementation
 
 To implement an alternative mechanism for key storage, you can replace the `org.eclipse.kura.core.crypto` bundle with a custom implementation.
 

--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -17,7 +17,7 @@ The default `CryptoServiceImpl` included with Kura utilizes a configurable encry
 
 The secret key must be either 16, 24, or 32 bytes (characters) long, it can be specified in the following ways:
 
-### Using systemd-credentials (recommended)
+### Option 1: Using systemd-credentials (recommended)
 
 !!! note
     systemd-credentials is available starting from systemd version 250. This method cannot be used on container based deployments.

--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -9,7 +9,7 @@ A notable use of the `CryptoService` is encrypting the configuration snapshot fi
 
 ## Encryption key
 
-The default `CryptoServiceImpl` bundled with Kura perfmorms encryption with a configurable encryption key. A well-known, default encryption key is used when no secret is provided. This default is intended only for development and testing purposes. For production deployments, users **MUST** replace the default encryption key.
+The default `CryptoServiceImpl` included with Kura utilizes a configurable encryption key for encryption purposes. When no secret key is provided, a commonly known default encryption key is used. This default should only be used in development and testing environments. For production deployments, it is **CRUCIAL** that users replace the default encryption key with a secure one.
 
 !!! warning
 

--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -17,24 +17,116 @@ The default `CryptoServiceImpl` included with Kura utilizes a configurable encry
 
 The secret key must be either 16, 24, or 32 bytes (characters) long, it can be specified in the following ways:
 
+### Using systemd-credentials (recommended)
+
+!!! note
+    systemd-credentials is available starting from systemd version 250. This method cannot be used on container based deployments.
+
+Strating from Eclipse Kura 6.0, the default `CryptoService` implementation supports loading the encryption key from a [systemd credential](https://systemd.io/CREDENTIALS/) named `kura_encryption_key`.
+
+It can be speficied using any of the methods supported by systemd. For example it can be stored in encrypted form in a configuration dropin of the `kura.service` unit, as shown below (adapted from Example 2 in [systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) man page).
+
+The commands should be run as root.
+
+```sh
+mkdir -p /etc/systemd/system/kura.service.d
+```
+
+```sh
+systemd-ask-password -n | ( echo "[Service]" && systemd-creds encrypt --name=kura_encryption_key -p - - ) >/etc/systemd/system/kura.service.d/50-encryption-key.conf
+```
+
+```sh
+systemctl daemon-reload
+```
+
+The result can be verified with `systemctl cat kura`, it should produce an output similar to the following:
+
+```sh
+systemctl cat kura
+# /lib/systemd/system/kura.service
+[Unit]
+Description=Kura
+Wants=dbus.service
+After=dbus.service
+
+....
+kura.service content
+....
+
+# /etc/systemd/system/kura.service.d/50-encryption-key.conf
+[Service]
+SetCredentialEncrypted=kura_encryption_key: \
+        Whxqht+dQJax1aZeCGLxmiAAAAABAAAADAAAABAAAADQfAnaQJMAVKCEJjcAAAAASk3/B \
+        EZuKkHQPNKDXe7zn68bjyhzE7ni2R+g2B9o9aWrtMT9OGztsK+WbpsjTr8ci4FKcFL/dd \
+        B1nKZ+O2Zt1Q==
+
+```
+
+!!! note
+
+    The setup above is just an example, systemd offers different ways to pass credentials to services. Please review systemd documentation to understand the different options and chose the most appropriate for your case.
+
 ### Using a Java system property
 
 The encryption key can be configured with the following Java system property:
 
 - `org.eclipse.kura.core.crypto.secretKey`
 
-Kura default start scripts will set the system property above to the content of the `KURA_CRYPTO_SECRET_KEY` environment variable.
+Kura default start scripts (see `/opt/eclipse/kura/bin/`) will set the system property above to the content of the `KURA_CRYPTO_SECRET_KEY` environment variable.
 
-### Using systemd-credentials
+#### Systemd deployments
 
-Strating from Eclipse Kura 6.0, the default `CryptoService` implementation supports loading the encryption key from a [systemd credential](https://systemd.io/CREDENTIALS/) named `kura_encryption_key`.
+!!! note
 
-It can be speficied using any of the methods supported by systemd. For example it can be stored in encrypted form in a configuration dropin of the `kura.service` unit, as shown below (adapted from Example 2 in [systemd-creds](https://www.freedesktop.org/software/systemd/man/latest/systemd-creds.html) man page)
+    Consider using systemd-credentials if available on your system
 
+A possible way to provide the key is creating an environment file like shown below. The commands must be run as root.
+
+```sh
+echo KURA_CRYPTO_SECRET_KEY=$(systemd-ask-password -n) > /etc/kura-key.conf
 ```
+
+Review the content of the `/etc/kura-key.conf` to verify if it needs escaping as explained in the description of the `EnvironmentFile` parameter in [systemd documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html).
+
+```sh
+chmod 400 /etc/kura-key.conf
+```
+
+```sh
 mkdir -p /etc/systemd/system/kura.service.d
-systemd-ask-password -n | ( echo "[Service]" && systemd-creds encrypt --name=kura_encryption_key -p - - ) >/etc/systemd/system/kura.service.d/50-encryption-key.conf
 ```
+
+```sh
+( echo "[Service]" && echo "EnvironmentFile=/etc/kura-key.conf" ) >/etc/systemd/system/kura.service.d/50-key-env-file.conf
+```
+
+```sh
+systemctl daemon-reload
+```
+
+The result can be verified with `systemctl cat kura`, it should produce an output similar to the following:
+
+```sh
+systemctl cat kura
+# /lib/systemd/system/kura.service
+[Unit]
+Description=Kura
+Wants=dbus.service
+After=dbus.service
+
+....
+kura.service content
+....
+
+# /etc/systemd/system/kura.service.d/50-key-env-file.conf
+[Service]
+EnvironmentFile=/etc/kura-key.conf
+```
+
+#### Contanier based deployments
+
+Specify the environment variable using the `--env` or `--env-file` command line option of the `docker`/`podman` `run` or `create` commands.
 
 ### Using a custom storage implementation
 
@@ -47,7 +139,6 @@ To implement an alternative mechanism for key storage, you can replace the `org.
     1. Systemd credential
     2. Java system property
     3. Default well-known key
-
 
 ## Key Functional Areas
 

--- a/docs/getting-started/install-kura.md
+++ b/docs/getting-started/install-kura.md
@@ -42,8 +42,8 @@ To install Eclipse Kura&trade; using the APT repository, perform the following s
 !!! note
     The above instructions might require `sudo` privileges depending on your system configuration.
 
-!!! note
-    Before first boot, please configure the Java system property `-Dorg.eclipse.kura.core.crypto.secretKey=<your-secret-key>` to set a custom secret key for Eclipse Kura's encryption services. The secret key must be either 16, 24, or 32 bytes (characters) long. Refer to the [crypto-service documentation](../../core-services/crypto-service) for more details.
+!!! warning
+    Before first boot, it is crucial to set a custom secret key for Eclipse Kura's encryption services. Refer to the [crypto-service documentation](../../core-services/crypto-service) for more details.
 
 ??? tip "Nightly builds APT repository"
 


### PR DESCRIPTION
> **Note**: We are using the Conventional Commits convention for our pull request titles. Please take a look at the [PR title format document](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#submitting-the-changes) for the supported [types](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#type) and [scopes](https://github.com/eclipse/kura/blob/develop/CONTRIBUTING.md#scope).

Brief description of the PR. [e.g. Added `null` check on `object` to avoid `NullPointerException`]

