### PR TITLE
docs: Improved failover page with disable procedure

### DIFF
--- a/docs/gateway-configuration/network-failover.md
+++ b/docs/gateway-configuration/network-failover.md
@@ -63,9 +63,7 @@ The **response** should match what the URI is returning when probed. Some exampl
 To **disable** the connectivity check feature:
 
 - remove the `[connectivity]` section from the configuration file; or
-- set `interval=0`; or
-- remove `uri`; or
-- set an empty URI, like `uri=`
+- set `enabled=false` in the `[connectivity]` section.
 
 ## DNS Priority
 


### PR DESCRIPTION
This pull request updates the documentation for disabling the connectivity check feature in the network failover configuration. The change clarifies the recommended way to disable the feature.

Documentation update:

* Updated the instructions in `docs/gateway-configuration/network-failover.md` to recommend setting `enabled=false` in the `[connectivity]` section as the method to disable the connectivity check feature, replacing the previous options.