### PR TITLE
docs: Fixed Network Threat Manager provider in documentation

### DIFF
--- a/docs/gateway-configuration/network-threat-manager.md
+++ b/docs/gateway-configuration/network-threat-manager.md
@@ -3,7 +3,7 @@
 Eclipse Kura provides a set of features to detect and prevent network attacks. The Network Threat Manager tab in the Security section of the Gateway Administration Console allows the user to activate these functions.
 
 !!! Warning
-    The Network Threat Manager tab is not available for the [No Network version of Eclipse Kura](../../getting-started/install-kura/#installer-types).
+    The Network Threat Manager feature is provided by the **kura-networking** package.
 
 ![Network Threat Manager](./images/network-threat-manager.png)
 


### PR DESCRIPTION
This pull request updates the documentation for the Network Threat Manager feature to clarify its availability. The main change is to specify that the Network Threat Manager is provided by the `kura-networking` package, rather than referencing the "No Network version" of Eclipse Kura.

- Documentation update:
  * Updated the warning in `network-threat-manager.md` to clarify that the Network Threat Manager feature is provided by the `kura-networking` package.