### PR TITLE
build(deps): bump commons-beanutils:commons-beanutils from 1.9.3 to 1.11.0 [backport release-5.6.0]

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -58,7 +58,7 @@ This project leverages the following third party content.
 * maven/mavencentral/com.sun.xml.bind/jaxb-osgi/2.3.3, BSD-3-Clause, approved, ee4j.jaxb-impl
 * maven/mavencentral/com.vertispan.j2cl.external/org.eclipse.core.jobs/0.10.0-3c97afeac, Apache-2.0, restricted, clearlydefined
 * maven/mavencentral/com.vertispan.j2cl.external/org.eclipse.equinox.preferences/0.10.0-3c97afeac, Apache-2.0, restricted, clearlydefined
-* maven/mavencentral/commons-beanutils/commons-beanutils/1.9.3, Apache-2.0, approved, CQ12654
+* maven/mavencentral/commons-beanutils/commons-beanutils/1.11.0, Apache-2.0, approved, #21555
 * maven/mavencentral/commons-codec/commons-codec/1.18.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #19214
 * maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, CQ10385
 * maven/mavencentral/commons-fileupload/commons-fileupload/1.5, Apache-2.0, approved, #7109

--- a/target-platform/config/kura.target-platform.build.properties
+++ b/target-platform/config/kura.target-platform.build.properties
@@ -69,7 +69,7 @@ javassist.distrib.version=3.30.2.GA
 com.google.gson.version=2.9.0
 bluez-dbus-osgi.version=0.1.4
 
-commons-beanutils.version=1.9.3
+commons-beanutils.version=1.11.0
 commons-collections.version=3.2.2
 org.apache.geronimo.specs.json.version=1.0.0.alpha-1
 org.apache.geronimo.specs.jms.version=1.0.0.alpha-2


### PR DESCRIPTION
Backport of https://github.com/eclipse-kura/kura/pull/5864