### PR TITLE
test: remove mockito-inline dependency

### DIFF
--- a/kura/test/pom.xml
+++ b/kura/test/pom.xml
@@ -62,12 +62,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.2</version>


### PR DESCRIPTION
Removed `mockito-inline` dependency from `tests/pom.xml` since it does not exists with such version anymore and is now embedded into `mockito-core`

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
