### PR TITLE
feat(api): Added getInternetConnectionStatus method to SystemService

### DIFF
--- a/kura/distrib/pom.xml
+++ b/kura/distrib/pom.xml
@@ -83,7 +83,7 @@
             ssh | openssh, openssl, busybox, libpam-modules,
             python3,
             openjdk-17-jre-headless | temurin-17-jdk | java-runtime-headless (= 17) | java-runtime-headless (= 21),
-            dos2unix, libtirpc3, chrony, chronyc | chrony
+            dos2unix, libtirpc3, chrony, chronyc | chrony, iputils-ping
         </deb.dependencies>
         <deb.recommendations></deb.recommendations>
         <deb.provides></deb.provides>

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/InternetConnectionStatus.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/InternetConnectionStatus.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Eurotech
+ *******************************************************************************/
+package org.eclipse.kura.system;
+
+/**
+ * Represents the status of the internet connection.
+ * 
+ * @since 3.0
+ */
+public enum InternetConnectionStatus {
+
+    UNAVAILABLE,
+    IP_ONLY,
+    FULL
+
+}

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
@@ -669,8 +669,9 @@ public interface SystemService {
      * Return the inet address used to check the internet connection. Must support ICMP protocol.
      * 
      * @since 3.0
-     * @return the inet address used to check the internet connection. Default value is 198.41.30.198 (eclipse.org ip
-     *         address at 2026-01-22)
+     * @return the inet address used to check the internet connection. Default value is 198.41.30.198 (current
+     *         eclipse.org IP address, which may change over time; this value should be updated if the eclipse.org IP
+     *         changes)
      */
     public String getInternetConnectionStatusCheckIp();
 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -145,6 +145,15 @@ public interface SystemService {
      * @since 3.0
      */
     public static final String KEY_NETWORK_CONFIGURATION_TIMEOUT = "kura.network.configuration.timeout";
+
+    /**
+     * @since 3.0
+     */
+    public static final String KEY_INTERNET_CONNECTION_STATUS_CHECK_HOST = "kura.internet.check.hostname";
+    /**
+     * @since 3.0
+     */
+    public static final String KEY_INTERNET_CONNECTION_STATUS_CHECK_IP = "kura.internet.check.ip";
 
     /**
      * @deprecated
@@ -645,5 +654,31 @@ public interface SystemService {
      * @return the timeout value in seconds
      */
     public int getNetworkConfigurationTimeout();
+
+    /**
+     * Indicates whether or not the device is connected to the internet and the status.
+     * The status is updated every 30 second and the verification process uses an ICMP request.
+     * 
+     * @since 3.0
+     * @return the {@link InternetConnectionStatus}
+     */
+    public InternetConnectionStatus getInternetConnectionStatus();
+
+    /**
+     * Return the inet address used to check the internet connection. Must support ICMP protocol.
+     * 
+     * @since 3.0
+     * @return the inet address used to check the internet connection. Default value is 198.41.30.198 (eclipse.org ip
+     *         address at 2026-01-22)
+     */
+    public String getInternetConnectionStatusCheckIp();
+
+    /**
+     * Return the hostname used to check the internet connection. Must support ICMP protocol.
+     * 
+     * @since 3.0
+     * @return the hostname address used to check the internet connection. Default value is eclipse.org
+     */
+    public String getInternetConnectionStatusCheckHost();
 
 }

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
@@ -675,7 +675,7 @@ public interface SystemService {
     public String getInternetConnectionStatusCheckIp();
 
     /**
-     * Return the hostname used to check the internet connection. Must support ICMP protocol.
+     * Returns the hostname used to check the internet connection. Must support ICMP protocol.
      * 
      * @since 3.0
      * @return the hostname address used to check the internet connection. Default value is eclipse.org

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
@@ -147,13 +147,14 @@ public interface SystemService {
     public static final String KEY_NETWORK_CONFIGURATION_TIMEOUT = "kura.network.configuration.timeout";
 
     /**
-     * @since 3.0
+     * @since 3.0 Hostname used to verify internet connection status.
      */
     public static final String KEY_INTERNET_CONNECTION_STATUS_CHECK_HOST = "kura.internet.check.hostname";
 
     /**
      * @since 3.0 Address in a format according to system IP version available (e.g. 198.41.30.198 in IPv4 or
-     *        ::ffff:c629:1ec6 in IPv6)
+     *        ::ffff:c629:1ec6 in IPv6) required to verify the internet connection status.
+     *        In order to use the functionality, an IPv6-only system must override this property with an IPv6 address.
      */
     public static final String KEY_INTERNET_CONNECTION_STATUS_CHECK_IP = "kura.internet.check.ip";
 
@@ -507,7 +508,7 @@ public interface SystemService {
 
     /**
      * Returns the system packages currently installed
-     * 
+     *
      * @return the list of the installed packages
      * @throws KuraProcessExecutionErrorException
      * @since 2.2
@@ -566,7 +567,7 @@ public interface SystemService {
 
     /**
      * Returns the default configuration for virtual network interfaces
-     * 
+     *
      * @return a String that represent the default configuration for virtual interfaces
      * @since 2.2
      */
@@ -590,7 +591,7 @@ public interface SystemService {
 
     /**
      * Returns a set of {@link ExtendedProperties}.
-     * 
+     *
      * @since 2.2
      * @return the extended properties, or empty if the SystemService implementation does not provide extended
      *         properties.
@@ -625,8 +626,8 @@ public interface SystemService {
     public String getJavaVmVendor();
 
     /**
-     * 
-     * 
+     *
+     *
      * @since 2.6
      * @return the String representing the Java System property jdk.vendor.version.
      */
@@ -660,7 +661,7 @@ public interface SystemService {
     /**
      * Indicates whether or not the device is connected to the internet and the status.
      * The status is updated every 30 seconds and the verification process uses an ICMP request.
-     * 
+     *
      * @since 3.0
      * @return the {@link InternetConnectionStatus}
      */
@@ -668,7 +669,7 @@ public interface SystemService {
 
     /**
      * Return the inet address used to check the internet connection. Must support ICMP protocol.
-     * 
+     *
      * @since 3.0
      * @return the inet address used to check the internet connection. Default value is 198.41.30.198 (current
      *         eclipse.org IP address, which may change over time; this value should be updated if the eclipse.org IP
@@ -678,7 +679,7 @@ public interface SystemService {
 
     /**
      * Returns the hostname used to check the internet connection. Must support ICMP protocol.
-     * 
+     *
      * @since 3.0
      * @return the hostname address used to check the internet connection. Default value is eclipse.org
      */

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
@@ -152,7 +152,8 @@ public interface SystemService {
     public static final String KEY_INTERNET_CONNECTION_STATUS_CHECK_HOST = "kura.internet.check.hostname";
 
     /**
-     * @since 3.0
+     * @since 3.0 Address in a format according to system IP version available (e.g. 198.41.30.198 in IPv4 or
+     *        ::ffff:c629:1ec6 in IPv6)
      */
     public static final String KEY_INTERNET_CONNECTION_STATUS_CHECK_IP = "kura.internet.check.ip";
 

--- a/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
+++ b/kura/org.eclipse.kura.api/src/main/java/org/eclipse/kura/system/SystemService.java
@@ -150,6 +150,7 @@ public interface SystemService {
      * @since 3.0
      */
     public static final String KEY_INTERNET_CONNECTION_STATUS_CHECK_HOST = "kura.internet.check.hostname";
+
     /**
      * @since 3.0
      */
@@ -657,7 +658,7 @@ public interface SystemService {
 
     /**
      * Indicates whether or not the device is connected to the internet and the status.
-     * The status is updated every 30 second and the verification process uses an ICMP request.
+     * The status is updated every 30 seconds and the verification process uses an ICMP request.
      * 
      * @since 3.0
      * @return the {@link InternetConnectionStatus}

--- a/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
+++ b/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
@@ -49,6 +49,7 @@ import java.util.Properties;
 import java.util.StringJoiner;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -107,6 +108,8 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
 
     private AtomicReference<InternetConnectionStatus> currentInternetStatus = new AtomicReference<>(
             InternetConnectionStatus.UNAVAILABLE);
+
+    private ScheduledFuture<?> currentTask;
 
     public void setExecutorService(CommandExecutorService executorService) {
         this.executorService = executorService;
@@ -502,8 +505,8 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
             throw new ComponentException("Error loading default properties", e);
         }
 
-        internetCheckerExecutor.scheduleAtFixedRate(this::checkInternetTask, 0, INTERNET_CHECK_TIME_INTERVAL,
-                TimeUnit.MILLISECONDS);
+        currentTask = internetCheckerExecutor.scheduleAtFixedRate(this::checkInternetTask, 5000,
+                INTERNET_CHECK_TIME_INTERVAL, TimeUnit.MILLISECONDS);
     }
 
     private void loadKuraCustom(Properties kuraCustomProps, String kuraCustomConfig) {
@@ -547,7 +550,20 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
     protected void deactivate(ComponentContext componentContext) {
         this.componentContext = null;
         this.kuraProperties = null;
-        this.internetCheckerExecutor.shutdownNow();
+
+        if (this.currentTask != null) {
+            this.currentTask.cancel(true);
+        }
+
+        if (this.internetCheckerExecutor != null) {
+            this.internetCheckerExecutor.shutdown();
+            try {
+                this.internetCheckerExecutor.awaitTermination(5000, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                currentThread().interrupt();
+                this.internetCheckerExecutor.shutdownNow();
+            }
+        }
     }
 
     public void updated(Map<String, Object> properties) {
@@ -1580,22 +1596,26 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
         if (this.executorService == null) {
             return;
         }
-        CommandStatus status = this.executorService
-                .execute(new Command(new String[] { "ping", "-c", "1", getInternetConnectionStatusCheckHost() }));
-        if (status.getExitStatus().isSuccessful()) {
-            this.currentInternetStatus.set(InternetConnectionStatus.FULL);
-            return;
+        try {
+            CommandStatus status = this.executorService
+                    .execute(new Command(new String[] { "ping", "-c", "1", getInternetConnectionStatusCheckHost() }));
+            if (status.getExitStatus().isSuccessful()) {
+                this.currentInternetStatus.set(InternetConnectionStatus.FULL);
+                return;
+            }
+
+            status = this.executorService
+                    .execute(new Command(new String[] { "ping", "-c", "1", getInternetConnectionStatusCheckIp() }));
+
+            if (status.getExitStatus().isSuccessful()) {
+                this.currentInternetStatus.set(InternetConnectionStatus.IP_ONLY);
+                return;
+            }
+
+            this.currentInternetStatus.set(InternetConnectionStatus.UNAVAILABLE);
+        } catch (Exception e) {
+            logger.error("Error while checking internet connection status", e);
         }
-
-        status = this.executorService
-                .execute(new Command(new String[] { "ping", "-c", "1", getInternetConnectionStatusCheckIp() }));
-
-        if (status.getExitStatus().isSuccessful()) {
-            this.currentInternetStatus.set(InternetConnectionStatus.IP_ONLY);
-            return;
-        }
-
-        this.currentInternetStatus.set(InternetConnectionStatus.UNAVAILABLE);
     }
 
 }

--- a/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
+++ b/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
@@ -103,7 +103,7 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
 
     private String primaryInterfaceMacAddress;
 
-    private AtomicReference<InternetConnectionStatus> currentInternetStatus = new AtomicReference<>(
+    private final AtomicReference<InternetConnectionStatus> currentInternetStatus = new AtomicReference<>(
             InternetConnectionStatus.UNAVAILABLE);
 
     private ScheduledFuture<?> currentTask;
@@ -508,7 +508,7 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
             return result;
         });
 
-        this.currentTask = internetCheckerExecutor.scheduleAtFixedRate(this::checkInternetTask, 5000,
+        this.currentTask = this.internetCheckerExecutor.scheduleAtFixedRate(this::checkInternetTask, 5000,
                 INTERNET_CHECK_TIME_INTERVAL, TimeUnit.MILLISECONDS);
     }
 
@@ -1635,7 +1635,7 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
         }
 
         CommandStatus status = this.executorService
-                .execute(new Command(new String[] { "ping", version, address, "-c", "1" }));
+                .execute(new Command(new String[] { "ping", version, address, "-c", "5" }));
 
         return status.getExitStatus().isSuccessful();
     }

--- a/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
+++ b/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
@@ -29,6 +29,7 @@ import java.io.StringReader;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.StandardProtocolFamily;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
@@ -1599,17 +1600,15 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
             return;
         }
         try {
-            CommandStatus status = this.executorService
-                    .execute(new Command(new String[] { "ping", "-c", "1", getInternetConnectionStatusCheckHost() }));
-            if (status.getExitStatus().isSuccessful()) {
+
+            if (isPingable(StandardProtocolFamily.INET, getInternetConnectionStatusCheckHost())
+                    || isPingable(StandardProtocolFamily.INET6, getInternetConnectionStatusCheckHost())) {
                 this.currentInternetStatus.set(InternetConnectionStatus.FULL);
                 return;
             }
 
-            status = this.executorService
-                    .execute(new Command(new String[] { "ping", "-c", "1", getInternetConnectionStatusCheckIp() }));
-
-            if (status.getExitStatus().isSuccessful()) {
+            if (isPingable(StandardProtocolFamily.INET, getInternetConnectionStatusCheckIp())
+                    || isPingable(StandardProtocolFamily.INET6, getInternetConnectionStatusCheckIp())) {
                 this.currentInternetStatus.set(InternetConnectionStatus.IP_ONLY);
                 return;
             }
@@ -1618,6 +1617,27 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
         } catch (Exception e) {
             logger.error("Error while checking internet connection status", e);
         }
+    }
+
+    private boolean isPingable(StandardProtocolFamily protocol, String address) {
+        String version;
+
+        switch (protocol) {
+        case INET:
+            version = "-4";
+            break;
+
+        case INET6:
+            version = "-6";
+            break;
+        default:
+            throw new IllegalArgumentException("Unexpected protocol: " + protocol);
+        }
+
+        CommandStatus status = this.executorService
+                .execute(new Command(new String[] { "ping", version, address, "-c", "1" }));
+
+        return status.getExitStatus().isSuccessful();
     }
 
 }

--- a/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
+++ b/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.StringJoiner;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.Charsets;
@@ -57,6 +61,7 @@ import org.eclipse.kura.executor.CommandExecutorService;
 import org.eclipse.kura.executor.CommandStatus;
 import org.eclipse.kura.net.NetInterfaceStatus;
 import org.eclipse.kura.system.ExtendedProperties;
+import org.eclipse.kura.system.InternetConnectionStatus;
 import org.eclipse.kura.system.SystemResourceInfo;
 import org.eclipse.kura.system.SystemResourceType;
 import org.eclipse.kura.system.SystemService;
@@ -68,6 +73,10 @@ import org.slf4j.LoggerFactory;
 
 public class SystemServiceImpl extends SuperSystemService implements SystemService {
 
+    private ScheduledExecutorService internetCheckerExecutor = Executors.newSingleThreadScheduledExecutor();
+
+    private static final String DEFAULT_INTERNET_CONNECTION_STATUS_CHECK_IP = "198.41.30.198";
+    private static final String DEFAULT_INTERNET_CONNECTION_STATUS_CHECK_HOST = "eclipse.org";
     private static final String SYS_CLASS_NET = "/sys/class/net/";
     private static final Logger logger = LoggerFactory.getLogger(SystemServiceImpl.class);
     private static final String PROPERTY_PROVIDER_SUFFIX = ".provider";
@@ -82,6 +91,8 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
     private static final String KURA_PATH = "/opt/eclipse/kura";
     private static final String OS_WINDOWS = "windows";
 
+    private static final int INTERNET_CHECK_TIME_INTERVAL = 30000;
+
     private static boolean onCloudbees = false;
 
     private Properties kuraProperties;
@@ -90,6 +101,9 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
     private CommandExecutorService executorService;
 
     private String primaryInterfaceMacAddress;
+
+    private AtomicReference<InternetConnectionStatus> currentInternetStatus = new AtomicReference<>(
+            InternetConnectionStatus.UNAVAILABLE);
 
     public void setExecutorService(CommandExecutorService executorService) {
         this.executorService = executorService;
@@ -440,6 +454,14 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
             if (System.getProperty(KEY_COMMAND_USER) != null) {
                 this.kuraProperties.put(KEY_COMMAND_USER, System.getProperty(KEY_COMMAND_USER));
             }
+            if (System.getProperty(KEY_INTERNET_CONNECTION_STATUS_CHECK_HOST) != null) {
+                this.kuraProperties.put(KEY_INTERNET_CONNECTION_STATUS_CHECK_HOST,
+                        System.getProperty(KEY_INTERNET_CONNECTION_STATUS_CHECK_HOST));
+            }
+            if (System.getProperty(KEY_INTERNET_CONNECTION_STATUS_CHECK_IP) != null) {
+                this.kuraProperties.put(KEY_INTERNET_CONNECTION_STATUS_CHECK_IP,
+                        System.getProperty(KEY_INTERNET_CONNECTION_STATUS_CHECK_IP));
+            }
 
             if (getKuraHome() == null) {
                 logger.error("Did not initialize kura.home");
@@ -476,6 +498,9 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
         } catch (IOException e) {
             throw new ComponentException("Error loading default properties", e);
         }
+
+        internetCheckerExecutor.scheduleAtFixedRate(this::checkInternetTask, 0, INTERNET_CHECK_TIME_INTERVAL,
+                TimeUnit.MILLISECONDS);
     }
 
     private void loadKuraCustom(Properties kuraCustomProps, String kuraCustomConfig) {
@@ -519,6 +544,7 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
     protected void deactivate(ComponentContext componentContext) {
         this.componentContext = null;
         this.kuraProperties = null;
+        this.internetCheckerExecutor.shutdownNow();
     }
 
     public void updated(Map<String, Object> properties) {
@@ -1518,6 +1544,17 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
         return getIntegerPropertyValue(KEY_NETWORK_CONFIGURATION_TIMEOUT, 30);
     }
 
+    @Override
+    public String getInternetConnectionStatusCheckHost() {
+        return getProperty(KEY_INTERNET_CONNECTION_STATUS_CHECK_HOST)
+                .orElse(DEFAULT_INTERNET_CONNECTION_STATUS_CHECK_HOST);
+    }
+
+    @Override
+    public String getInternetConnectionStatusCheckIp() {
+        return getProperty(KEY_INTERNET_CONNECTION_STATUS_CHECK_IP).orElse(DEFAULT_INTERNET_CONNECTION_STATUS_CHECK_IP);
+    }
+
     private int getIntegerPropertyValue(String propertyName, int defaultValue) {
         final Optional<String> propertyValue = getProperty(propertyName);
         if (propertyValue.isPresent() && !propertyValue.get().trim().isEmpty()) {
@@ -1529,6 +1566,30 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
             }
         }
         return defaultValue;
+    }
+
+    @Override
+    public InternetConnectionStatus getInternetConnectionStatus() {
+        return this.currentInternetStatus.get();
+    }
+
+    private void checkInternetTask() {
+        CommandStatus status = this.executorService
+                .execute(new Command(new String[] { "ping", "-c", "1", getInternetConnectionStatusCheckHost() }));
+        if (status.getExitStatus().isSuccessful()) {
+            this.currentInternetStatus.set(InternetConnectionStatus.FULL);
+            return;
+        }
+
+        status = this.executorService
+                .execute(new Command(new String[] { "ping", "-c", "1", getInternetConnectionStatusCheckIp() }));
+
+        if (status.getExitStatus().isSuccessful()) {
+            this.currentInternetStatus.set(InternetConnectionStatus.IP_ONLY);
+            return;
+        }
+
+        this.currentInternetStatus.set(InternetConnectionStatus.UNAVAILABLE);
     }
 
 }

--- a/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
+++ b/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
@@ -53,7 +53,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.kura.KuraProcessExecutionErrorException;
 import org.eclipse.kura.executor.Command;
@@ -73,7 +72,11 @@ import org.slf4j.LoggerFactory;
 
 public class SystemServiceImpl extends SuperSystemService implements SystemService {
 
-    private ScheduledExecutorService internetCheckerExecutor = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledExecutorService internetCheckerExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+        final Thread result = Executors.defaultThreadFactory().newThread(r);
+        result.setName("internet-status-checker");
+        return result;
+    });
 
     private static final String DEFAULT_INTERNET_CONNECTION_STATUS_CHECK_IP = "198.41.30.198";
     private static final String DEFAULT_INTERNET_CONNECTION_STATUS_CHECK_HOST = "eclipse.org";
@@ -1242,8 +1245,8 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
 
     private void parseSystemPackages(List<SystemResourceInfo> packagesInfo, CommandStatus status,
             SystemResourceType type) {
-        String[] packages = new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(), Charsets.UTF_8)
-                .split("\n");
+        String[] packages = new String(((ByteArrayOutputStream) status.getOutputStream()).toByteArray(),
+                StandardCharsets.UTF_8).split("\n");
         Arrays.asList(packages).stream().forEach(p -> {
             String[] fields = p.split("\\s+"); // this works for dpkg and rpm where separator for version and name is a
                                                // sequence of spaces
@@ -1307,8 +1310,8 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
         CommandStatus status = this.executorService.execute(command);
         if (logger.isDebugEnabled()) {
             logger.debug("execute command {} :: exited with code - {}", command, status.getExitStatus().getExitCode());
-            logger.debug("execute stderr {}", new String(err.toByteArray(), Charsets.UTF_8));
-            logger.debug("execute stdout {}", new String(out.toByteArray(), Charsets.UTF_8));
+            logger.debug("execute stderr {}", new String(err.toByteArray(), StandardCharsets.UTF_8));
+            logger.debug("execute stdout {}", new String(out.toByteArray(), StandardCharsets.UTF_8));
         }
         return status;
     }
@@ -1574,6 +1577,9 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
     }
 
     private void checkInternetTask() {
+        if (this.executorService == null) {
+            return;
+        }
         CommandStatus status = this.executorService
                 .execute(new Command(new String[] { "ping", "-c", "1", getInternetConnectionStatusCheckHost() }));
         if (status.getExitStatus().isSuccessful()) {

--- a/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
+++ b/kura/org.eclipse.kura.core.system/src/main/java/org/eclipse/kura/core/system/SystemServiceImpl.java
@@ -73,11 +73,7 @@ import org.slf4j.LoggerFactory;
 
 public class SystemServiceImpl extends SuperSystemService implements SystemService {
 
-    private ScheduledExecutorService internetCheckerExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
-        final Thread result = Executors.defaultThreadFactory().newThread(r);
-        result.setName("internet-status-checker");
-        return result;
-    });
+    private ScheduledExecutorService internetCheckerExecutor;
 
     private static final String DEFAULT_INTERNET_CONNECTION_STATUS_CHECK_IP = "198.41.30.198";
     private static final String DEFAULT_INTERNET_CONNECTION_STATUS_CHECK_HOST = "eclipse.org";
@@ -505,7 +501,13 @@ public class SystemServiceImpl extends SuperSystemService implements SystemServi
             throw new ComponentException("Error loading default properties", e);
         }
 
-        currentTask = internetCheckerExecutor.scheduleAtFixedRate(this::checkInternetTask, 5000,
+        this.internetCheckerExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            final Thread result = Executors.defaultThreadFactory().newThread(r);
+            result.setName("internet-status-checker");
+            return result;
+        });
+
+        this.currentTask = internetCheckerExecutor.scheduleAtFixedRate(this::checkInternetTask, 5000,
                 INTERNET_CHECK_TIME_INTERVAL, TimeUnit.MILLISECONDS);
     }
 

--- a/kura/org.eclipse.kura.rest.system.provider/src/main/java/org/eclipse/kura/rest/system/dto/FrameworkPropertiesDTO.java
+++ b/kura/org.eclipse.kura.rest.system.provider/src/main/java/org/eclipse/kura/rest/system/dto/FrameworkPropertiesDTO.java
@@ -1,15 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2023, 2026 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
- ******************************************************************************/
+ *******************************************************************************/
 package org.eclipse.kura.rest.system.dto;
 
 import java.util.List;
@@ -55,6 +55,7 @@ public class FrameworkPropertiesDTO {
     private String primaryNetworkInterfaceName;
     private String fileSeparator;
     private String firmwareVersion;
+    private String internetConnectionStatus;
 
     // kura
     private String kuraDataDirectory;
@@ -223,6 +224,10 @@ public class FrameworkPropertiesDTO {
 
         if (filter.test("firmwareVersion")) {
             this.firmwareVersion = systemService.getFirmwareVersion();
+        }
+
+        if (filter.test("internetConnectionStatus")) {
+            this.internetConnectionStatus = systemService.getInternetConnectionStatus().toString();
         }
     }
 

--- a/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
@@ -332,4 +332,15 @@ public class SystemServiceTest {
         assertEquals(InternetConnectionStatus.UNAVAILABLE, systemService.getInternetConnectionStatus());
     }
 
+    @TestTarget(targetPlatforms = { TestTarget.PLATFORM_ALL })
+    @Test
+    public void shouldGetDefaultInternetConnectionStatusCheckHost() {
+        assertEquals("eclipse.org", systemService.getInternetConnectionStatusCheckHost());
+    }
+
+    @TestTarget(targetPlatforms = { TestTarget.PLATFORM_ALL })
+    @Test
+    public void shouldGetDefaultInternetConnectionStatusCheckIp() {
+        assertEquals("198.41.30.198", systemService.getInternetConnectionStatusCheckIp());
+    }
 }

--- a/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
@@ -23,8 +23,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -45,7 +43,6 @@ public class SystemServiceTest {
     private static CommandExecutorService executorService = null;
     private static CountDownLatch dependencyLatch = new CountDownLatch(2);    // initialize with number of dependencies
     private boolean onCloudbees = false;
-    private InternetConnectionStatus currentInternetStatus;
 
     @BeforeClass
     public static void setUp() {
@@ -331,12 +328,8 @@ public class SystemServiceTest {
 
     @TestTarget(targetPlatforms = { TestTarget.PLATFORM_ALL })
     @Test
-    public void shouldNotBeConnectedToInternetOnCi() {
-        givenFirstCheckInternetExecutorRun();
-
-        whenInternetConnectionStatusIsChecked();
-
-        thenInternetConnectionStatusIs(isCI() ? InternetConnectionStatus.UNAVAILABLE : InternetConnectionStatus.FULL);
+    public void shouldNotBeConnectedToInternet() {
+        assertEquals(InternetConnectionStatus.UNAVAILABLE, systemService.getInternetConnectionStatus());
     }
 
     @TestTarget(targetPlatforms = { TestTarget.PLATFORM_ALL })
@@ -350,26 +343,4 @@ public class SystemServiceTest {
     public void shouldGetDefaultInternetConnectionStatusCheckIp() {
         assertEquals("198.41.30.198", systemService.getInternetConnectionStatusCheckIp());
     }
-
-    private boolean isCI() {
-        return Files.exists(Path.of("/tmp/isJenkins.txt"));
-    }
-
-    private void givenFirstCheckInternetExecutorRun() {
-        try {
-            Thread.sleep(6000l);
-        } catch (InterruptedException e) {
-            fail(e.getMessage());
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    private void whenInternetConnectionStatusIsChecked() {
-        this.currentInternetStatus = systemService.getInternetConnectionStatus();
-    }
-
-    private void thenInternetConnectionStatusIs(InternetConnectionStatus status) {
-        assertEquals(status, systemService.getInternetConnectionStatus());
-    }
-
 }

--- a/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
@@ -23,6 +23,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -43,6 +45,7 @@ public class SystemServiceTest {
     private static CommandExecutorService executorService = null;
     private static CountDownLatch dependencyLatch = new CountDownLatch(2);    // initialize with number of dependencies
     private boolean onCloudbees = false;
+    private InternetConnectionStatus currentInternetStatus;
 
     @BeforeClass
     public static void setUp() {
@@ -328,8 +331,12 @@ public class SystemServiceTest {
 
     @TestTarget(targetPlatforms = { TestTarget.PLATFORM_ALL })
     @Test
-    public void shouldNotBeConnectedToInternet() {
-        assertEquals(InternetConnectionStatus.UNAVAILABLE, systemService.getInternetConnectionStatus());
+    public void shouldNotBeConnectedToInternetOnCi() {
+        givenFirstCheckInternetExecutorRun();
+
+        whenInternetConnectionStatusIsChecked();
+
+        thenInternetConnectionStatusIs(isCI() ? InternetConnectionStatus.UNAVAILABLE : InternetConnectionStatus.FULL);
     }
 
     @TestTarget(targetPlatforms = { TestTarget.PLATFORM_ALL })
@@ -343,4 +350,26 @@ public class SystemServiceTest {
     public void shouldGetDefaultInternetConnectionStatusCheckIp() {
         assertEquals("198.41.30.198", systemService.getInternetConnectionStatusCheckIp());
     }
+
+    private boolean isCI() {
+        return Files.exists(Path.of("/tmp/isJenkins.txt"));
+    }
+
+    private void givenFirstCheckInternetExecutorRun() {
+        try {
+            Thread.sleep(6000l);
+        } catch (InterruptedException e) {
+            fail(e.getMessage());
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void whenInternetConnectionStatusIsChecked() {
+        this.currentInternetStatus = systemService.getInternetConnectionStatus();
+    }
+
+    private void thenInternetConnectionStatusIs(InternetConnectionStatus status) {
+        assertEquals(status, systemService.getInternetConnectionStatus());
+    }
+
 }

--- a/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
+++ b/kura/test/org.eclipse.kura.core.system.test/src/main/java/org/eclipse/kura/core/system/test/SystemServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2026 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.kura.executor.CommandExecutorService;
+import org.eclipse.kura.system.InternetConnectionStatus;
 import org.eclipse.kura.system.SystemService;
 import org.eclipse.kura.test.annotation.TestTarget;
 import org.junit.BeforeClass;
@@ -323,6 +324,12 @@ public class SystemServiceTest {
     @Test
     public void shouldGetDefaultNetworkConfigurationTimeoutProperty() {
         assertEquals(30, systemService.getNetworkConfigurationTimeout());
+    }
+
+    @TestTarget(targetPlatforms = { TestTarget.PLATFORM_ALL })
+    @Test
+    public void shouldNotBeConnectedToInternet() {
+        assertEquals(InternetConnectionStatus.UNAVAILABLE, systemService.getInternetConnectionStatus());
     }
 
 }

--- a/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/java/org/eclipse/kura/rest/system/provider/test/SystemServiceMockDecorator.java
+++ b/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/java/org/eclipse/kura/rest/system/provider/test/SystemServiceMockDecorator.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2023 Eurotech and/or its affiliates and others
- * 
+ * Copyright (c) 2023, 2026 Eurotech and/or its affiliates and others
+ *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *  Eurotech
  *******************************************************************************/

--- a/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/java/org/eclipse/kura/rest/system/provider/test/SystemServiceMockDecorator.java
+++ b/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/java/org/eclipse/kura/rest/system/provider/test/SystemServiceMockDecorator.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 
 import org.eclipse.kura.system.ExtendedProperties;
 import org.eclipse.kura.system.ExtendedPropertyGroup;
+import org.eclipse.kura.system.InternetConnectionStatus;
 import org.eclipse.kura.system.SystemService;
 
 public class SystemServiceMockDecorator {
@@ -122,7 +123,10 @@ public class SystemServiceMockDecorator {
         when(service.isLegacyBluetoothBeaconScan()).thenReturn(false);
         when(service.isLegacyPPPLoggingEnabled()).thenReturn(false);
         when(service.getKuraWebEnabled()).thenReturn(PROPERTIES_FALSE_STRING_VALUE);
-        
+        when(service.getInternetConnectionStatus()).thenReturn(InternetConnectionStatus.UNAVAILABLE);
+        when(service.getInternetConnectionStatusCheckHost()).thenReturn(PROPERTIES_VALUE);
+        when(service.getInternetConnectionStatusCheckIp()).thenReturn(PROPERTIES_VALUE);
+
         Properties kuraProperties = new Properties();
         kuraProperties.put(SystemService.KEY_KURA_HAVE_NET_ADMIN, false);
         when(service.getProperties()).thenReturn(kuraProperties);
@@ -130,7 +134,7 @@ public class SystemServiceMockDecorator {
 
     private static void initExtendedProperties(SystemService service) {
         ExtendedProperties extendedProperties = mock(ExtendedProperties.class);
-        
+
         List<ExtendedPropertyGroup> groups = new ArrayList<>();
         groups.add(createExtendedPropertyGroup("group1"));
         groups.add(createExtendedPropertyGroup("group2"));
@@ -218,7 +222,7 @@ public class SystemServiceMockDecorator {
         when(service.getKuraWebEnabled()).thenThrow(RuntimeException.class);
 
         when(service.getExtendedProperties()).thenThrow(RuntimeException.class);
-        
+
         when(service.getProperties()).thenThrow(RuntimeException.class);
     }
 

--- a/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/resources/FRAMEWORK_PROPERTIES_FILTER_REQUEST
+++ b/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/resources/FRAMEWORK_PROPERTIES_FILTER_REQUEST
@@ -30,6 +30,7 @@
         "primaryNetworkInterfaceName",
         "fileSeparator",
         "firmwareVersion",
+        "internetConnectionStatus",
         "kuraDataDirectory",
         "kuraFrameworkConfigDirectory",
         "kuraHomeDirectory",

--- a/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/resources/FRAMEWORK_PROPERTIES_RESPONSE
+++ b/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/resources/FRAMEWORK_PROPERTIES_RESPONSE
@@ -29,7 +29,7 @@
     "primaryNetworkInterfaceName":"test",
     "fileSeparator":"test",
     "firmwareVersion":"test",
-    "internetConnectionStatus": "FULL",
+    "internetConnectionStatus": "UNAVAILABLE",
     "kuraDataDirectory":"test",
     "kuraFrameworkConfigDirectory":"test",
     "kuraHomeDirectory":"test",

--- a/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/resources/FRAMEWORK_PROPERTIES_RESPONSE
+++ b/kura/test/org.eclipse.kura.rest.system.provider.test/src/main/resources/FRAMEWORK_PROPERTIES_RESPONSE
@@ -29,6 +29,7 @@
     "primaryNetworkInterfaceName":"test",
     "fileSeparator":"test",
     "firmwareVersion":"test",
+    "internetConnectionStatus": "FULL",
     "kuraDataDirectory":"test",
     "kuraFrameworkConfigDirectory":"test",
     "kuraHomeDirectory":"test",


### PR DESCRIPTION
The following method has been added to the SystemService class:
- getInternetConnectionStatus: This method allows you to check whether the device is connected to the internet.

The method checks:

1. The ability to reach the internet address.
2. resolve the hostname.

By default the host to reach is eclipse.org and its current ip is used in case the dns resolver doesn't work