### PR TITLE
ci: leverage new project structure for generating SBOMs

### DIFF
--- a/.github/workflows/kura-core-sbom.yml
+++ b/.github/workflows/kura-core-sbom.yml
@@ -15,12 +15,12 @@ on:
     types:
       - completed
 
+# Product specific settings
 env:
   JAVA_VERSION: '17' # java version used by the product
   JAVA_DISTRO: 'temurin' # java distro used by the product
-  NODE_VERSION: "20.x"
-  REGISTRY_URL: "https://registry.npmjs.org"
-  PRODUCT_PATH: "./kura"
+  PRODUCT_PATH: "kura" # path within project repository for SBOM source
+  PLUGIN_VERSION: '2.9.1' # cyclonedx-maven-plugin version to use
   WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
   INPUT_TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
   EVENT_NAME: ${{ github.event_name }}
@@ -31,12 +31,11 @@ permissions:
 
 jobs:
   generate-sbom:
-    name: Generate SBOM
-    runs-on: ubuntu-22.04
+    name: Generate Kura core SBOM
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
-    permissions:
-      packages: read
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }} # required for DependencyTrack upload
     steps:
       - name: Set checkout ref
         id: set-checkout-ref
@@ -69,55 +68,15 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRO }}
 
-      - name: Build target platform
+      - name: Generate sbom
         run: |
-          mvn -f target-platform/pom.xml clean install
-
-      - name: Build Kura core
-        run: |
-          mvn -f kura/pom.xml clean install -Dmaven.test.skip=true
-
-      - name: Get version
-        id: get-version
-        run: "echo \"resolved-version=\
-          $(mvn
-            --file ./kura/pom.xml
-            -Dexec.executable=echo
-            -Dexec.args='${project.version}'
-            --quiet exec:exec --non-recursive
-          )\" >> \"${GITHUB_OUTPUT}\""
-        shell: bash
-
-      - name: Setup Node SDK
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: ${{ env.REGISTRY_URL }}
-
-      - name: Install cdxgen
-        run: |
-          npm install -g @cyclonedx/cdxgen
-
-      - name: Generate SBOM
-        working-directory: ${{ env.PRODUCT_PATH }}
-        run: |
-          FETCH_LICENSE=1 CDXGEN_DEBUG_MODE=debug cdxgen \
-            -r -o ./bom.json \
-            -t jar \
-            --exclude "**/test/**" \
-            --exclude "**/target-definition/**" \
-            --exclude "**/target/**" \
-            --exclude "**/distrib/**" \
-            --filter "kura" \
-            --project-version "${{ steps.get-version.outputs.resolved-version }}" \
-            --project-name "kura-core" \
-            --deep
+          mvn org.cyclonedx:cyclonedx-maven-plugin:${{ env.PLUGIN_VERSION }}:makeAggregateBom -DprojectType=framework -DexcludeArtifactId=target-definition,emulator,distrib,test,tools,kura-addon-archetype,kura-bom -f ${{ env.PRODUCT_PATH }}/pom.xml
 
       - name: Extract product version
-        id: version
+        id: get-version
         shell: bash
         run: |
-          VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/bom.json)"
+          VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/target/bom.json)"
 
           # Substitute "-SNAPSHOT" suffix with "@dev" if present
           VERSION="${VERSION/-SNAPSHOT/@dev}"

--- a/.github/workflows/target-platform-sbom.yml
+++ b/.github/workflows/target-platform-sbom.yml
@@ -19,7 +19,8 @@ on:
 env:
   JAVA_VERSION: '17' # java version used by the product
   JAVA_DISTRO: 'temurin' # java distro used by the product
-  PRODUCT_PATH: 'target-platform/target-platform-bom' # path within project repository for SBOM source
+  PRODUCT_PATH: 'target-platform' # path within project repository for SBOM source
+  PLUGIN_VERSION: '2.9.1' # cyclonedx-maven-plugin version to use
   WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
   INPUT_TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
   EVENT_NAME: ${{ github.event_name }}
@@ -30,6 +31,7 @@ permissions:
 
 jobs:
   generate-sbom:
+    name: Generate Kura target platform SBOM
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
@@ -68,10 +70,10 @@ jobs:
 
       - name: Generate sbom
         run: |
-          mvn -f target-platform/pom.xml clean install
+          mvn org.cyclonedx:cyclonedx-maven-plugin:${{ env.PLUGIN_VERSION }}:makeAggregateBom -DprojectType=framework -f ${{ env.PRODUCT_PATH }}/pom.xml
 
       - name: Extract product version
-        id: version
+        id: get-version
         shell: bash
         run: |
           VERSION="$(jq -r '.metadata.component.version' < ./${{ env.PRODUCT_PATH }}/target/bom.json)"


### PR DESCRIPTION
This PR modifies the CI workflows to generate the SBOM for the target platform and the core part by leveraging the new project structure introduced in https://github.com/eclipse-kura/kura/pull/6149.

Now it is sufficient to generate the SBOM with `cdxgen`.

**Related Issue:** https://github.com/eclipse-kura/kura/pull/6149.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
