### PR TITLE
ci: Added tests folder to exclusions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ node {
                                 ${analysisParameters} \
                                 -Dsonar.core.codeCoveragePlugin=jacoco \
                                 -Dsonar.projectKey=org.eclipse.kura:kura \
-                                -Dsonar.exclusions=**/*.xml,**/*.yml,test-util/**/*.java \
+                                -Dsonar.exclusions=test/**/*,**/*.xml,**/*.yml,test-util/**/* \
                                 -Dsonar.test.exclusions=**/*
                         """
                     }


### PR DESCRIPTION
This pull request makes a small update to the SonarQube analysis configuration in the `Jenkinsfile`. The change refines the file exclusion patterns to ensure that all files in the `test` and `test-util` directories are properly excluded from analysis.

* Updated the `-Dsonar.exclusions` parameter to exclude all files in `test/**/*` and `test-util/**/*`, rather than only Java files in `test-util`, improving the accuracy of the SonarQube scan.