### PR TITLE
ci: pin versions of Actions and Reusable Workflows

### DIFF
--- a/.github/workflows/kura-core-sbom.yml
+++ b/.github/workflows/kura-core-sbom.yml
@@ -92,7 +92,7 @@ jobs:
 
   store-sbom-data:
     needs: ['generate-sbom']
-    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@88508d92f2638d942a88744431f017225ed8c14c # main@08/04/2026
     with:
       projectName: 'kura-core'
       projectVersion: ${{ needs.generate-sbom.outputs.project-version }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
 
     - name: Checkout ${{ github.ref }} branch in ${{ github.repository }} repository.
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         fetch-depth: '0'
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: '21'
@@ -48,7 +48,7 @@ jobs:
     - name: Check file existence
       id: check_files
       continue-on-error: true
-      uses: thebinaryfelix/check-file-existence-action@1.0.0
+      uses: thebinaryfelix/check-file-existence-action@436223737a098725b8d10ab1950a03efba5e6fc6 # 1.0.0
       with:
         files: './kura/distrib/RELEASE_NOTES.txt'
 
@@ -101,7 +101,7 @@ jobs:
         rm known-issues.txt
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
         title: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"
         commit-message: "chore: add Kura ${{ steps.get-version.outputs.resolved-version }} release notes"

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5.2.1
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 14

--- a/.github/workflows/target-platform-sbom.yml
+++ b/.github/workflows/target-platform-sbom.yml
@@ -92,7 +92,7 @@ jobs:
 
   store-sbom-data:
     needs: ['generate-sbom']
-    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@88508d92f2638d942a88744431f017225ed8c14c # main@08/04/2026
     with:
       projectName: 'kura-target-platform'
       projectVersion: ${{ needs.generate-sbom.outputs.project-version }}

--- a/.github/workflows/version-uptick.yml
+++ b/.github/workflows/version-uptick.yml
@@ -28,12 +28,12 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         ref: ${{ github.event.inputs.target_branch }}
 
     - name: Download version upticker tool
-      uses: carlosperate/download-file-action@v1
+      uses: carlosperate/download-file-action@8b89cb8b4807765e7d63fe765cc600eb1919af11 # v1.1.2
       with:
         file-url: https://kura-repo.s3.us-west-2.amazonaws.com/esf_upticker_tool/version-uptick-0.2.0-linux-x86_64
 
@@ -57,12 +57,12 @@ jobs:
 
     - name: Get version
       id: get-version
-      uses: JActions/maven-version@v1.0.1
+      uses: JActions/maven-version@aafa242403588c1c69d619b3cec9c2ff6abd57ac # v1.0.1
       with:
         pom: ./kura/pom.xml
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
         title: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"
         commit-message: "chore: automated uptick to ${{ steps.get-version.outputs.version }}"


### PR DESCRIPTION
Pin version of Actions and Reusable Workflows in our automations as per Eclipse Foundation security recommendations.

I used https://github.com/suzuki-shunsuke/pinact to perform the pinning for all actions apart from the `eclipse-csi` ones which were performed manually.

The action that were not pinned use Reusable Workflow that we developed and therefore are considered safe.