### PR TITLE
chore(org.eclipse.kura.cloud.base.provider): Deactivate sonar rule

### DIFF
--- a/kura/org.eclipse.kura.cloud.base.provider/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
+++ b/kura/org.eclipse.kura.cloud.base.provider/src/main/java/org/eclipse/kura/core/data/transport/mqtt/MqttDataTransport.java
@@ -57,6 +57,7 @@ import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("java:S2789")
 public class MqttDataTransport implements DataTransportService, MqttCallback, ConfigurableComponent, SslServiceListener,
         CloudConnectionStatusComponent {
 


### PR DESCRIPTION
Deactivate sonar rule with id: `java:S2789` to allow develop build to pass.