### PR TITLE
docs: update docker hub links following migration

### DIFF
--- a/docs/core-services/crypto-service.md
+++ b/docs/core-services/crypto-service.md
@@ -128,7 +128,7 @@ EnvironmentFile=/etc/kura-key.conf
 
 Specify the environment variable using the `--env` or `--env-file` command line option of the `docker`/`podman` `run` or `create` commands.
 
-For additional information about Eclipse Kura containers see: https://hub.docker.com/r/eclipse/kura/
+For additional information about Eclipse Kura containers see: https://hub.docker.com/r/eclipsekura/kura/
 
 ### Option 3: Using a custom storage implementation
 

--- a/docs/getting-started/docker-quick-start.md
+++ b/docs/getting-started/docker-quick-start.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Eclipse Kura is also available as a Docker container available in [Docker Hub](https://hub.docker.com/r/eclipse/kura/).
+Eclipse Kura is also available as a Docker container available in [Docker Hub](https://hub.docker.com/r/eclipsekura/kura/).
 
 To download and run, use the following command:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -235,7 +235,7 @@ extra:
     - icon: fontawesome/brands/github
       link: https://github.com/eclipse-kura/kura
     - icon: fontawesome/brands/docker
-      link: https://hub.docker.com/r/eclipse/kura
+      link: https://hub.docker.com/r/eclipsekura/kura
   scope: "/kura/"
   analytics:
     provider: google


### PR DESCRIPTION
Update links to dockerhub repository following dockerhub migration (see: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3988)