### PR TITLE
docs: Added section for ppp-based modems (#6151) [backport docs-release-5.4]

### DIFF
--- a/docs/gateway-configuration/network-failover.md
+++ b/docs/gateway-configuration/network-failover.md
@@ -63,6 +63,16 @@ The **response** should match what the URI is returning when probed. Some exampl
 To **disable** the connectivity check feature:
 
 - remove the `[connectivity]` section from the configuration file; or
-- set `interval=0`; or
-- remove `uri`; or
-- set an empty URI, like `uri=`
+- set `enabled=false` in the `[connectivity]` section.
+
+## Network Failover with PPP-based Modems
+
+When NetworkManager uses `ppp` technology to establish a cellular connection, a value of 20000 is always added to the modem interface's route metric, causing an improper behavior of the failover feature. This is a NetworkManager known-issue presented [here](https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1867). The workarounds for this issue depend on the desired behavior and they are presented below.
+
+### Cellular connection as primary WAN interface
+If the cellular connection is intended to act as the primary WAN interface, all other WAN interfaces must be assigned a priority higher than `20000 + <primary WAN priority>`. For example, if the cellular interface (`ppp0`) uses a priority of 500, the other WAN interfaces (`eth1`, `end1`, etc.) should be configured with a priority greater than 20500.
+
+The main limitation of this approach is that the failover mechanism will not switch back to the secondary WAN interfaces when the cellular connection lacks global connectivity.
+
+### Cellular connection as backup WAN interface
+If the cellular connection is used as a backup WAN interface, priorities can be configured as in normal operation. The modem interface will retain a high route metric and will only be used as a fallback when the primary connection becomes unavailable.


### PR DESCRIPTION
* Added section for ppp-based modems
* Update docs/gateway-configuration/network-failover.md
* Fixed typo
---------
(cherry picked from commit 9fa2cd1f5cf671a281ee98d9d754e69b5eb75ece)
