### PR TITLE
build(deps): updated jersey from 3.1.9 to 3.1.11

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -191,16 +191,16 @@ This project leverages the following third party content.
 * maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/3.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 * maven/mavencentral/org.glassfish.hk2/hk2-locator/3.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
 * maven/mavencentral/org.glassfish.hk2/hk2-utils/3.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.glassfish
-* maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-* maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-* maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-* maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-* maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-* maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-* maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-* maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-* maven/mavencentral/org.glassfish.jersey.media/jersey-media-sse/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
-* maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet-core/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.core/jersey-client/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.media/jersey-media-sse/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
+* maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.11, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 * maven/mavencentral/jakarta.inject/jakarta.inject-api/2.0.1, Apache-2.0, approved, ee4j.cdi
 * maven/mavencentral/jakarta.validation/jakarta.validation-api/3.0.2, Apache-2.0, approved, ee4j.validation
 * maven/mavencentral/org.javassist/javassist/3.30.2-GA, Apache-2.0 AND LGPL-2.1-or-later AND MPL-1.1, approved, #12108

--- a/target-platform/target-platform-bom/pom.xml
+++ b/target-platform/target-platform-bom/pom.xml
@@ -75,7 +75,7 @@
         <hk2.version>3.1.1</hk2.version>
         <io.netty.version>4.1.127.Final</io.netty.version>
         <javassist.version>3.30.2-GA</javassist.version>
-        <jersey.version>3.1.9</jersey.version>
+        <jersey.version>3.1.11</jersey.version>
         <log4j.version>2.23.1</log4j.version>
         <mimepull.version>1.10.0</mimepull.version>
         <org.apache.aries.spifly.dynamic.bundle.version>1.3.7</org.apache.aries.spifly.dynamic.bundle.version>


### PR DESCRIPTION
This PR updates jersey target platform dependencies from 3.1.9 to 3.1.11.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: Tested session/v1 login and some GET requests with basic auth enabled to check REST endpoints still work.

**Any side note on the changes made:** N/A.
