### PR TITLE
docs: Added a note about dhcp issue in Zimaboard

### DIFF
--- a/docs/getting-started/zima-board-quick-start.md
+++ b/docs/getting-started/zima-board-quick-start.md
@@ -4,7 +4,7 @@
 
 ## Eclipse Kura&trade; Installation
 
-## Notes
+## Known Issues
 
 On Ubuntu 24.04 with NetworkManager and DHCP (IPv4), a network interface fails to obtain an IPv4 address automatically. The issue is due to this [bug](https://bugs.launchpad.net/ubuntu/+source/network-manager/+bug/2116733).
 

--- a/docs/getting-started/zima-board-quick-start.md
+++ b/docs/getting-started/zima-board-quick-start.md
@@ -1,3 +1,42 @@
 # ZimaBoard/Blade Quick Start
 
 ## Overview
+
+## Eclipse Kura&trade; Installation
+
+## Notes
+
+On Ubuntu 24.04 with NetworkManager and DHCP (IPv4), a network interface fails to obtain an IPv4 address automatically. The issue is due to this [bug](https://bugs.launchpad.net/ubuntu/+source/network-manager/+bug/2116733).
+
+To fix it, the `AppArmor` configuration has to be updated as follows:
+
+- edit the `/etc/apparmor.d/sbin.dhclient` file and add the following lines in the main section:
+
+```
+  # Added to fix dhclient
+  /usr/libexec/nm-dhcp-helper                     Pxrm,
+  signal (receive) peer=/usr/libexec/nm-dhcp-helper,
+```
+
+- add the following at the end of the file:
+
+```
+# Added to fix dhclient
+/usr/libexec/nm-dhcp-helper {
+  #include <abstractions/base>
+  #include <abstractions/dbus>
+  /usr/libexec/nm-dhcp-helper mr,
+
+  /run/NetworkManager/private-dhcp rw,
+  signal (send) peer=/sbin/dhclient,
+
+  /var/lib/NetworkManager/*lease r,
+  signal (receive) peer=/usr/sbin/NetworkManager,
+  ptrace (readby) peer=/usr/sbin/NetworkManager,
+  network inet dgram,
+  network inet6 dgram,
+}
+```
+
+
+

--- a/docs/getting-started/zima-board-quick-start.md
+++ b/docs/getting-started/zima-board-quick-start.md
@@ -37,6 +37,3 @@ To fix it, the `AppArmor` configuration has to be updated as follows:
   network inet6 dgram,
 }
 ```
-
-
-


### PR DESCRIPTION
This pull request adds troubleshooting notes to the ZimaBoard/Blade Quick Start documentation, specifically addressing a known DHCP issue on Ubuntu 24.04 with NetworkManager. It provides detailed steps to update the AppArmor configuration to resolve the problem.

Documentation updates:

* Added a "Notes" section to `docs/getting-started/zima-board-quick-start.md` describing a workaround for a DHCP issue on Ubuntu 24.04 by updating the `/etc/apparmor.d/sbin.dhclient` file and including necessary AppArmor rules.