### PR TITLE
build: updated nexus deployment link

### DIFF
--- a/.jenkins/nexusUtils.groovy
+++ b/.jenkins/nexusUtils.groovy
@@ -31,7 +31,7 @@ def uploadPackages(String repoDistribution, String repoModule, Boolean setupProm
                         -w '%{http_code}' \
                         -H \"Content-Type: multipart/form-data\" \
                         --data-binary \"@./${it}\" \
-                        \"https://repo3.eclipse.org/repository/kura-apt-dev/\" \
+                        \"https://repo.eclipse.org/repository/kura-apt-dev/\" \
                         -o /dev/null
                     """,
                     returnStdout: true


### PR DESCRIPTION
Alignment after eclipse migrated from `repo3` to `repo`