### PR TITLE
docs: Added multiple gps support note

### DIFF
--- a/docs/core-services/position-service.md
+++ b/docs/core-services/position-service.md
@@ -18,7 +18,7 @@ This service provides the following configuration parameters:
 
 - **static** - specifies true or false whether to use a static position instead of a GPS. (Required field.)
 
-- **provider** - species which position provider use, can be gpsd or serial. 
+- **provider** - specifies which position provider use. Possible options are: 
     - **gpsd** - gpsd service daemon if is available on the system. 
     - **serial** - direct access to gps device through serial or usb port.
     - **modemManager** - location information retrieved through a Modem Manager controlled modem
@@ -51,3 +51,7 @@ This service provides the following configuration parameters:
 - **stopbits** - sets the number of stop bits for the serial communication to the GPS device.
 
 - **parity** - sets the parity for the serial communication to the GPS device.
+
+## Multiple GPS module support
+
+Eclipse Kura provides limited support for systems with multiple GPS modules. When more than one module is installed and managed by gpsd, Kura will monitor all of them. The reported position is taken from the first module that has a valid fix; if multiple modules have a fix, Kura selects the one that comes first in lexicographical order.


### PR DESCRIPTION
This pull request updates the documentation for the position service to clarify configuration options and to document support for multiple GPS modules. The main improvements include clarifying the `provider` parameter and adding a new section on how multiple GPS modules are handled.

Documentation improvements:

* Clarified the description of the `provider` configuration parameter, listing all possible options and correcting a typo.

New feature documentation:

* Added a section explaining support for multiple GPS modules, describing how Kura selects which module to use when several are present.