### PR TITLE
docs: Network threat manager page update

### DIFF
--- a/docs/gateway-configuration/network-threat-manager.md
+++ b/docs/gateway-configuration/network-threat-manager.md
@@ -1,6 +1,6 @@
 # Network Threat Manager
 
-Eclipse Kura provides a set of features to detect and prevent network attacks. The Security section in the Gateway Administration Console shows the Network Threat Manager tab where is it possible to activate these functions.
+Eclipse Kura provides a set of features to detect and prevent network attacks. The Network Threat Manager tab in the Security section of the Gateway Administration Console allows the user to activate these functions.
 
 !!! Warning
     The Network Threat Manager tab is not available for the [No Network version of Eclipse Kura](../../getting-started/install-kura/#installer-types).
@@ -9,71 +9,73 @@ Eclipse Kura provides a set of features to detect and prevent network attacks. T
 
 ## Flooding protection
 
-The flooding protection function is used to prevent DDos (Distributed Denial-of-Service) attacks using the firewall. When enabled, the feature adds a set of firewall rules to the **mangle** table.
+The flooding protection function is used to prevent DDos (Distributed Denial-of-Service) attacks using specific firewall rules. When enabled, the feature modifies the **filter** and **mangle** tables in the _iptables_ firewall to close or limit common attacks.
 
 ### Flooding protection for IPv4
 
+The **flooding.protection.enabled** property is used to enable the feature.
 The following rules are added to the **mangle** table and they are implemented to block invalid or malicious network packets:
 
 ```
-iptables -A prerouting-kura -m conntrack --ctstate INVALID -j DROP
-iptables -A prerouting-kura -p tcp ! --syn -m conntrack --ctstate NEW -j DROP
-iptables -A prerouting-kura -p tcp -m conntrack --ctstate NEW -m tcpmss ! --mss 536:65535 -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags FIN,SYN FIN,SYN -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags SYN,RST SYN,RST -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags FIN,RST FIN,RST -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags FIN,ACK FIN -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags ACK,URG URG -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags ACK,FIN FIN -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags ACK,PSH PSH -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags ALL ALL -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags ALL NONE -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags ALL FIN,PSH,URG -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags ALL SYN,FIN,PSH,URG -j DROP
-iptables -A prerouting-kura -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP
-iptables -A prerouting-kura -p icmp -j DROP
-iptables -A prerouting-kura -f -j DROP
+-A prerouting-kura -m conntrack --ctstate INVALID -j DROP
+-A prerouting-kura -p tcp -m tcp ! --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j DROP
+-A prerouting-kura -p tcp -m conntrack --ctstate NEW -m tcpmss ! --mss 536:65535 -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN FIN,SYN -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags SYN,RST SYN,RST -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,RST FIN,RST -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,ACK FIN -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags ACK,URG URG -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,ACK FIN -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags PSH,ACK PSH -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG FIN,SYN,RST,PSH,ACK,URG -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG NONE -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG FIN,PSH,URG -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG FIN,SYN,PSH,URG -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG FIN,SYN,RST,ACK,URG -j DROP
+-A prerouting-kura -p icmp -m icmp --icmp-type 8 -m state --state NEW,RELATED,ESTABLISHED -j DROP
+-A prerouting-kura -f -j DROP
+-A prerouting-kura -j RETURN
 ```
 
 To further filter the incoming TCP fragmented packets, specific system configuration files are configured.
-The **flooding.protection.enabled** property is used to enable the feature.
+When enabled, the device will not respond to ping requests.
 
 ### Flooding protection for IPv6
 
-The same rules applied to the IPv4 are used for preventing attack on IPv6. In addition, some rules are implemented to drop specific IPv6 headers and limit the incoming ICMPv6 packets. Moreover, the incoming TCP fragmented packets are dropped configuring specific system files.
+The same rules applied to the IPv4 are used for preventing attack on IPv6. In addition, some of them are implemented to drop specific IPv6 headers and limit the incoming ICMPv6 packets. Moreover, the incoming TCP fragmented packets are dropped configuring specific system files.
 
 The following rules are applied to the **mangle** table:
 
 ```
-ip6tables -A prerouting-kura -m conntrack --ctstate INVALID -j DROP
-ip6tables -A prerouting-kura -p tcp ! --syn -m conntrack --ctstate NEW -j DROP
-ip6tables -A prerouting-kura -p tcp -m conntrack --ctstate NEW -m tcpmss ! --mss 536:65535 -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags FIN,SYN FIN,SYN -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags SYN,RST SYN,RST -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags FIN,RST FIN,RST -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags FIN,ACK FIN -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags ACK,URG URG -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags ACK,FIN FIN -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags ACK,PSH PSH -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags ALL ALL -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags ALL NONE -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags ALL FIN,PSH,URG -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags ALL SYN,FIN,PSH,URG -j DROP
-ip6tables -A prerouting-kura -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP
-ip6tables -A prerouting-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 128 -j DROP
-ip6tables -A prerouting-kura -p ipv6-icmp -m ipv6-icmp --icmpv6-type 129 -j DROP
-ip6tables -A prerouting-kura -m ipv6header --header dst --soft -j DROP
-ip6tables -A prerouting-kura -m ipv6header --header hop --soft -j DROP
-ip6tables -A prerouting-kura -m ipv6header --header route --soft -j DROP
-ip6tables -A prerouting-kura -m ipv6header --header frag --soft -j DROP
-ip6tables -A prerouting-kura -m ipv6header --header auth --soft -j DROP
-ip6tables -A prerouting-kura -m ipv6header --header esp --soft -j DROP
-ip6tables -A prerouting-kura -m ipv6header --header none --soft -j DROP
-ip6tables -A prerouting-kura -m rt --rt-type 0 -j DROP
-ip6tables -A output-kura -m rt --rt-type 0 -j DROP
+-A prerouting-kura -m conntrack --ctstate INVALID -j DROP
+-A prerouting-kura -p tcp -m tcp ! --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j DROP
+-A prerouting-kura -p tcp -m conntrack --ctstate NEW -m tcpmss ! --mss 536:65535 -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN FIN,SYN -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags SYN,RST SYN,RST -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,RST FIN,RST -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,ACK FIN -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags ACK,URG URG -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,ACK FIN -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags PSH,ACK PSH -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG FIN,SYN,RST,PSH,ACK,URG -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG NONE -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG FIN,PSH,URG -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG FIN,SYN,PSH,URG -j DROP
+-A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG FIN,SYN,RST,ACK,URG -j DROP
+-A prerouting-kura -p ipv6-icmp -m icmp6 --icmpv6-type 128 -j DROP
+-A prerouting-kura -m ipv6header --header ipv6-opts --soft -j DROP
+-A prerouting-kura -m ipv6header --header hop-by-hop --soft -j DROP
+-A prerouting-kura -m ipv6header --header ipv6-route --soft -j DROP
+-A prerouting-kura -m ipv6header --header ipv6-frag --soft -j DROP
+-A prerouting-kura -m ipv6header --header ah --soft -j DROP
+-A prerouting-kura -m ipv6header --header esp --soft -j DROP
+-A prerouting-kura -m ipv6header --header ipv6-nonxt --soft -j DROP
+-A prerouting-kura -m rt --rt-type 0 -j DROP
+-A prerouting-kura -j RETURN
 ```
 
 Also in this case, to enable the feature and add the rules to the firewall, the **flooding.protection.enabled.ipv6** property has to be set to true. If the device doesn't support IPv6, this property is ignored.
+When enabled, the device will not respond to ping requests.
 
 !!! Warning
     To recover the device state when the IPv6 flooding protection feature is disabled, a reboot is required. So, to disable the feature, set the **flooding.protection.enabled.ipv6** property to false tha reboot the device.

--- a/docs/gateway-configuration/network-threat-manager.md
+++ b/docs/gateway-configuration/network-threat-manager.md
@@ -34,7 +34,6 @@ The following rules are added to the **mangle** table and they are implemented t
 -A prerouting-kura -p tcp -m tcp --tcp-flags FIN,SYN,RST,PSH,ACK,URG FIN,SYN,RST,ACK,URG -j DROP
 -A prerouting-kura -p icmp -m icmp --icmp-type 8 -m state --state NEW,RELATED,ESTABLISHED -j DROP
 -A prerouting-kura -f -j DROP
--A prerouting-kura -j RETURN
 ```
 
 To further filter the incoming TCP fragmented packets, specific system configuration files are configured.
@@ -71,7 +70,6 @@ The following rules are applied to the **mangle** table:
 -A prerouting-kura -m ipv6header --header esp --soft -j DROP
 -A prerouting-kura -m ipv6header --header ipv6-nonxt --soft -j DROP
 -A prerouting-kura -m rt --rt-type 0 -j DROP
--A prerouting-kura -j RETURN
 ```
 
 Also in this case, to enable the feature and add the rules to the firewall, the **flooding.protection.enabled.ipv6** property has to be set to true. If the device doesn't support IPv6, this property is ignored.


### PR DESCRIPTION
This pull request updates the documentation for the Network Threat Manager, clarifying how flooding protection works for both IPv4 and IPv6 in Eclipse Kura. The changes provide more accurate descriptions of firewall rule application, update the example rules to match actual `iptables`/`ip6tables` syntax, and clarify the effects of enabling the protection features.

**Documentation improvements:**

* Clarified the description of the Network Threat Manager tab and its location in the Gateway Administration Console.
* Improved the explanation of flooding protection, specifying that it modifies both the `filter` and `mangle` tables in `iptables` and affects device responses to ping requests.

**Technical accuracy and examples:**

* Updated the example IPv4 and IPv6 firewall rules to use more accurate and current `iptables`/`ip6tables` syntax, reflecting actual rule usage and module names.
* Clarified the enabling properties for both IPv4 and IPv6 flooding protection, and the behavioral changes when the feature is enabled (such as dropping ping requests).
* Noted that a device reboot is required after disabling IPv6 flooding protection to recover the device state.