### PR TITLE
chore(archetype): improvements on DEB metadata retrieval

### DIFF
--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/deb/control/control
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/deb/control/control
@@ -4,7 +4,7 @@ Section: admin
 Priority: optional
 Depends: kura-core (>= 6.0.0~), kura-core(<< 7.0.0~)
 Architecture: [[deb.architecture]]
-Maintainer: Eclipse Kura Developers <kura-dev@eclipse.org>
+Maintainer: [[deb.maintainer]]
 Description: [[summary]]
   [[long.description]]
-Homepage: https://eclipse-kura.github.io/kura/ (add correct link to documentation here)
+Homepage: [[deb.docs]]

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/distrib/pom.xml
@@ -46,6 +46,8 @@
             all, amd64, arm64
         -->
         <deb.architecture>all</deb.architecture>
+        <deb.maintainer>${project.organization.name} &lt;${project.developers[0].email}&gt;</deb.maintainer>
+        <deb.docs>${project.url}</deb.docs>
 
         <!-- final name of the generated debian package -->
         <package.name>${artifactId}</package.name>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/pom.xml
@@ -45,7 +45,7 @@
         </license>
     </licenses>
     <!-- Documentation URL -->
-    <url>https://www.eurotech.com/</url>
+    <url>https://eclipse-kura.github.io/kura</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/pom.xml
@@ -15,7 +15,8 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    child.project.url.inherit.append.path="false">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>${groupId}</groupId>
@@ -43,6 +44,8 @@
             <url>https://www.eclipse.org/legal/epl-2.0/</url>
         </license>
     </licenses>
+    <!-- Documentation URL -->
+    <url>https://www.eurotech.com/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/pom.xml
+++ b/kura/tools/kura-addon-archetype/src/main/resources/archetype-resources/tests/pom.xml
@@ -240,11 +240,6 @@
                                 </requirement>
                                 <requirement>
                                     <type>p2-installable-unit</type>
-                                    <id>org.eclipse.equinox.console</id>
-                                    <versionRange>0.0.0</versionRange>
-                                </requirement>
-                                <requirement>
-                                    <type>p2-installable-unit</type>
                                     <id>org.apache.felix.gogo.command</id>
                                     <versionRange>0.0.0</versionRange>
                                 </requirement>


### PR DESCRIPTION
Debian package metadata `Maintainer` and `Homepage` are now constructed from Maven metadata `<url>` and `<developers>`. Removed duplicate requirement in tests.

**Related Issue:** N/A.

**Description of the solution adopted:** N/A.

**Screenshots:** N/A.

**Manual Tests**: N/A.

**Any side note on the changes made:** N/A.
